### PR TITLE
[Backport release/3.12] gdal raster as-features: avoid missing features with --skip-nodata

### DIFF
--- a/apps/gdalalg_raster_as_features.cpp
+++ b/apps/gdalalg_raster_as_features.cpp
@@ -281,6 +281,11 @@ class GDALRasterAsFeaturesLayer final
                 m_row++;
             }
 
+            if (m_row >= m_window.nYSize)
+            {
+                NextWindow();
+            }
+
             if (feature)
             {
                 return feature.release();

--- a/autotest/utilities/test_gdalalg_raster_as_features.py
+++ b/autotest/utilities/test_gdalalg_raster_as_features.py
@@ -11,6 +11,7 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import gdaltest
 import pytest
 
 from osgeo import gdal, ogr
@@ -248,3 +249,35 @@ def test_gdalalg_raster_as_features_zero_width(alg, tmp_vsimem):
     lyr = ds.GetLayer(0)
 
     assert lyr.GetFeatureCount() == 0
+
+
+def test_gdalalg_as_features_empty_row_at_end_of_block(alg, tmp_vsimem):
+    # See https://github.com/OSGeo/gdal/issues/14348
+
+    gdaltest.importorskip_gdal_array()
+    np = pytest.importorskip("numpy")
+
+    src_fname = tmp_vsimem / "src.tif"
+
+    with gdal.GetDriverByName("GTiff").Create(
+        src_fname,
+        64,
+        64,
+        1,
+        options={"TILED": True, "BLOCKXSIZE": 32, "BLOCKYSIZE": 32},
+    ) as ds:
+        ds.GetRasterBand(1).SetNoDataValue(0)
+        data = np.zeros((64, 64))
+        data[63, 63] = 1
+        ds.WriteArray(data)
+
+    alg["input"] = src_fname
+    alg["output-format"] = "MEM"
+    alg["skip-nodata"] = True
+
+    assert alg.Run()
+
+    ds = alg.Output()
+    lyr = ds.GetLayer(0)
+
+    assert lyr.GetFeatureCount() == 1


### PR DESCRIPTION
Backport #14351
 **Authored by:** @dbaston