### PR TITLE
JP2Grok: let Grok library handle JP2 box rewrites

### DIFF
--- a/.github/workflows/ubuntu_26.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_26.04/Dockerfile.ci
@@ -230,7 +230,7 @@ RUN curl -LO -fsS https://github.com/apache/arrow/archive/refs/heads/main.zip \
     && rm -rf arrow-main
 
 # Build Grok JPEG 2000 library
-ARG GROK_VERSION=master
+ARG GROK_VERSION=v20.2.7
 
 RUN git clone --recursive --depth 1 --branch ${GROK_VERSION} \
     https://github.com/GrokImageCompression/grok.git grok-git && \

--- a/autotest/gdrivers/jp2grok.py
+++ b/autotest/gdrivers/jp2grok.py
@@ -1069,6 +1069,97 @@ def test_jp2grok_multitile_multirow(tmp_vsimem):
 
 
 ###############################################################################
+# Test in-place rewrite of JP2 boxes via GA_Update
+
+
+def test_jp2grok_rewrite_boxes(tmp_path):
+    gdaltest.importorskip_gdal_array()
+    np = pytest.importorskip("numpy")
+
+    tmpfile = tmp_path / "jp2grok_rewrite.jp2"
+
+    sr = osr.SpatialReference()
+    sr.ImportFromEPSG(32631)
+
+    # Create a file with known pixel data and no georef
+    src_ds = gdal.GetDriverByName("MEM").Create("", 20, 20)
+
+    pixel_data = np.arange(20 * 20, dtype=np.uint8).reshape(20, 20)
+    src_ds.GetRasterBand(1).WriteArray(pixel_data)
+    out_ds = gdaltest.jp2grok_drv.CreateCopy(
+        tmpfile, src_ds, options=["REVERSIBLE=YES"]
+    )
+    del out_ds
+    del src_ds
+
+    # Add geotransform and projection
+    ds = gdal.Open(tmpfile, gdal.GA_Update)
+    ds.SetSpatialRef(sr)
+    ds.SetGeoTransform([0, 1, 0, 3, 0, -1])
+    ds = None
+
+    # Check they were written into the file (not PAM)
+    assert gdal.VSIStatL(tmp_path / ".aux.xml") is None
+    ds = gdal.Open(tmpfile)
+    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+    assert ds.GetGeoTransform() == (0, 1, 0, 3, 0, -1)
+    # Verify pixel data survived the transcode
+    got = ds.GetRasterBand(1).ReadAsArray()
+    assert np.array_equal(got, pixel_data)
+    ds = None
+
+    # Modify geotransform
+    ds = gdal.Open(tmpfile, gdal.GA_Update)
+    ds.SetGeoTransform([1, 2, 0, 4, 0, -2])
+    ds = None
+    assert gdal.VSIStatL(tmp_path / ".aux.xml") is None
+
+    ds = gdal.Open(tmpfile)
+    assert ds.GetGeoTransform() == (1, 2, 0, 4, 0, -2)
+    assert np.array_equal(ds.GetRasterBand(1).ReadAsArray(), pixel_data)
+    ds = None
+
+    # Replace projection+geotransform with GCPs
+    ds = gdal.Open(tmpfile, gdal.GA_Update)
+    gcps = [gdal.GCP(0, 1, 2, 3, 4)]
+    ds.SetGCPs(gcps, sr.ExportToWkt())
+    ds = None
+    assert gdal.VSIStatL(tmp_path / ".aux.xml") is None
+
+    ds = gdal.Open(tmpfile)
+    assert ds.GetGCPCount() == 1
+    got_gcp = ds.GetGCPs()[0]
+    assert got_gcp.GCPX == 0
+    assert got_gcp.GCPY == 1
+    assert got_gcp.GCPZ == 2
+    assert got_gcp.GCPPixel == 3
+    assert got_gcp.GCPLine == 4
+    assert ds.GetGCPSpatialRef().GetAuthorityCode(None) == "32631"
+    ds = None
+
+    # Add metadata
+    ds = gdal.Open(tmpfile, gdal.GA_Update)
+    ds.SetMetadataItem("FOO", "BAR")
+    ds = None
+    assert gdal.VSIStatL(tmp_path / ".aux.xml") is None
+
+    ds = gdal.Open(tmpfile)
+    assert ds.GetMetadata() == {"FOO": "BAR"}
+    ds = None
+
+    # Add IPR box
+    ds = gdal.Open(tmpfile, gdal.GA_Update)
+    ds.SetMetadata(["<fake_ipr_box/>"], "xml:IPR")
+    ds = None
+    assert gdal.VSIStatL(tmp_path / ".aux.xml") is None
+
+    ds = gdal.Open(tmpfile)
+    assert ds.GetMetadata("xml:IPR")[0] == "<fake_ipr_box/>"
+    assert np.array_equal(ds.GetRasterBand(1).ReadAsArray(), pixel_data)
+    ds = None
+
+
+###############################################################################
 # Test driver metadata
 
 

--- a/frmts/grok/grkdatasetbase.h
+++ b/frmts/grok/grkdatasetbase.h
@@ -1133,7 +1133,7 @@ struct GRKCodecWrapper
         {
             const GByte *asocData = poGMLJP2Box->GetWritableData();
             int asocLen = static_cast<int>(poGMLJP2Box->GetDataLength());
-            flattenAndSetAsocBoxes(asocData, asocLen);
+            flattenAndSetAsocBoxes(psImage, asocData, asocLen);
         }
 
         /* XMP UUID */
@@ -1162,12 +1162,8 @@ struct GRKCodecWrapper
                 const GByte *p = poMDBox->GetWritableData();
                 GIntBig n = poMDBox->GetDataLength();
                 if (n > 0)
-                {
-                    psImage->meta->xml_len = static_cast<size_t>(n);
-                    psImage->meta->xml_buf =
-                        static_cast<uint8_t *>(malloc(psImage->meta->xml_len));
-                    memcpy(psImage->meta->xml_buf, p, psImage->meta->xml_len);
-                }
+                    grk_image_meta_set_field(psImage->meta, "xml", p,
+                                             static_cast<size_t>(n));
             }
         }
 
@@ -1252,7 +1248,8 @@ struct GRKCodecWrapper
         }
     }
 
-    void flattenAndSetAsocBoxes(const GByte *asocData, int asocDataLen)
+    static void flattenAndSetAsocBoxes(grk_image *image, const GByte *asocData,
+                                       int asocDataLen)
     {
         struct AsocEntry
         {
@@ -1311,7 +1308,7 @@ struct GRKCodecWrapper
                     entries[i].xml.empty() ? nullptr : entries[i].xml.data();
                 asocs[i].xml_len = static_cast<uint32_t>(entries[i].xml.size());
             }
-            grk_image_meta_set_asocs(psImage->meta, asocs.data(),
+            grk_image_meta_set_asocs(image->meta, asocs.data(),
                                      static_cast<uint32_t>(asocs.size()));
         }
     }
@@ -1358,6 +1355,187 @@ struct GRKCodecWrapper
             CPLError(CE_Failure, CPLE_AppDefined, "grk_compress_init() failed");
             return false;
         }
+        return true;
+    }
+
+    /**
+     * @brief Rewrite JP2 boxes via Grok transcode.
+     *
+     * Replaces the driver-side box rewriting logic in Close() by using
+     * grk_transcode() to copy the codestream verbatim while writing
+     * updated metadata boxes.
+     *
+     * @param pszFilename source (and destination) file path
+     * @param poDS        dataset carrying updated metadata
+     * @return true on success
+     */
+    static bool rewriteBoxes(const char *pszFilename, GDALDataset *poDS)
+    {
+        CPLDebug("GROK", "Rewriting boxes via transcode for %s", pszFilename);
+
+        /* Read source header to get image */
+        grk_stream_params srcStreamParams{};
+        safe_strcpy(srcStreamParams.file, pszFilename);
+
+        grk_decompress_parameters dparams{};
+        auto *decCodec = grk_decompress_init(&srcStreamParams, &dparams);
+        if (!decCodec)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "grk_decompress_init() failed for rewrite");
+            return false;
+        }
+
+        grk_header_info srcHeader{};
+        if (!grk_decompress_read_header(decCodec, &srcHeader))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "grk_decompress_read_header() failed for rewrite");
+            grk_object_unref(decCodec);
+            return false;
+        }
+
+        auto *srcImage = grk_decompress_get_image(decCodec);
+        if (!srcImage)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "grk_decompress_get_image() failed for rewrite");
+            grk_object_unref(decCodec);
+            return false;
+        }
+
+        /* Prepare updated metadata on the image */
+        if (!srcImage->meta)
+            srcImage->meta = grk_image_meta_new();
+
+        /* GeoTIFF UUID */
+        GDALJP2Metadata oJP2MD;
+        if (poDS->GetGCPCount() > 0)
+        {
+            oJP2MD.SetGCPs(poDS->GetGCPCount(), poDS->GetGCPs());
+            oJP2MD.SetSpatialRef(poDS->GetGCPSpatialRef());
+        }
+        else
+        {
+            const OGRSpatialReference *poSRS = poDS->GetSpatialRef();
+            if (poSRS)
+                oJP2MD.SetSpatialRef(poSRS);
+            GDALGeoTransform gt;
+            if (poDS->GetGeoTransform(gt) == CE_None &&
+                gt != GDALGeoTransform())
+                oJP2MD.SetGeoTransform(gt);
+        }
+        const char *pszAreaOrPoint =
+            poDS->GetMetadataItem(GDALMD_AREA_OR_POINT);
+        oJP2MD.bPixelIsPoint =
+            pszAreaOrPoint && EQUAL(pszAreaOrPoint, GDALMD_AOP_POINT);
+
+        {
+            std::unique_ptr<GDALJP2Box> poGeoBox(oJP2MD.CreateJP2GeoTIFF());
+            if (poGeoBox)
+            {
+                const GByte *p = poGeoBox->GetWritableData();
+                GIntBig n = poGeoBox->GetDataLength();
+                if (n > 16)
+                    grk_image_meta_set_field(srcImage->meta, "geotiff", p + 16,
+                                             static_cast<size_t>(n - 16));
+            }
+        }
+
+        /* IPR box */
+        {
+            std::unique_ptr<GDALJP2Box> poIPRBox(
+                GDALJP2Metadata::CreateIPRBox(poDS));
+            if (poIPRBox)
+            {
+                const GByte *p = poIPRBox->GetWritableData();
+                GIntBig n = poIPRBox->GetDataLength();
+                if (n > 0)
+                    grk_image_meta_set_field(srcImage->meta, "ipr", p,
+                                             static_cast<size_t>(n));
+            }
+        }
+
+        /* XMP UUID */
+        {
+            std::unique_ptr<GDALJP2Box> poXMPBox(
+                GDALJP2Metadata::CreateXMPBox(poDS));
+            if (poXMPBox)
+            {
+                const GByte *p = poXMPBox->GetWritableData();
+                GIntBig n = poXMPBox->GetDataLength();
+                if (n > 16)
+                    grk_image_meta_set_field(srcImage->meta, "xmp", p + 16,
+                                             static_cast<size_t>(n - 16));
+            }
+        }
+
+        /* GDAL metadata XML box */
+        {
+            std::unique_ptr<GDALJP2Box> poMDBox(
+                GDALJP2Metadata::CreateGDALMultiDomainMetadataXMLBox(poDS,
+                                                                     false));
+            if (poMDBox)
+            {
+                const GByte *p = poMDBox->GetWritableData();
+                GIntBig n = poMDBox->GetDataLength();
+                if (n > 0)
+                    grk_image_meta_set_field(srcImage->meta, "xml", p,
+                                             static_cast<size_t>(n));
+            }
+        }
+
+        /* GMLJP2 asoc boxes */
+        bool bHasSRS = poDS->GetSpatialRef() != nullptr &&
+                       !poDS->GetSpatialRef()->IsEmpty();
+        GDALGeoTransform gt;
+        bool bHasGT =
+            poDS->GetGeoTransform(gt) == CE_None && gt != GDALGeoTransform();
+        if (bHasSRS && bHasGT && poDS->GetGCPCount() == 0)
+        {
+            std::unique_ptr<GDALJP2Box> poGMLBox(oJP2MD.CreateGMLJP2(
+                poDS->GetRasterXSize(), poDS->GetRasterYSize()));
+            if (poGMLBox)
+            {
+                const GByte *asocData = poGMLBox->GetWritableData();
+                int asocLen = static_cast<int>(poGMLBox->GetDataLength());
+                flattenAndSetAsocBoxes(srcImage, asocData, asocLen);
+            }
+        }
+
+        /* Transcode: copy codestream, rewrite boxes */
+        grk_cparameters cparams{};
+        grk_compress_set_default_params(&cparams);
+        cparams.cod_format = GRK_FMT_JP2;
+
+        CPLString osTmpFilename(CPLSPrintf("%s.tmp", pszFilename));
+
+        grk_stream_params transSrcParams{};
+        safe_strcpy(transSrcParams.file, pszFilename);
+
+        grk_stream_params dstParams{};
+        safe_strcpy(dstParams.file, osTmpFilename.c_str());
+
+        uint64_t written =
+            grk_transcode(&transSrcParams, &dstParams, &cparams, srcImage);
+        grk_object_unref(decCodec);
+
+        if (written == 0)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "grk_transcode() failed for box rewrite");
+            VSIUnlink(osTmpFilename);
+            return false;
+        }
+
+        if (VSIRename(osTmpFilename, pszFilename) != 0)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined, "Failed to rename %s to %s",
+                     osTmpFilename.c_str(), pszFilename);
+            VSIUnlink(osTmpFilename);
+            return false;
+        }
+
         return true;
     }
 

--- a/frmts/openjpeg/opjdatasetbase.h
+++ b/frmts/openjpeg/opjdatasetbase.h
@@ -711,6 +711,11 @@ struct OPJCodecWrapper
     {
     }
 
+    static bool rewriteBoxes(const char *, GDALDataset *)
+    {
+        return false;
+    }
+
     bool compressTile(int tileIndex, GByte *buff, uint32_t buffLen)
     {
         if (!pCodec || !pStream)

--- a/frmts/opjlike/jp2opjlikedataset.cpp
+++ b/frmts/opjlike/jp2opjlikedataset.cpp
@@ -861,261 +861,278 @@ CPLErr JP2OPJLikeDataset<CODEC, BASE>::Close(GDALProgressFunc, void *)
         {
             if (this->bRewrite)
             {
-                GDALJP2Box oBox(this->fp_);
-                vsi_l_offset nOffsetJP2C = 0;
-                vsi_l_offset nLengthJP2C = 0;
-                vsi_l_offset nOffsetXML = 0;
-                vsi_l_offset nOffsetASOC = 0;
-                vsi_l_offset nOffsetUUID = 0;
-                vsi_l_offset nOffsetIHDR = 0;
-                vsi_l_offset nLengthIHDR = 0;
-                int bMSIBox = FALSE;
-                int bGMLData = FALSE;
-                int bUnsupportedConfiguration = FALSE;
-                if (oBox.ReadFirst())
+                if (BASE::canPerformDirectIO())
                 {
-                    while (strlen(oBox.GetType()) > 0)
+                    /* Grok handles box rewriting natively via transcode */
+                    VSIFCloseL(this->fp_);
+                    this->fp_ = nullptr;
+                    if (!CODEC::rewriteBoxes(GetDescription(), this))
+                        eErr = CE_Failure;
+                }
+                else
+                {
+                    GDALJP2Box oBox(this->fp_);
+                    vsi_l_offset nOffsetJP2C = 0;
+                    vsi_l_offset nLengthJP2C = 0;
+                    vsi_l_offset nOffsetXML = 0;
+                    vsi_l_offset nOffsetASOC = 0;
+                    vsi_l_offset nOffsetUUID = 0;
+                    vsi_l_offset nOffsetIHDR = 0;
+                    vsi_l_offset nLengthIHDR = 0;
+                    int bMSIBox = FALSE;
+                    int bGMLData = FALSE;
+                    int bUnsupportedConfiguration = FALSE;
+                    if (oBox.ReadFirst())
                     {
-                        if (EQUAL(oBox.GetType(), "jp2c"))
+                        while (strlen(oBox.GetType()) > 0)
                         {
-                            if (nOffsetJP2C == 0)
+                            if (EQUAL(oBox.GetType(), "jp2c"))
                             {
-                                nOffsetJP2C = VSIFTellL(this->fp_);
-                                nLengthJP2C = oBox.GetDataLength();
-                            }
-                            else
-                                bUnsupportedConfiguration = TRUE;
-                        }
-                        else if (EQUAL(oBox.GetType(), "jp2h"))
-                        {
-                            GDALJP2Box oSubBox(this->fp_);
-                            if (oSubBox.ReadFirstChild(&oBox) &&
-                                EQUAL(oSubBox.GetType(), "ihdr"))
-                            {
-                                nOffsetIHDR = VSIFTellL(this->fp_);
-                                nLengthIHDR = oSubBox.GetDataLength();
-                            }
-                        }
-                        else if (EQUAL(oBox.GetType(), "xml "))
-                        {
-                            if (nOffsetXML == 0)
-                                nOffsetXML = VSIFTellL(this->fp_);
-                        }
-                        else if (EQUAL(oBox.GetType(), "asoc"))
-                        {
-                            if (nOffsetASOC == 0)
-                                nOffsetASOC = VSIFTellL(this->fp_);
-
-                            GDALJP2Box oSubBox(this->fp_);
-                            if (oSubBox.ReadFirstChild(&oBox) &&
-                                EQUAL(oSubBox.GetType(), "lbl "))
-                            {
-                                char *pszLabel = reinterpret_cast<char *>(
-                                    oSubBox.ReadBoxData());
-                                if (pszLabel != nullptr &&
-                                    EQUAL(pszLabel, "gml.data"))
+                                if (nOffsetJP2C == 0)
                                 {
-                                    bGMLData = TRUE;
+                                    nOffsetJP2C = VSIFTellL(this->fp_);
+                                    nLengthJP2C = oBox.GetDataLength();
                                 }
                                 else
                                     bUnsupportedConfiguration = TRUE;
-                                CPLFree(pszLabel);
+                            }
+                            else if (EQUAL(oBox.GetType(), "jp2h"))
+                            {
+                                GDALJP2Box oSubBox(this->fp_);
+                                if (oSubBox.ReadFirstChild(&oBox) &&
+                                    EQUAL(oSubBox.GetType(), "ihdr"))
+                                {
+                                    nOffsetIHDR = VSIFTellL(this->fp_);
+                                    nLengthIHDR = oSubBox.GetDataLength();
+                                }
+                            }
+                            else if (EQUAL(oBox.GetType(), "xml "))
+                            {
+                                if (nOffsetXML == 0)
+                                    nOffsetXML = VSIFTellL(this->fp_);
+                            }
+                            else if (EQUAL(oBox.GetType(), "asoc"))
+                            {
+                                if (nOffsetASOC == 0)
+                                    nOffsetASOC = VSIFTellL(this->fp_);
+
+                                GDALJP2Box oSubBox(this->fp_);
+                                if (oSubBox.ReadFirstChild(&oBox) &&
+                                    EQUAL(oSubBox.GetType(), "lbl "))
+                                {
+                                    char *pszLabel = reinterpret_cast<char *>(
+                                        oSubBox.ReadBoxData());
+                                    if (pszLabel != nullptr &&
+                                        EQUAL(pszLabel, "gml.data"))
+                                    {
+                                        bGMLData = TRUE;
+                                    }
+                                    else
+                                        bUnsupportedConfiguration = TRUE;
+                                    CPLFree(pszLabel);
+                                }
+                                else
+                                    bUnsupportedConfiguration = TRUE;
+                            }
+                            else if (EQUAL(oBox.GetType(), "uuid"))
+                            {
+                                if (nOffsetUUID == 0)
+                                    nOffsetUUID = VSIFTellL(this->fp_);
+                                if (GDALJP2Metadata::IsUUID_MSI(oBox.GetUUID()))
+                                    bMSIBox = TRUE;
+                                else if (!GDALJP2Metadata::IsUUID_XMP(
+                                             oBox.GetUUID()))
+                                    bUnsupportedConfiguration = TRUE;
+                            }
+                            else if (!EQUAL(oBox.GetType(), "jP  ") &&
+                                     !EQUAL(oBox.GetType(), "ftyp") &&
+                                     !EQUAL(oBox.GetType(), "rreq") &&
+                                     !EQUAL(oBox.GetType(), "jp2h") &&
+                                     !EQUAL(oBox.GetType(), "jp2i"))
+                            {
+                                bUnsupportedConfiguration = TRUE;
+                            }
+
+                            if (bUnsupportedConfiguration || !oBox.ReadNext())
+                                break;
+                        }
+                    }
+
+                    const char *pszGMLJP2;
+                    int bGeoreferencingCompatOfGMLJP2 =
+                        (!m_oSRS.IsEmpty() && bGeoTransformValid &&
+                         nGCPCount == 0);
+                    if (bGeoreferencingCompatOfGMLJP2 &&
+                        ((this->bHasGeoreferencingAtOpening && bGMLData) ||
+                         (!this->bHasGeoreferencingAtOpening)))
+                        pszGMLJP2 = "GMLJP2=YES";
+                    else
+                        pszGMLJP2 = "GMLJP2=NO";
+
+                    const char *pszGeoJP2;
+                    int bGeoreferencingCompatOfGeoJP2 =
+                        (!m_oSRS.IsEmpty() || nGCPCount != 0 ||
+                         bGeoTransformValid);
+                    if (bGeoreferencingCompatOfGeoJP2 &&
+                        ((this->bHasGeoreferencingAtOpening && bMSIBox) ||
+                         (!this->bHasGeoreferencingAtOpening) ||
+                         this->nGCPCount > 0))
+                        pszGeoJP2 = "GeoJP2=YES";
+                    else
+                        pszGeoJP2 = "GeoJP2=NO";
+
+                    /* Test that the length of the JP2C box is not 0 */
+                    int bJP2CBoxOKForRewriteInPlace = TRUE;
+                    if (nOffsetJP2C > 16 && !bUnsupportedConfiguration)
+                    {
+                        VSIFSeekL(this->fp_, nOffsetJP2C - 8, SEEK_SET);
+                        GByte abyBuffer[8];
+                        VSIFReadL(abyBuffer, 1, 8, this->fp_);
+                        if (memcmp(abyBuffer + 4, "jp2c", 4) == 0 &&
+                            abyBuffer[0] == 0 && abyBuffer[1] == 0 &&
+                            abyBuffer[2] == 0 && abyBuffer[3] == 0)
+                        {
+                            if (nLengthJP2C + 8 < UINT32_MAX)
+                            {
+                                CPLDebug(CODEC::debugId(),
+                                         "Patching length of JP2C box with "
+                                         "real length");
+                                VSIFSeekL(this->fp_, nOffsetJP2C - 8, SEEK_SET);
+                                GUInt32 nLength =
+                                    static_cast<GUInt32>(nLengthJP2C) + 8;
+                                CPL_MSBPTR32(&nLength);
+                                if (VSIFWriteL(&nLength, 1, 4, this->fp_) != 1)
+                                    eErr = CE_Failure;
                             }
                             else
-                                bUnsupportedConfiguration = TRUE;
+                                bJP2CBoxOKForRewriteInPlace = FALSE;
                         }
-                        else if (EQUAL(oBox.GetType(), "uuid"))
-                        {
-                            if (nOffsetUUID == 0)
-                                nOffsetUUID = VSIFTellL(this->fp_);
-                            if (GDALJP2Metadata::IsUUID_MSI(oBox.GetUUID()))
-                                bMSIBox = TRUE;
-                            else if (!GDALJP2Metadata::IsUUID_XMP(
-                                         oBox.GetUUID()))
-                                bUnsupportedConfiguration = TRUE;
-                        }
-                        else if (!EQUAL(oBox.GetType(), "jP  ") &&
-                                 !EQUAL(oBox.GetType(), "ftyp") &&
-                                 !EQUAL(oBox.GetType(), "rreq") &&
-                                 !EQUAL(oBox.GetType(), "jp2h") &&
-                                 !EQUAL(oBox.GetType(), "jp2i"))
-                        {
-                            bUnsupportedConfiguration = TRUE;
-                        }
-
-                        if (bUnsupportedConfiguration || !oBox.ReadNext())
-                            break;
                     }
-                }
 
-                const char *pszGMLJP2;
-                int bGeoreferencingCompatOfGMLJP2 =
-                    (!m_oSRS.IsEmpty() && bGeoTransformValid && nGCPCount == 0);
-                if (bGeoreferencingCompatOfGMLJP2 &&
-                    ((this->bHasGeoreferencingAtOpening && bGMLData) ||
-                     (!this->bHasGeoreferencingAtOpening)))
-                    pszGMLJP2 = "GMLJP2=YES";
-                else
-                    pszGMLJP2 = "GMLJP2=NO";
-
-                const char *pszGeoJP2;
-                int bGeoreferencingCompatOfGeoJP2 =
-                    (!m_oSRS.IsEmpty() || nGCPCount != 0 || bGeoTransformValid);
-                if (bGeoreferencingCompatOfGeoJP2 &&
-                    ((this->bHasGeoreferencingAtOpening && bMSIBox) ||
-                     (!this->bHasGeoreferencingAtOpening) ||
-                     this->nGCPCount > 0))
-                    pszGeoJP2 = "GeoJP2=YES";
-                else
-                    pszGeoJP2 = "GeoJP2=NO";
-
-                /* Test that the length of the JP2C box is not 0 */
-                int bJP2CBoxOKForRewriteInPlace = TRUE;
-                if (nOffsetJP2C > 16 && !bUnsupportedConfiguration)
-                {
-                    VSIFSeekL(this->fp_, nOffsetJP2C - 8, SEEK_SET);
-                    GByte abyBuffer[8];
-                    VSIFReadL(abyBuffer, 1, 8, this->fp_);
-                    if (memcmp(abyBuffer + 4, "jp2c", 4) == 0 &&
-                        abyBuffer[0] == 0 && abyBuffer[1] == 0 &&
-                        abyBuffer[2] == 0 && abyBuffer[3] == 0)
+                    if (nOffsetJP2C == 0 || bUnsupportedConfiguration)
                     {
-                        if (nLengthJP2C + 8 < UINT32_MAX)
+                        eErr = CE_Failure;
+                        CPLError(
+                            CE_Failure, CPLE_AppDefined,
+                            "Cannot rewrite file due to unsupported JP2 box "
+                            "configuration");
+                        VSIFCloseL(this->fp_);
+                    }
+                    else if (bJP2CBoxOKForRewriteInPlace &&
+                             (nOffsetXML == 0 || nOffsetXML > nOffsetJP2C) &&
+                             (nOffsetASOC == 0 || nOffsetASOC > nOffsetJP2C) &&
+                             (nOffsetUUID == 0 || nOffsetUUID > nOffsetJP2C))
+                    {
+                        CPLDebug(CODEC::debugId(),
+                                 "Rewriting boxes after codestream");
+
+                        /* Update IPR flag */
+                        if (nLengthIHDR == 14)
                         {
-                            CPLDebug(
-                                CODEC::debugId(),
-                                "Patching length of JP2C box with real length");
-                            VSIFSeekL(this->fp_, nOffsetJP2C - 8, SEEK_SET);
-                            GUInt32 nLength =
-                                static_cast<GUInt32>(nLengthJP2C) + 8;
-                            CPL_MSBPTR32(&nLength);
-                            if (VSIFWriteL(&nLength, 1, 4, this->fp_) != 1)
+                            VSIFSeekL(this->fp_, nOffsetIHDR + nLengthIHDR - 1,
+                                      SEEK_SET);
+                            GByte bIPR = GetMetadata("xml:IPR") != nullptr;
+                            if (VSIFWriteL(&bIPR, 1, 1, this->fp_) != 1)
+                                eErr = CE_Failure;
+                        }
+
+                        VSIFSeekL(this->fp_, nOffsetJP2C + nLengthJP2C,
+                                  SEEK_SET);
+
+                        GDALJP2Metadata oJP2MD;
+                        if (GetGCPCount() > 0)
+                        {
+                            oJP2MD.SetGCPs(GetGCPCount(), GetGCPs());
+                            oJP2MD.SetSpatialRef(GetGCPSpatialRef());
+                        }
+                        else
+                        {
+                            const OGRSpatialReference *poSRS = GetSpatialRef();
+                            if (poSRS != nullptr)
+                            {
+                                oJP2MD.SetSpatialRef(poSRS);
+                            }
+                            if (bGeoTransformValid)
+                            {
+                                oJP2MD.SetGeoTransform(m_gt);
+                            }
+                        }
+
+                        const char *pszAreaOrPoint =
+                            GetMetadataItem(GDALMD_AREA_OR_POINT);
+                        oJP2MD.bPixelIsPoint =
+                            pszAreaOrPoint != nullptr &&
+                            EQUAL(pszAreaOrPoint, GDALMD_AOP_POINT);
+
+                        if (!WriteIPRBox(this->fp_, this))
+                            eErr = CE_Failure;
+
+                        if (bGeoreferencingCompatOfGMLJP2 &&
+                            EQUAL(pszGMLJP2, "GMLJP2=YES"))
+                        {
+                            GDALJP2Box *poBox =
+                                oJP2MD.CreateGMLJP2(nRasterXSize, nRasterYSize);
+                            if (!WriteBox(this->fp_, poBox))
+                                eErr = CE_Failure;
+                            delete poBox;
+                        }
+
+                        if (!WriteXMLBoxes(this->fp_, this) ||
+                            !WriteGDALMetadataBox(this->fp_, this, nullptr))
+                            eErr = CE_Failure;
+
+                        if (bGeoreferencingCompatOfGeoJP2 &&
+                            EQUAL(pszGeoJP2, "GeoJP2=YES"))
+                        {
+                            GDALJP2Box *poBox = oJP2MD.CreateJP2GeoTIFF();
+                            if (!WriteBox(this->fp_, poBox))
+                                eErr = CE_Failure;
+                            delete poBox;
+                        }
+
+                        if (!WriteXMPBox(this->fp_, this))
+                            eErr = CE_Failure;
+
+                        if (VSIFTruncateL(this->fp_, VSIFTellL(this->fp_)) != 0)
+                            eErr = CE_Failure;
+
+                        if (VSIFCloseL(this->fp_) != 0)
+                            eErr = CE_Failure;
+                    }
+                    else
+                    {
+                        VSIFCloseL(this->fp_);
+
+                        CPLDebug(CODEC::debugId(), "Rewriting whole file");
+
+                        const char *const apszOptions[] = {
+                            "USE_SRC_CODESTREAM=YES",
+                            "CODEC=JP2",
+                            "WRITE_METADATA=YES",
+                            pszGMLJP2,
+                            pszGeoJP2,
+                            nullptr};
+                        CPLString osTmpFilename(
+                            CPLSPrintf("%s.tmp", GetDescription()));
+                        GDALDataset *poOutDS =
+                            CreateCopy(osTmpFilename, this, FALSE,
+                                       const_cast<char **>(apszOptions),
+                                       GDALDummyProgress, nullptr);
+                        if (poOutDS)
+                        {
+                            if (GDALClose(poOutDS) != CE_None)
+                                eErr = CE_Failure;
+                            if (VSIRename(osTmpFilename, GetDescription()) != 0)
                                 eErr = CE_Failure;
                         }
                         else
-                            bJP2CBoxOKForRewriteInPlace = FALSE;
-                    }
-                }
-
-                if (nOffsetJP2C == 0 || bUnsupportedConfiguration)
-                {
-                    eErr = CE_Failure;
-                    CPLError(CE_Failure, CPLE_AppDefined,
-                             "Cannot rewrite file due to unsupported JP2 box "
-                             "configuration");
-                    VSIFCloseL(this->fp_);
-                }
-                else if (bJP2CBoxOKForRewriteInPlace &&
-                         (nOffsetXML == 0 || nOffsetXML > nOffsetJP2C) &&
-                         (nOffsetASOC == 0 || nOffsetASOC > nOffsetJP2C) &&
-                         (nOffsetUUID == 0 || nOffsetUUID > nOffsetJP2C))
-                {
-                    CPLDebug(CODEC::debugId(),
-                             "Rewriting boxes after codestream");
-
-                    /* Update IPR flag */
-                    if (nLengthIHDR == 14)
-                    {
-                        VSIFSeekL(this->fp_, nOffsetIHDR + nLengthIHDR - 1,
-                                  SEEK_SET);
-                        GByte bIPR = GetMetadata("xml:IPR") != nullptr;
-                        if (VSIFWriteL(&bIPR, 1, 1, this->fp_) != 1)
-                            eErr = CE_Failure;
-                    }
-
-                    VSIFSeekL(this->fp_, nOffsetJP2C + nLengthJP2C, SEEK_SET);
-
-                    GDALJP2Metadata oJP2MD;
-                    if (GetGCPCount() > 0)
-                    {
-                        oJP2MD.SetGCPs(GetGCPCount(), GetGCPs());
-                        oJP2MD.SetSpatialRef(GetGCPSpatialRef());
-                    }
-                    else
-                    {
-                        const OGRSpatialReference *poSRS = GetSpatialRef();
-                        if (poSRS != nullptr)
                         {
-                            oJP2MD.SetSpatialRef(poSRS);
+                            eErr = CE_Failure;
+                            VSIUnlink(osTmpFilename);
                         }
-                        if (bGeoTransformValid)
-                        {
-                            oJP2MD.SetGeoTransform(m_gt);
-                        }
+                        VSIUnlink(
+                            CPLSPrintf("%s.tmp.aux.xml", GetDescription()));
                     }
-
-                    const char *pszAreaOrPoint =
-                        GetMetadataItem(GDALMD_AREA_OR_POINT);
-                    oJP2MD.bPixelIsPoint =
-                        pszAreaOrPoint != nullptr &&
-                        EQUAL(pszAreaOrPoint, GDALMD_AOP_POINT);
-
-                    if (!WriteIPRBox(this->fp_, this))
-                        eErr = CE_Failure;
-
-                    if (bGeoreferencingCompatOfGMLJP2 &&
-                        EQUAL(pszGMLJP2, "GMLJP2=YES"))
-                    {
-                        GDALJP2Box *poBox =
-                            oJP2MD.CreateGMLJP2(nRasterXSize, nRasterYSize);
-                        if (!WriteBox(this->fp_, poBox))
-                            eErr = CE_Failure;
-                        delete poBox;
-                    }
-
-                    if (!WriteXMLBoxes(this->fp_, this) ||
-                        !WriteGDALMetadataBox(this->fp_, this, nullptr))
-                        eErr = CE_Failure;
-
-                    if (bGeoreferencingCompatOfGeoJP2 &&
-                        EQUAL(pszGeoJP2, "GeoJP2=YES"))
-                    {
-                        GDALJP2Box *poBox = oJP2MD.CreateJP2GeoTIFF();
-                        if (!WriteBox(this->fp_, poBox))
-                            eErr = CE_Failure;
-                        delete poBox;
-                    }
-
-                    if (!WriteXMPBox(this->fp_, this))
-                        eErr = CE_Failure;
-
-                    if (VSIFTruncateL(this->fp_, VSIFTellL(this->fp_)) != 0)
-                        eErr = CE_Failure;
-
-                    if (VSIFCloseL(this->fp_) != 0)
-                        eErr = CE_Failure;
-                }
-                else
-                {
-                    VSIFCloseL(this->fp_);
-
-                    CPLDebug(CODEC::debugId(), "Rewriting whole file");
-
-                    const char *const apszOptions[] = {"USE_SRC_CODESTREAM=YES",
-                                                       "CODEC=JP2",
-                                                       "WRITE_METADATA=YES",
-                                                       pszGMLJP2,
-                                                       pszGeoJP2,
-                                                       nullptr};
-                    CPLString osTmpFilename(
-                        CPLSPrintf("%s.tmp", GetDescription()));
-                    GDALDataset *poOutDS =
-                        CreateCopy(osTmpFilename, this, FALSE,
-                                   const_cast<char **>(apszOptions),
-                                   GDALDummyProgress, nullptr);
-                    if (poOutDS)
-                    {
-                        if (GDALClose(poOutDS) != CE_None)
-                            eErr = CE_Failure;
-                        if (VSIRename(osTmpFilename, GetDescription()) != 0)
-                            eErr = CE_Failure;
-                    }
-                    else
-                    {
-                        eErr = CE_Failure;
-                        VSIUnlink(osTmpFilename);
-                    }
-                    VSIUnlink(CPLSPrintf("%s.tmp.aux.xml", GetDescription()));
                 }
             }
             else


### PR DESCRIPTION
## What does this PR do?

This is a small PR that lets Grok library handle JP2 box rewrites through its transcoding capabilities.

Note: I have tried to minimize changes - the diff for `jp2opjlikedataset.cpp` is mostly indentation caused by adding a single if/else branch

## What are related issues/pull requests?

#14268

## AI tool usage

 - [x] AI supported my development of this PR.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed