### PR TITLE
GTI: adjusments to overview handling

### DIFF
--- a/autotest/gdrivers/gti.py
+++ b/autotest/gdrivers/gti.py
@@ -2278,7 +2278,8 @@ def test_gti_ovr_lyr_name(tmp_vsimem):
         vrt_ds.GetRasterBand(1).GetOverviewCount()
 
 
-def test_gti_ovr_of_ovr(tmp_vsimem):
+@pytest.mark.parametrize("add_factor", [True, False])
+def test_gti_ovr_of_ovr(tmp_vsimem, add_factor):
 
     index_filename = str(tmp_vsimem / "index.gti.gpkg")
 
@@ -2290,19 +2291,22 @@ def test_gti_ovr_of_ovr(tmp_vsimem):
     src_ds = gdal.Open(os.path.join(os.getcwd(), "data", "byte.tif"))
     index_ds, lyr = create_basic_tileindex(index_filename, src_ds)
     lyr.SetMetadataItem("OVERVIEW_0_DATASET", ovr_filename)
+    if add_factor:
+        lyr.SetMetadataItem("OVERVIEW_0_FACTOR", "1")
     del index_ds
 
     vrt_ds = gdal.Open(index_filename)
     ovr_ds = gdal.Open(ovr_filename)
-    assert vrt_ds.GetRasterBand(1).GetOverviewCount() == 2
+    assert vrt_ds.GetRasterBand(1).GetOverviewCount() == (1 if add_factor else 2)
     assert (
         vrt_ds.GetRasterBand(1).GetOverview(0).ReadRaster()
         == ovr_ds.GetRasterBand(1).ReadRaster()
     )
-    assert (
-        vrt_ds.GetRasterBand(1).GetOverview(1).ReadRaster()
-        == ovr_ds.GetRasterBand(1).GetOverview(0).ReadRaster()
-    )
+    if vrt_ds.GetRasterBand(1).GetOverviewCount() == 2:
+        assert (
+            vrt_ds.GetRasterBand(1).GetOverview(1).ReadRaster()
+            == ovr_ds.GetRasterBand(1).GetOverview(0).ReadRaster()
+        )
 
 
 def test_gti_ovr_of_ovr_OVERVIEW_LEVEL_NONE(tmp_vsimem):
@@ -2326,6 +2330,30 @@ def test_gti_ovr_of_ovr_OVERVIEW_LEVEL_NONE(tmp_vsimem):
     assert (
         vrt_ds.GetRasterBand(1).GetOverview(0).ReadRaster()
         == ovr_ds.GetRasterBand(1).ReadRaster()
+    )
+
+
+def test_gti_ovr_factor_on_geotiff(tmp_vsimem):
+
+    index_filename = str(tmp_vsimem / "index.gti.gpkg")
+
+    ovr_filename = str(tmp_vsimem / "byte_ovr.tif")
+    ovr_ds = gdal.Translate(ovr_filename, "data/byte.tif", width=10)
+    ovr_ds.BuildOverviews("NEAR", [2])
+    ovr_ds = None
+
+    src_ds = gdal.Open(os.path.join(os.getcwd(), "data", "byte.tif"))
+    index_ds, lyr = create_basic_tileindex(index_filename, src_ds)
+    lyr.SetMetadataItem("OVERVIEW_0_DATASET", ovr_filename)
+    lyr.SetMetadataItem("OVERVIEW_0_FACTOR", "2")
+    del index_ds
+
+    vrt_ds = gdal.Open(index_filename)
+    ovr_ds = gdal.Open(ovr_filename)
+    assert vrt_ds.GetRasterBand(1).GetOverviewCount() == 1
+    assert (
+        vrt_ds.GetRasterBand(1).GetOverview(0).ReadRaster()
+        == ovr_ds.GetRasterBand(1).GetOverview(0).ReadRaster()
     )
 
 
@@ -2625,6 +2653,18 @@ def test_gti_xml(tmp_vsimem):
     assert vrt_ds.GetRasterBand(1).GetOverviewCount() == 1
     assert vrt_ds.GetRasterBand(1).GetOverview(0).XSize == 10
     del vrt_ds
+
+    xml_content = f"""<GDALTileIndexDataset>
+  <IndexDataset>{index_filename}</IndexDataset>
+      <Overview>
+          <Factor>2</Factor>
+          <Factor>4</Factor>
+      </Overview>
+</GDALTileIndexDataset>"""
+    with pytest.raises(
+        Exception, match="At most one of Factor element is allowed per Overview child"
+    ):
+        gdal.Open(xml_content)
 
     tile_ovr_filename = str(tmp_vsimem / "byte_ovr.tif")
     gdal.Translate(tile_ovr_filename, "data/byte.tif", width=10)

--- a/autotest/gdrivers/gti.py
+++ b/autotest/gdrivers/gti.py
@@ -2761,6 +2761,67 @@ def test_gti_xml(tmp_vsimem):
         vrt_ds.GetRasterBand(1).GetOverviewCount()
 
 
+@pytest.mark.parametrize("prefix", ["", "GTI:"])
+def test_gti_xml_relative_filename(tmp_vsimem, prefix):
+
+    index_filename = str(tmp_vsimem / "index.gti.gpkg")
+
+    tile_filename = str(tmp_vsimem / "byte.tif")
+    gdal.Translate(tile_filename, "data/byte.tif")
+
+    src_ds = gdal.Open(tile_filename)
+    index_ds, _ = create_basic_tileindex(index_filename, src_ds)
+    del index_ds
+
+    tile_ovr_filename = str(tmp_vsimem / "byte_ovr.tif")
+    gdal.Translate(tile_ovr_filename, "data/byte.tif", width=10)
+    with gdal.Open(tile_ovr_filename) as ds:
+        expected_cs_ovr = ds.GetRasterBand(1).Checksum()
+
+    index2_filename = str(tmp_vsimem / "index2.gti.gpkg")
+    create_basic_tileindex(index2_filename, gdal.Open(tile_ovr_filename))
+
+    xml_filename = str(tmp_vsimem / "index.xml")
+    xml_content = f"""<GDALTileIndexDataset>
+  <IndexDataset>index.gti.gpkg</IndexDataset>
+  <Overview>
+      <Dataset>{prefix}index2.gti.gpkg</Dataset>
+  </Overview>
+</GDALTileIndexDataset>"""
+    gdal.FileFromMemBuffer(xml_filename, xml_content)
+
+    gti_ds = gdal.Open(xml_filename)
+    assert gti_ds.GetRasterBand(1).Checksum() == 4672
+    assert gti_ds.GetRasterBand(1).GetOverviewCount() == 1
+    assert gti_ds.GetRasterBand(1).GetOverview(0).Checksum() == expected_cs_ovr
+
+
+def test_gti_gpkg_relative_filename(tmp_vsimem):
+
+    index_filename = str(tmp_vsimem / "index.gti.gpkg")
+
+    tile_filename = str(tmp_vsimem / "byte.tif")
+    gdal.Translate(tile_filename, "data/byte.tif")
+
+    tile_ovr_filename = str(tmp_vsimem / "byte_ovr.tif")
+    gdal.Translate(tile_ovr_filename, "data/byte.tif", width=10)
+    with gdal.Open(tile_ovr_filename) as ds:
+        expected_cs_ovr = ds.GetRasterBand(1).Checksum()
+
+    src_ds = gdal.Open(tile_filename)
+    index_ds, index_lyr = create_basic_tileindex(index_filename, src_ds)
+    index_lyr.SetMetadataItem("OVERVIEW_0_DATASET", "index2.gti.gpkg")
+    del index_ds
+
+    index2_filename = str(tmp_vsimem / "index2.gti.gpkg")
+    create_basic_tileindex(index2_filename, gdal.Open(tile_ovr_filename))
+
+    gti_ds = gdal.Open(index_filename)
+    assert gti_ds.GetRasterBand(1).Checksum() == 4672
+    assert gti_ds.GetRasterBand(1).GetOverviewCount() == 1
+    assert gti_ds.GetRasterBand(1).GetOverview(0).Checksum() == expected_cs_ovr
+
+
 def test_gti_open_options(tmp_vsimem):
 
     index_filename = str(tmp_vsimem / "index.gti.gpkg")

--- a/doc/source/drivers/raster/gti.rst
+++ b/doc/source/drivers/raster/gti.rst
@@ -151,7 +151,7 @@ PostGIS, ...), the following layer metadata items may be set:
   those items is not needed.
 
 * ``GEOTRANSFORM=<gt0>,<gt1>,<gt2>,<gt3>,<gt4>,<gt5>``: defines the GeoTransform.
-  Used together with ``XSIZE`` and ``YSIZE``, this is an alternate way of
+  Used together with ``XSIZE`` and ``YSIZE``, this is an alternate way of
   defining the extent and resolution os the virtual mosaic.
 
   It is not necessary to define this item if ``RESX=`` and ``RESY`` are set
@@ -236,47 +236,14 @@ PostGIS, ...), the following layer metadata items may be set:
 
   Unit of the band.
 
-* ``OVERVIEW_<idx>_DATASET=<string>`` where idx is an integer index (starting at 0
-  since GDAL 3.9.2, starting at 1 in GDAL 3.9.0 and 3.9.1)
+* ``OVERVIEW_<idx>_DATASET=<string>``. See :ref:`raster.gti.overview.mdi`
 
-  Name of the dataset to use as the first overview level. This may be a
-  raster dataset (for example a GeoTIFF file, or another GTI dataset).
-  This may also be a vector dataset with a GTI compatible layer, potentially
-  specified with ``OVERVIEW_<idx>_LAYER``.
+* ``OVERVIEW_<idx>_LAYER=<string>``. See :ref:`raster.gti.overview.mdi`
 
-  Starting with GDAL 3.9.2, overviews of ``OVERVIEW_<idx>_DATASET=<string>``
-  are also automatically added, unless ``OVERVIEW_<idx>_OPEN_OPTIONS=OVERVIEW_LEVEL=NONE``
-  is specified.
+* ``OVERVIEW_<idx>_OPEN_OPTIONS=<key1=value1>[,key2=value2]...``.
+  See :ref:`raster.gti.overview.mdi`
 
-* ``OVERVIEW_<idx>_OPEN_OPTIONS=<key1=value1>[,key2=value2]...`` where idx is an integer index (starting at 0
-  since GDAL 3.9.2, starting at 1 in GDAL 3.9.0 and 3.9.1)
-
-  Open options(s) to use to open ``OVERVIEW_<idx>_DATASET``.
-
-* ``OVERVIEW_<idx>_LAYER=<string>`` where idx is an integer index (starting at 0
-  since GDAL 3.9.2, starting at 1 in GDAL 3.9.0 and 3.9.1)
-
-  Only taken into account if ``OVERVIEW_<idx>_DATASET=<string>`` is not specified,
-  or points to a GTI dataset.
-
-  Name of the vector layer to use as the first overview level, assuming
-  ``OVERVIEW_<idx>_DATASET`` points to a vector dataset. ``OVERVIEW_<idx>_DATASET``
-  may also not be specified, in which case the vector dataset of the full
-  resolution virtual mosaic is used.
-
-* ``OVERVIEW_<idx>_FACTOR=<int>`` where idx is an integer index (starting at 0
-  since GDAL 3.9.2, starting at 1 in GDAL 3.9.0 and 3.9.1)
-
-  Sub-sampling factor, strictly greater than 1.
-
-  Only taken into account if ``OVERVIEW_<idx>_DATASET=<string>`` is not specified,
-  or points to a GTI dataset.
-
-  If ``OVERVIEW_<idx>_DATASET`` and ``OVERVIEW_<idx>_LAYER`` are not specified, then all tiles of the full
-  resolution virtual mosaic are used, with the specified sub-sampling factor
-  (it is recommended, but not required, that those tiles do have a corresponding overview).
-  ``OVERVIEW_<idx>_DATASET`` and/or ``OVERVIEW_<idx>_LAYER`` may also be
-  specified to point to another tile index.
+* ``OVERVIEW_<idx>_FACTOR=<int>``. See  :ref:`raster.gti.overview.mdi`
 
 * ``INTERLEAVE=<val>`` (starting with GDAL 3.13) where ``<val>`` can be
   ``PIXEL`` or ``BAND`` specifies how pixels belonging to multiple bands are
@@ -400,7 +367,10 @@ mentioned in the previous section.
             <MDI key="FOO">BAR</MDI>
         </Metadata>
 
-        <Overview>                                     <!-- optional -->
+        <!-- Overview specification.
+             Not required, but overviews must be explicitly specified if desired.
+        -->
+        <Overview>
             <!-- 1st overview level will reuse the tile index of the
                  IndexDataset and IndexLayer elements, with all tiles considered
                  downsampled by a factor of 2 -->
@@ -413,21 +383,42 @@ mentioned in the previous section.
             <Factor>4</Factor>
         </Overview>
         <Overview>                                     <!-- optional -->
-            <!-- 3rd overview level (and potentially 4th, 5th... depending on
-                 the number of overview levels in the pointed GeoTIFF file.
-                 Only since GDAL 3.9.2)
+            <!-- 3rd overview level using a GeoTIFF file. If that file has itself
+                 overviews, they will also be added.
+                 To only specify the full resolution of the designated dataset,
+                 explicitly add <Factor>1</Factor>
             -->
             <Dataset>some.tif</Dataset>
         </Overview>
         <Overview>                                     <!-- optional -->
+            <!-- 4th overview level. -->
+            <Dataset>another.tif</Dataset>
+            <! -- The reduction factor is relative to the size of the full
+                  resolution layer of the designated dataset,
+                  and *not* relative to the size of the full
+                  resolution layer of the GTI dataset.
+                  It is also possible to select a particular overview by
+                  using the OVERVIEW_LEVEL open option.
+            -->
+            <Factor>4</Factor>
+        </Overview>
+        <Overview>                                     <!-- optional -->
+            <!-- 5th overview level. -->
+            <Dataset>another.tif</Dataset>
+            <! -- Use the overview level of index 2 -->
+             <OpenOptions>
+                  <OOI key="OVERVIEW_LEVEL">2</OOI>
+             </OpenOptions>
+        </Overview>
+        <Overview>                                     <!-- optional -->
             <!-- Last overview level points to another GTI dataset -->
             <Dataset>other.gti.gpkg</Dataset>
-            <Layer>other_layer</Layer>
+            <Layer>other_layer</Layer>                 <!-- optional -->
             <OpenOptions>                              <!-- optional -->
-                <OOI key="XMIN">0</OOI>
-                <OOI key="YMIN">1</OOI>
-                <OOI key="XMAX">2</OOI>
-                <OOI key="YMAX">3</OOI>
+                <OOI key="XMIN">2</OOI>
+                <OOI key="YMIN">49</OOI>
+                <OOI key="XMAX">3</OOI>
+                <OOI key="YMAX">50</OOI>
             </OpenOptions>
         </Overview>
 
@@ -584,6 +575,195 @@ also defined as layer metadata items or in the .gti XML file
       ``200MB``, ``1G``) or as a percentage of usable RAM (``10%``).
       Note that, in case of multi-threaded optimizations described in the
       paragraph below, the value applies for each warped source.
+
+
+Overviews
+---------
+
+By default the minimal configuration of a GTI dataset does not expose explicit
+overviews. But downsampled pixel requests to a GTI dataset may use overviews
+of the source tiles referenced by the GTI dataset when they exist.
+
+It is possible to provide explicit overview levels that the GTI dataset will
+expose to external users (and of course use for downsampled pixel requests).
+This can be done through one or several ``<Overview>`` elements in the
+GTI XML format, or by using specific layer metadata keys starting with
+``OVERVIEW_{idx}`` when using a vector dataset as the GTI dataset.
+
+In both cases, each added overview level may be:
+- a downsampled version of the main GTI dataset
+- another GTI dataset, at its full resolution or at a subsampled one
+- any other GDAL recognized raster file, at its full resolution or at a subsampled one.
+
+The order of declaration may matter. Overview levels directly or indirectly
+specified by later XML or metadata items are only added if their size is smaller
+than the previously added overview.
+
+.. _raster.gti.overview.xml:
+
+Overviews in XML
+++++++++++++++++
+
+The general syntax for each overview level is:
+
+   .. code-block:: xml
+
+        <Overview>
+            <Dataset>other.gti.gpkg</Dataset>
+            <Layer>other_layer</Layer>
+            <Factor>numeric_value_larger_than_one>
+            <OpenOptions>
+                <OOI key="key">value</OOI>
+            </OpenOptions>
+        </Overview>
+
+All elements are optional, but at least one of ``Dataset``, ``Layer`` or ``Factor``
+must be specific. Note also that at most one of those child elements is allowed
+per ``<Overview>`` element. So typically if several levels from a same dataset are
+needed, one ``<Overview>`` element per level must be specified.
+
+.. example::
+
+   This example uses the tile index of the IndexDataset and IndexLayer elements,
+   with all source tiles downsampled by a factor of 2.
+
+   .. code-block:: xml
+
+        <Overview>
+            <Factor>2</Factor>
+        </Overview>
+
+.. example::
+
+   This example uses a GeoTIFF file, and all its potential overviews, as overviews
+   of the GTI dataset
+
+   .. code-block:: xml
+
+        <Overview>
+            <Dataset>some.tif</Dataset>
+        </Overview>
+
+.. example::
+
+   This example uses the overview level of a GeoTIFF file whose dimensions are
+   at least four times smaller than the full resolution layer of ``another.tif``.
+
+   .. code-block:: xml
+
+        <Overview>
+            <Dataset>another.tif</Dataset>
+            <Factor>4</Factor>
+        </Overview>
+
+.. example::
+
+   This example uses the overview of index 2 of a GeoTIFF file (so given that
+   overview indexing starts at 0, and the full resolution layer is not including
+   in this numbering, this is the 4th layer in size of the file)
+
+   .. code-block:: xml
+
+        <Overview>
+            <Dataset>another.tif</Dataset>
+             <OpenOptions>
+                  <OOI key="OVERVIEW_LEVEL">2</OOI>
+             </OpenOptions>
+        </Overview>
+
+.. example::
+
+   This example points to another GTI dataset, with an explicit layer name,
+   and by adjusting its extent to the one of the main GTI dataset (assuming
+   such extent is 2,49,3,50).
+
+   .. code-block:: xml
+
+        <Overview>
+            <Dataset>other.gti.gpkg</Dataset>
+            <Layer>other_layer</Layer>
+            <OpenOptions>
+                <OOI key="XMIN">2</OOI>
+                <OOI key="YMIN">49</OOI>
+                <OOI key="XMAX">3</OOI>
+                <OOI key="YMAX">50</OOI>
+            </OpenOptions>
+        </Overview>
+
+
+.. _raster.gti.overview.mdi:
+
+Overviews as metadata items of a GDAL vector layer
+++++++++++++++++++++++++++++++++++++++++++++++++++
+
+The recognized metadata items all start with ``OVERVIEW_<idx>_`` where idx is
+an integer index (starting at 0 since GDAL 3.9.2, starting at 1 in previous versions
+
+* ``OVERVIEW_<idx>_DATASET=<string>``
+
+  Name of the dataset to use as an overview level. This may be a
+  raster dataset (for example a GeoTIFF file, or another GTI dataset).
+  This may also be a vector dataset with a GTI compatible layer, potentially
+  specified with ``OVERVIEW_<idx>_LAYER``.
+
+  Starting with GDAL 3.9.2, overviews of ``OVERVIEW_<idx>_DATASET=<string>``
+  are also automatically added, unless ``OVERVIEW_<idx>_OPEN_OPTIONS=OVERVIEW_LEVEL=NONE``
+  is specified (or, since 3.13, ``OVERVIEW_<idx>_FACTOR=1``)
+
+* ``OVERVIEW_<idx>_OPEN_OPTIONS=<key1=value1>[,key2=value2]...``
+
+  Open options(s) to use to open ``OVERVIEW_<idx>_DATASET``.
+
+* ``OVERVIEW_<idx>_LAYER=<string>``
+
+  Only taken into account if ``OVERVIEW_<idx>_DATASET=<string>`` is not specified,
+  or points to a GTI dataset.
+
+  Name of the vector layer to use as an overview level, assuming
+  ``OVERVIEW_<idx>_DATASET`` points to a vector dataset. ``OVERVIEW_<idx>_DATASET``
+  may also not be specified, in which case the vector dataset of the full
+  resolution virtual mosaic is used.
+
+* ``OVERVIEW_<idx>_FACTOR=<int>``
+
+  Sub-sampling factor, greater or equal to 1 (1 accepted only since GDAL 3.13)
+
+  Before GDAL 3.13, was only taken into account if ``OVERVIEW_<idx>_DATASET=<string>``
+  was not not specified, or pointed to a GTI dataset. Since GDAL 3.13,
+  ``OVERVIEW_<idx>_FACTOR`` is also accepted on any valid ``OVERVIEW_<idx>_DATASET``.
+
+  If ``OVERVIEW_<idx>_DATASET`` and ``OVERVIEW_<idx>_LAYER`` are not specified, then all tiles of the full
+  resolution virtual mosaic are used, with the specified sub-sampling factor
+  (it is recommended, but not required, that those tiles do have a corresponding overview).
+  ``OVERVIEW_<idx>_DATASET`` and/or ``OVERVIEW_<idx>_LAYER`` may also be
+  specified to point to another tile index.
+
+.. example::
+
+   This example is the equivalent of all the examples of the :ref:`raster.gti.overview.xml` section.
+
+   .. code-block::
+
+        # Use the sources of the current GTI file, downsampled by a factor of 2
+        OVERVIEW_0_FACTOR=2
+
+        # Use the full resolution of some.tif and all its potential overviews.
+        OVERVIEW_1_DATASET=some.tif
+
+        # Use the first overview level of another.tif that is at least smaller
+        # than the dimensions of its full resolution layer divided by a factor of 4.
+        OVERVIEW_2_DATASET=another.tif
+        OVERVIEW_2_FACTOR=4
+
+        # Use the overview of index 2 from another.tif
+        OVERVIEW_3_DATASET=another.tif
+        OVERVIEW_3_OPEN_OPTIONS=OVERVIEW_LEVEL=2
+
+        # Use 'other_layer' of 'other.gti.gpkg' and adjust its extent to the one
+        # of the main GTI dataset (assuming such extent is 2,49,3,50).
+        OVERVIEW_4_DATASET=other.gti.gpkg
+        OVERVIEW_4_LAYER=layer
+        OVERVIEW_4_OPEN_OPTIONS=XMIN=2,YMIN=49,XMAX=3,YMAX=50
 
 
 Multi-threading optimizations

--- a/frmts/gti/gdaltileindexdataset.cpp
+++ b/frmts/gti/gdaltileindexdataset.cpp
@@ -348,7 +348,8 @@ class GDALTileIndexDataset final : public GDALPamDataset
         m_aoOverviewDescriptor{};
 
     //! Array of overview datasets.
-    std::vector<std::unique_ptr<GDALDataset>> m_apoOverviews{};
+    std::vector<std::unique_ptr<GDALDataset, GDALDatasetUniquePtrReleaser>>
+        m_apoOverviews{};
 
     //! Cache of buffers used by VRTComplexSource to avoid memory reallocation.
     VRTSource::WorkingState m_oWorkingState{};
@@ -764,6 +765,35 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
              strstr(reinterpret_cast<const char *>(poOpenInfo->pabyHeader),
                     "<GDALTileIndexDataset"))
     {
+        if (CPLTestBool(CPLGetConfigOption("GDAL_XML_VALIDATION", "YES")))
+        {
+            const char *pszXSD = CPLFindFile("gdal", "gdaltileindex.xsd");
+            if (pszXSD != nullptr)
+            {
+                CPLErrorAccumulator oAccumulator;
+                int bRet;
+                {
+                    auto oContext = oAccumulator.InstallForCurrentScope();
+                    CPL_IGNORE_RET_VAL(oContext);
+                    bRet = CPLValidateXML(poOpenInfo->pszFilename, pszXSD,
+                                          nullptr);
+                }
+                if (!bRet)
+                {
+                    const auto &aoErrors = oAccumulator.GetErrors();
+                    if (!aoErrors.empty() &&
+                        aoErrors[0].msg.find("missing libxml2 support") ==
+                            std::string::npos)
+                    {
+                        for (size_t i = 0; i < aoErrors.size(); i++)
+                        {
+                            CPLError(CE_Warning, CPLE_AppDefined, "%s",
+                                     aoErrors[i].msg.c_str());
+                        }
+                    }
+                }
+            }
+        }
         // CPLParseXMLFile() emits an error in case of failure
         m_psXMLTree.reset(CPLParseXMLFile(poOpenInfo->pszFilename));
         if (m_psXMLTree == nullptr)
@@ -855,7 +885,8 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
             CSLFetchNameValue(poOpenInfo->papszOpenOptions, "FACTOR"))
     {
         dfOvrFactor = CPLAtof(pszFactor);
-        if (!(dfOvrFactor > 1.0))
+        // Written that way to catch NaN
+        if (!(dfOvrFactor >= 1.0))
         {
             CPLError(CE_Failure, CPLE_AppDefined, "Wrong overview factor");
             return false;
@@ -2416,6 +2447,20 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
     {
         if (psRoot)
         {
+            // Return the number of child elements of psNode whose name is pszElt
+            const auto CountChildElements =
+                [](const CPLXMLNode *psNode, const char *pszElt)
+            {
+                int nCount = 0;
+                for (const CPLXMLNode *psIter = psNode->psChild; psIter;
+                     psIter = psIter->psNext)
+                {
+                    if (strcmp(psIter->pszValue, pszElt) == 0)
+                        ++nCount;
+                }
+                return nCount;
+            };
+
             for (const CPLXMLNode *psIter = psRoot->psChild; psIter;
                  psIter = psIter->psNext)
             {
@@ -2438,6 +2483,17 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
                             GTI_XML_OVERVIEW_FACTOR, GTI_XML_OVERVIEW_ELEMENT);
                         return false;
                     }
+
+                    if (CountChildElements(psIter, GTI_XML_OVERVIEW_FACTOR) > 1)
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "At most one of %s element "
+                                 "is allowed per %s child.",
+                                 GTI_XML_OVERVIEW_FACTOR,
+                                 GTI_XML_OVERVIEW_ELEMENT);
+                        return false;
+                    }
+
                     m_aoOverviewDescriptor.emplace_back(
                         std::string(pszDataset ? pszDataset : ""),
                         CPLStringList(
@@ -2950,11 +3006,61 @@ void GDALTileIndexDataset::LoadOverviews()
                 }
             }
 
-            std::unique_ptr<GDALDataset> poOvrDS(GDALDataset::Open(
-                !osResolvedDSName.empty() ? osResolvedDSName.c_str()
-                                          : GetDescription(),
-                GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR, nullptr,
-                aosNewOpenOptions.List(), nullptr));
+            std::unique_ptr<GDALDataset, GDALDatasetUniquePtrReleaser> poOvrDS(
+                GDALDataset::Open(!osResolvedDSName.empty()
+                                      ? osResolvedDSName.c_str()
+                                      : GetDescription(),
+                                  GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR,
+                                  nullptr, aosNewOpenOptions.List(), nullptr));
+
+            // Make it possible to use the Factor option on a GeoTIFF for
+            // example and translate it to an overview level.
+            if (poOvrDS && dfFactor > 1 &&
+                poOvrDS->GetRasterCount() == GetRasterCount() &&
+                aosOpenOptions.FetchNameValue("OVERVIEW_LEVEL") == nullptr)
+            {
+                auto poBand = poOvrDS->GetRasterBand(1);
+                for (int iOvr = 0; iOvr < poBand->GetOverviewCount(); ++iOvr)
+                {
+                    auto poOvrBand = poBand->GetOverview(iOvr);
+                    if (dfFactor * poOvrBand->GetXSize() <=
+                            poOvrDS->GetRasterXSize() ||
+                        dfFactor * poOvrBand->GetYSize() <=
+                            poOvrDS->GetRasterYSize())
+                    {
+                        GDALDataset *poNewOvrDS = GDALCreateOverviewDataset(
+                            poOvrDS.get(), iOvr, /*bThisLevelOnly = */ true);
+                        if (!poNewOvrDS)
+                            continue;
+
+                        const auto RelativeDifferenceBelowThreshold =
+                            [](double a, double b, double dfRelativeThreshold)
+                        {
+                            return std::fabs(a - b) <=
+                                   std::fabs(a) * dfRelativeThreshold;
+                        };
+                        constexpr double RELATIVE_THRESHOLD = 0.01;
+                        if (RelativeDifferenceBelowThreshold(
+                                dfFactor * poOvrBand->GetXSize(),
+                                poOvrDS->GetRasterXSize(),
+                                RELATIVE_THRESHOLD) &&
+                            RelativeDifferenceBelowThreshold(
+                                dfFactor * poOvrBand->GetYSize(),
+                                poOvrDS->GetRasterYSize(), RELATIVE_THRESHOLD))
+                        {
+                            CPLDebug("GTI",
+                                     "Using overview of size %dx%d as best "
+                                     "approximation for requested overview of "
+                                     "factor %f of %s",
+                                     poOvrBand->GetXSize(),
+                                     poOvrBand->GetYSize(), dfFactor,
+                                     osResolvedDSName.c_str());
+                        }
+
+                        poOvrDS.reset(poNewOvrDS);
+                    }
+                }
+            }
 
             const auto IsSmaller =
                 [](const GDALDataset *a, const GDALDataset *b)
@@ -2972,11 +3078,17 @@ void GDALTileIndexDataset::LoadOverviews()
             {
                 if (poOvrDS->GetRasterCount() == GetRasterCount())
                 {
+                    CPLDebug(
+                        "GTI", "Using overview of size %dx%d from %s",
+                        poOvrDS->GetRasterXSize(), poOvrDS->GetRasterYSize(),
+                        osResolvedDSName.empty() ? GetDescription()
+                                                 : osResolvedDSName.c_str());
                     m_apoOverviews.emplace_back(std::move(poOvrDS));
                     // Add the overviews of the overview, unless the OVERVIEW_LEVEL
-                    // option option is specified
+                    // option option or FACTOR is specified
                     if (aosOpenOptions.FetchNameValue("OVERVIEW_LEVEL") ==
-                        nullptr)
+                            nullptr &&
+                        dfFactor == 0)
                     {
                         const int nOverviewCount = m_apoOverviews.back()
                                                        ->GetRasterBand(1)
@@ -2985,8 +3097,9 @@ void GDALTileIndexDataset::LoadOverviews()
                         {
                             aosNewOpenOptions.SetNameValue("OVERVIEW_LEVEL",
                                                            CPLSPrintf("%d", i));
-                            std::unique_ptr<GDALDataset> poOvrOfOvrDS(
-                                GDALDataset::Open(
+                            std::unique_ptr<GDALDataset,
+                                            GDALDatasetUniquePtrReleaser>
+                                poOvrOfOvrDS(GDALDataset::Open(
                                     !osResolvedDSName.empty()
                                         ? osResolvedDSName.c_str()
                                         : GetDescription(),
@@ -2999,6 +3112,14 @@ void GDALTileIndexDataset::LoadOverviews()
                                 IsSmaller(poOvrOfOvrDS.get(),
                                           m_apoOverviews.back().get()))
                             {
+                                CPLDebug("GTI",
+                                         "Using automatically overview of size "
+                                         "%dx%d from %s",
+                                         poOvrOfOvrDS->GetRasterXSize(),
+                                         poOvrOfOvrDS->GetRasterYSize(),
+                                         osResolvedDSName.empty()
+                                             ? GetDescription()
+                                             : osResolvedDSName.c_str());
                                 m_apoOverviews.emplace_back(
                                     std::move(poOvrOfOvrDS));
                             }
@@ -3011,6 +3132,15 @@ void GDALTileIndexDataset::LoadOverviews()
                              "%s has not the same number of bands as %s",
                              poOvrDS->GetDescription(), GetDescription());
                 }
+            }
+            else if (poOvrDS)
+            {
+                CPLDebug("GTI",
+                         "Skipping overview of size %dx%d from %s as it is "
+                         "larger than a previously added overview",
+                         poOvrDS->GetRasterXSize(), poOvrDS->GetRasterYSize(),
+                         osResolvedDSName.empty() ? GetDescription()
+                                                  : osResolvedDSName.c_str());
             }
         }
     }

--- a/frmts/gti/gdaltileindexdataset.cpp
+++ b/frmts/gti/gdaltileindexdataset.cpp
@@ -232,6 +232,11 @@ class GDALTileIndexDataset final : public GDALPamDataset
   private:
     friend class GDALTileIndexBand;
 
+    /** Directory where the main (.xml / .gti.gpkg) file is located.
+     * Used for relative filenames resolution.
+     */
+    std::string m_osBaseDir{};
+
     //! Optional GTI XML
     CPLXMLTreeCloser m_psXMLTree{nullptr};
 
@@ -741,13 +746,14 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
     eAccess = poOpenInfo->eAccess;
 
     CPLXMLNode *psRoot = nullptr;
-    const char *pszIndexDataset = poOpenInfo->pszFilename;
+    std::string osIndexDataset(poOpenInfo->pszFilename);
 
-    if (STARTS_WITH(poOpenInfo->pszFilename, GTI_PREFIX))
+    if (cpl::starts_with(osIndexDataset, GTI_PREFIX))
     {
-        pszIndexDataset = poOpenInfo->pszFilename + strlen(GTI_PREFIX);
+        osIndexDataset = osIndexDataset.substr(strlen(GTI_PREFIX));
+        m_osBaseDir = CPLGetPathSafe(osIndexDataset.c_str());
     }
-    else if (STARTS_WITH(poOpenInfo->pszFilename, "<GDALTileIndexDataset"))
+    else if (cpl::starts_with(osIndexDataset, "<GDALTileIndexDataset"))
     {
         // CPLParseXMLString() emits an error in case of failure
         m_psXMLTree.reset(CPLParseXMLString(poOpenInfo->pszFilename));
@@ -763,6 +769,11 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
         if (m_psXMLTree == nullptr)
             return false;
         m_bXMLUpdatable = (poOpenInfo->eAccess == GA_Update);
+        m_osBaseDir = CPLGetPathSafe(osIndexDataset.c_str());
+    }
+    else
+    {
+        m_osBaseDir = CPLGetPathSafe(osIndexDataset.c_str());
     }
 
     if (m_psXMLTree)
@@ -775,23 +786,34 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
             return false;
         }
 
-        pszIndexDataset = CPLGetXMLValue(psRoot, "IndexDataset", nullptr);
+        const char *pszIndexDataset =
+            CPLGetXMLValue(psRoot, "IndexDataset", nullptr);
         if (!pszIndexDataset)
         {
             CPLError(CE_Failure, CPLE_AppDefined,
                      "Missing IndexDataset element.");
             return false;
         }
+
+        if (!m_osBaseDir.empty() && CPLIsFilenameRelative(pszIndexDataset))
+        {
+            osIndexDataset = CPLFormFilenameSafe(m_osBaseDir.c_str(),
+                                                 pszIndexDataset, nullptr);
+        }
+        else
+        {
+            osIndexDataset = pszIndexDataset;
+        }
     }
 
-    if (ENDS_WITH_CI(pszIndexDataset, ".gti.gpkg") &&
+    if (ENDS_WITH_CI(osIndexDataset.c_str(), ".gti.gpkg") &&
         poOpenInfo->nHeaderBytes >= 100 &&
         STARTS_WITH(reinterpret_cast<const char *>(poOpenInfo->pabyHeader),
                     "SQLite format 3"))
     {
         const char *const apszAllowedDrivers[] = {"GPKG", nullptr};
         m_poVectorDS.reset(GDALDataset::Open(
-            std::string("GPKG:\"").append(pszIndexDataset).append("\"").c_str(),
+            std::string("GPKG:\"").append(osIndexDataset).append("\"").c_str(),
             GDAL_OF_VECTOR | GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR |
                 ((poOpenInfo->nOpenFlags & GDAL_OF_UPDATE) ? GDAL_OF_UPDATE
                                                            : GDAL_OF_READONLY),
@@ -809,11 +831,12 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
     }
     else
     {
-        m_poVectorDS.reset(GDALDataset::Open(
-            pszIndexDataset, GDAL_OF_VECTOR | GDAL_OF_VERBOSE_ERROR |
-                                 ((poOpenInfo->nOpenFlags & GDAL_OF_UPDATE)
-                                      ? GDAL_OF_UPDATE
-                                      : GDAL_OF_READONLY)));
+        m_poVectorDS.reset(
+            GDALDataset::Open(osIndexDataset.c_str(),
+                              GDAL_OF_VECTOR | GDAL_OF_VERBOSE_ERROR |
+                                  ((poOpenInfo->nOpenFlags & GDAL_OF_UPDATE)
+                                       ? GDAL_OF_UPDATE
+                                       : GDAL_OF_READONLY)));
         if (!m_poVectorDS)
         {
             return false;
@@ -823,7 +846,7 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
     if (m_poVectorDS->GetLayerCount() == 0)
     {
         CPLError(CE_Failure, CPLE_AppDefined, "%s has no vector layer",
-                 poOpenInfo->pszFilename);
+                 osIndexDataset.c_str());
         return false;
     }
 
@@ -932,7 +955,7 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
                      "%s has more than one layer. LAYER open option "
                      "must be defined to specify which one to "
                      "use as the tile index",
-                     pszIndexDataset);
+                     osIndexDataset.c_str());
         }
         else if (psRoot)
         {
@@ -940,7 +963,7 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
                      "%s has more than one layer. IndexLayer element must be "
                      "defined to specify which one to "
                      "use as the tile index",
-                     pszIndexDataset);
+                     osIndexDataset.c_str());
         }
         else
         {
@@ -948,7 +971,7 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
                      "%s has more than one layer. %s "
                      "metadata item must be defined to specify which one to "
                      "use as the tile index",
-                     pszIndexDataset, MD_DS_TILE_INDEX_LAYER);
+                     osIndexDataset.c_str(), MD_DS_TILE_INDEX_LAYER);
         }
         return false;
     }
@@ -2907,8 +2930,29 @@ void GDALTileIndexDataset::LoadOverviews()
                 aosNewOpenOptions.SetNameValue("@LAYER", osLyrName.c_str());
             }
 
+            std::string osResolvedDSName(osDSName);
+            if (!m_osBaseDir.empty() && !osResolvedDSName.empty() &&
+                CPLIsFilenameRelative(osResolvedDSName.c_str()))
+            {
+                if (cpl::starts_with(osResolvedDSName, GTI_PREFIX))
+                {
+                    osResolvedDSName =
+                        GTI_PREFIX +
+                        CPLFormFilenameSafe(m_osBaseDir.c_str(),
+                                            osResolvedDSName.c_str() +
+                                                strlen(GTI_PREFIX),
+                                            nullptr);
+                }
+                else
+                {
+                    osResolvedDSName = CPLFormFilenameSafe(
+                        m_osBaseDir.c_str(), osResolvedDSName.c_str(), nullptr);
+                }
+            }
+
             std::unique_ptr<GDALDataset> poOvrDS(GDALDataset::Open(
-                !osDSName.empty() ? osDSName.c_str() : GetDescription(),
+                !osResolvedDSName.empty() ? osResolvedDSName.c_str()
+                                          : GetDescription(),
                 GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR, nullptr,
                 aosNewOpenOptions.List(), nullptr));
 
@@ -2943,8 +2987,9 @@ void GDALTileIndexDataset::LoadOverviews()
                                                            CPLSPrintf("%d", i));
                             std::unique_ptr<GDALDataset> poOvrOfOvrDS(
                                 GDALDataset::Open(
-                                    !osDSName.empty() ? osDSName.c_str()
-                                                      : GetDescription(),
+                                    !osResolvedDSName.empty()
+                                        ? osResolvedDSName.c_str()
+                                        : GetDescription(),
                                     GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR,
                                     nullptr, aosNewOpenOptions.List(),
                                     nullptr));

--- a/gcore/gdal_cpp_functions.h
+++ b/gcore/gdal_cpp_functions.h
@@ -258,8 +258,8 @@ void GDALRasterIOExtraArgSetResampleAlg(GDALRasterIOExtraArg *psExtraArg,
                                         int nXSize, int nYSize, int nBufXSize,
                                         int nBufYSize);
 
-GDALDataset *GDALCreateOverviewDataset(GDALDataset *poDS, int nOvrLevel,
-                                       bool bThisLevelOnly);
+GDALDataset CPL_DLL *GDALCreateOverviewDataset(GDALDataset *poDS, int nOvrLevel,
+                                               bool bThisLevelOnly);
 
 // Should cover particular cases of #3573, #4183, #4506, #6578
 // Behavior is undefined if fVal1 or fVal2 are NaN (should be tested before

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -437,7 +437,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "GDAL_WARP_USE_AFFINE_OPTIMIZATION", // from gdalwarpkernel.cpp
    "GDAL_WARP_USE_TRANSLATION_OPTIM", // from gdalwarpoperation.cpp
    "GDAL_WMS_MAX_CONNECTIONS", // from gdalogcapidataset.cpp
-   "GDAL_XML_VALIDATION", // from ogrgmlasconf.cpp, ogrvrtdriver.cpp, pdfcreatefromcomposition.cpp
+   "GDAL_XML_VALIDATION", // from gdaltileindexdataset.cpp, ogrgmlasconf.cpp, ogrvrtdriver.cpp, pdfcreatefromcomposition.cpp
    "GDAL_ZARR_SHARD_INDEX_CACHE_MAX_BYTES", // from zarr_v3_codec_sharding.cpp
    "GDAL_ZARR_USE_OPTIMIZED_CODE_PATHS", // from zarr_array.cpp
    "GDALCUTLINE_SKIP_CONTAINMENT_TEST", // from gdalcutline.cpp


### PR DESCRIPTION
- allow Factor=1 (for full resolution) in Overview element
- allow Factor to work with a non-GTI datasets
- XML validation against the schema
- explicit detection of repeated Factor elements with the same Overview
- better doc

Fixes #14345, fixes #14346

(on top of PR #14350 to avoid merge conflicts)