### PR TITLE
gdal vector clip: make sure clipping geom is valid

### DIFF
--- a/apps/gdalalg_vector_clip.cpp
+++ b/apps/gdalalg_vector_clip.cpp
@@ -238,17 +238,31 @@ bool GDALVectorClipAlgorithm::RunStep(GDALPipelineStepRunContext &)
             if (m_activeLayer.empty() ||
                 m_activeLayer == poSrcLayer->GetDescription())
             {
+                const OGRSpatialReference *clipSRS =
+                    poClipGeom->getSpatialReference();
+                const OGRSpatialReference *layerSRS =
+                    poSrcLayer->GetSpatialRef();
+
                 auto poClipGeomForLayer =
                     std::unique_ptr<OGRGeometry>(poClipGeom->clone());
-                if (poClipGeomForLayer->getSpatialReference() &&
-                    poSrcLayer->GetSpatialRef())
+                if (clipSRS && layerSRS && !clipSRS->IsSame(layerSRS))
                 {
                     ret = poClipGeomForLayer->transformTo(
                               poSrcLayer->GetSpatialRef()) == OGRERR_NONE;
+                    if (ret && !poClipGeomForLayer->IsValid())
+                    {
+                        ReportError(
+                            CE_Failure, CPLE_AppDefined,
+                            "Clipping geometry became invalid upon "
+                            "transformation to the layer SRS. You can "
+                            "try transforming the geometry and repairing it "
+                            "separately with 'gdal vector reproject' "
+                            "and 'gdal vector make-valid'.");
+                        ret = false;
+                    }
                 }
                 if (ret)
                 {
-
                     outDS->AddLayer(
                         *poSrcLayer,
                         std::make_unique<GDALVectorClipAlgorithmLayer>(

--- a/apps/gdalalg_vector_clip.cpp
+++ b/apps/gdalalg_vector_clip.cpp
@@ -208,6 +208,13 @@ bool GDALVectorClipAlgorithm::RunStep(GDALPipelineStepRunContext &)
         ReportError(CE_Failure, CPLE_AppDefined, "%s", errMsg.c_str());
         return false;
     }
+    if (!poClipGeom->IsValid())
+    {
+        ReportError(CE_Failure, CPLE_AppDefined,
+                    "Clipping geometry is invalid. You can attempt to correct "
+                    "it with 'gdal vector make-valid'.");
+        return false;
+    }
 
     auto poLikeDS = m_likeDataset.GetDatasetRef();
     if (bSrcLayerHasSRS && !poClipGeom->getSpatialReference() && poLikeDS &&
@@ -241,6 +248,7 @@ bool GDALVectorClipAlgorithm::RunStep(GDALPipelineStepRunContext &)
                 }
                 if (ret)
                 {
+
                     outDS->AddLayer(
                         *poSrcLayer,
                         std::make_unique<GDALVectorClipAlgorithmLayer>(

--- a/apps/gdalalg_vector_clip.cpp
+++ b/apps/gdalalg_vector_clip.cpp
@@ -228,70 +228,63 @@ bool GDALVectorClipAlgorithm::RunStep(GDALPipelineStepRunContext &)
 
     auto outDS = std::make_unique<GDALVectorPipelineOutputDataset>(*poSrcDS);
 
-    bool ret = true;
-    for (int i = 0; ret && i < nLayerCount; ++i)
+    for (int i = 0; i < nLayerCount; ++i)
     {
-        auto poSrcLayer = poSrcDS->GetLayer(i);
-        ret = (poSrcLayer != nullptr);
-        if (ret)
+        const auto poSrcLayer = poSrcDS->GetLayer(i);
+        if (poSrcLayer == nullptr)
         {
-            if (m_activeLayer.empty() ||
-                m_activeLayer == poSrcLayer->GetDescription())
+            return false;
+        }
+
+        if (m_activeLayer.empty() ||
+            m_activeLayer == poSrcLayer->GetDescription())
+        {
+            const OGRSpatialReference *clipSRS =
+                poClipGeom->getSpatialReference();
+            const OGRSpatialReference *layerSRS = poSrcLayer->GetSpatialRef();
+
+            auto poClipGeomForLayer =
+                std::unique_ptr<OGRGeometry>(poClipGeom->clone());
+            if (clipSRS && layerSRS && !clipSRS->IsSame(layerSRS))
             {
-                const OGRSpatialReference *clipSRS =
-                    poClipGeom->getSpatialReference();
-                const OGRSpatialReference *layerSRS =
-                    poSrcLayer->GetSpatialRef();
-
-                auto poClipGeomForLayer =
-                    std::unique_ptr<OGRGeometry>(poClipGeom->clone());
-                if (clipSRS && layerSRS && !clipSRS->IsSame(layerSRS))
+                if (poClipGeomForLayer->transformTo(
+                        poSrcLayer->GetSpatialRef()) != OGRERR_NONE)
                 {
-                    ret = poClipGeomForLayer->transformTo(
-                              poSrcLayer->GetSpatialRef()) == OGRERR_NONE;
-
-                    if (!ret)
-                    {
-                        ReportError(CE_Failure, CPLE_AppDefined,
-                                    "Could not transform clipping geometry to "
-                                    "layer SRS.");
-                        ret = false;
-                    }
-
-                    if (ret && !poClipGeomForLayer->IsValid())
-                    {
-                        ReportError(
-                            CE_Failure, CPLE_AppDefined,
-                            "Clipping geometry became invalid upon "
-                            "transformation to the layer SRS. You can "
-                            "try transforming the geometry and repairing it "
-                            "separately with 'gdal vector reproject' "
-                            "and 'gdal vector make-valid'.");
-                        ret = false;
-                    }
+                    ReportError(CE_Failure, CPLE_AppDefined,
+                                "Could not transform clipping geometry to "
+                                "layer SRS.");
+                    return false;
                 }
-                if (ret)
+
+                if (!poClipGeomForLayer->IsValid())
                 {
-                    outDS->AddLayer(
-                        *poSrcLayer,
-                        std::make_unique<GDALVectorClipAlgorithmLayer>(
-                            *poSrcLayer, std::move(poClipGeomForLayer)));
+                    ReportError(
+                        CE_Failure, CPLE_AppDefined,
+                        "Clipping geometry became invalid upon "
+                        "transformation to the layer SRS. You can "
+                        "try transforming the geometry and repairing it "
+                        "separately with 'gdal vector reproject' "
+                        "and 'gdal vector make-valid'.");
+                    return false;
                 }
             }
-            else
-            {
-                outDS->AddLayer(
-                    *poSrcLayer,
-                    std::make_unique<GDALVectorPipelinePassthroughLayer>(
-                        *poSrcLayer));
-            }
+
+            outDS->AddLayer(*poSrcLayer,
+                            std::make_unique<GDALVectorClipAlgorithmLayer>(
+                                *poSrcLayer, std::move(poClipGeomForLayer)));
+        }
+        else
+        {
+            outDS->AddLayer(
+                *poSrcLayer,
+                std::make_unique<GDALVectorPipelinePassthroughLayer>(
+                    *poSrcLayer));
         }
     }
 
-    if (ret)
-        m_outputDataset.Set(std::move(outDS));
+    m_outputDataset.Set(std::move(outDS));
 
-    return ret;
+    return true;
 }
 
 GDALVectorClipAlgorithmStandalone::~GDALVectorClipAlgorithmStandalone() =

--- a/apps/gdalalg_vector_clip.cpp
+++ b/apps/gdalalg_vector_clip.cpp
@@ -249,6 +249,15 @@ bool GDALVectorClipAlgorithm::RunStep(GDALPipelineStepRunContext &)
                 {
                     ret = poClipGeomForLayer->transformTo(
                               poSrcLayer->GetSpatialRef()) == OGRERR_NONE;
+
+                    if (!ret)
+                    {
+                        ReportError(CE_Failure, CPLE_AppDefined,
+                                    "Could not transform clipping geometry to "
+                                    "layer SRS.");
+                        ret = false;
+                    }
+
                     if (ret && !poClipGeomForLayer->IsValid())
                     {
                         ReportError(

--- a/autotest/utilities/test_gdalalg_vector_clip.py
+++ b/autotest/utilities/test_gdalalg_vector_clip.py
@@ -466,6 +466,23 @@ def test_gdalalg_vector_clip_geom_invalid_after_transform():
         clip.Run()
 
 
+def test_gdalalg_vector_clip_geom_fails_to_transform():
+
+    srs = osr.SpatialReference("+proj=gnom +lat_0=90 +lon_0=-50 +R=6.4e6")
+
+    ds = gdal.GetDriverByName("MEM").CreateVector("")
+    ds.CreateLayer("features", srs=srs)
+
+    clip = get_clip_alg()
+    clip["input"] = ds
+    clip["geometry"] = "POLYGON ((-20 -20, 0 -20, 0 0, -20 0, -20 -20))"
+    clip["geometry-crs"] = "EPSG:4326"
+    clip["output-format"] = "MEM"
+
+    with pytest.raises(Exception, match="Could not transform clipping geometry"):
+        clip.Run()
+
+
 def test_gdalalg_vector_clip_intersection_incompatible_geometry_type():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 0, 0, 0, gdal.GDT_Unknown)

--- a/autotest/utilities/test_gdalalg_vector_clip.py
+++ b/autotest/utilities/test_gdalalg_vector_clip.py
@@ -449,6 +449,23 @@ def test_gdalalg_vector_clip_geom_invalid():
         clip.Run()
 
 
+def test_gdalalg_vector_clip_geom_invalid_after_transform():
+
+    srs = osr.SpatialReference("+proj=gnom +lat_0=90 +lon_0=-50 +R=6.4e6")
+
+    ds = gdal.GetDriverByName("MEM").CreateVector("")
+    ds.CreateLayer("features", srs=srs)
+
+    clip = get_clip_alg()
+    clip["input"] = ds
+    clip["geometry"] = "POLYGON ((-20 1, 0 1, 0 2, -10 1.0000001, -20 2, -20 1))"
+    clip["geometry-crs"] = "EPSG:4326"
+    clip["output-format"] = "MEM"
+
+    with pytest.raises(Exception, match="geometry became invalid"):
+        clip.Run()
+
+
 def test_gdalalg_vector_clip_intersection_incompatible_geometry_type():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 0, 0, 0, gdal.GDT_Unknown)

--- a/autotest/utilities/test_gdalalg_vector_clip.py
+++ b/autotest/utilities/test_gdalalg_vector_clip.py
@@ -436,6 +436,19 @@ def test_gdalalg_vector_clip_geom_not_rectangle():
     assert out_lyr.GetNextFeature() is None
 
 
+def test_gdalalg_vector_clip_geom_invalid():
+
+    clip = get_clip_alg()
+    clip["input"] = "../ogr/data/poly.shp"
+    clip["geometry"] = (
+        "POLYGON ((478919 4763746, 480410 4763753, 478974 4764785, 479934 4764846, 478919 4763746))"
+    )
+    clip["output-format"] = "MEM"
+
+    with pytest.raises(Exception, match="geometry is invalid"):
+        clip.Run()
+
+
 def test_gdalalg_vector_clip_intersection_incompatible_geometry_type():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 0, 0, 0, gdal.GDT_Unknown)


### PR DESCRIPTION
- Match behavior of ogr2ogr when clipping geometry is invalid. 
- Check if geometry becomes invalid upon transformation.
- Emit error message if transformation fails.
- Use early returns to simplify code