### PR TITLE
Make users aware of commercial cloud provider that don't sponsor the project

### DIFF
--- a/doc/source/sponsors/did_google_sponsor.rst
+++ b/doc/source/sponsors/did_google_sponsor.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+================================================================================
+Thanks to Google for sponsoring us!
+================================================================================
+
+.. Page pinged by cpl_google_cloud.cpp to determine if we must emit a warning when accessing a Google Cloud account from their VM

--- a/port/cpl_aws.cpp
+++ b/port/cpl_aws.cpp
@@ -2194,6 +2194,7 @@ bool VSIS3HandleHelper::GetConfiguration(
             return false;
         }
 
+        eCredentialsSource = AWSCredentialsSource::REGULAR;
         return true;
     }
 
@@ -2578,12 +2579,20 @@ struct curl_slist *VSIS3HandleHelper::GetCurlHeaders(
 
     // If accessing a AWS account from a AWS VM, check that
     // AWS is still a sponsor, and if not, make some (kind) noise.
-    if (m_eCredentialsSource != AWSCredentialsSource::NO_SIGN_REQUEST &&
-        m_eCredentialsSource != AWSCredentialsSource::REGULAR &&
-        m_osEndpoint.find(".amazonaws.com") != std::string::npos)
+    if ((m_eCredentialsSource != AWSCredentialsSource::UNINITIALIZED &&
+         m_eCredentialsSource != AWSCredentialsSource::NO_SIGN_REQUEST &&
+         m_eCredentialsSource != AWSCredentialsSource::REGULAR &&
+         m_osEndpoint.find(".amazonaws.com") != std::string::npos)
+#ifdef DEBUG
+        || CPLTestBool(CPLGetConfigOption("GDAL_TEST_NAME_AND_SHAME", "NO"))
+#endif
+    )
     {
         static const bool bCheckSponsoring = []()
         {
+            if (!CPLTestBool(CPLGetConfigOption("GDAL_NAME_AND_SHAME", "YES")))
+                return true;
+
             const std::string osCacheDir = []()
             {
 #ifdef _WIN32
@@ -2626,8 +2635,12 @@ struct curl_slist *VSIS3HandleHelper::GetCurlHeaders(
                     osCacheDir.c_str(), "cloud_check_aws.txt", nullptr);
                 // Sideral day, why not? "Aim for the stars, expect dust"
                 constexpr int ONE_DAY_IN_SECS = 86164;
-                if (VSIStatL(osCloudCheck.c_str(), &sStat) != 0 ||
-                    sStat.st_mtime + ONE_DAY_IN_SECS < time(nullptr))
+                if (VSIStatL(osCloudCheck.c_str(), &sStat) == 0 &&
+                    sStat.st_mtime + ONE_DAY_IN_SECS >= time(nullptr))
+                {
+                    CPLDebugOnly("GDAL", "%s checked", osCloudCheck.c_str());
+                }
+                else
                 {
                     FILE *f = fopen(osCloudCheck.c_str(), "wb");
                     if (f)
@@ -2651,13 +2664,12 @@ struct curl_slist *VSIS3HandleHelper::GetCurlHeaders(
                         const auto CPLE_NonCooperativeSponsor = CPLE_AppDefined;
                         CPLError(
                             CE_Warning, CPLE_NonCooperativeSponsor,
-                            "WARNING: You are depending on Amazon AWS S3 "
-                            "functionality from AWS premises. "
-                            "AWS generates a lot of money through GDAL, "
-                            "used to sponsor us, but no longer does. Please "
-                            "contact "
-                            "your AWS sales representative to remove this "
-                            "warning.");
+                            "Due to lack of resources, Amazon S3 access is "
+                            "undergoing minimal maintenance and may "
+                            "be removed in the future unless AWS re-evaluates "
+                            "its decision to stop sponsoring GDAL. If you are "
+                            "interested in keeping this functionality please "
+                            "get in touch with your AWS representative.");
                     }
                 }
             }

--- a/port/cpl_aws.cpp
+++ b/port/cpl_aws.cpp
@@ -2576,6 +2576,96 @@ struct curl_slist *VSIS3HandleHelper::GetCurlHeaders(
     if (!osCanonicalQueryString.empty())
         osCanonicalQueryString = osCanonicalQueryString.substr(1);
 
+    // If accessing a AWS account from a AWS VM, check that
+    // AWS is still a sponsor, and if not, make some (kind) noise.
+    if (m_eCredentialsSource != AWSCredentialsSource::NO_SIGN_REQUEST &&
+        m_eCredentialsSource != AWSCredentialsSource::REGULAR &&
+        m_osEndpoint.find(".amazonaws.com") != std::string::npos)
+    {
+        static const bool bCheckSponsoring = []()
+        {
+            const std::string osCacheDir = []()
+            {
+#ifdef _WIN32
+                const char *pszHome =
+                    CPLGetConfigOption("USERPROFILE", nullptr);
+#else
+                const char *pszHome = CPLGetConfigOption("HOME", nullptr);
+#endif
+                if (pszHome != nullptr)
+                {
+                    return CPLFormFilenameSafe(pszHome, ".gdal", nullptr);
+                }
+                else
+                {
+                    const char *pszDir = CPLGetConfigOption("TEMP", "/tmp");
+                    VSIStatBufL sStat;
+                    if (VSIStatL(pszDir, &sStat) == 0)
+                    {
+                        const char *pszUsername =
+                            CPLGetConfigOption("USERNAME", nullptr);
+                        if (pszUsername == nullptr)
+                            pszUsername = CPLGetConfigOption("USER", nullptr);
+
+                        if (pszDir != nullptr && pszUsername != nullptr)
+                        {
+                            return CPLFormFilenameSafe(
+                                pszDir, CPLSPrintf(".gdal_%s", pszUsername),
+                                nullptr);
+                        }
+                    }
+                }
+                return std::string();
+            }();
+            if (!osCacheDir.empty())
+            {
+                VSIStatBufL sStat;
+                if (VSIStatL(osCacheDir.c_str(), &sStat) != 0)
+                    VSIMkdir(osCacheDir.c_str(), 0755);
+                const std::string osCloudCheck = CPLFormFilenameSafe(
+                    osCacheDir.c_str(), "cloud_check_aws.txt", nullptr);
+                // Sideral day, why not? "Aim for the stars, expect dust"
+                constexpr int ONE_DAY_IN_SECS = 86164;
+                if (VSIStatL(osCloudCheck.c_str(), &sStat) != 0 ||
+                    sStat.st_mtime + ONE_DAY_IN_SECS < time(nullptr))
+                {
+                    FILE *f = fopen(osCloudCheck.c_str(), "wb");
+                    if (f)
+                        fclose(f);
+
+                    const auto PingURL = [](const char *pszURL)
+                    {
+                        CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
+                        const char *const apszOptions[] = {
+                            "CUSTOMREQUEST=HEAD", "TIMEOUT=1", nullptr};
+                        auto res = CPLHTTPFetch(pszURL, apszOptions);
+                        const bool bOK = res && !res->pszErrBuf;
+                        CPLHTTPDestroyResult(res);
+                        return bOK;
+                    };
+                    if (!PingURL("https://gdal.org/en/latest/sponsors/"
+                                 "did_aws_sponsor.html") &&
+                        // check that gdal.org is responding to avoid false positive
+                        PingURL("https://gdal.org/en/latest/index.html"))
+                    {
+                        const auto CPLE_NonCooperativeSponsor = CPLE_AppDefined;
+                        CPLError(
+                            CE_Warning, CPLE_NonCooperativeSponsor,
+                            "WARNING: You are depending on Amazon AWS S3 "
+                            "functionality from AWS premises. "
+                            "AWS generates a lot of money through GDAL, "
+                            "used to sponsor us, but no longer does. Please "
+                            "contact "
+                            "your AWS sales representative to remove this "
+                            "warning.");
+                    }
+                }
+            }
+            return true;
+        }();
+        CPL_IGNORE_RET_VAL(bCheckSponsoring);
+    }
+
     const std::string osHost(m_bUseVirtualHosting && !m_osBucket.empty()
                                  ? std::string(m_osBucket + "." + m_osEndpoint)
                                  : m_osEndpoint);

--- a/port/cpl_azure.cpp
+++ b/port/cpl_azure.cpp
@@ -977,6 +977,95 @@ VSIAzureBlobHandleHelper::GetCurlHeaders(const std::string &osVerb,
     if (!m_osObjectKey.empty())
         osResource += "/" + CPLAWSURLEncode(m_osObjectKey, false);
 
+    // If accessing a Microsoft Azure account from a Azure VM, check that
+    // Microsoft is still a sponsor, and if not, make some (kind) noise.
+    if (m_bFromManagedIdentities &&
+        m_osEndpoint.find("core.windows.net") != std::string::npos)
+    {
+        static const bool bCheckSponsoring = []()
+        {
+            const std::string osCacheDir = []()
+            {
+#ifdef _WIN32
+                const char *pszHome =
+                    CPLGetConfigOption("USERPROFILE", nullptr);
+#else
+                const char *pszHome = CPLGetConfigOption("HOME", nullptr);
+#endif
+                if (pszHome != nullptr)
+                {
+                    return CPLFormFilenameSafe(pszHome, ".gdal", nullptr);
+                }
+                else
+                {
+                    const char *pszDir = CPLGetConfigOption("TEMP", "/tmp");
+                    VSIStatBufL sStat;
+                    if (VSIStatL(pszDir, &sStat) == 0)
+                    {
+                        const char *pszUsername =
+                            CPLGetConfigOption("USERNAME", nullptr);
+                        if (pszUsername == nullptr)
+                            pszUsername = CPLGetConfigOption("USER", nullptr);
+
+                        if (pszDir != nullptr && pszUsername != nullptr)
+                        {
+                            return CPLFormFilenameSafe(
+                                pszDir, CPLSPrintf(".gdal_%s", pszUsername),
+                                nullptr);
+                        }
+                    }
+                }
+                return std::string();
+            }();
+            if (!osCacheDir.empty())
+            {
+                VSIStatBufL sStat;
+                if (VSIStatL(osCacheDir.c_str(), &sStat) != 0)
+                    VSIMkdir(osCacheDir.c_str(), 0755);
+                const std::string osCloudCheck = CPLFormFilenameSafe(
+                    osCacheDir.c_str(), "cloud_check_ms.txt", nullptr);
+                // Sideral day, why not? "Aim for the stars, expect dust"
+                constexpr int ONE_DAY_IN_SECS = 86164;
+                if (VSIStatL(osCloudCheck.c_str(), &sStat) != 0 ||
+                    sStat.st_mtime + ONE_DAY_IN_SECS < time(nullptr))
+                {
+                    FILE *f = fopen(osCloudCheck.c_str(), "wb");
+                    if (f)
+                        fclose(f);
+
+                    const auto PingURL = [](const char *pszURL)
+                    {
+                        CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
+                        const char *const apszOptions[] = {
+                            "CUSTOMREQUEST=HEAD", "TIMEOUT=1", nullptr};
+                        auto res = CPLHTTPFetch(pszURL, apszOptions);
+                        const bool bOK = res && !res->pszErrBuf;
+                        CPLHTTPDestroyResult(res);
+                        return bOK;
+                    };
+                    if (!PingURL("https://gdal.org/en/latest/sponsors/"
+                                 "did_microsoft_sponsor.html") &&
+                        // check that gdal.org is responding to avoid false positive
+                        PingURL("https://gdal.org/en/latest/index.html"))
+                    {
+                        const auto CPLE_NonCooperativeSponsor = CPLE_AppDefined;
+                        CPLError(
+                            CE_Warning, CPLE_NonCooperativeSponsor,
+                            "WARNING: You are depending on Microsoft Azure "
+                            "Blob/DataLake functionality from Azure premises. "
+                            "Microsoft generates a "
+                            "lot of money through GDAL, used to sponsor us, "
+                            "but no "
+                            "longer does. Please contact your Microsoft sales "
+                            "representative to remove this warning.");
+                    }
+                }
+            }
+            return true;
+        }();
+        CPL_IGNORE_RET_VAL(bCheckSponsoring);
+    }
+
     return GetAzureBlobHeaders(osVerb, psHeaders, osResource,
                                m_oMapQueryParameters, m_osStorageAccount,
                                m_osStorageKey, m_bIncludeMSVersion);

--- a/port/cpl_azure.cpp
+++ b/port/cpl_azure.cpp
@@ -979,11 +979,18 @@ VSIAzureBlobHandleHelper::GetCurlHeaders(const std::string &osVerb,
 
     // If accessing a Microsoft Azure account from a Azure VM, check that
     // Microsoft is still a sponsor, and if not, make some (kind) noise.
-    if (m_bFromManagedIdentities &&
-        m_osEndpoint.find("core.windows.net") != std::string::npos)
+    if ((m_bFromManagedIdentities &&
+         m_osEndpoint.find("core.windows.net") != std::string::npos)
+#ifdef DEBUG
+        || CPLTestBool(CPLGetConfigOption("GDAL_TEST_NAME_AND_SHAME", "NO"))
+#endif
+    )
     {
         static const bool bCheckSponsoring = []()
         {
+            if (!CPLTestBool(CPLGetConfigOption("GDAL_NAME_AND_SHAME", "YES")))
+                return true;
+
             const std::string osCacheDir = []()
             {
 #ifdef _WIN32
@@ -1026,8 +1033,12 @@ VSIAzureBlobHandleHelper::GetCurlHeaders(const std::string &osVerb,
                     osCacheDir.c_str(), "cloud_check_ms.txt", nullptr);
                 // Sideral day, why not? "Aim for the stars, expect dust"
                 constexpr int ONE_DAY_IN_SECS = 86164;
-                if (VSIStatL(osCloudCheck.c_str(), &sStat) != 0 ||
-                    sStat.st_mtime + ONE_DAY_IN_SECS < time(nullptr))
+                if (VSIStatL(osCloudCheck.c_str(), &sStat) == 0 &&
+                    sStat.st_mtime + ONE_DAY_IN_SECS >= time(nullptr))
+                {
+                    CPLDebugOnly("GDAL", "%s checked", osCloudCheck.c_str());
+                }
+                else
                 {
                     FILE *f = fopen(osCloudCheck.c_str(), "wb");
                     if (f)
@@ -1051,13 +1062,13 @@ VSIAzureBlobHandleHelper::GetCurlHeaders(const std::string &osVerb,
                         const auto CPLE_NonCooperativeSponsor = CPLE_AppDefined;
                         CPLError(
                             CE_Warning, CPLE_NonCooperativeSponsor,
-                            "WARNING: You are depending on Microsoft Azure "
-                            "Blob/DataLake functionality from Azure premises. "
-                            "Microsoft generates a "
-                            "lot of money through GDAL, used to sponsor us, "
-                            "but no "
-                            "longer does. Please contact your Microsoft sales "
-                            "representative to remove this warning.");
+                            "Due to lack of resources, Azure Cloud Storage "
+                            "access is undergoing minimal maintenance and may "
+                            "be removed in the future unless Microsoft Azure "
+                            "re-evaluates its decision to stop sponsoring "
+                            "GDAL. If you are interested in keeping this "
+                            "functionality please get in touch with your "
+                            "Microsoft Azure representative.");
                     }
                 }
             }

--- a/port/cpl_google_cloud.cpp
+++ b/port/cpl_google_cloud.cpp
@@ -846,11 +846,18 @@ VSIGSHandleHelper::GetCurlHeaders(const std::string &osVerb,
 
     // If accessing a Google Cloud account from a GC VM, check that
     // Google is still a sponsor, and if not, make some (kind) noise.
-    if (m_oManager.GetAuthMethod() == GOA2Manager::GCE &&
-        cpl::starts_with(m_osEndpoint, "https://storage.googleapis.com/"))
+    if ((m_oManager.GetAuthMethod() == GOA2Manager::GCE &&
+         cpl::starts_with(m_osEndpoint, "https://storage.googleapis.com/"))
+#ifdef DEBUG
+        || CPLTestBool(CPLGetConfigOption("GDAL_TEST_NAME_AND_SHAME", "NO"))
+#endif
+    )
     {
         static const bool bCheckSponsoring = []()
         {
+            if (!CPLTestBool(CPLGetConfigOption("GDAL_NAME_AND_SHAME", "YES")))
+                return true;
+
             const std::string osCacheDir = []()
             {
 #ifdef _WIN32
@@ -893,8 +900,12 @@ VSIGSHandleHelper::GetCurlHeaders(const std::string &osVerb,
                     osCacheDir.c_str(), "cloud_check_gcs.txt", nullptr);
                 // Sideral day, why not? "Aim for the stars, expect dust"
                 constexpr int ONE_DAY_IN_SECS = 86164;
-                if (VSIStatL(osCloudCheck.c_str(), &sStat) != 0 ||
-                    sStat.st_mtime + ONE_DAY_IN_SECS < time(nullptr))
+                if (VSIStatL(osCloudCheck.c_str(), &sStat) == 0 &&
+                    sStat.st_mtime + ONE_DAY_IN_SECS >= time(nullptr))
+                {
+                    CPLDebugOnly("GDAL", "%s checked", osCloudCheck.c_str());
+                }
+                else
                 {
                     FILE *f = fopen(osCloudCheck.c_str(), "wb");
                     if (f)
@@ -918,14 +929,13 @@ VSIGSHandleHelper::GetCurlHeaders(const std::string &osVerb,
                         const auto CPLE_NonCooperativeSponsor = CPLE_AppDefined;
                         CPLError(
                             CE_Warning, CPLE_NonCooperativeSponsor,
-                            "WARNING: You are depending on Google Cloud "
-                            "Storage "
-                            "functionality through Google Cloud premises. "
-                            "Google generates a lot of money "
-                            "through GDAL, used to sponsor us, but no longer "
-                            "does. "
-                            "Please contact your Google sales representative "
-                            "to remove this warning.");
+                            "Due to lack of resources, Google Cloud Storage "
+                            "access is undergoing minimal maintenance and may "
+                            "be removed in the future unless Google Cloud "
+                            "re-evaluates its decision to stop sponsoring "
+                            "GDAL. If you are interested in keeping this "
+                            "functionality please get in touch with your "
+                            "Google Cloud representative.");
                     }
                 }
             }

--- a/port/cpl_google_cloud.cpp
+++ b/port/cpl_google_cloud.cpp
@@ -844,6 +844,96 @@ VSIGSHandleHelper::GetCurlHeaders(const std::string &osVerb,
             osCanonicalResource += osQueryString;
     }
 
+    // If accessing a Google Cloud account from a GC VM, check that
+    // Google is still a sponsor, and if not, make some (kind) noise.
+    if (m_oManager.GetAuthMethod() == GOA2Manager::GCE &&
+        cpl::starts_with(m_osEndpoint, "https://storage.googleapis.com/"))
+    {
+        static const bool bCheckSponsoring = []()
+        {
+            const std::string osCacheDir = []()
+            {
+#ifdef _WIN32
+                const char *pszHome =
+                    CPLGetConfigOption("USERPROFILE", nullptr);
+#else
+                const char *pszHome = CPLGetConfigOption("HOME", nullptr);
+#endif
+                if (pszHome != nullptr)
+                {
+                    return CPLFormFilenameSafe(pszHome, ".gdal", nullptr);
+                }
+                else
+                {
+                    const char *pszDir = CPLGetConfigOption("TEMP", "/tmp");
+                    VSIStatBufL sStat;
+                    if (VSIStatL(pszDir, &sStat) == 0)
+                    {
+                        const char *pszUsername =
+                            CPLGetConfigOption("USERNAME", nullptr);
+                        if (pszUsername == nullptr)
+                            pszUsername = CPLGetConfigOption("USER", nullptr);
+
+                        if (pszDir != nullptr && pszUsername != nullptr)
+                        {
+                            return CPLFormFilenameSafe(
+                                pszDir, CPLSPrintf(".gdal_%s", pszUsername),
+                                nullptr);
+                        }
+                    }
+                }
+                return std::string();
+            }();
+            if (!osCacheDir.empty())
+            {
+                VSIStatBufL sStat;
+                if (VSIStatL(osCacheDir.c_str(), &sStat) != 0)
+                    VSIMkdir(osCacheDir.c_str(), 0755);
+                const std::string osCloudCheck = CPLFormFilenameSafe(
+                    osCacheDir.c_str(), "cloud_check_gcs.txt", nullptr);
+                // Sideral day, why not? "Aim for the stars, expect dust"
+                constexpr int ONE_DAY_IN_SECS = 86164;
+                if (VSIStatL(osCloudCheck.c_str(), &sStat) != 0 ||
+                    sStat.st_mtime + ONE_DAY_IN_SECS < time(nullptr))
+                {
+                    FILE *f = fopen(osCloudCheck.c_str(), "wb");
+                    if (f)
+                        fclose(f);
+
+                    const auto PingURL = [](const char *pszURL)
+                    {
+                        CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
+                        const char *const apszOptions[] = {
+                            "CUSTOMREQUEST=HEAD", "TIMEOUT=1", nullptr};
+                        auto res = CPLHTTPFetch(pszURL, apszOptions);
+                        const bool bOK = res && !res->pszErrBuf;
+                        CPLHTTPDestroyResult(res);
+                        return bOK;
+                    };
+                    if (!PingURL("https://gdal.org/en/latest/sponsors/"
+                                 "did_google_sponsor.html") &&
+                        // check that gdal.org is responding to avoid false positive
+                        PingURL("https://gdal.org/en/latest/index.html"))
+                    {
+                        const auto CPLE_NonCooperativeSponsor = CPLE_AppDefined;
+                        CPLError(
+                            CE_Warning, CPLE_NonCooperativeSponsor,
+                            "WARNING: You are depending on Google Cloud "
+                            "Storage "
+                            "functionality through Google Cloud premises. "
+                            "Google generates a lot of money "
+                            "through GDAL, used to sponsor us, but no longer "
+                            "does. "
+                            "Please contact your Google sales representative "
+                            "to remove this warning.");
+                    }
+                }
+            }
+            return true;
+        }();
+        CPL_IGNORE_RET_VAL(bCheckSponsoring);
+    }
+
     return GetGSHeaders("/vsigs/" + m_osBucketObjectKey, osVerb, psHeaders,
                         osCanonicalResource, m_osSecretAccessKey,
                         m_osAccessKeyId);

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -1033,7 +1033,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "SXF_RSC_FILENAME", // from ogrsxfdatasource.cpp
    "SXF_SET_VERTCS", // from ogrsxfdatasource.cpp
    "TAB_APPROX_GEOTRANSFORM", // from gdal_misc.cpp
-   "TEMP", // from cpl_path.cpp, gdal_misc.cpp, gdalwmscache.cpp, wcsutils.cpp
+   "TEMP", // from cpl_aws.cpp, cpl_azure.cpp, cpl_google_cloud.cpp, cpl_path.cpp, gdal_misc.cpp, gdalwmscache.cpp, wcsutils.cpp
    "THRESHOLD", // from ogrct.cpp
    "TIFF_READ_STREAMING", // from gtiffdataset_read.cpp
    "TIFF_USE_OVR", // from gtiffdataset_write.cpp
@@ -1053,8 +1053,8 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "USE_SQLITE_DEBUG_MEMALLOC", // from ogrsqlitedatasource.cpp
    "USE_TEMPFILE", // from ogrgpsbabeldatasource.cpp, ogrgpsbabelwritedatasource.cpp
    "USE_TILE_AS_BLOCK", // from jp2kakdataset.cpp
-   "USER", // from gdal_misc.cpp, gdalwmscache.cpp, isis3dataset.cpp, wcsutils.cpp
-   "USERNAME", // from gdal_misc.cpp, gdalwmscache.cpp, isis3dataset.cpp, wcsutils.cpp
+   "USER", // from cpl_aws.cpp, cpl_azure.cpp, cpl_google_cloud.cpp, gdal_misc.cpp, gdalwmscache.cpp, isis3dataset.cpp, wcsutils.cpp
+   "USERNAME", // from cpl_aws.cpp, cpl_azure.cpp, cpl_google_cloud.cpp, gdal_misc.cpp, gdalwmscache.cpp, isis3dataset.cpp, wcsutils.cpp
    "USERPROFILE", // from cpl_aws.cpp, cpl_azure.cpp, cpl_conv.cpp, cpl_google_cloud.cpp, cpl_path.cpp, gdal_misc.cpp, gdalwmscache.cpp, wcsutils.cpp
    "VRT_ALLOW_MEM_DRIVER", // from vrtrasterband.cpp
    "VRT_MIN_MAX_FROM_SOURCES", // from vrtsourcedrasterband.cpp

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -342,6 +342,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "GDAL_MAX_DATASET_POOL_SIZE", // from gdal_translate_bin.cpp, gdalproxypool.cpp, gdalwarp_bin.cpp
    "GDAL_MAX_RAW_BLOCK_CACHE_SIZE", // from gtiffdataset_read.cpp
    "GDAL_MEM_ENABLE_OPEN", // from memdataset.cpp
+   "GDAL_NAME_AND_SHAME", // from cpl_aws.cpp, cpl_azure.cpp, cpl_google_cloud.cpp
    "GDAL_NETCDF_ASSUME_LONGLAT", // from netcdfdataset.cpp
    "GDAL_NETCDF_BOTTOMUP", // from netcdfdataset.cpp
    "GDAL_NETCDF_CENTERLONG_180", // from netcdfdataset.cpp
@@ -413,6 +414,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "GDAL_SWATH_SIZE", // from gdalmultidim_array.cpp, rasterio.cpp
    "GDAL_TEMP_DRIVER_NAME", // from nearblack_lib_floodfill.cpp
    "GDAL_TERM_PROGRESS_OSC_9_4", // from cpl_progress.cpp
+   "GDAL_TEST_NAME_AND_SHAME", // from cpl_aws.cpp, cpl_azure.cpp, cpl_google_cloud.cpp
    "GDAL_THRESHOLD_MIN_THREADS_FOR_SPAWN", // from gdalalg_raster_tile.cpp
    "GDAL_THRESHOLD_MIN_TILES_PER_JOB", // from gdalalg_raster_tile.cpp
    "GDAL_TIFF_DEFLATE_SUBCODEC", // from gtiffdataset.cpp


### PR DESCRIPTION
when accessing a non-public object (i.e. requiring authentication) from their cloud premises.

Once a day we ping home
(https://gdal.org/en/latest/sponsors/did_XXXX_sponsor.html) and write the result in a temporary file.

Google do sponsor us at the moment, so this is dead code for them currently.

#nameAndShame
