### PR TITLE
GTI: ensure SRS gets applied to spatial filters (fixes #14301)

### DIFF
--- a/autotest/gdrivers/gti.py
+++ b/autotest/gdrivers/gti.py
@@ -25,6 +25,8 @@ from osgeo import gdal, ogr
 
 pytestmark = [pytest.mark.require_driver("GTI"), pytest.mark.require_driver("GPKG")]
 
+_UNSET = object()
+
 
 def create_basic_tileindex(
     index_filename,
@@ -35,6 +37,7 @@ def create_basic_tileindex(
     sort_values=None,
     lyr_name="index",
     add_to_existing=False,
+    lyr_srs=_UNSET,
 ):
     if isinstance(src_ds, list):
         src_ds_list = src_ds
@@ -44,9 +47,11 @@ def create_basic_tileindex(
         index_ds = ogr.Open(index_filename, update=1)
     else:
         index_ds = ogr.GetDriverByName("GPKG").CreateDataSource(index_filename)
-    lyr = index_ds.CreateLayer(
-        lyr_name, srs=(src_ds_list[0].GetSpatialRef() if src_ds_list else None)
-    )
+    if lyr_srs is _UNSET:
+        srs = src_ds_list[0].GetSpatialRef() if src_ds_list else None
+    else:
+        srs = lyr_srs
+    lyr = index_ds.CreateLayer(lyr_name, srs=srs)
     lyr.CreateField(ogr.FieldDefn(location_field_name))
     if sort_values:
         lyr.CreateField(ogr.FieldDefn(sort_field_name, sort_field_type))
@@ -3372,16 +3377,18 @@ def test_gti_srs_metadata_spatial_filter(tmp_vsimem):
     spatial filters applied during raster reads must be transformed into the
     layer's native CRS before querying the index.
 
-    byte.tif is EPSG:26711 (UTM zone 11N). Setting SRS=EPSG:3857 creates a
-    mismatch: without the fix, SetSpatialFilterRect receives EPSG:3857
-    coordinates but applies them directly to the UTM index layer, which finds
-    no matching tiles and returns an all-zero raster.
+    byte.tif is EPSG:26711 (UTM zone 11N). Setting SRS=EPSG:3857 with
+    SRS_BEHAVIOR=REPROJECT creates a warped layer: without it,
+    SetSpatialFilterRect receives EPSG:3857 coordinates but applies them
+    directly to the UTM index layer, which finds no matching tiles and returns
+    an all-zero raster.
     """
     index_filename = str(tmp_vsimem / "index.gti.gpkg")
 
     src_ds = gdal.Open(os.path.join(os.getcwd(), "data", "byte.tif"))
     index_ds, lyr = create_basic_tileindex(index_filename, src_ds)
     lyr.SetMetadataItem("SRS", "EPSG:3857")
+    lyr.SetMetadataItem("SRS_BEHAVIOR", "REPROJECT")
     del index_ds
 
     ds = gdal.Open(index_filename)
@@ -3394,11 +3401,12 @@ def test_gti_srs_metadata_spatial_filter(tmp_vsimem):
 
 
 def test_gti_srs_open_option_spatial_filter(tmp_vsimem):
-    """SRS specified via open option must also create the warped layer so that
-    spatial filters during raster reads are correctly transformed.
+    """SRS specified via open option with SRS_BEHAVIOR=REPROJECT must create a
+    warped layer so that spatial filters during raster reads are correctly
+    transformed.
 
     This exercises the same code path as test_gti_srs_metadata_spatial_filter
-    but uses the SRS open option instead of layer metadata, and also covers the
+    but uses open options instead of layer metadata, and also covers the
     destructor fix: when a warped layer wraps the index layer, the destructor
     must not pass the wrapper to ReleaseResultSet.
     """
@@ -3408,7 +3416,87 @@ def test_gti_srs_open_option_spatial_filter(tmp_vsimem):
     index_ds, _ = create_basic_tileindex(index_filename, src_ds)
     del index_ds
 
-    ds = gdal.OpenEx(index_filename, open_options=["SRS=EPSG:3857"])
+    ds = gdal.OpenEx(
+        index_filename, open_options=["SRS=EPSG:3857", "SRS_BEHAVIOR=REPROJECT"]
+    )
     assert ds is not None
     assert ds.GetSpatialRef().GetAuthorityCode(None) == "3857"
     assert ds.GetRasterBand(1).Checksum() != 0
+
+
+###############################################################################
+
+
+def test_gti_srs_behavior_invalid(tmp_vsimem):
+    """SRS_BEHAVIOR with an unrecognized value must fail with a clear error."""
+
+    index_filename = str(tmp_vsimem / "index.gti.gpkg")
+
+    src_ds = gdal.Open(os.path.join(os.getcwd(), "data", "byte.tif"))
+    index_ds, _ = create_basic_tileindex(index_filename, src_ds)
+    del index_ds
+
+    with pytest.raises(Exception, match="Invalid value for SRS_BEHAVIOR"):
+        gdal.OpenEx(
+            index_filename, open_options=["SRS=EPSG:3857", "SRS_BEHAVIOR=INVALID"]
+        )
+
+
+###############################################################################
+
+
+def test_gti_srs_mismatch_no_behavior_warns(tmp_vsimem):
+    """SRS set to a different CRS than the layer's CRS without SRS_BEHAVIOR
+    must emit a warning directing the user to set SRS_BEHAVIOR."""
+
+    index_filename = str(tmp_vsimem / "index.gti.gpkg")
+
+    src_ds = gdal.Open(os.path.join(os.getcwd(), "data", "byte.tif"))
+    index_ds, _ = create_basic_tileindex(index_filename, src_ds)
+    del index_ds
+
+    with gdaltest.error_raised(gdal.CE_Warning, match="SRS_BEHAVIOR"):
+        ds = gdal.OpenEx(index_filename, open_options=["SRS=EPSG:3857"])
+    assert ds is not None
+    assert ds.GetSpatialRef().GetAuthorityCode(None) == "3857"
+
+
+###############################################################################
+
+
+def test_gti_srs_behavior_override(tmp_vsimem):
+    """SRS_BEHAVIOR=OVERRIDE must apply the specified SRS without creating a
+    warped layer, so the dataset SRS is updated but no reprojection occurs."""
+
+    index_filename = str(tmp_vsimem / "index.gti.gpkg")
+
+    src_ds = gdal.Open(os.path.join(os.getcwd(), "data", "byte.tif"))
+    index_ds, _ = create_basic_tileindex(index_filename, src_ds)
+    del index_ds
+
+    with gdaltest.error_raised(gdal.CE_None):
+        ds = gdal.OpenEx(
+            index_filename, open_options=["SRS=EPSG:3857", "SRS_BEHAVIOR=OVERRIDE"]
+        )
+    assert ds is not None
+    assert ds.GetSpatialRef().GetAuthorityCode(None) == "3857"
+
+
+###############################################################################
+
+
+def test_gti_srs_no_layer_srs_silent(tmp_vsimem):
+    """SRS specified via open option when the tile index layer has no SRS must
+    be applied silently without any warning."""
+
+    index_filename = str(tmp_vsimem / "index.gti.gpkg")
+
+    src_ds = gdal.Open(os.path.join(os.getcwd(), "data", "byte.tif"))
+    # Create tile index with no SRS on the layer
+    index_ds, _ = create_basic_tileindex(index_filename, src_ds, lyr_srs=None)
+    del index_ds
+
+    with gdaltest.error_raised(gdal.CE_None):
+        ds = gdal.OpenEx(index_filename, open_options=["SRS=EPSG:3857"])
+    assert ds is not None
+    assert ds.GetSpatialRef().GetAuthorityCode(None) == "3857"

--- a/autotest/gdrivers/gti.py
+++ b/autotest/gdrivers/gti.py
@@ -3004,11 +3004,9 @@ def test_gti_read_non_existing_source(tmp_vsimem):
 
     vrt_ds = gdal.Open(index_filename)
 
-    with (
-        gdal.config_option("GDAL_NUM_THREADS", "1"),
-        gdaltest.error_raised(gdal.CE_Failure),
-        gdaltest.disable_exceptions(),
-    ):
+    with gdal.config_option("GDAL_NUM_THREADS", "1"), gdaltest.error_raised(
+        gdal.CE_Failure
+    ), gdaltest.disable_exceptions():
         assert vrt_ds.ReadRaster() is None
 
 

--- a/autotest/gdrivers/gti.py
+++ b/autotest/gdrivers/gti.py
@@ -2999,9 +2999,11 @@ def test_gti_read_non_existing_source(tmp_vsimem):
 
     vrt_ds = gdal.Open(index_filename)
 
-    with gdal.config_option("GDAL_NUM_THREADS", "1"), gdaltest.error_raised(
-        gdal.CE_Failure
-    ), gdaltest.disable_exceptions():
+    with (
+        gdal.config_option("GDAL_NUM_THREADS", "1"),
+        gdaltest.error_raised(gdal.CE_Failure),
+        gdaltest.disable_exceptions(),
+    ):
         assert vrt_ds.ReadRaster() is None
 
 
@@ -3360,3 +3362,53 @@ def test_gti_band_interleave_rgba(tmp_vsimem):
     assert ds.ReadRaster(band_list=[4, 3, 2, 1]) == src_ds.ReadRaster(
         band_list=[4, 3, 2, 1]
     )
+
+
+###############################################################################
+
+
+def test_gti_srs_metadata_spatial_filter(tmp_vsimem):
+    """When output SRS differs from the index layer SRS (via SRS layer metadata),
+    spatial filters applied during raster reads must be transformed into the
+    layer's native CRS before querying the index.
+
+    byte.tif is EPSG:26711 (UTM zone 11N). Setting SRS=EPSG:3857 creates a
+    mismatch: without the fix, SetSpatialFilterRect receives EPSG:3857
+    coordinates but applies them directly to the UTM index layer, which finds
+    no matching tiles and returns an all-zero raster.
+    """
+    index_filename = str(tmp_vsimem / "index.gti.gpkg")
+
+    src_ds = gdal.Open(os.path.join(os.getcwd(), "data", "byte.tif"))
+    index_ds, lyr = create_basic_tileindex(index_filename, src_ds)
+    lyr.SetMetadataItem("SRS", "EPSG:3857")
+    del index_ds
+
+    ds = gdal.Open(index_filename)
+    assert ds.GetSpatialRef().GetAuthorityCode(None) == "3857"
+
+    assert ds.GetRasterBand(1).Checksum() != 0
+
+
+###############################################################################
+
+
+def test_gti_srs_open_option_spatial_filter(tmp_vsimem):
+    """SRS specified via open option must also create the warped layer so that
+    spatial filters during raster reads are correctly transformed.
+
+    This exercises the same code path as test_gti_srs_metadata_spatial_filter
+    but uses the SRS open option instead of layer metadata, and also covers the
+    destructor fix: when a warped layer wraps the index layer, the destructor
+    must not pass the wrapper to ReleaseResultSet.
+    """
+    index_filename = str(tmp_vsimem / "index.gti.gpkg")
+
+    src_ds = gdal.Open(os.path.join(os.getcwd(), "data", "byte.tif"))
+    index_ds, _ = create_basic_tileindex(index_filename, src_ds)
+    del index_ds
+
+    ds = gdal.OpenEx(index_filename, open_options=["SRS=EPSG:3857"])
+    assert ds is not None
+    assert ds.GetSpatialRef().GetAuthorityCode(None) == "3857"
+    assert ds.GetRasterBand(1).Checksum() != 0

--- a/doc/source/drivers/raster/gti.rst
+++ b/doc/source/drivers/raster/gti.rst
@@ -163,13 +163,38 @@ PostGIS, ...), the following layer metadata items may be set:
   of the mosaic. Possible values are ``red``, ``green``, ``blue``, ``alpha``,
   ``undefined``
 
-* ``SRS=<string>``: defines the SRS of the virtual mosaic, using any value
+* ``SRS=<string>``: specifies the SRS of the virtual mosaic, using any value
   supported by the :cpp:func:`OGRSpatialReference::SetFromUserInput` call, which
   includes EPSG Projected, Geographic or Compound CRS (i.e. EPSG:4296), a
   well known text (WKT) CRS definition, PROJ.4 declarations, etc.
 
   It is not necessary to define this element if the virtual mosaic SRS is
   recorded as the SRS of the vector layer of the tile index.
+
+  When ``SRS`` is set and the vector layer already has a different SRS, a
+  warning is emitted unless ``SRS_BEHAVIOR`` is also set. See
+  ``SRS_BEHAVIOR`` below.
+
+* ``SRS_BEHAVIOR=OVERRIDE|REPROJECT``: controls how the ``SRS`` parameter
+  interacts with an existing SRS on the vector layer.
+
+  - ``OVERRIDE``: use the specified SRS as the dataset SRS without
+    reprojecting tile coordinates. Use this when the layer's SRS metadata is
+    missing or incorrect and you want to correct it.
+  - ``REPROJECT``: reproject tile coordinates from the layer's native SRS to
+    the specified SRS on the fly, including transforming spatial filters applied
+    during raster reads. Use this when you want the virtual mosaic in a
+    different projection than the tile index layer.
+
+  If ``SRS`` is set and differs from the vector layer's SRS and
+  ``SRS_BEHAVIOR`` is not specified, a warning is emitted. If the vector
+  layer has no SRS, the specified ``SRS`` is used silently regardless of this
+  option.
+
+  .. note::
+     For on-the-fly reprojection of the whole GTI mosaic output, wrapping
+     the GTI file in a warped VRT (e.g. via ``gdal raster reproject``) is
+     an alternative that does not require ``SRS_BEHAVIOR``.
 
 * ``LOCATION_FIELD=<string>``: name of the field where the tile location is
   stored. Defaults to ``location``.
@@ -515,8 +540,18 @@ also defined as layer metadata items or in the .gti XML file
 -  .. oo:: SRS
       :choices: <string>
 
-      Override/sets the Spatial Reference System in one of the formats supported
-      by :cpp:func:`OGRSpatialReference::SetFromUserInput`.
+      Specifies the Spatial Reference System in one of the formats supported
+      by :cpp:func:`OGRSpatialReference::SetFromUserInput`. When set and the
+      vector layer already has a different SRS, see ``SRS_BEHAVIOR``.
+
+-  .. oo:: SRS_BEHAVIOR
+      :choices: OVERRIDE, REPROJECT
+
+      Controls how ``SRS`` interacts with an existing SRS on the vector layer.
+      ``OVERRIDE`` sets the dataset SRS without reprojecting tile coordinates.
+      ``REPROJECT`` reprojects tile coordinates from the layer's native SRS to
+      the specified SRS on the fly. If ``SRS`` is set and differs from the
+      layer's SRS and this option is not specified, a warning is emitted.
 
 -  .. oo:: MINX
       :choices: <float>

--- a/frmts/gti/gdaltileindexdataset.cpp
+++ b/frmts/gti/gdaltileindexdataset.cpp
@@ -257,8 +257,9 @@ class GDALTileIndexDataset final : public GDALPamDataset
     //! Vector layer with the sources
     OGRLayer *m_poLayer = nullptr;
 
-    //! Whether m_poLayer should be freed with m_poVectorDS->ReleaseResultSet()
-    bool m_bIsSQLResultLayer = false;
+    //! Non-null when m_poLayer was created with ExecuteSQL() and must be freed
+    //! with m_poVectorDS->ReleaseResultSet()
+    OGRLayer *m_poLayerToRelease = nullptr;
 
     //! When the SRS of m_poLayer is not the one we expose
     std::unique_ptr<OGRWarpedLayer> m_poWarpedLayerKeeper{};
@@ -912,7 +913,7 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
                      m_osSQL.c_str());
             return false;
         }
-        m_bIsSQLResultLayer = true;
+        m_poLayerToRelease = m_poLayer;
     }
     else if (m_poVectorDS->GetLayerCount() == 1)
     {
@@ -2727,14 +2728,12 @@ static GDALDataset *GDALTileIndexDatasetOpen(GDALOpenInfo *poOpenInfo)
 
 GDALTileIndexDataset::~GDALTileIndexDataset()
 {
-    if (m_poVectorDS && m_bIsSQLResultLayer)
+    if (m_poVectorDS && m_poLayerToRelease)
     {
-        // If a warped layer was created, m_poLayer points to it rather than
-        // to the original SQL result layer, so retrieve the base layer.
-        OGRLayer *poLayerToRelease = m_poWarpedLayerKeeper
-                                         ? m_poWarpedLayerKeeper->GetBaseLayer()
-                                         : m_poLayer;
-        m_poVectorDS->ReleaseResultSet(poLayerToRelease);
+        // Reset the warped layer before releasing the SQL result layer, since
+        // the warped layer holds a reference to it.
+        m_poWarpedLayerKeeper.reset();
+        m_poVectorDS->ReleaseResultSet(m_poLayerToRelease);
     }
 
     GDALTileIndexDataset::FlushCache(true);

--- a/frmts/gti/gdaltileindexdataset.cpp
+++ b/frmts/gti/gdaltileindexdataset.cpp
@@ -80,6 +80,7 @@ constexpr const char *MD_XSIZE = "XSIZE";
 constexpr const char *MD_YSIZE = "YSIZE";
 constexpr const char *MD_COLOR_INTERPRETATION = "COLOR_INTERPRETATION";
 constexpr const char *MD_SRS = "SRS";
+constexpr const char *MD_SRS_BEHAVIOR = "SRS_BEHAVIOR";
 constexpr const char *MD_LOCATION_FIELD = "LOCATION_FIELD";
 constexpr const char *MD_SORT_FIELD = "SORT_FIELD";
 constexpr const char *MD_SORT_FIELD_ASC = "SORT_FIELD_ASC";
@@ -103,6 +104,7 @@ constexpr const char *const apszTIOptions[] = {MD_RESX,
                                                MD_YSIZE,
                                                MD_COLOR_INTERPRETATION,
                                                MD_SRS,
+                                               MD_SRS_BEHAVIOR,
                                                MD_LOCATION_FIELD,
                                                MD_SORT_FIELD,
                                                MD_SORT_FIELD_ASC,
@@ -1205,6 +1207,7 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
     std::vector<GDALColorInterp> aeColorInterp;
 
     const char *pszSRS = GetOption(MD_SRS);
+    const char *pszSRSBehavior = GetOption(MD_SRS_BEHAVIOR);
     m_oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     if (pszSRS)
     {
@@ -1214,6 +1217,14 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
             OGRERR_NONE)
         {
             CPLError(CE_Failure, CPLE_AppDefined, "Invalid %s", MD_SRS);
+            return false;
+        }
+        if (pszSRSBehavior && !EQUAL(pszSRSBehavior, "OVERRIDE") &&
+            !EQUAL(pszSRSBehavior, "REPROJECT"))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Invalid value for %s: must be OVERRIDE or REPROJECT",
+                     MD_SRS_BEHAVIOR);
             return false;
         }
     }
@@ -1472,29 +1483,49 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
         }
     }
 
-    // If the output SRS differs from the layer's geometry SRS and the STAC
-    // auto-detection path did not already create a warped layer, create one
-    // now.  This ensures that SetSpatialFilterRect() calls during raster reads
-    // operate in the output SRS coordinate space and are correctly transformed
-    // back to the layer's native SRS before being applied to the index.
-    if (!m_poWarpedLayerKeeper && !m_oSRS.IsEmpty())
+    // When SRS was explicitly specified and differs from the layer's geometry
+    // SRS, apply the behavior requested via SRS_BEHAVIOR:
+    //   REPROJECT  - wrap the layer in an OGRWarpedLayer so that
+    //                SetSpatialFilterRect() calls during raster reads operate
+    //                in the output SRS and are correctly transformed back to
+    //                the layer's native SRS before being applied to the index.
+    //   OVERRIDE   - keep m_oSRS as-is without reprojecting the layer (the
+    //                caller asserts the SRS metadata was simply wrong/missing).
+    //   (unset)    - emit a warning asking the user to be explicit.
+    // If the layer has no SRS, we always use the specified SRS silently.
+    if (!m_poWarpedLayerKeeper && !m_oSRS.IsEmpty() && pszSRS)
     {
         const auto poLayerSRS = m_poLayer->GetSpatialRef();
         if (poLayerSRS && !m_oSRS.IsSame(poLayerSRS))
         {
-            auto poCT = std::unique_ptr<OGRCoordinateTransformation>(
-                OGRCreateCoordinateTransformation(poLayerSRS, &m_oSRS));
-            auto poInvCT = std::unique_ptr<OGRCoordinateTransformation>(
-                poCT ? poCT->GetInverse() : nullptr);
-            if (poCT && poInvCT)
+            if (pszSRSBehavior && EQUAL(pszSRSBehavior, "REPROJECT"))
             {
-                m_poWarpedLayerKeeper = std::make_unique<OGRWarpedLayer>(
-                    m_poLayer, /* iGeomField = */ 0,
-                    /* bTakeOwnership = */ false, std::move(poCT),
-                    std::move(poInvCT));
-                m_poLayer = m_poWarpedLayerKeeper.get();
-                poLayerDefn = m_poLayer->GetLayerDefn();
+                auto poCT = std::unique_ptr<OGRCoordinateTransformation>(
+                    OGRCreateCoordinateTransformation(poLayerSRS, &m_oSRS));
+                auto poInvCT = std::unique_ptr<OGRCoordinateTransformation>(
+                    poCT ? poCT->GetInverse() : nullptr);
+                if (poCT && poInvCT)
+                {
+                    m_poWarpedLayerKeeper = std::make_unique<OGRWarpedLayer>(
+                        m_poLayer, /* iGeomField = */ 0,
+                        /* bTakeOwnership = */ false, std::move(poCT),
+                        std::move(poInvCT));
+                    m_poLayer = m_poWarpedLayerKeeper.get();
+                    poLayerDefn = m_poLayer->GetLayerDefn();
+                }
             }
+            else if (!pszSRSBehavior || !EQUAL(pszSRSBehavior, "OVERRIDE"))
+            {
+                CPLError(
+                    CE_Warning, CPLE_AppDefined,
+                    "%s is not consistent with the SRS of the vector layer. "
+                    "If you intend to override the dataset SRS without "
+                    "reprojection, specify %s=OVERRIDE. If you intend to "
+                    "reproject from the source layer SRS to the specified "
+                    "SRS, specify %s=REPROJECT.",
+                    MD_SRS, MD_SRS_BEHAVIOR, MD_SRS_BEHAVIOR);
+            }
+            // OVERRIDE: m_oSRS is already set; no warping needed.
         }
     }
 
@@ -5474,6 +5505,12 @@ void GDALRegister_GTI()
         "  <Option name='SORT_FIELD_ASC' type='boolean'/>"
         "  <Option name='FILTER' type='string'/>"
         "  <Option name='SRS' type='string'/>"
+        "  <Option name='SRS_BEHAVIOR' type='string-select' "
+        "description='How to handle a mismatch between SRS and the vector "
+        "layer SRS'>"
+        "    <Value>OVERRIDE</Value>"
+        "    <Value>REPROJECT</Value>"
+        "  </Option>"
         "  <Option name='RESX' type='float'/>"
         "  <Option name='RESY' type='float'/>"
         "  <Option name='MINX' type='float'/>"

--- a/frmts/gti/gdaltileindexdataset.cpp
+++ b/frmts/gti/gdaltileindexdataset.cpp
@@ -259,7 +259,7 @@ class GDALTileIndexDataset final : public GDALPamDataset
     bool m_bIsSQLResultLayer = false;
 
     //! When the SRS of m_poLayer is not the one we expose
-    std::unique_ptr<OGRLayer> m_poWarpedLayerKeeper{};
+    std::unique_ptr<OGRWarpedLayer> m_poWarpedLayerKeeper{};
 
     //! Geotransform matrix of the tile index
     GDALGeoTransform m_gt{};
@@ -1472,6 +1472,32 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
         }
     }
 
+    // If the output SRS differs from the layer's geometry SRS and the STAC
+    // auto-detection path did not already create a warped layer, create one
+    // now.  This ensures that SetSpatialFilterRect() calls during raster reads
+    // operate in the output SRS coordinate space and are correctly transformed
+    // back to the layer's native SRS before being applied to the index.
+    if (!m_poWarpedLayerKeeper && !m_oSRS.IsEmpty())
+    {
+        const auto poLayerSRS = m_poLayer->GetSpatialRef();
+        if (poLayerSRS && !m_oSRS.IsSame(poLayerSRS))
+        {
+            auto poCT = std::unique_ptr<OGRCoordinateTransformation>(
+                OGRCreateCoordinateTransformation(poLayerSRS, &m_oSRS));
+            auto poInvCT = std::unique_ptr<OGRCoordinateTransformation>(
+                poCT ? poCT->GetInverse() : nullptr);
+            if (poCT && poInvCT)
+            {
+                m_poWarpedLayerKeeper = std::make_unique<OGRWarpedLayer>(
+                    m_poLayer, /* iGeomField = */ 0,
+                    /* bTakeOwnership = */ false, std::move(poCT),
+                    std::move(poInvCT));
+                m_poLayer = m_poWarpedLayerKeeper.get();
+                poLayerDefn = m_poLayer->GetLayerDefn();
+            }
+        }
+    }
+
     OGREnvelope sEnvelope;
     if (nCountMinMaxXY == 4)
     {
@@ -2671,7 +2697,14 @@ static GDALDataset *GDALTileIndexDatasetOpen(GDALOpenInfo *poOpenInfo)
 GDALTileIndexDataset::~GDALTileIndexDataset()
 {
     if (m_poVectorDS && m_bIsSQLResultLayer)
-        m_poVectorDS->ReleaseResultSet(m_poLayer);
+    {
+        // If a warped layer was created, m_poLayer points to it rather than
+        // to the original SQL result layer, so retrieve the base layer.
+        OGRLayer *poLayerToRelease = m_poWarpedLayerKeeper
+                                         ? m_poWarpedLayerKeeper->GetBaseLayer()
+                                         : m_poLayer;
+        m_poVectorDS->ReleaseResultSet(poLayerToRelease);
+    }
 
     GDALTileIndexDataset::FlushCache(true);
 }


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
When a user provided the open options `SRS` and `MINX/MINY/MAXX/MAXY` the spatial filter rectangles were not being transformed from the output SRS to the index layer's native SRS.
This uses the same `OGRWarpedLayer` wrapper in the case of a custom SRS being provided as is used in the auto-detection case for STAC items with projection metadata.

This ensures that the asset geometry comparisons/filters are correct if a user provides a `SRS` open option to set the GTI layer's SRS. I tested the failing examples from #14301 and now they work as expected!

## What are related issues/pull requests?
#14301 

## AI tool usage

 - [x] AI (Claude) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [x] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Fedora 43
* Compiler: GCC 15.2.1
