### PR TITLE
JP2Grok: add transcode capabilities

### DIFF
--- a/.github/workflows/ubuntu_26.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_26.04/Dockerfile.ci
@@ -230,7 +230,7 @@ RUN curl -LO -fsS https://github.com/apache/arrow/archive/refs/heads/main.zip \
     && rm -rf arrow-main
 
 # Build Grok JPEG 2000 library
-ARG GROK_VERSION=v20.2.7
+ARG GROK_VERSION=v20.2.8
 
 RUN git clone --recursive --depth 1 --branch ${GROK_VERSION} \
     https://github.com/GrokImageCompression/grok.git grok-git && \

--- a/autotest/gdrivers/jp2grok.py
+++ b/autotest/gdrivers/jp2grok.py
@@ -1163,6 +1163,197 @@ def test_jp2grok_rewrite_boxes(tmp_path):
 # Test driver metadata
 
 
+###############################################################################
+# Helper: build a small georeferenced source JP2 for transcode tests.
+
+
+def _make_transcode_source(tmp_path, epsg, gt, src_options=None):
+    np = pytest.importorskip("numpy")
+    sr = osr.SpatialReference()
+    sr.ImportFromEPSG(epsg)
+    mem_ds = gdal.GetDriverByName("MEM").Create("", 20, 20)
+    pixel_data = np.arange(20 * 20, dtype=np.uint8).reshape(20, 20)
+    mem_ds.GetRasterBand(1).WriteArray(pixel_data)
+    mem_ds.SetSpatialRef(sr)
+    mem_ds.SetGeoTransform(list(gt))
+
+    src_jp2 = str(tmp_path / "transcode_src.jp2")
+    out_ds = gdaltest.jp2grok_drv.CreateCopy(
+        src_jp2, mem_ds, options=(src_options or ["REVERSIBLE=YES"])
+    )
+    del out_ds
+    del mem_ds
+    return src_jp2, pixel_data
+
+
+###############################################################################
+# Test transcode with PLT/TLM/SOP/EPH markers and progression order changes.
+#
+# A single parametrized test verifies that:
+#  - each marker option actually causes the corresponding marker to be
+#    written (checked via GetJPEG2000StructureAsString)
+#  - PROGRESSION actually changes the COD SGcod_Progress field
+#  - pixel data and georeferencing are preserved across transcode
+
+
+@pytest.mark.parametrize(
+    "options,expect_plt,expect_tlm,expect_sop,expect_eph,expect_progression",
+    [
+        # PLT + TLM only
+        (["PLT=YES", "TLM=YES"], True, True, False, False, None),
+        # SOP + EPH only
+        ([], False, False, False, False, None),
+        (["SOP=YES", "EPH=YES"], False, False, True, True, None),
+        # Progression-order change (RPCL); also keep PLT/TLM on to exercise
+        # the combined code path
+        (
+            ["PLT=YES", "TLM=YES", "PROGRESSION=RPCL"],
+            True,
+            True,
+            False,
+            False,
+            "RPCL",
+        ),
+    ],
+    ids=["plt_tlm", "default", "sop_eph", "progression_rpcl"],
+)
+def test_jp2grok_transcode_markers(
+    tmp_path,
+    options,
+    expect_plt,
+    expect_tlm,
+    expect_sop,
+    expect_eph,
+    expect_progression,
+):
+    gdaltest.importorskip_gdal_array()
+    np = pytest.importorskip("numpy")
+
+    src_jp2, pixel_data = _make_transcode_source(
+        tmp_path, 32631, (500000, 1, 0, 5000000, 0, -1)
+    )
+
+    dst_jp2 = str(tmp_path / "transcode_dst.jp2")
+    src_ds = gdal.Open(src_jp2)
+    out_ds = gdaltest.jp2grok_drv.CreateCopy(
+        dst_jp2, src_ds, options=["TRANSCODE=YES"] + options
+    )
+    del out_ds
+    del src_ds
+
+    # Pixel data and georeferencing must survive transcode
+    ds = gdal.Open(dst_jp2)
+    assert ds is not None
+    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+    assert ds.GetGeoTransform() == (500000, 1, 0, 5000000, 0, -1)
+    assert np.array_equal(ds.GetRasterBand(1).ReadAsArray(), pixel_data)
+    ds = None
+
+    # Check that the requested markers and progression were actually written
+    structure = gdal.GetJPEG2000StructureAsString(dst_jp2, ["ALL=YES"])
+
+    if expect_plt:
+        assert '<Marker name="PLT"' in structure
+    else:
+        assert '<Marker name="PLT"' not in structure
+
+    if expect_tlm:
+        assert '<Marker name="TLM"' in structure
+    else:
+        assert '<Marker name="TLM"' not in structure
+
+    # SOP/EPH are encoded in the COD Scod field's description text.
+    if expect_sop:
+        assert "SOP marker segments may be used" in structure
+    else:
+        assert "No SOP marker segments" in structure
+    if expect_eph:
+        assert "EPH marker segments may be used" in structure
+    else:
+        assert "No EPH marker segments" in structure
+
+    if expect_progression is not None:
+        assert (
+            f'<Field name="SGcod_Progress" type="uint8" '
+            f'description="{expect_progression}">' in structure
+        )
+
+
+###############################################################################
+# Test transcode from the existing byte.jp2 test fixture.
+#
+# Unlike the parametrized cases above, this exercises transcode on a real
+# third-party JP2 with a GeoTIFF UUID box already present, checking that
+# metadata (SRS, GeoTransform) and pixel data survive a round-trip through
+# grk_transcode() when the source was NOT created by the Grok driver itself.
+# PLT=YES is included to exercise PLT insertion on a file that did not
+# originally carry a PLT marker.
+
+
+def test_jp2grok_transcode_byte(tmp_path):
+
+    src_ds = gdal.Open("data/jpeg2000/byte.jp2")
+    src_wkt = src_ds.GetProjectionRef()
+    src_gt = src_ds.GetGeoTransform()
+    src_cs = src_ds.GetRasterBand(1).Checksum()
+
+    dst_jp2 = str(tmp_path / "transcode_byte.jp2")
+    out_ds = gdaltest.jp2grok_drv.CreateCopy(
+        dst_jp2, src_ds, options=["TRANSCODE=YES", "PLT=YES"]
+    )
+    del out_ds
+    del src_ds
+
+    ds = gdal.Open(dst_jp2)
+    assert ds is not None
+
+    sr1 = osr.SpatialReference()
+    sr1.SetFromUserInput(ds.GetProjectionRef())
+    sr2 = osr.SpatialReference()
+    sr2.SetFromUserInput(src_wkt)
+    assert sr1.IsSame(sr2), "bad spatial reference after transcode"
+
+    got_gt = ds.GetGeoTransform()
+    for i in range(6):
+        assert got_gt[i] == pytest.approx(src_gt[i], abs=1e-8)
+
+    assert ds.GetRasterBand(1).Checksum() == src_cs
+    ds = None
+
+    # PLT=YES should have actually inserted a PLT marker
+    structure = gdal.GetJPEG2000StructureAsString(dst_jp2, ["ALL=YES"])
+    assert '<Marker name="PLT"' in structure
+
+
+###############################################################################
+# Test transcode warns about ignored options
+
+
+def test_jp2grok_transcode_ignored_options(tmp_path):
+
+    src_ds = gdal.Open("data/jpeg2000/byte.jp2")
+    dst_jp2 = str(tmp_path / "transcode_ignored.jp2")
+
+    with gdaltest.error_raised(gdal.CE_Warning, match="ignored when TRANSCODE=YES"):
+        out_ds = gdaltest.jp2grok_drv.CreateCopy(
+            dst_jp2,
+            src_ds,
+            options=["TRANSCODE=YES", "QUALITY=50", "REVERSIBLE=YES"],
+        )
+        del out_ds
+
+    del src_ds
+
+    # Verify the file was still created successfully despite warnings
+    ds = gdal.Open(dst_jp2)
+    assert ds is not None
+    ds = None
+
+
+###############################################################################
+# Test driver metadata
+
+
 def test_jp2grok_driver_metadata():
 
     drv = gdal.GetDriverByName("JP2Grok")

--- a/cmake/helpers/CheckDependentLibrariesGrok.cmake
+++ b/cmake/helpers/CheckDependentLibrariesGrok.cmake
@@ -2,4 +2,4 @@ gdal_check_package(Grok "Enable JPEG2000 support with Grok library"
                    CONFIG
                    CAN_DISABLE
                    TARGETS GROK::grokj2k
-                   VERSION 20.2)
+                   VERSION 20.2.8)

--- a/doc/source/drivers/raster/jp2grok.rst
+++ b/doc/source/drivers/raster/jp2grok.rst
@@ -410,6 +410,41 @@ The following creation options are available:
       will be ignored in that mode. Can be useful in some use cases when
       adding/correcting georeferencing, metadata, ...
 
+-  .. co:: TRANSCODE
+      :choices: YES, NO
+      :default: NO
+
+      When the source dataset is JPEG 2000, transcode the codestream
+      without a full decompression/recompression round-trip. The
+      underlying codestream data is copied verbatim while the following
+      options may be used to modify markers or progression:
+
+      - :co:`PLT` – insert PLT (Packet Length, Tile-part) marker segments
+      - :co:`TLM` – insert TLM (Tile-part Length) marker segments
+      - :co:`SOP` – insert SOP (Start Of Packet) marker segments
+      - :co:`EPH` – insert EPH (End of Packet Header) marker segments
+      - :co:`PROGRESSION` – change the progression order
+        (``LRCP``, ``RLCP``, ``RPCL``, ``PCRL``, ``CPRL``)
+
+      JP2 metadata boxes (GeoTIFF UUID, XMP, GMLJP2, IPR, GDAL xml) are
+      regenerated from the current dataset metadata.
+
+      Because the codestream coefficients are copied rather than
+      re-encoded, creation options that would affect the pixel data
+      (``QUALITY``, ``REVERSIBLE``, ``BLOCKXSIZE``, ``BLOCKYSIZE``,
+      ``RESOLUTIONS``, ``YCBCR420``, ``YCC``, ``NBITS``, ``1BIT_ALPHA``,
+      ``PRECINCTS``, ``TILEPARTS``, ``CODEBLOCK_WIDTH``,
+      ``CODEBLOCK_HEIGHT``, ``CODEBLOCK_STYLE``, ``USE_SRC_CODESTREAM``)
+      are ignored — a warning is emitted if any are supplied.
+
+      Example:
+
+      ::
+
+          gdal_translate -of JP2Grok -co TRANSCODE=YES \
+              -co PLT=YES -co TLM=YES -co PROGRESSION=RPCL \
+              input.jp2 output.jp2
+
 -  .. co:: COMMENT
       :choices: <string>
 

--- a/frmts/grok/grkdatasetbase.h
+++ b/frmts/grok/grkdatasetbase.h
@@ -1359,30 +1359,34 @@ struct GRKCodecWrapper
     }
 
     /**
-     * @brief Rewrite JP2 boxes via Grok transcode.
+     * @brief Shared transcode implementation: copy codestream while
+     *        rewriting JP2 metadata boxes from @p poDS.
      *
-     * Replaces the driver-side box rewriting logic in Close() by using
-     * grk_transcode() to copy the codestream verbatim while writing
-     * updated metadata boxes.
+     * Used by both rewriteBoxes() (in-place rewrite via tmp file) and
+     * transcode() (explicit src -> dst with extra cparams set by caller).
      *
-     * @param pszFilename source (and destination) file path
-     * @param poDS        dataset carrying updated metadata
+     * @param pszSrcFilename source file path
+     * @param pszDstFilename destination file path (may equal src only via
+     *                       external caller serialization — prefer tmp)
+     * @param poDS           dataset carrying metadata for output boxes
+     * @param cparams        compression parameters (already configured by
+     *                       caller for PLT/TLM/SOP/EPH/progression etc.)
+     * @param pszErrorCtx    short context label used in error messages
      * @return true on success
      */
-    static bool rewriteBoxes(const char *pszFilename, GDALDataset *poDS)
+    static bool doTranscode(const char *pszSrcFilename,
+                            const char *pszDstFilename, GDALDataset *poDS,
+                            grk_cparameters *cparams, const char *pszErrorCtx)
     {
-        CPLDebug("GROK", "Rewriting boxes via transcode for %s", pszFilename);
-
-        /* Read source header to get image */
         grk_stream_params srcStreamParams{};
-        safe_strcpy(srcStreamParams.file, pszFilename);
+        safe_strcpy(srcStreamParams.file, pszSrcFilename);
 
         grk_decompress_parameters dparams{};
         auto *decCodec = grk_decompress_init(&srcStreamParams, &dparams);
         if (!decCodec)
         {
             CPLError(CE_Failure, CPLE_AppDefined,
-                     "grk_decompress_init() failed for rewrite");
+                     "grk_decompress_init() failed for %s", pszErrorCtx);
             return false;
         }
 
@@ -1390,7 +1394,7 @@ struct GRKCodecWrapper
         if (!grk_decompress_read_header(decCodec, &srcHeader))
         {
             CPLError(CE_Failure, CPLE_AppDefined,
-                     "grk_decompress_read_header() failed for rewrite");
+                     "grk_decompress_read_header() failed for %s", pszErrorCtx);
             grk_object_unref(decCodec);
             return false;
         }
@@ -1399,12 +1403,11 @@ struct GRKCodecWrapper
         if (!srcImage)
         {
             CPLError(CE_Failure, CPLE_AppDefined,
-                     "grk_decompress_get_image() failed for rewrite");
+                     "grk_decompress_get_image() failed for %s", pszErrorCtx);
             grk_object_unref(decCodec);
             return false;
         }
 
-        /* Prepare updated metadata on the image */
         if (!srcImage->meta)
             srcImage->meta = grk_image_meta_new();
 
@@ -1503,27 +1506,50 @@ struct GRKCodecWrapper
             }
         }
 
-        /* Transcode: copy codestream, rewrite boxes */
+        grk_stream_params transSrcParams{};
+        safe_strcpy(transSrcParams.file, pszSrcFilename);
+
+        grk_stream_params dstParams{};
+        safe_strcpy(dstParams.file, pszDstFilename);
+
+        uint64_t written =
+            grk_transcode(&transSrcParams, &dstParams, cparams, srcImage);
+        grk_object_unref(decCodec);
+
+        if (written == 0)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "grk_transcode() failed for %s", pszErrorCtx);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @brief Rewrite JP2 boxes via Grok transcode.
+     *
+     * Replaces the driver-side box rewriting logic in Close() by using
+     * grk_transcode() to copy the codestream verbatim while writing
+     * updated metadata boxes.
+     *
+     * @param pszFilename source (and destination) file path
+     * @param poDS        dataset carrying updated metadata
+     * @return true on success
+     */
+    static bool rewriteBoxes(const char *pszFilename, GDALDataset *poDS)
+    {
+        CPLDebug("GROK", "Rewriting boxes via transcode for %s", pszFilename);
+
         grk_cparameters cparams{};
         grk_compress_set_default_params(&cparams);
         cparams.cod_format = GRK_FMT_JP2;
 
         CPLString osTmpFilename(CPLSPrintf("%s.tmp", pszFilename));
 
-        grk_stream_params transSrcParams{};
-        safe_strcpy(transSrcParams.file, pszFilename);
-
-        grk_stream_params dstParams{};
-        safe_strcpy(dstParams.file, osTmpFilename.c_str());
-
-        uint64_t written =
-            grk_transcode(&transSrcParams, &dstParams, &cparams, srcImage);
-        grk_object_unref(decCodec);
-
-        if (written == 0)
+        if (!doTranscode(pszFilename, osTmpFilename.c_str(), poDS, &cparams,
+                         "box rewrite"))
         {
-            CPLError(CE_Failure, CPLE_AppDefined,
-                     "grk_transcode() failed for box rewrite");
             VSIUnlink(osTmpFilename);
             return false;
         }
@@ -1537,6 +1563,90 @@ struct GRKCodecWrapper
         }
 
         return true;
+    }
+
+    /**
+     * @brief Transcode a JP2 file without full decompression/recompression.
+     *
+     * Copies the codestream while optionally inserting PLT/TLM/SOP/EPH
+     * markers and/or reordering the progression order.  Metadata boxes
+     * (GeoTIFF, XMP, GMLJP2, etc.) are written from @p poDS.
+     *
+     * @param pszSrcFilename source JP2/J2K file path
+     * @param pszDstFilename destination file path
+     * @param poDS           dataset carrying metadata for output boxes
+     * @param papszOptions   creation options (PLT, TLM, SOP, EPH, PROGRESSION)
+     * @return true on success
+     */
+    static bool transcode(const char *pszSrcFilename,
+                          const char *pszDstFilename, GDALDataset *poDS,
+                          CSLConstList papszOptions)
+    {
+        CPLDebug("GROK", "Transcoding %s -> %s", pszSrcFilename,
+                 pszDstFilename);
+
+        /* Warn about options that are meaningless in transcode mode */
+        static const char *const apszIgnoredOptions[] = {"QUALITY",
+                                                         "REVERSIBLE",
+                                                         "BLOCKXSIZE",
+                                                         "BLOCKYSIZE",
+                                                         "RESOLUTIONS",
+                                                         "YCBCR420",
+                                                         "YCC",
+                                                         "NBITS",
+                                                         "1BIT_ALPHA",
+                                                         "PRECINCTS",
+                                                         "TILEPARTS",
+                                                         "CODEBLOCK_WIDTH",
+                                                         "CODEBLOCK_HEIGHT",
+                                                         "CODEBLOCK_STYLE",
+                                                         "USE_SRC_CODESTREAM",
+                                                         nullptr};
+        for (int i = 0; apszIgnoredOptions[i]; i++)
+        {
+            if (CSLFetchNameValue(papszOptions, apszIgnoredOptions[i]))
+            {
+                CPLError(CE_Warning, CPLE_NotSupported,
+                         "Option %s ignored when TRANSCODE=YES",
+                         apszIgnoredOptions[i]);
+            }
+        }
+
+        grk_cparameters cparams{};
+        grk_compress_set_default_params(&cparams);
+        cparams.cod_format = GRK_FMT_JP2;
+
+        if (CPLTestBool(CSLFetchNameValueDef(papszOptions, "PLT", "FALSE")))
+            cparams.write_plt = true;
+        if (CPLTestBool(CSLFetchNameValueDef(papszOptions, "TLM", "FALSE")))
+            cparams.write_tlm = true;
+        if (CPLTestBool(CSLFetchNameValueDef(papszOptions, "SOP", "FALSE")))
+            cparams.write_sop = true;
+        if (CPLTestBool(CSLFetchNameValueDef(papszOptions, "EPH", "FALSE")))
+            cparams.write_eph = true;
+
+        const char *pszProgOrder =
+            CSLFetchNameValue(papszOptions, "PROGRESSION");
+        if (pszProgOrder)
+        {
+            if (EQUAL(pszProgOrder, "LRCP"))
+                cparams.transcode_prog_order = GRK_LRCP;
+            else if (EQUAL(pszProgOrder, "RLCP"))
+                cparams.transcode_prog_order = GRK_RLCP;
+            else if (EQUAL(pszProgOrder, "RPCL"))
+                cparams.transcode_prog_order = GRK_RPCL;
+            else if (EQUAL(pszProgOrder, "PCRL"))
+                cparams.transcode_prog_order = GRK_PCRL;
+            else if (EQUAL(pszProgOrder, "CPRL"))
+                cparams.transcode_prog_order = GRK_CPRL;
+            else
+                CPLError(CE_Warning, CPLE_NotSupported,
+                         "Unknown PROGRESSION value for transcode: %s",
+                         pszProgOrder);
+        }
+
+        return doTranscode(pszSrcFilename, pszDstFilename, poDS, &cparams,
+                           "transcode");
     }
 
     /**
@@ -2956,6 +3066,10 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
             "source dataset is JPEG2000, whether to reuse the codestream of "
             "the "
             "source dataset unmodified' default='NO'/>"
+            "   <Option name='TRANSCODE' type='boolean' "
+            "description='Transcode source JP2 without full decompression. "
+            "Supports PLT, TLM, SOP, EPH, and PROGRESSION options.' "
+            "default='NO'/>"
             "   <Option name='CODEBLOCK_STYLE' type='string' "
             "description='Comma-separated combination of BYPASS, RESET, "
             "TERMALL, "

--- a/frmts/openjpeg/opjdatasetbase.h
+++ b/frmts/openjpeg/opjdatasetbase.h
@@ -716,6 +716,12 @@ struct OPJCodecWrapper
         return false;
     }
 
+    static bool transcode(const char *, const char *, GDALDataset *,
+                          CSLConstList)
+    {
+        return false;
+    }
+
     bool compressTile(int tileIndex, GByte *buff, uint32_t buffLen)
     {
         if (!pCodec || !pStream)

--- a/frmts/opjlike/jp2opjlikedataset.cpp
+++ b/frmts/opjlike/jp2opjlikedataset.cpp
@@ -2140,6 +2140,40 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
         return nullptr;
     }
 
+    /* -------------------------------------------------------------------- */
+    /*      Transcode short-circuit (Grok only).                            */
+    /* -------------------------------------------------------------------- */
+    if (CPLFetchBool(papszOptions, "TRANSCODE", false))
+    {
+        if (!BASE::canPerformDirectIO())
+        {
+            CPLError(CE_Failure, CPLE_NotSupported,
+                     "TRANSCODE=YES is only supported by the JP2Grok driver");
+            return nullptr;
+        }
+
+        CPLString osSrcFilename(poSrcDS->GetDescription());
+        if (poSrcDS->GetDriver() != nullptr &&
+            poSrcDS->GetDriver() == GDALGetDriverByName("VRT"))
+        {
+            VRTDataset *poVRTDS = dynamic_cast<VRTDataset *>(poSrcDS);
+            if (poVRTDS)
+            {
+                GDALDataset *poSimpleSourceDS =
+                    poVRTDS->GetSingleSimpleSource();
+                if (poSimpleSourceDS)
+                    osSrcFilename = poSimpleSourceDS->GetDescription();
+            }
+        }
+
+        if (!CODEC::transcode(osSrcFilename, pszFilename, poSrcDS,
+                              papszOptions))
+            return nullptr;
+
+        GDALOpenInfo oOpenInfo(pszFilename, GA_ReadOnly);
+        return Open(&oOpenInfo);
+    }
+
     const bool bInspireTG = CPLFetchBool(papszOptions, "INSPIRE_TG", false);
 
     /* -------------------------------------------------------------------- */


### PR DESCRIPTION
## What does this PR do?

Add JPEG 2000 transcode capabilities to GDAL via JP2Grok driver:

1. add PLT and TLM markers
1. add SOP/EPH markers
1. change progression

Example command line:

```
gdal_translate -of JP2Grok -co TRANSCODE=YES [-co PLT=YES] [-co TLM=YES] [-co SOP=YES] [-co EPH=YES] [-co PROGRESSION=RPCL] input.jp2 output.jp2
```

## AI tool usage

 - [x] Claude Code AI supported my development of this PR.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed