### PR TITLE
Shapefile: emit warning when record number in .shx doesn't match one in .dbf

### DIFF
--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -6346,3 +6346,36 @@ def test_ogr_shape_read_shp_xml(tmp_vsimem):
         "/vsimem/test_ogr_shape_read_shp_xml/test.dbf",
         "/vsimem/test_ogr_shape_read_shp_xml/test.shp.xml",
     ]
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_ogr_shape_inconsistent_record_count(tmp_vsimem):
+
+    with gdal.GetDriverByName("ESRI Shapefile").CreateVector(
+        tmp_vsimem / "tmp.shp"
+    ) as ds:
+        lyr = ds.CreateLayer("tmp")
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (1 2)"))
+        lyr.CreateFeature(f)
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (2 3)"))
+        lyr.CreateFeature(f)
+
+    with gdal.VSIFile(tmp_vsimem / "tmp.dbf", "rb+") as f:
+        f.seek(4)
+        f.write(b"\x01")
+
+    with gdaltest.error_raised(
+        gdal.CE_Warning, match="Inconsistent record number in .shx (2) and in .dbf (1)"
+    ):
+        ds = ogr.Open(tmp_vsimem / "tmp.shp")
+
+    lyr = ds.GetLayer(0)
+    # Current behaviour, but could as well be 1.
+    assert lyr.GetFeatureCount() == 2
+    lyr.GetNextFeature()
+    lyr.GetNextFeature()

--- a/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
+++ b/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
@@ -65,9 +65,15 @@ OGRShapeLayer::OGRShapeLayer(OGRShapeDataSource *poDSIn,
         m_nTotalShapeCount = m_hSHP->nRecords;
         if (m_hDBF != nullptr && m_hDBF->nRecords != m_nTotalShapeCount)
         {
-            CPLDebug("Shape",
-                     "Inconsistent record number in .shp (%d) and in .dbf (%d)",
-                     m_hSHP->nRecords, m_hDBF->nRecords);
+            CPLError(
+                CE_Warning, CPLE_AppDefined,
+                "Inconsistent record number in .shx (%d) and in .dbf (%d). "
+                "Using (arbitrarily) the former.\n"
+                "This dataset is likely corrupted. You may try to re-open "
+                "this dataset with the SHAPE_RESTORE_SHX configuration "
+                "option set to YES to attempt repairing it, but first "
+                "back up the original .shp, .shx and .dbf files.",
+                m_hSHP->nRecords, m_hDBF->nRecords);
         }
     }
     else if (m_hDBF != nullptr)


### PR DESCRIPTION
This used to be just a debug message, but it might be hard for users to guess that there is something suspicious that requires them to enable debug traces.

Hopefully not too many non-corrupted datasets ship with such discrepancy...

Fixes #14316
