### PR TITLE
Resampling: fix wrong NaN handling for bilinear/cubic/cubicspline/lanczos

### DIFF
--- a/autotest/gcore/rasterio.py
+++ b/autotest/gcore/rasterio.py
@@ -4074,3 +4074,48 @@ def test_rasterio_resampling_output_type_not_native_type_numpy(operate_in_buf_ty
         assert got[0][0] == pytest.approx(5)
     else:
         assert got[0][0] == pytest.approx(4.514563083648682)
+
+
+@pytest.mark.parametrize("dt", [gdal.GDT_Float32, gdal.GDT_Float64])
+@pytest.mark.parametrize("factor", [2, 4, 8])
+@pytest.mark.parametrize(
+    "resample_alg",
+    [
+        gdal.GRIORA_Bilinear,
+        gdal.GRIORA_Cubic,
+        gdal.GRIORA_CubicSpline,
+        gdal.GRIORA_Lanczos,
+        gdal.GRIORA_Mode,
+        gdal.GRIORA_Average,
+        gdal.GRIORA_RMS,
+    ],
+)
+def test_rasterio_resampling_nan_nodata(dt, factor, resample_alg):
+    # Check that NaN, when declared as band nodata, and present in values
+    # does not "contaminate" the results.
+
+    w = 16
+    h = 16
+    src_ds = gdal.GetDriverByName("MEM").Create("", w, h, 1, dt)
+    src_ds.GetRasterBand(1).SetNoDataValue(float("nan"))
+    src_ds.GetRasterBand(1).Fill(1)
+    src_ds.GetRasterBand(1).WriteRaster(
+        7,
+        7,
+        1,
+        1,
+        (
+            struct.pack("f", float("nan"))
+            if dt == gdal.GDT_Float32
+            else struct.pack("d", float("nan"))
+        ),
+    )
+
+    buf_w = w // factor
+    buf_h = h // factor
+    buf = src_ds.ReadRaster(0, 0, w, h, buf_w, buf_h, resample_alg=resample_alg)
+    if dt == gdal.GDT_Float32:
+        buf = struct.unpack("f" * (buf_w * buf_h), buf)
+    else:
+        buf = struct.unpack("d" * (buf_w * buf_h), buf)
+    assert buf == pytest.approx((1.0,) * (buf_w * buf_h))

--- a/gcore/overview.cpp
+++ b/gcore/overview.cpp
@@ -2771,7 +2771,7 @@ GDALResampleConvolutionHorizontal(const T *pChunk, const double *padfWeights,
     return dfVal1 + dfVal2;
 }
 
-template <class T>
+template <class T, bool bHasNaN>
 static inline void GDALResampleConvolutionHorizontalWithMask(
     const T *pChunk, const GByte *pabyMask, const double *padfWeights,
     int nSrcPixelCount, double &dfVal, double &dfWeightSum)
@@ -2781,25 +2781,50 @@ static inline void GDALResampleConvolutionHorizontalWithMask(
     int i = 0;
     for (; i < nSrcPixelCount - 3; i += 4)
     {
-        const double dfWeight0 = padfWeights[i] * pabyMask[i];
-        const double dfWeight1 = padfWeights[i + 1] * pabyMask[i + 1];
-        const double dfWeight2 = padfWeights[i + 2] * pabyMask[i + 2];
-        const double dfWeight3 = padfWeights[i + 3] * pabyMask[i + 3];
-        dfVal += double(pChunk[i + 0]) * dfWeight0;
-        dfVal += double(pChunk[i + 1]) * dfWeight1;
-        dfVal += double(pChunk[i + 2]) * dfWeight2;
-        dfVal += double(pChunk[i + 3]) * dfWeight3;
+        double dfWeight0 = padfWeights[i + 0] * pabyMask[i + 0];
+        double dfWeight1 = padfWeights[i + 1] * pabyMask[i + 1];
+        double dfWeight2 = padfWeights[i + 2] * pabyMask[i + 2];
+        double dfWeight3 = padfWeights[i + 3] * pabyMask[i + 3];
+
+        const auto MulNaNAware = [](double v, double &w, double &val)
+        {
+            if constexpr (bHasNaN)
+            {
+                if (std::isnan(v))
+                {
+                    w = 0;
+                    return;
+                }
+            }
+            val += v * w;
+        };
+
+        MulNaNAware(double(pChunk[i + 0]), dfWeight0, dfVal);
+        MulNaNAware(double(pChunk[i + 1]), dfWeight1, dfVal);
+        MulNaNAware(double(pChunk[i + 2]), dfWeight2, dfVal);
+        MulNaNAware(double(pChunk[i + 3]), dfWeight3, dfVal);
         dfWeightSum += dfWeight0 + dfWeight1 + dfWeight2 + dfWeight3;
     }
     for (; i < nSrcPixelCount; ++i)
     {
         const double dfWeight = padfWeights[i] * pabyMask[i];
-        dfVal += double(pChunk[i]) * dfWeight;
-        dfWeightSum += dfWeight;
+        if constexpr (bHasNaN)
+        {
+            if (!std::isnan(pChunk[i]))
+            {
+                dfVal += double(pChunk[i]) * dfWeight;
+                dfWeightSum += dfWeight;
+            }
+        }
+        else
+        {
+            dfVal += double(pChunk[i]) * dfWeight;
+            dfWeightSum += dfWeight;
+        }
     }
 }
 
-template <class T>
+template <class T, bool bHasNaN>
 static inline void GDALResampleConvolutionHorizontal_3rows(
     const T *pChunkRow1, const T *pChunkRow2, const T *pChunkRow3,
     const double *padfWeights, int nSrcPixelCount, double &dfRes1,
@@ -2812,51 +2837,62 @@ static inline void GDALResampleConvolutionHorizontal_3rows(
     double dfVal5 = 0.0;
     double dfVal6 = 0.0;
     int i = 0;  // Used after for.
+
+    const auto MulNaNAware = [](double a, double w)
+    {
+        if constexpr (bHasNaN)
+        {
+            if (std::isnan(a))
+                return 0.0;
+        }
+        return a * w;
+    };
+
     for (; i < nSrcPixelCount - 3; i += 4)
     {
-        dfVal1 += double(pChunkRow1[i + 0]) * padfWeights[i + 0];
-        dfVal1 += double(pChunkRow1[i + 1]) * padfWeights[i + 1];
-        dfVal2 += double(pChunkRow1[i + 2]) * padfWeights[i + 2];
-        dfVal2 += double(pChunkRow1[i + 3]) * padfWeights[i + 3];
-        dfVal3 += double(pChunkRow2[i + 0]) * padfWeights[i + 0];
-        dfVal3 += double(pChunkRow2[i + 1]) * padfWeights[i + 1];
-        dfVal4 += double(pChunkRow2[i + 2]) * padfWeights[i + 2];
-        dfVal4 += double(pChunkRow2[i + 3]) * padfWeights[i + 3];
-        dfVal5 += double(pChunkRow3[i + 0]) * padfWeights[i + 0];
-        dfVal5 += double(pChunkRow3[i + 1]) * padfWeights[i + 1];
-        dfVal6 += double(pChunkRow3[i + 2]) * padfWeights[i + 2];
-        dfVal6 += double(pChunkRow3[i + 3]) * padfWeights[i + 3];
+        dfVal1 += MulNaNAware(double(pChunkRow1[i + 0]), padfWeights[i + 0]);
+        dfVal1 += MulNaNAware(double(pChunkRow1[i + 1]), padfWeights[i + 1]);
+        dfVal2 += MulNaNAware(double(pChunkRow1[i + 2]), padfWeights[i + 2]);
+        dfVal2 += MulNaNAware(double(pChunkRow1[i + 3]), padfWeights[i + 3]);
+        dfVal3 += MulNaNAware(double(pChunkRow2[i + 0]), padfWeights[i + 0]);
+        dfVal3 += MulNaNAware(double(pChunkRow2[i + 1]), padfWeights[i + 1]);
+        dfVal4 += MulNaNAware(double(pChunkRow2[i + 2]), padfWeights[i + 2]);
+        dfVal4 += MulNaNAware(double(pChunkRow2[i + 3]), padfWeights[i + 3]);
+        dfVal5 += MulNaNAware(double(pChunkRow3[i + 0]), padfWeights[i + 0]);
+        dfVal5 += MulNaNAware(double(pChunkRow3[i + 1]), padfWeights[i + 1]);
+        dfVal6 += MulNaNAware(double(pChunkRow3[i + 2]), padfWeights[i + 2]);
+        dfVal6 += MulNaNAware(double(pChunkRow3[i + 3]), padfWeights[i + 3]);
     }
     for (; i < nSrcPixelCount; ++i)
     {
-        dfVal1 += double(pChunkRow1[i]) * padfWeights[i];
-        dfVal3 += double(pChunkRow2[i]) * padfWeights[i];
-        dfVal5 += double(pChunkRow3[i]) * padfWeights[i];
+        dfVal1 += MulNaNAware(double(pChunkRow1[i]), padfWeights[i]);
+        dfVal3 += MulNaNAware(double(pChunkRow2[i]), padfWeights[i]);
+        dfVal5 += MulNaNAware(double(pChunkRow3[i]), padfWeights[i]);
     }
     dfRes1 = dfVal1 + dfVal2;
     dfRes2 = dfVal3 + dfVal4;
     dfRes3 = dfVal5 + dfVal6;
 }
 
-template <class T>
+template <class T, bool bHasNaN>
 static inline void GDALResampleConvolutionHorizontalPixelCountLess8_3rows(
     const T *pChunkRow1, const T *pChunkRow2, const T *pChunkRow3,
     const double *padfWeights, int nSrcPixelCount, double &dfRes1,
     double &dfRes2, double &dfRes3)
 {
-    GDALResampleConvolutionHorizontal_3rows(pChunkRow1, pChunkRow2, pChunkRow3,
-                                            padfWeights, nSrcPixelCount, dfRes1,
-                                            dfRes2, dfRes3);
+    GDALResampleConvolutionHorizontal_3rows<T, bHasNaN>(
+        pChunkRow1, pChunkRow2, pChunkRow3, padfWeights, nSrcPixelCount, dfRes1,
+        dfRes2, dfRes3);
 }
 
-template <class T>
+template <class T, bool bHasNaN>
 static inline void GDALResampleConvolutionHorizontalPixelCount4_3rows(
     const T *pChunkRow1, const T *pChunkRow2, const T *pChunkRow3,
     const double *padfWeights, double &dfRes1, double &dfRes2, double &dfRes3)
 {
-    GDALResampleConvolutionHorizontal_3rows(pChunkRow1, pChunkRow2, pChunkRow3,
-                                            padfWeights, 4, dfRes1, dfRes2,
-                                            dfRes3);
+    GDALResampleConvolutionHorizontal_3rows<T, bHasNaN>(
+        pChunkRow1, pChunkRow2, pChunkRow3, padfWeights, 4, dfRes1, dfRes2,
+        dfRes3);
 }
 
 /************************************************************************/
@@ -3135,7 +3171,7 @@ static inline void GDALResampleConvolutionHorizontalWithMaskSSE2(
 /************************************************************************/
 
 template <>
-inline void GDALResampleConvolutionHorizontalWithMask<GByte>(
+inline void GDALResampleConvolutionHorizontalWithMask<GByte, false>(
     const GByte *pChunk, const GByte *pabyMask,
     const double *padfWeightsAligned, int nSrcPixelCount, double &dfVal,
     double &dfWeightSum)
@@ -3146,7 +3182,7 @@ inline void GDALResampleConvolutionHorizontalWithMask<GByte>(
 }
 
 template <>
-inline void GDALResampleConvolutionHorizontalWithMask<GUInt16>(
+inline void GDALResampleConvolutionHorizontalWithMask<GUInt16, false>(
     const GUInt16 *pChunk, const GByte *pabyMask,
     const double *padfWeightsAligned, int nSrcPixelCount, double &dfVal,
     double &dfWeightSum)
@@ -3210,7 +3246,7 @@ static inline void GDALResampleConvolutionHorizontal_3rows_SSE2(
 /************************************************************************/
 
 template <>
-inline void GDALResampleConvolutionHorizontal_3rows<GByte>(
+inline void GDALResampleConvolutionHorizontal_3rows<GByte, false>(
     const GByte *pChunkRow1, const GByte *pChunkRow2, const GByte *pChunkRow3,
     const double *padfWeightsAligned, int nSrcPixelCount, double &dfRes1,
     double &dfRes2, double &dfRes3)
@@ -3221,7 +3257,7 @@ inline void GDALResampleConvolutionHorizontal_3rows<GByte>(
 }
 
 template <>
-inline void GDALResampleConvolutionHorizontal_3rows<GUInt16>(
+inline void GDALResampleConvolutionHorizontal_3rows<GUInt16, false>(
     const GUInt16 *pChunkRow1, const GUInt16 *pChunkRow2,
     const GUInt16 *pChunkRow3, const double *padfWeightsAligned,
     int nSrcPixelCount, double &dfRes1, double &dfRes2, double &dfRes3)
@@ -3276,7 +3312,8 @@ static inline void GDALResampleConvolutionHorizontalPixelCountLess8_3rows_SSE2(
 /************************************************************************/
 
 template <>
-inline void GDALResampleConvolutionHorizontalPixelCountLess8_3rows<GByte>(
+inline void
+GDALResampleConvolutionHorizontalPixelCountLess8_3rows<GByte, false>(
     const GByte *pChunkRow1, const GByte *pChunkRow2, const GByte *pChunkRow3,
     const double *padfWeightsAligned, int nSrcPixelCount, double &dfRes1,
     double &dfRes2, double &dfRes3)
@@ -3287,7 +3324,8 @@ inline void GDALResampleConvolutionHorizontalPixelCountLess8_3rows<GByte>(
 }
 
 template <>
-inline void GDALResampleConvolutionHorizontalPixelCountLess8_3rows<GUInt16>(
+inline void
+GDALResampleConvolutionHorizontalPixelCountLess8_3rows<GUInt16, false>(
     const GUInt16 *pChunkRow1, const GUInt16 *pChunkRow2,
     const GUInt16 *pChunkRow3, const double *padfWeightsAligned,
     int nSrcPixelCount, double &dfRes1, double &dfRes2, double &dfRes3)
@@ -3329,7 +3367,7 @@ static inline void GDALResampleConvolutionHorizontalPixelCount4_3rows_SSE2(
 /************************************************************************/
 
 template <>
-inline void GDALResampleConvolutionHorizontalPixelCount4_3rows<GByte>(
+inline void GDALResampleConvolutionHorizontalPixelCount4_3rows<GByte, false>(
     const GByte *pChunkRow1, const GByte *pChunkRow2, const GByte *pChunkRow3,
     const double *padfWeightsAligned, double &dfRes1, double &dfRes2,
     double &dfRes3)
@@ -3340,7 +3378,7 @@ inline void GDALResampleConvolutionHorizontalPixelCount4_3rows<GByte>(
 }
 
 template <>
-inline void GDALResampleConvolutionHorizontalPixelCount4_3rows<GUInt16>(
+inline void GDALResampleConvolutionHorizontalPixelCount4_3rows<GUInt16, false>(
     const GUInt16 *pChunkRow1, const GUInt16 *pChunkRow2,
     const GUInt16 *pChunkRow3, const double *padfWeightsAligned, double &dfRes1,
     double &dfRes2, double &dfRes3)
@@ -3446,6 +3484,23 @@ static CPLErr GDALResampleChunk_ConvolutionT(
         // cppcheck-suppress unreadVariable
         // (1 << 63) - 1024: largest int64 that a double can hold
         fDstMax = static_cast<Twork>(9223372036854774784LL);
+    }
+
+    bool bHasNaN = false;
+    if (pabyChunkNodataMask)
+    {
+        if constexpr (std::is_floating_point_v<T>)
+        {
+            for (size_t i = 0;
+                 i < static_cast<size_t>(nChunkXSize) * nChunkYSize; ++i)
+            {
+                if (std::isnan(pChunk[i]))
+                {
+                    bHasNaN = true;
+                    break;
+                }
+            }
+        }
     }
 
     auto replaceValIfNodata = [bHasNoData, isIntegerDT, fDstMin, fDstMax,
@@ -3667,10 +3722,30 @@ static CPLErr GDALResampleChunk_ConvolutionT(
                     double dfVal1 = 0.0;
                     double dfVal2 = 0.0;
                     double dfVal3 = 0.0;
-                    GDALResampleConvolutionHorizontalPixelCount4_3rows(
-                        pChunk + j, pChunk + j + nChunkXSize,
-                        pChunk + j + 2 * nChunkXSize, padfWeights, dfVal1,
-                        dfVal2, dfVal3);
+                    if constexpr (std::is_floating_point_v<T>)
+                    {
+                        if (bHasNaN)
+                        {
+                            GDALResampleConvolutionHorizontalPixelCount4_3rows<
+                                T, true>(pChunk + j, pChunk + j + nChunkXSize,
+                                         pChunk + j + 2 * nChunkXSize,
+                                         padfWeights, dfVal1, dfVal2, dfVal3);
+                        }
+                        else
+                        {
+                            GDALResampleConvolutionHorizontalPixelCount4_3rows<
+                                T, false>(pChunk + j, pChunk + j + nChunkXSize,
+                                          pChunk + j + 2 * nChunkXSize,
+                                          padfWeights, dfVal1, dfVal2, dfVal3);
+                        }
+                    }
+                    else
+                    {
+                        GDALResampleConvolutionHorizontalPixelCount4_3rows<
+                            T, false>(pChunk + j, pChunk + j + nChunkXSize,
+                                      pChunk + j + 2 * nChunkXSize, padfWeights,
+                                      dfVal1, dfVal2, dfVal3);
+                    }
                     padfHorizontalFiltered[static_cast<size_t>(iSrcLineOff) *
                                                nDstXSize +
                                            iDstPixel - nDstXOff] =
@@ -3697,10 +3772,32 @@ static CPLErr GDALResampleChunk_ConvolutionT(
                     double dfVal1 = 0.0;
                     double dfVal2 = 0.0;
                     double dfVal3 = 0.0;
-                    GDALResampleConvolutionHorizontalPixelCountLess8_3rows(
-                        pChunk + j, pChunk + j + nChunkXSize,
-                        pChunk + j + 2 * nChunkXSize, padfWeights,
-                        nSrcPixelCount, dfVal1, dfVal2, dfVal3);
+                    if constexpr (std::is_floating_point_v<T>)
+                    {
+                        if (bHasNaN)
+                        {
+                            GDALResampleConvolutionHorizontalPixelCountLess8_3rows<
+                                T, true>(pChunk + j, pChunk + j + nChunkXSize,
+                                         pChunk + j + 2 * nChunkXSize,
+                                         padfWeights, nSrcPixelCount, dfVal1,
+                                         dfVal2, dfVal3);
+                        }
+                        else
+                        {
+                            GDALResampleConvolutionHorizontalPixelCountLess8_3rows<
+                                T, false>(pChunk + j, pChunk + j + nChunkXSize,
+                                          pChunk + j + 2 * nChunkXSize,
+                                          padfWeights, nSrcPixelCount, dfVal1,
+                                          dfVal2, dfVal3);
+                        }
+                    }
+                    else
+                    {
+                        GDALResampleConvolutionHorizontalPixelCountLess8_3rows<
+                            T, false>(pChunk + j, pChunk + j + nChunkXSize,
+                                      pChunk + j + 2 * nChunkXSize, padfWeights,
+                                      nSrcPixelCount, dfVal1, dfVal2, dfVal3);
+                    }
                     padfHorizontalFiltered[static_cast<size_t>(iSrcLineOff) *
                                                nDstXSize +
                                            iDstPixel - nDstXOff] =
@@ -3730,10 +3827,30 @@ static CPLErr GDALResampleChunk_ConvolutionT(
                     double dfVal1 = 0.0;
                     double dfVal2 = 0.0;
                     double dfVal3 = 0.0;
-                    GDALResampleConvolutionHorizontal_3rows(
-                        pChunk + j, pChunk + j + nChunkXSize,
-                        pChunk + j + 2 * nChunkXSize, padfWeights,
-                        nSrcPixelCount, dfVal1, dfVal2, dfVal3);
+                    if constexpr (std::is_floating_point_v<T>)
+                    {
+                        if (bHasNaN)
+                        {
+                            GDALResampleConvolutionHorizontal_3rows<T, true>(
+                                pChunk + j, pChunk + j + nChunkXSize,
+                                pChunk + j + 2 * nChunkXSize, padfWeights,
+                                nSrcPixelCount, dfVal1, dfVal2, dfVal3);
+                        }
+                        else
+                        {
+                            GDALResampleConvolutionHorizontal_3rows<T, false>(
+                                pChunk + j, pChunk + j + nChunkXSize,
+                                pChunk + j + 2 * nChunkXSize, padfWeights,
+                                nSrcPixelCount, dfVal1, dfVal2, dfVal3);
+                        }
+                    }
+                    else
+                    {
+                        GDALResampleConvolutionHorizontal_3rows<T, false>(
+                            pChunk + j, pChunk + j + nChunkXSize,
+                            pChunk + j + 2 * nChunkXSize, padfWeights,
+                            nSrcPixelCount, dfVal1, dfVal2, dfVal3);
+                    }
                     padfHorizontalFiltered[static_cast<size_t>(iSrcLineOff) *
                                                nDstXSize +
                                            iDstPixel - nDstXOff] =
@@ -3802,9 +3919,27 @@ static CPLErr GDALResampleChunk_ConvolutionT(
                 }
 
                 double dfVal = 0.0;
-                GDALResampleConvolutionHorizontalWithMask(
-                    pChunk + j, pabyChunkNodataMask + j, padfWeights,
-                    nSrcPixelCount, dfVal, dfWeightSum);
+                if constexpr (std::is_floating_point_v<T>)
+                {
+                    if (bHasNaN)
+                    {
+                        GDALResampleConvolutionHorizontalWithMask<T, true>(
+                            pChunk + j, pabyChunkNodataMask + j, padfWeights,
+                            nSrcPixelCount, dfVal, dfWeightSum);
+                    }
+                    else
+                    {
+                        GDALResampleConvolutionHorizontalWithMask<T, false>(
+                            pChunk + j, pabyChunkNodataMask + j, padfWeights,
+                            nSrcPixelCount, dfVal, dfWeightSum);
+                    }
+                }
+                else
+                {
+                    GDALResampleConvolutionHorizontalWithMask<T, false>(
+                        pChunk + j, pabyChunkNodataMask + j, padfWeights,
+                        nSrcPixelCount, dfVal, dfWeightSum);
+                }
                 const size_t nTempOffset =
                     static_cast<size_t>(iSrcLineOff) * nDstXSize + iDstPixel -
                     nDstXOff;


### PR DESCRIPTION
when the band nodata value is also NaN.

If there is no nodata value or set a non-NaN value, then NaN source pixels will "contaminate" the output. Considered as a feature currently.

Fixes #14353
