### PR TITLE
[Backport release/3.12] gdal raster edit: avoid error when used within a pipeline and previous step is anonymous VRT

### DIFF
--- a/apps/gdalalg_raster_edit.cpp
+++ b/apps/gdalalg_raster_edit.cpp
@@ -235,6 +235,7 @@ bool GDALRasterEditAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
     GDALDataset *poDS = m_dataset.GetDatasetRef();
     if (poDS)
     {
+        // Standalone mode
         if (poDS->GetAccess() != GA_Update && !m_readOnly)
         {
             ReportError(CE_Failure, CPLE_AppDefined,
@@ -245,21 +246,35 @@ bool GDALRasterEditAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
     }
     else
     {
+        // Pipeline mode
         const auto poSrcDS = m_inputDataset[0].GetDatasetRef();
         CPLAssert(poSrcDS);
         CPLAssert(m_outputDataset.GetName().empty());
         CPLAssert(!m_outputDataset.GetDatasetRef());
-
-        CPLStringList aosOptions;
-        aosOptions.push_back("-of");
-        aosOptions.push_back("VRT");
-        GDALTranslateOptions *psOptions =
-            GDALTranslateOptionsNew(aosOptions.List(), nullptr);
-        GDALDatasetH hSrcDS = GDALDataset::ToHandle(poSrcDS);
-        auto poRetDS = GDALDataset::FromHandle(
-            GDALTranslate("", hSrcDS, psOptions, nullptr));
-        GDALTranslateOptionsFree(psOptions);
-        m_outputDataset.Set(std::unique_ptr<GDALDataset>(poRetDS));
+        auto poDriver = poSrcDS->GetDriver();
+        if (poDriver && EQUAL(poDriver->GetDescription(), "VRT") &&
+            poSrcDS->GetDescription()[0] == '\0')
+        {
+            // We can directly edit an anonymous input VRT file
+            // and we actually need to do that since the generic code path
+            // in the other branch will try ot serialize and serialize a XML
+            // file pointing to an anonymous source.
+            m_outputDataset.Set(poSrcDS);
+        }
+        else
+        {
+            // Create a in-memory VRT to avoid modifying the source dataset.
+            CPLStringList aosOptions;
+            aosOptions.push_back("-of");
+            aosOptions.push_back("VRT");
+            GDALTranslateOptions *psOptions =
+                GDALTranslateOptionsNew(aosOptions.List(), nullptr);
+            GDALDatasetH hSrcDS = GDALDataset::ToHandle(poSrcDS);
+            auto poRetDS = GDALDataset::FromHandle(
+                GDALTranslate("", hSrcDS, psOptions, nullptr));
+            GDALTranslateOptionsFree(psOptions);
+            m_outputDataset.Set(std::unique_ptr<GDALDataset>(poRetDS));
+        }
         poDS = m_outputDataset.GetDatasetRef();
     }
 

--- a/autotest/utilities/test_gdalalg_raster_edit.py
+++ b/autotest/utilities/test_gdalalg_raster_edit.py
@@ -393,6 +393,20 @@ def test_gdalalg_raster_pipeline_edit_metadata(tmp_vsimem):
         assert ds.GetMetadata() == {"AREA_OR_POINT": "Area", "bar": "baz"}
 
 
+def test_gdalalg_raster_pipeline_complex():
+    """Test case of https://github.com/OSGeo/gdal/issues/14331"""
+
+    src_ds = gdal.Open("../gcore/data/byte.tif")
+    ds = gdal.GetDriverByName("MEM").CreateCopy("", src_ds)
+    with gdal.alg.raster.pipeline(
+        input=ds,
+        pipeline="read ! reproject --dst-crs EPSG:4326 ! edit --metadata DESC=stuff",
+    ) as alg:
+        ds = alg.Output()
+        assert ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+        assert ds.GetMetadataItem("DESC") == "stuff"
+
+
 def test_gdalalg_raster_edit_gcp_from_list_of_values():
 
     mem_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)


### PR DESCRIPTION
Backport #14332
 **Authored by:** @rouault