### PR TITLE
CI: Add channel for windows and jq

### DIFF
--- a/ci/travis/conda/upload.sh
+++ b/ci/travis/conda/upload.sh
@@ -25,7 +25,7 @@ if [ -z "$files" ]; then
 fi
 
 echo "Anaconda token is available, attempting to upload"
-conda install -c conda-forge python=3.12 anaconda-client jq curl -y
+conda install -c conda-forge -c defaults python=3.12 anaconda-client jq curl -y --strict-channel-priority
 
 # remove any existing packages for the same version
 for f in $files; do


### PR DESCRIPTION
#14335 worked for all OSs except Windows, which seems to only have `jq` on the default channel.

