### PR TITLE
CI: Conda master builds remove duplicate versions

### DIFF
--- a/ci/travis/conda/upload.sh
+++ b/ci/travis/conda/upload.sh
@@ -25,8 +25,9 @@ if [ -z "$files" ]; then
 fi
 
 echo "Anaconda token is available, attempting to upload"
-conda install -c conda-forge python=3.12 anaconda-client -y
+conda install -c conda-forge python=3.12 anaconda-client jq curl -y
 
+# remove any existing packages for the same version
 for f in $files; do
   filename=$(basename "$f")
 
@@ -36,9 +37,24 @@ for f in $files; do
   # extract version number (e.g. 3.12.99)
   version=$(echo "$filename" | sed -E 's/^.+-([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
 
-  echo "Removing gdal-master/$pkg/$version/$CONDA_SUBDIR"
-  anaconda -t "$ANACONDA_TOKEN" remove -f "gdal-master/$pkg/$version/$CONDA_SUBDIR" || true
+  existing_files=$(curl -s https://api.anaconda.org/package/gdal-master/$pkg | jq -r \
+    --arg version "$version" \
+    --arg subdir "$CONDA_SUBDIR" '
+    .files[]
+    | select(.version == $version)
+    | select(.attrs.subdir == $subdir)
+    | .full_name
+  ')
 
+  for ef in $existing_files; do
+    echo "Removing $ef"
+    anaconda -t "$ANACONDA_TOKEN" remove --force "$ef" || true
+  done
+done
+
+# upload new packages
+for f in $files; do
+  filename=$(basename "$f")
   echo "Uploading $filename"
   anaconda -t "$ANACONDA_TOKEN" upload --force --no-progress --user gdal-master "$f"
 done

--- a/ci/travis/conda/upload.sh
+++ b/ci/travis/conda/upload.sh
@@ -48,7 +48,7 @@ for f in $files; do
 
   for ef in $existing_files; do
     echo "Removing $ef"
-    anaconda -t "$ANACONDA_TOKEN" remove --force "$ef" || true
+    anaconda -t "$ANACONDA_TOKEN" remove --force "$ef"
   done
 done
 

--- a/doc/source/download.rst
+++ b/doc/source/download.rst
@@ -246,9 +246,9 @@ GDAL subpackages may need to be updated individually, because the master version
     conda list gdal
     gdal --version
     # remove current master version
-    conda remove gdal --yes
+    conda remove gdal libgdal-core --yes
     # install latest GDAL master build
-    conda install -c gdal-master -c conda-forge gdal-master::gdal --yes
+    conda install -c gdal-master -c conda-forge gdal libgdal-core --yes
     gdal --version
 
 .. _pixi:


### PR DESCRIPTION
My monthly update to working with the Conda master builds. The changes added in #14191 didn't work (see [logs here](https://productionresultssa15.blob.core.windows.net/actions-results/2bd93868-8afd-43e8-90b7-81aba8b1c3ad/workflow-job-run-d284be71-4a71-5913-80d2-7b9c6f61039b/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-04-11T07%3A52%3A51Z&sig=gmZswaBcbgm7d%2FLSOlikvCcvJ6IkmI7kkDKDq%2FLFvLk%3D&ske=2026-04-11T08%3A51%3A29Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-04-11T04%3A51%3A29Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-04-11T07%3A42%3A46Z&sv=2025-11-05)):

```
2026-04-10T18:28:01.8193151Z Removing gdal-master/libgdal-core/3.12.99/win-64
2026-04-10T18:28:03.8542048Z Using Anaconda API: https://api.anaconda.org
2026-04-10T18:28:04.0267786Z [WARNING] 
2026-04-10T18:28:04.0268164Z Traceback (most recent call last):
2026-04-10T18:28:04.0269070Z   File "C:\Users\runneradmin\miniconda3\envs\test\Lib\site-packages\binstar_client\commands\remove.py", line 30, in main
2026-04-10T18:28:04.0270079Z     aserver_api.remove_dist(spec.user, spec.package, spec.version, spec.basename)
2026-04-10T18:28:04.0271044Z   File "C:\Users\runneradmin\miniconda3\envs\test\Lib\site-packages\binstar_client\__init__.py", line 489, in remove_dist
2026-04-10T18:28:04.0271967Z     self._check_response(res)
2026-04-10T18:28:04.0272702Z   File "C:\Users\runneradmin\miniconda3\envs\test\Lib\site-packages\binstar_client\__init__.py", line 242, in _check_response
2026-04-10T18:28:04.0273670Z     raise ErrCls(msg, res.status_code)
2026-04-10T18:28:04.0274225Z binstar_client.errors.NotFound: (" distribution 'win-64' does not exist", 404)
```

The "paths" such as `gdal-master/libgdal-core/3.12.99/win-64` are simply labels, so the issue of multiple packages for the same version has reappeared (see for example the two versions at https://anaconda.org/channels/gdal-master/packages/libgdal-core/files?versions=3.12.99&platforms=win-64). 

It appears the Python `anaconda-client` has no way to work with platforms, and returns lists of files for a particular version as strings:

```bash
anaconda show gdal-master/gdal/3.12.99
Using Anaconda API: https://api.anaconda.org
version 3.12.99
   + linux-64/gdal-3.12.99-py310hea6e582_2112.conda
   + linux-64/gdal-3.12.99-py311hd474574_2112.conda
   + linux-64/gdal-3.12.99-py312h5fc20e3_2112.conda
   + linux-64/gdal-3.12.99-py313h1ee8c46_2112.conda
   + linux-64/gdal-3.12.99-py314hca3c80c_2112.conda
   + linux-64/gdal-3.12.99-py314hd76b233_2112.conda
   + linux-aarch64/gdal-3.12.99-py310h380ccc7_2112.conda
   + linux-aarch64/gdal-3.12.99-py311hdb99de0_2112.conda
```

The [remove docs](https://www.anaconda.com/docs/tools/anaconda-org/maintainer-guide/hosted-packages#removing-a-previous-version-of-a-package) require the full "filename" rather than a folder. 

The approach has been updated to use the https://api.anaconda.org/ to get a JSON list of files, parse this with `jq`, and then delete the files before uploading again. As the files are known to exist the script has been updated to fail on error, rather than hiding them as previously. 

I have tested the scripts in bash, but not on a test Anaconda repository. 

Apologies @rouault for another PR on this. Feel free to assign any CI Conda issues to me in the future as I've gone through the related scripts many times..



