### PR TITLE
JPEG: automatically set georeferencing for Hello world picture taken by Reid Wiseman from Artemis II

### DIFF
--- a/frmts/jpeg/jpgdataset.cpp
+++ b/frmts/jpeg/jpgdataset.cpp
@@ -3681,10 +3681,82 @@ JPGDatasetCommon *JPGDataset::OpenStage2(JPGDatasetOpenArgs *psArgs,
 
     poDS->bIsSubfile = bIsSubfile;
 
+    poDS->ArtemisIIEasterEgg();
+
     return poDS;
 }
 
 #if !defined(JPGDataset)
+
+/************************************************************************/
+/*                         ArtemisIIEasterEgg()                         */
+/************************************************************************/
+
+void JPGDatasetCommon::ArtemisIIEasterEgg()
+{
+    // Is this the Artemis II mythic image of https://www.nasa.gov/wp-content/uploads/2026/04/art002e000192.jpg ?
+    // If so, then use georeferencing kindly provided by Simeon Schmauß (https://mastodon.social/@stim3on@fosstodon.org)
+    // in https://fosstodon.org/@stim3on/116353715518726592
+    GDALGeoTransform gt;
+    // Do cheapest tests first...
+    if (nRasterXSize == 5568 && nRasterYSize == 3712 &&
+        strstr(GetDescription(), "art002e000192") != nullptr &&
+        GetSpatialRef() == nullptr && GetGeoTransform(gt) != CE_None)
+    {
+        const char *pszWKT =
+            "PROJCRS[\"Tilted perspective projection for Hello world picture "
+            "taken by Reid Wiseman from Artemis II\","
+            "    BASEGEOGCRS[\"WGS84\","
+            "        DATUM[\"World Geodetic System 1984\","
+            "            ELLIPSOID[\"WGS 84\",6378137,298.257223563,"
+            "                LENGTHUNIT[\"metre\",1]],"
+            "            ID[\"EPSG\",6326]],"
+            "        PRIMEM[\"Greenwich\",0,"
+            "            ANGLEUNIT[\"degree\",0.0174532925199433],"
+            "            ID[\"EPSG\",8901]]],"
+            "    CONVERSION[\"Tilted perspective - Hello world - Artemis II\","
+            "        METHOD[\"PROJ tpers\"],"
+            "        PARAMETER[\"lat_0\",-1.6359082148,"
+            "            ANGLEUNIT[\"degree\",0.0174532925199433,"
+            "                ID[\"EPSG\",9122]]],"
+            "        PARAMETER[\"lon_0\",-17.4323556611,"
+            "            ANGLEUNIT[\"degree\",0.0174532925199433,"
+            "                ID[\"EPSG\",9122]]],"
+            "        PARAMETER[\"h\",10290019.124,"
+            "            LENGTHUNIT[\"metre\",1,"
+            "                ID[\"EPSG\",9001]]],"
+            "        PARAMETER[\"tilt\",-4.15,"
+            "            ANGLEUNIT[\"degree\",0.0174532925199433,"
+            "                ID[\"EPSG\",9122]]],"
+            "        PARAMETER[\"azi\",121.5,"
+            "            ANGLEUNIT[\"degree\",0.0174532925199433,"
+            "                ID[\"EPSG\",9122]]]],"
+            "    CS[Cartesian,2],"
+            "        AXIS[\"(E)\",east,"
+            "            ORDER[1],"
+            "            LENGTHUNIT[\"metre\",1,"
+            "                ID[\"EPSG\",9001]]],"
+            "        AXIS[\"(N)\",north,"
+            "            ORDER[2],"
+            "            LENGTHUNIT[\"metre\",1,"
+            "                ID[\"EPSG\",9001]]],"
+            "    REMARK[\"Credits to Simeon Schmauß for deriving this CRS: "
+            "https://fosstodon.org/@stim3on/116353715518726592\"]]";
+
+        m_oSRS.importFromWkt(pszWKT);
+        bGeoTransformValid = true;
+        m_gt[0] = -5.2217134991559219e+06;
+        m_gt[1] = 2.6965734323778038e+03;
+        m_gt[2] = -1.2177960904732563e+03;
+        m_gt[3] = 7.5987852091184044e+06;
+        m_gt[4] = -1.2009140912982348e+03;
+        m_gt[5] = -2.6924269785799042e+03;
+        GDALDataset::SetMetadataItem(
+            "GEOREFERENCING_CREDITS",
+            "Simeon Schmauß: "
+            "https://fosstodon.org/@stim3on/116353715518726592");
+    }
+}
 
 /************************************************************************/
 /*                         LoadWorldFileOrTab()                         */

--- a/frmts/jpeg/jpgdataset.h
+++ b/frmts/jpeg/jpgdataset.h
@@ -253,6 +253,8 @@ class JPGDatasetCommon CPL_NON_FINAL : public GDALPamDataset
                            GDALProgressFunc, void *,
                            CSLConstList papszOptions) override;
 
+    void ArtemisIIEasterEgg();
+
     CPL_DISALLOW_COPY_ASSIGN(JPGDatasetCommon)
 
   public:


### PR DESCRIPTION
Huge thanks to Simeon Schmauß (@sschmaus) for the hard work into deriving the CRS and the (approximate) geotransformation matrix!

Details at https://mastodon.social/@stim3on@fosstodon.org/116353749166350828

Co-authored-by: Simeon Schmauß


With that PR:
```
$ gdalinfo /vsicurl/https://www.nasa.gov/wp-content/uploads/2026/04/art002e000192.jpg
[...]
Coordinate System is:
PROJCRS["Tilted perspective projection for Hello world picture taken by Reid Wiseman from Artemis II",
    BASEGEOGCRS["WGS84",
        DATUM["World Geodetic System 1984",
            ELLIPSOID["WGS 84",6378137,298.257223563,
                LENGTHUNIT["metre",1]],
            ID["EPSG",6326]],
        PRIMEM["Greenwich",0,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8901]]],
    CONVERSION["Tilted perspective - Hello world - Artemis II",
        METHOD["PROJ tpers"],
        PARAMETER["lat_0",-1.6359082148,
            ANGLEUNIT["degree",0.0174532925199433,
                ID["EPSG",9122]]],
        PARAMETER["lon_0",-17.4323556611,
            ANGLEUNIT["degree",0.0174532925199433,
                ID["EPSG",9122]]],
        PARAMETER["h",10290019.124,
            LENGTHUNIT["metre",1,
                ID["EPSG",9001]]],
        PARAMETER["tilt",-4.15,
            ANGLEUNIT["degree",0.0174532925199433,
                ID["EPSG",9122]]],
        PARAMETER["azi",121.5,
            ANGLEUNIT["degree",0.0174532925199433,
                ID["EPSG",9122]]]],
    CS[Cartesian,2],
        AXIS["(E)",east,
            ORDER[1],
            LENGTHUNIT["metre",1,
                ID["EPSG",9001]]],
        AXIS["(N)",north,
            ORDER[2],
            LENGTHUNIT["metre",1,
                ID["EPSG",9001]]],
    REMARK["Credits to Simeon Schmauß: https://fosstodon.org/@stim3on/116353715518726592"]]
Data axis to CRS axis mapping: 1,2
GeoTransform =
  -5221713.499155922, 2696.573432377804, -1217.796090473256
  7598785.209118404, -1200.914091298235, -2692.426978579904
```

With OpenStreetMap overlayed on it in QGIS:

<img width="1584" height="753" alt="image" src="https://github.com/user-attachments/assets/4f0db1b9-e284-42d4-8eaf-c2eac28c8f02" />
