### PR TITLE
CI: Strip out any \r when running on Windows for Conda uploads

### DIFF
--- a/ci/travis/conda/upload.sh
+++ b/ci/travis/conda/upload.sh
@@ -44,7 +44,7 @@ for f in $files; do
     | select(.version == $version)
     | select(.attrs.subdir == $subdir)
     | .full_name
-  ')
+    ' | tr -d '\r')
 
   for ef in $existing_files; do
     echo "Removing $ef"


### PR DESCRIPTION
Follow-up (hopefully the last) to #14339.

The Windows runner adds '\r' to the last file in the list. This PR removes them to avoid 404 errors. 

```
2026-04-13T00:06:26.3822255Z binstar_client.errors.NotFound:
 (" distribution 'win-64/libgdal-arrow-parquet-3.12.99-h847dad1_2112.conda\\r' does not exist", 404) 
```

