### PR TITLE
Doc: Add PAM projection example

### DIFF
--- a/doc/source/programs/gdal_raster_reproject.rst
+++ b/doc/source/programs/gdal_raster_reproject.rst
@@ -334,3 +334,16 @@ Examples
    .. code-block:: bash
 
         $ gdal raster reproject --dst-crs=EPSG:32632 in.tif out.tif --overwrite
+
+.. example::
+   :title: Converting a raster that use an embedded custom CRS
+
+   In this example, the input file has an embedded custom CRS with a WKT2 definition
+   that is not recognized by GDAL, but that can be reprojected to the known ESRI:54052 code.
+
+   Using ``"PROFILE=BASELINE"`` creates a :term:`PAM` file with a top-level `ESRI:54052 <https://spatialreference.org/ref/esri/54052/>`__ code,
+   rather than using the embedded metadata tags to define the CRS. See :ref:`GTiff <raster.gtiff>` ``PROFILE``.
+
+   .. code-block:: bash
+
+        $ gdal raster reproject --creation-option "PROFILE=BASELINE" --dst-crs=ESRI:54052 input.tif output.tif --overwrite

--- a/doc/source/programs/gdal_raster_reproject.rst
+++ b/doc/source/programs/gdal_raster_reproject.rst
@@ -336,13 +336,13 @@ Examples
         $ gdal raster reproject --dst-crs=EPSG:32632 in.tif out.tif --overwrite
 
 .. example::
-   :title: Converting a raster that use an embedded custom CRS
+   :title: Converting a raster that uses an embedded CRS without a known identifier
 
-   In this example, the input file has an embedded custom CRS with a WKT2 definition
-   that is not recognized by GDAL, but that can be reprojected to the known ESRI:54052 code.
+   In this example, the input file has an embedded CRS defined in WKT2 but without an associated identifier,
+   and it will be reprojected to the known `ESRI:54052 <https://spatialreference.org/ref/esri/54052/>`__ CRS identifier.
 
-   Using ``"PROFILE=BASELINE"`` creates a :term:`PAM` file with a top-level `ESRI:54052 <https://spatialreference.org/ref/esri/54052/>`__ code,
-   rather than using the embedded metadata tags to define the CRS. See :ref:`GTiff <raster.gtiff>` ``PROFILE``.
+   Using ``"PROFILE=BASELINE"`` creates a :term:`PAM` file that stores the CRS using the ``ESRI:54052`` identifier,
+   instead of embedding CRS information in GeoTIFF metadata tags. See :ref:`GTiff <raster.gtiff>` ``PROFILE``.
 
    .. code-block:: bash
 


### PR DESCRIPTION
Moved from #14285. The example aims to show how to force the creation of a PAM file for a TIFF so that it has an identifying `ESRI:54052` code that can be read by GDAL and other software. I may have misunderstood where/how to set CRS metadata though. My steps are as follows:

Using the attached file: [tileSG-000-019_3-3.tif](https://github.com/user-attachments/files/26625338/tileSG-000-019_3-3.tif)

There is no EPSG code associated with the raster - but there is a raw CRS in the image metadata:

```bash
gdal raster info tileSG-000-019_3-3.tif

PROJCRS["Interrupted_Goode_Homolosine",
    BASEGEOGCRS["GCS_unnamed ellipse",
        DATUM["unknown",
            ELLIPSOID["Unknown",6378137,298.257223563,
                LENGTHUNIT["metre",1,
```			
			
I understood the file to be in https://spatialreference.org/ref/esri/54052/ (although this may be an incorrect assumption).
Trying to set the CRS fails to set an identifying CRS code:

```bash
gdal raster edit --crs=ESRI:54052 tileSG-000-019_3-3.tif
gdal raster info tileSG-000-019_3-3.tif

PROJCRS["World_Goode_Homolosine_Land",
    BASEGEOGCRS["WGS 84",
        DATUM["World Geodetic System 1984"
```

There is no `ESRI:54052` code in the CRS details. 

Reprojecting also fails to add a code:
		
```
gdal raster reproject --dst-crs=ESRI:54052 tileSG-000-019_3-3.tif out.tif
gdal raster info out.tif

PROJCRS["World_Goode_Homolosine_Land",
    BASEGEOGCRS["WGS 84",
        DATUM["World Geodetic System 1984",
            ELLIPSOID["WGS 84",6378137,298.257223563,
                LENGTHUNIT["metre",1]],
```

Still no code. However the following forces the creation of `out2.tif.aux.xml`, and now the CRS output includes a code:
		
```bash
gdal raster reproject --creation-option "PROFILE=BASELINE" --dst-crs=ESRI:54052 tileSG-000-019_3-3.tif out2.tif
gdal raster info out2.tif

PROJCRS["World_Goode_Homolosine_Land",
...
    ID["ESRI",54052]]
```

<img width="668" height="220" alt="image" src="https://github.com/user-attachments/assets/e778e384-1dc3-4e5e-a3df-b4c1b802fc96" />
