### PR TITLE
OGRGeometryFactory::transformWithOptions(): make sure polygons are closed in polar reprojection code

### DIFF
--- a/ogr/ogrgeometryfactory.cpp
+++ b/ogr/ogrgeometryfactory.cpp
@@ -3524,7 +3524,7 @@ static void CutGeometryOnDateLineAndAddToMulti(OGRGeometryCollection *poMulti,
 /*                            RemovePoint()                             */
 /************************************************************************/
 
-static void RemovePoint(OGRGeometry *poGeom, OGRPoint *poPoint)
+static void RemovePoint(OGRGeometry *poGeom, const OGRPoint *poPoint)
 {
     const OGRwkbGeometryType eType = wkbFlatten(poGeom->getGeometryType());
     switch (eType)
@@ -3561,14 +3561,11 @@ static void RemovePoint(OGRGeometry *poGeom, OGRPoint *poPoint)
         case wkbPolygon:
         {
             OGRPolygon *poPoly = poGeom->toPolygon();
-            if (poPoly->getExteriorRing() != nullptr)
+            for (auto *poRing : *poPoly)
             {
-                RemovePoint(poPoly->getExteriorRing(), poPoint);
-                for (int i = 0; i < poPoly->getNumInteriorRings(); ++i)
-                {
-                    RemovePoint(poPoly->getInteriorRing(i), poPoint);
-                }
+                RemovePoint(poRing, poPoint);
             }
+            poPoly->closeRings();
             break;
         }
 
@@ -3577,9 +3574,9 @@ static void RemovePoint(OGRGeometry *poGeom, OGRPoint *poPoint)
         case wkbGeometryCollection:
         {
             OGRGeometryCollection *poGC = poGeom->toGeometryCollection();
-            for (int i = 0; i < poGC->getNumGeometries(); ++i)
+            for (auto *poPart : *poGC)
             {
-                RemovePoint(poGC->getGeometryRef(i), poPoint);
+                RemovePoint(poPart, poPoint);
             }
             break;
         }


### PR DESCRIPTION
Exposed by a recent change in GEOS
(https://github.com/libgeos/geos/pull/1412)

Co-authored-by: Dan Baston <dbaston@gmail.com>
