### PR TITLE
CSharp bindings: user-defined string encoding and improved safety

### DIFF
--- a/swig/csharp/CMakeLists.txt
+++ b/swig/csharp/CMakeLists.txt
@@ -163,7 +163,8 @@ list(APPEND GDAL_SWIG_COMMON_INTERFACE_FILES
    ${PROJECT_SOURCE_DIR}/swig/include/csharp/osr_csharp.i
    ${PROJECT_SOURCE_DIR}/swig/include/csharp/swig_csharp_extensions.i
    ${PROJECT_SOURCE_DIR}/swig/include/csharp/typemaps_csharp.i
-   ${PROJECT_SOURCE_DIR}/swig/include/csharp/csharp_strings.i)
+   ${PROJECT_SOURCE_DIR}/swig/include/csharp/csharp_strings.i
+   ${PROJECT_SOURCE_DIR}/swig/include/csharp/csharp_string_encoder.i)
 
 # function for csharp wrapper build
 function (gdal_csharp_wrap)

--- a/swig/include/csharp/csharp_string_encoder.i
+++ b/swig/include/csharp/csharp_string_encoder.i
@@ -3,7 +3,7 @@
  * Name:     csharp_string_encoder.i
  * Project:  GDAL CSharp Interface
  * Purpose:  String encoder and decoder for C# marshalling
- * Author:  Michael Bucari-Tovo, mbucari1@gmail.com
+ * Author:   Michael Bucari-Tovo, mbucari1@gmail.com
  *
  ******************************************************************************
  * Copyright (c) 2026, Michael Bucari-Tovo

--- a/swig/include/csharp/csharp_string_encoder.i
+++ b/swig/include/csharp/csharp_string_encoder.i
@@ -1,0 +1,67 @@
+/******************************************************************************
+ *
+ * Name:     csharp_string_encoder.i
+ * Project:  GDAL CSharp Interface
+ * Purpose:  String encoder and decoder for C# marshalling
+ * Author:  Michael Bucari-Tovo, mbucari1@gmail.com
+ *
+ ******************************************************************************
+ * Copyright (c) 2026, Michael Bucari-Tovo
+ *
+ * SPDX-License-Identifier: MIT
+ *****************************************************************************/
+
+/*
+ * The default string encoderdecoder implementation used
+ * by all GDAL modules. Should be imported only by OSR.
+ */
+
+%{
+typedef struct {} DefaultStringEncoder;
+%}
+%typemap(csclassmodifiers) DefaultStringEncoder "public class";
+%typemap(csinterfaces)     DefaultStringEncoder "IStringEncoder";
+%typemap(csdisposing)      DefaultStringEncoder "";
+%typemap(csdispose)        DefaultStringEncoder "";
+%typemap(csimports)        DefaultStringEncoder %{
+
+  using System;
+  using System.Text;
+  using System.Runtime.InteropServices;
+
+  /* Interface for encoding/decoding string to/from Gdal unmanaged strings. */
+  public interface IStringEncoder {
+    /* Encode a string to a null-terminated array of bytes to be sent to Gdal unmanaged */
+    byte[] ToNullTerminated(string str);
+    /* Decode an unmanaged, null-terminated string from Gdal to a managed string */
+    string FromNullTerminated(IntPtr pStr);
+  }
+%}
+
+%typemap(csbody)           DefaultStringEncoder %{
+  public virtual string FromNullTerminated(IntPtr pStr) {
+#if NETCOREAPP1_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+    return Marshal.PtrToStringUTF8(pStr);
+#else
+    if (pStr == IntPtr.Zero) return null;
+    unsafe {
+      byte* pBytes = (byte*)pStr.ToPointer();
+      int len = 0;
+      checked {
+        while (pBytes[len] != 0) len++;
+      }
+      return Encoding.UTF8.GetString(pBytes, len);
+    }
+#endif
+  }
+  public virtual byte[] ToNullTerminated(string str) {
+    if (str == null) return null;
+    int byteCount = Encoding.UTF8.GetByteCount(str);
+    var bts = new byte[byteCount + 1];
+    Encoding.UTF8.GetBytes(str, 0, str.Length, bts, 0);
+    return bts;
+  }
+%}
+
+%ignore DefaultStringEncoder::DefaultStringEncoder();
+struct  DefaultStringEncoder{};

--- a/swig/include/csharp/csharp_strings.i
+++ b/swig/include/csharp/csharp_strings.i
@@ -97,7 +97,8 @@ static CSharpUtf8StringHelperCallback SWIG_csharp_string_callback = NULL;
 
     public static IntPtr DecodeStringToPinnedGCHandle(IntPtr pUtf8Bts) {
       string value = $module.StringEncoder?.FromNullTerminated(pUtf8Bts);
-      if (value == null) return IntPtr.Zero;
+      if (value == null)
+        return IntPtr.Zero;
       var handle = System.Runtime.InteropServices.GCHandle.Alloc(value,
                      System.Runtime.InteropServices.GCHandleType.Pinned);
       return System.Runtime.InteropServices.GCHandle.ToIntPtr(handle);
@@ -108,7 +109,8 @@ static CSharpUtf8StringHelperCallback SWIG_csharp_string_callback = NULL;
   public static readonly Utf8StringHelper utf8StringHelper = new Utf8StringHelper();
 
   internal static string StringFromPinnedGCHandle(IntPtr pinnedHandle){
-    if (pinnedHandle == IntPtr.Zero) return null;
+    if (pinnedHandle == IntPtr.Zero)
+      return null;
     var handle = System.Runtime.InteropServices.GCHandle.FromIntPtr(pinnedHandle);
     string value = handle.Target as string;
     handle.Free();
@@ -130,7 +132,7 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
  ******************************************************************************/
 
 %typemap(cstype) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) "string"
-%typemap(imtype) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) "IntPtr"
+%typemap(imtype, out="IntPtr") (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) "byte[]"
 
 %typemap(in) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) %{
   $1 = ($1_ltype)$input;
@@ -144,15 +146,9 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
   $result = SWIG_csharp_string_callback((const char *)$1);
 %}
 
-%typemap(csin,
-  pre="
-    byte[] bts$csinput = $module.StringEncoder?.ToNullTerminated($csinput);
-    unsafe {
-      fixed (byte* pBts$csinput = bts$csinput) {",
-  terminator="    }}",
-  cshin="$csinput"
-  ) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string)
-  "(IntPtr)pBts$csinput"
+%typemap(csin) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) %{
+  $module.StringEncoder?.ToNullTerminated($csinput)
+%}
 
 %typemap(csout, excode=SWIGEXCODE) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string)
 {
@@ -166,18 +162,6 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 /*
  * Typemap for UTF-8 char* string properties.
  */
-
-%typemap(csvarin, excode=SWIGEXCODE2) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) %{
-  /* %typemap(csvarin) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) */
-  set {
-    byte[] bts$csinput = $module.StringEncoder?.ToNullTerminated($csinput);
-    unsafe {
-      fixed (byte* pBts$csinput = bts$csinput) {
-        $imcall;$excode
-      }
-    }
-  }
-%}
 
 %typemap(csvarout, excode=SWIGEXCODE2) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) %{
   get {
@@ -249,18 +233,13 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
  * caller doesn't want to see changes.
  */
 
-%typemap(imtype) (char **ignorechange) "ref IntPtr"
+%typemap(imtype) (char **ignorechange) "ref byte[]"
 %typemap(cstype) (char **ignorechange) "ref string"
 %typemap(csin,
-  pre="
-    byte[] bts$csinput = $module.StringEncoder?.ToNullTerminated($csinput);
-    unsafe {
-      fixed (byte* pBts$csinput = bts$csinput) {
-        IntPtr temp$csinput = (IntPtr)pBts$csinput;",
-  terminator="    }}",
+  pre="    byte[] bts$csinput = $module.StringEncoder?.ToNullTerminated($csinput);",
   cshin="$csinput"
   ) (char** ignorechange)
-  "ref temp$csinput"
+  "ref bts$csinput"
 
 %typemap(in, noblock="1") (char **ignorechange)
 {
@@ -307,6 +286,21 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
       }
       GC.SuppressFinalize(this);
     }
+    public static string[] DecodeStringArray(IntPtr pList) {
+      int count = 0;
+      if (pList != IntPtr.Zero) checked {
+        while (System.Runtime.InteropServices.Marshal.ReadIntPtr(pList, count*IntPtr.Size) != IntPtr.Zero)
+          count++;
+      }
+      string[] ret = new string[count];
+      if (count > 0) {
+        for(int cx = 0; cx < count; cx++) {
+          IntPtr objPtr = System.Runtime.InteropServices.Marshal.ReadIntPtr(pList, cx * IntPtr.Size);
+          ret[cx]= $module.StringEncoder?.FromNullTerminated(objPtr);
+        }
+      }
+      return ret;
+    }
   }
 %}
 
@@ -326,27 +320,6 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
   "temp$csinput._ar"
 
 /*
- * C# code to marshal NULL terminated lists of NULL terminated UTF-8 strings.
- */
-
-%define CS_MARSHAL_STRING_LIST()
-  IntPtr cPtr = $imcall;
-  IntPtr objPtr;
-  int count = 0;
-  if (cPtr != IntPtr.Zero) {
-    while (System.Runtime.InteropServices.Marshal.ReadIntPtr(cPtr, count*IntPtr.Size) != IntPtr.Zero)
-      ++count;
-  }
-  string[] ret = new string[count];
-  if (count > 0) {
-    for(int cx = 0; cx < count; cx++) {
-      objPtr = System.Runtime.InteropServices.Marshal.ReadIntPtr(cPtr, cx * System.Runtime.InteropServices.Marshal.SizeOf(typeof(IntPtr)));
-      ret[cx]= $module.StringEncoder?.FromNullTerminated(objPtr);
-    }
-  }
-%enddef
-
-/*
  * Marshal char**options, char **dict to string[] and don't free the unmanaged
  * string list.
  */
@@ -354,7 +327,8 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 %typemap(csout, excode=SWIGEXCODE) char**options, char **dict
 {
   /* %typemap(csout) char**options, char **dict */
-  CS_MARSHAL_STRING_LIST()
+  IntPtr cPtr = $imcall;
+  string[] ret = $modulePINVOKE.StringListMarshal.DecodeStringArray(cPtr);
   $excode
   return ret;
 }
@@ -366,11 +340,16 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 
 %typemap(csout, excode=SWIGEXCODE) char** CSL, char **dictAndCSLDestroy {
   /* %typemap(csout) char** CSL, char **dictAndCSLDestroy */
-  CS_MARSHAL_STRING_LIST()
-  if (cPtr != IntPtr.Zero)
-    $modulePINVOKE.StringListDestroy(cPtr);
-  $excode
-  return ret;
+  IntPtr cPtr = $imcall;
+  try {
+    string[] ret = $modulePINVOKE.StringListMarshal.DecodeStringArray(cPtr);
+    $excode
+    return ret;
+  }
+  finally {
+    if (cPtr != IntPtr.Zero)
+      $modulePINVOKE.StringListDestroy(cPtr);
+  }
 }
 
 /*

--- a/swig/include/csharp/csharp_strings.i
+++ b/swig/include/csharp/csharp_strings.i
@@ -13,16 +13,20 @@
  *****************************************************************************/
 
 /*******************************************************************************
- * Marshaler for NULL terminated UTF-8 encoded strings                         *
+ * Marshaller for NULL terminated UTF-8 encoded strings                        *
  * Creates a callback function which is used from the native runtime to create *
  * .NET strings. The managed Utf8StringHelper registers a callback function    *
  * with the native runtime which is used by the native runtime to create .NET  *
- * strings. When called by the native runtime, the .NET function allocates     *
- * unmanaged memory and decodes the UTF-8 string into a length-prefixed UTF-16 *
- * string into that buffer. A pointer to that buffer is returned. When the     *
- * callback returns to managed .NET, a managed string is created from the      *
- * unmanaged buffer using LengthPrefixedUtf16UnmanagedToString, which frees    *
- * the unmanaged memory that was allocated by the callback function.           *
+ * strings. When called by the native runtime, the .NET function decodes the   *
+ * unmanaged memory into a managed string and returns a new pinned GCHandle    *
+ * for that string. A pointer to that GCHandle is returned. When the callback  *
+ * returns to managed .NET, the managed string is retrieved from the GCHandle  *
+ * and the GCHandle is freed by calling StringFromPinnedGCHandle.              *
+ *                                                                             *
+ * IMPORTANT:                                                                  *
+ * Every call to SWIG_csharp_string_callback MUST be followed by exactly       *
+ * one call to StringFromPinnedGCHandle() on the returned pointer.             *
+ * Failure to do so will result in memory leaks or double frees.               *
  ******************************************************************************/
 
 %insert(runtime) %{
@@ -31,18 +35,57 @@ typedef char * (SWIGSTDCALL* CSharpUtf8StringHelperCallback)(const char *);
 static CSharpUtf8StringHelperCallback SWIG_csharp_string_callback = NULL;
 %}
 
+%pragma(csharp) modulecode=%{
+  /* Interface for marshalling string to/from Gdal unmanaged strings. */
+  public interface IStringMarshaller {
+    /* Convert a string to a null-terminated array of bytes to be sent to Gdal unmanaged */
+    byte[] ToNullTerminated(string str);
+    /* Convert an unmanaged, null-terminated string from Gdal to a managed string */
+    string FromNullTerminated(IntPtr pStr);
+  }
+  internal static readonly IStringMarshaller s_DefaultStringMarshaller = new DefaultStringMarshaller();
+  internal static IStringMarshaller s_StringMarshaller;
+  public static IStringMarshaller StringMarshaller {
+    get {
+      if (s_StringMarshaller == null)
+        s_StringMarshaller = s_DefaultStringMarshaller;
+      return s_StringMarshaller;
+    }
+    set {
+      s_StringMarshaller = value;
+    }
+  }
+  internal class DefaultStringMarshaller : IStringMarshaller {
+    public unsafe string FromNullTerminated(IntPtr pStr) {
+      if (pStr == IntPtr.Zero) return null;
+      byte* pBytes = (byte*)pStr.ToPointer();
+#if NET6_0_OR_GREATER
+      ReadOnlySpan<byte> nativeBytes = System.Runtime.InteropServices.MemoryMarshal.CreateReadOnlySpanFromNullTerminated(pBytes);
+      return System.Text.Encoding.UTF8.GetString(nativeBytes);
+#else
+      int len = 0;
+      checked {
+        while (pBytes[len] != 0) len++;
+      }
+      return System.Text.Encoding.UTF8.GetString(pBytes, len);
+#endif
+    }
+    public byte[] ToNullTerminated(string str) {
+      if (str == null) return null;
+      int byteCount = System.Text.Encoding.UTF8.GetByteCount(str);
+      var bts = new byte[byteCount + 1];
+      System.Text.Encoding.UTF8.GetBytes(str, 0, str.Length, bts, 0);
+      return bts;
+    }
+  }
+%}
+
 %pragma(csharp) imclasscode=%{
   public class Utf8StringHelper {
 
     public delegate System.IntPtr Utf8StringDelegate(System.IntPtr message);
 
-   /*
-    * IMPORTANT:
-    * Every call to SWIG_csharp_string_callback MUST be followed by exactly one call
-    * to LengthPrefixedUtf16UnmanagedToString on the returned pointer.
-    * Failure to do so will result in memory leaks or double frees.
-    */
-    static Utf8StringDelegate stringDelegate = new Utf8StringDelegate($modulePINVOKE.Utf8UnmanagedToLengthPrefixedUtf16Unmanaged);
+    static Utf8StringDelegate stringDelegate = new Utf8StringDelegate(DecodeStringToPinnedGCHandle);
 
     [global::System.Runtime.InteropServices.DllImport("$dllimport", EntryPoint="RegisterUtf8StringCallback_$module")]
     public static extern void RegisterUtf8StringCallback_$module(Utf8StringDelegate stringDelegate);
@@ -50,65 +93,27 @@ static CSharpUtf8StringHelperCallback SWIG_csharp_string_callback = NULL;
     static Utf8StringHelper() {
       RegisterUtf8StringCallback_$module(stringDelegate);
     }
+
+    public unsafe static IntPtr DecodeStringToPinnedGCHandle(IntPtr pUtf8Bts)
+    {
+      string value = $module.StringMarshaller?.FromNullTerminated(pUtf8Bts);
+	  if (value == null) return IntPtr.Zero;	  
+      var handle = System.Runtime.InteropServices.GCHandle.Alloc(value,
+                     System.Runtime.InteropServices.GCHandleType.Pinned);
+      return System.Runtime.InteropServices.GCHandle.ToIntPtr(handle);
+    }
   }
 
   //Instantiate the helper class so that the static constructor executes
   public static readonly Utf8StringHelper utf8StringHelper = new Utf8StringHelper();
 
-  public unsafe static IntPtr Utf8UnmanagedToLengthPrefixedUtf16Unmanaged(IntPtr pUtf8Bts)
+  internal static string StringFromPinnedGCHandle(IntPtr pinnedHandle)
   {
-    if (pUtf8Bts == IntPtr.Zero)
-      return IntPtr.Zero;
-
-    byte* pStringUtf8 = (byte*)pUtf8Bts;
-    int len = 0;
-    while (pStringUtf8[len] != 0) len = checked(len + 1);
-
-    var charCount = System.Text.Encoding.UTF8.GetCharCount(pStringUtf8, len);
-    int size = checked(sizeof(int) + charCount * sizeof(char));
-    var bstrDest = System.Runtime.InteropServices.Marshal.AllocHGlobal(size);
-    *(int*)bstrDest = charCount;
-
-    System.Text.Encoding.UTF8.GetChars(pStringUtf8, len, (char*)IntPtr.Add(bstrDest, sizeof(int)), charCount);
-    return bstrDest;
-  }
-
-  public unsafe static string LengthPrefixedUtf16UnmanagedToString(IntPtr pBstr)
-  {
-    if (pBstr == IntPtr.Zero)
-      return null;
-
-    try
-    {
-      int charCount = *(int*)pBstr;
-      if (charCount < 0)
-        return null;
-      int charStart = sizeof(int) / sizeof(char);
-      return new string((char*)pBstr, charStart, charCount);
-    }
-    finally
-    {
-      System.Runtime.InteropServices.Marshal.FreeHGlobal(pBstr);
-    }
-  }
-
-  public unsafe static IntPtr StringToUtf8Unmanaged(string str)
-  {
-    if (str == null)
-      return IntPtr.Zero;
-
-    int byteCount = System.Text.Encoding.UTF8.GetByteCount(str);
-    IntPtr unmanagedString = System.Runtime.InteropServices.Marshal.AllocHGlobal(byteCount + 1);
-
-    byte* ptr = (byte*)unmanagedString.ToPointer();
-    fixed (char *pStr = str)
-    {
-      System.Text.Encoding.UTF8.GetBytes(pStr, str.Length, ptr, byteCount);
-      // null-terminate
-      ptr[byteCount] = 0;
-    }
-
-    return unmanagedString;
+    if (pinnedHandle == IntPtr.Zero) return null;
+    var handle = System.Runtime.InteropServices.GCHandle.FromIntPtr(pinnedHandle);
+    string value = handle.Target as string;
+    handle.Free();
+    return value;
   }
 %}
 
@@ -133,21 +138,28 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 %}
 
 %typemap(out) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) %{
+ /*
+  * %typemap(out) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string)
+  * GCHandle is released by %typemap(csout) or %typemap(csvarout) of same
+  */
   $result = SWIG_csharp_string_callback((const char *)$1);
 %}
 
 %typemap(csin,
-  pre="    IntPtr temp$csinput = $modulePINVOKE.StringToUtf8Unmanaged($csinput);",
-  post="    System.Runtime.InteropServices.Marshal.FreeHGlobal(temp$csinput);",
+  pre="
+  byte[] bts$csinput = $module.StringMarshaller?.ToNullTerminated($csinput);
+  unsafe {
+    fixed (byte* pBts$csinput = bts$csinput) {",
+  terminator="    }}",
   cshin="$csinput"
   ) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string)
-  "temp$csinput"
+  "(IntPtr)pBts$csinput"
 
 %typemap(csout, excode=SWIGEXCODE) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string)
 {
   /* %typemap(csout) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) */
   IntPtr cPtr = $imcall;
-  string ret = $modulePINVOKE.LengthPrefixedUtf16UnmanagedToString(cPtr);
+  string ret = $modulePINVOKE.StringFromPinnedGCHandle(cPtr);
   $excode
   return ret;
 }
@@ -159,12 +171,11 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 %typemap(csvarin, excode=SWIGEXCODE2) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) %{
   /* %typemap(csvarin) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) */
   set {
-    IntPtr temp$csinput = $modulePINVOKE.StringToUtf8Unmanaged($csinput);
-    try {
-      $imcall;$excode
-    }
-    finally {
-      System.Runtime.InteropServices.Marshal.FreeHGlobal(temp$csinput);
+    byte[] bts$csinput = $module.StringMarshaller?.ToNullTerminated($csinput);
+    unsafe {
+      fixed (byte* pBts$csinput = bts$csinput) {
+        $imcall;$excode
+      }
     }
   }
 %}
@@ -173,7 +184,7 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
   get {
     /* %typemap(csvarout) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) */
     IntPtr cPtr = $imcall;
-    string ret = $modulePINVOKE.LengthPrefixedUtf16UnmanagedToString(cPtr);
+    string ret = $modulePINVOKE.StringFromPinnedGCHandle(cPtr);
     $excode
     return ret;
   }
@@ -184,7 +195,10 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
  */
 
 %typemap(out) (retStringAndCPLFree*) %{
-  /* %typemap(out) (retStringAndCPLFree*) */
+ /*
+  * %typemap(out) (retStringAndCPLFree*)
+  * GCHandle is released by %typemap(csout) (char *)
+  */
   if($1)
   {
     $result = SWIG_csharp_string_callback((const char *)$1);
@@ -205,14 +219,17 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 %typemap(in) (char **argout), (char **username), (char **usrname), (char **type) %{ $1 = ($1_ltype)$input; %}
 %typemap(csin,
   pre="    IntPtr temp$csinput = IntPtr.Zero;",
-  post="    $csinput = $modulePINVOKE.LengthPrefixedUtf16UnmanagedToString(temp$csinput);",
+  post="    $csinput = $modulePINVOKE.StringFromPinnedGCHandle(temp$csinput);",
   cshin="out $csinput"
   ) (char** argout), (char **username), (char **usrname), (char **type)
   "ref temp$csinput"
 
 %typemap(argout) (char **argout)
 {
-  /* %typemap(argout) (char **argout) */
+ /*
+  * %typemap(argout) (char **argout)
+  * GCHandle is released by %typemap(csin)
+  */
   char* temp_string;
   temp_string = SWIG_csharp_string_callback(*$1);
   if (*$1)
@@ -221,7 +238,10 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 }
 %typemap(argout) (char **username), (char **usrname), (char **type)
 {
-  /* %typemap(argout) (char **username), (char **usrname), (char **type) */
+ /*
+  * %typemap(argout) (char **username), (char **usrname), (char **type)
+  * GCHandle is released by %typemap(csin)
+  */
   *$1 = SWIG_csharp_string_callback(*$1);
 }
 
@@ -233,9 +253,11 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 %typemap(imtype) (char **ignorechange) "ref IntPtr"
 %typemap(cstype) (char **ignorechange) "ref string"
 %typemap(csin,
-  pre="    IntPtr temp$csinput = $modulePINVOKE.StringToUtf8Unmanaged($csinput);",
-  post="    System.Runtime.InteropServices.Marshal.FreeHGlobal(temp$csinput);",
-  cshin="ref $csinput"
+  pre="
+    byte[] bts$csinput = $module.StringMarshaller?.ToNullTerminated($csinput);
+    unsafe { fixed (byte* pBts$csinput = bts$csinput) { IntPtr temp$csinput = (IntPtr)pBts$csinput;",
+  terminator="    }}",
+  cshin="$csinput"
   ) (char** ignorechange)
   "ref temp$csinput"
 
@@ -254,27 +276,32 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 }
 
 /******************************************************************************
- * Marshaler for NULL terminated lists of NULL terminated UTF-8 strings.     *
+ * Marshaller for NULL terminated lists of NULL terminated UTF-8 strings.     *
  *****************************************************************************/
 
 %pragma(csharp) imclasscode=%{
   public class StringListMarshal : IDisposable {
     public readonly IntPtr[] _ar;
+    private readonly System.Runtime.InteropServices.GCHandle[] _handles;
     private int _isDisposed;
     public StringListMarshal(string[] ar) {
       if (ar == null)
         return;
-      _ar = new IntPtr[ar.Length+1];
+      _handles = new System.Runtime.InteropServices.GCHandle[ar.Length];
+      _ar = new IntPtr[ar.Length + 1];
       for (int cx = 0; cx < ar.Length; cx++) {
-        _ar[cx] = $modulePINVOKE.StringToUtf8Unmanaged(ar[cx]);
+        byte[] bts = $module.StringMarshaller?.ToNullTerminated(ar[cx]);
+        _handles[cx] = System.Runtime.InteropServices.GCHandle.Alloc(bts, System.Runtime.InteropServices.GCHandleType.Pinned);
+        _ar[cx] = _handles[cx].AddrOfPinnedObject();
       }
       _ar[ar.Length] = IntPtr.Zero;
     }
     ~StringListMarshal() => Dispose();
     public virtual void Dispose() {
-      if (System.Threading.Interlocked.CompareExchange(ref _isDisposed, 1, 0) == 0 && _ar != null) {
-        for (int cx = 0; cx < _ar.Length - 1; cx++) {
-            System.Runtime.InteropServices.Marshal.FreeHGlobal(_ar[cx]);
+      if (System.Threading.Interlocked.CompareExchange(ref _isDisposed, 1, 0) == 0 && _handles != null) {
+         for (int cx = 0; cx < _handles.Length; cx++) {
+           _handles[cx].Free();
+           _ar[cx] = IntPtr.Zero;
         }
       }
       GC.SuppressFinalize(this);
@@ -313,7 +340,7 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
   if (count > 0) {
     for(int cx = 0; cx < count; cx++) {
       objPtr = System.Runtime.InteropServices.Marshal.ReadIntPtr(cPtr, cx * System.Runtime.InteropServices.Marshal.SizeOf(typeof(IntPtr)));
-      ret[cx]= (objPtr == IntPtr.Zero) ? null : $module.Utf8BytesToString(objPtr);
+      ret[cx]= $module.StringMarshaller?.FromNullTerminated(objPtr);
     }
   }
 %enddef

--- a/swig/include/csharp/csharp_strings.i
+++ b/swig/include/csharp/csharp_strings.i
@@ -439,16 +439,8 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 	  string message = e != null ? " Inner Exception: " + e.Message : Utf8UnmanagedToString(pMessage);
       SWIGPendingException.Set(new ArgumentOutOfRangeException(Utf8UnmanagedToString(pParamName), message));
     }
-    unsafe static string Utf8UnmanagedToString(IntPtr pUtf8Bts) {
-      if (pUtf8Bts == IntPtr.Zero)
-        return null;
-
-      byte* pStringUtf8 = (byte*)pUtf8Bts;
-      int len = 0;
-      while (pStringUtf8[len] != 0) len = checked(len + 1);
-
-      return System.Text.Encoding.UTF8.GetString(pStringUtf8, len);
-    }
+    unsafe static string Utf8UnmanagedToString(IntPtr pUtf8Bts)
+	  => $module.StringEncoder?.FromNullTerminated(pUtf8Bts);
   }
   //Instantiate the helper class so that the static constructor executes
   static readonly ExceptionHelperUtf8 exceptionHelperUtf8 = new ExceptionHelperUtf8();

--- a/swig/include/csharp/csharp_strings.i
+++ b/swig/include/csharp/csharp_strings.i
@@ -83,17 +83,15 @@ typedef struct {} CsharpDummyObject;
 struct CsharpDummyObject{};
 
 %pragma(csharp) modulecode=%{
-  internal static readonly I$moduleStringEncoder s_DefaultStringEncoder = new Default$moduleStringEncoder();
-  internal static I$moduleStringEncoder s_StringEncoder;
-  public static I$moduleStringEncoder StringEncoder {
-    get {
-      if (s_StringEncoder == null)
-        s_StringEncoder = s_DefaultStringEncoder;
-      return s_StringEncoder;
-    }
-    set {
-      s_StringEncoder = value;
-    }
+  private static readonly I$moduleStringEncoder s_DefaultStringEncoder = new Default$moduleStringEncoder();
+  [System.ThreadStatic]
+  private static I$moduleStringEncoder s_ThreadStringEncoder;
+  public static I$moduleStringEncoder StringEncoder
+    => ThreadStringEncoder ?? GlobalStringEncoder ?? s_DefaultStringEncoder;
+  public static I$moduleStringEncoder GlobalStringEncoder { get; set; }
+  public static I$moduleStringEncoder ThreadStringEncoder {    
+    get => s_ThreadStringEncoder;
+    set => s_ThreadStringEncoder = value;
   }
 %}
 
@@ -162,6 +160,7 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
   "$module.StringEncoder?.ToNullTerminated($csinput)"
   
 %define CS_RETURN_UTF8_STRING
+
   IntPtr cPtr = $imcall;
   string ret = $modulePINVOKE.StringFromPinnedGCHandle(cPtr);
   $excode

--- a/swig/include/csharp/csharp_strings.i
+++ b/swig/include/csharp/csharp_strings.i
@@ -34,30 +34,31 @@ typedef char * (SWIGSTDCALL* CSharpUtf8StringHelperCallback)(const char *);
 static CSharpUtf8StringHelperCallback SWIG_csharp_string_callback = NULL;
 %}
 
-%pragma(csharp) modulecode=%{
+/*
+ * Define a dummy type so that we can extend it to add custom types
+ * inside the module namespace using the csimports typemap
+ */
+%{
+typedef struct {} CsharpDummyObject;
+%}
+%typemap(csclassmodifiers) CsharpDummyObject "internal class";
+%typemap(csimports) CsharpDummyObject %{
+  using System;
+  using System.Text;
+  using System.Runtime.InteropServices;
+
   /* Interface for encoding/decoding string to/from Gdal unmanaged strings. */
-  public interface IStringEncoder {
+  public interface I$moduleStringEncoder {
     /* Encode a string to a null-terminated array of bytes to be sent to Gdal unmanaged */
     byte[] ToNullTerminated(string str);
     /* Decode an unmanaged, null-terminated string from Gdal to a managed string */
     string FromNullTerminated(IntPtr pStr);
   }
-  internal static readonly IStringEncoder s_DefaultStringEncoder = new DefaultStringEncoder();
-  internal static IStringEncoder s_StringEncoder;
-  public static IStringEncoder StringEncoder {
-    get {
-      if (s_StringEncoder == null)
-        s_StringEncoder = s_DefaultStringEncoder;
-      return s_StringEncoder;
-    }
-    set {
-      s_StringEncoder = value;
-    }
-  }
-  internal class DefaultStringEncoder : IStringEncoder {
-    public string FromNullTerminated(IntPtr pStr) {
+  
+  public class Default$moduleStringEncoder : I$moduleStringEncoder {
+    public virtual string FromNullTerminated(IntPtr pStr) {
 #if NETCOREAPP1_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-      return System.Runtime.InteropServices.Marshal.PtrToStringUTF8(pStr);
+      return Marshal.PtrToStringUTF8(pStr);
 #else
       if (pStr == IntPtr.Zero) return null;
       unsafe {
@@ -66,16 +67,32 @@ static CSharpUtf8StringHelperCallback SWIG_csharp_string_callback = NULL;
         checked {
           while (pBytes[len] != 0) len++;
         }
-        return System.Text.Encoding.UTF8.GetString(pBytes, len);
+        return Encoding.UTF8.GetString(pBytes, len);
       }
 #endif
     }
-    public byte[] ToNullTerminated(string str) {
+    public virtual byte[] ToNullTerminated(string str) {
       if (str == null) return null;
-      int byteCount = System.Text.Encoding.UTF8.GetByteCount(str);
+      int byteCount = Encoding.UTF8.GetByteCount(str);
       var bts = new byte[byteCount + 1];
-      System.Text.Encoding.UTF8.GetBytes(str, 0, str.Length, bts, 0);
+      Encoding.UTF8.GetBytes(str, 0, str.Length, bts, 0);
       return bts;
+    }
+  }
+%}
+struct CsharpDummyObject{};
+
+%pragma(csharp) modulecode=%{
+  internal static readonly I$moduleStringEncoder s_DefaultStringEncoder = new Default$moduleStringEncoder();
+  internal static I$moduleStringEncoder s_StringEncoder;
+  public static I$moduleStringEncoder StringEncoder {
+    get {
+      if (s_StringEncoder == null)
+        s_StringEncoder = s_DefaultStringEncoder;
+      return s_StringEncoder;
+    }
+    set {
+      s_StringEncoder = value;
     }
   }
 %}

--- a/swig/include/csharp/csharp_strings.i
+++ b/swig/include/csharp/csharp_strings.i
@@ -85,13 +85,13 @@ struct CsharpDummyObject{};
 %pragma(csharp) modulecode=%{
   private static readonly I$moduleStringEncoder s_DefaultStringEncoder = new Default$moduleStringEncoder();
   [System.ThreadStatic]
-  private static I$moduleStringEncoder s_ThreadStringEncoder;
+  private static I$moduleStringEncoder s_ThreadLocalStringEncoder;
   public static I$moduleStringEncoder StringEncoder
-    => ThreadStringEncoder ?? GlobalStringEncoder ?? s_DefaultStringEncoder;
+    => ThreadLocalStringEncoder ?? GlobalStringEncoder ?? s_DefaultStringEncoder;
   public static I$moduleStringEncoder GlobalStringEncoder { get; set; }
-  public static I$moduleStringEncoder ThreadStringEncoder {    
-    get => s_ThreadStringEncoder;
-    set => s_ThreadStringEncoder = value;
+  public static I$moduleStringEncoder ThreadLocalStringEncoder {    
+    get => s_ThreadLocalStringEncoder;
+    set => s_ThreadLocalStringEncoder = value;
   }
 %}
 

--- a/swig/include/csharp/csharp_strings.i
+++ b/swig/include/csharp/csharp_strings.i
@@ -12,22 +12,21 @@
  * SPDX-License-Identifier: MIT
  *****************************************************************************/
 
-/*******************************************************************************
- * Marshaller for NULL terminated UTF-8 encoded strings                        *
- * Creates a callback function which is used from the native runtime to create *
- * .NET strings. The managed Utf8StringHelper registers a callback function    *
- * with the native runtime which is used by the native runtime to create .NET  *
- * strings. When called by the native runtime, the .NET function decodes the   *
- * unmanaged memory into a managed string and returns a new pinned GCHandle    *
- * for that string. A pointer to that GCHandle is returned. When the callback  *
- * returns to managed .NET, the managed string is retrieved from the GCHandle  *
- * and the GCHandle is freed by calling StringFromPinnedGCHandle.              *
- *                                                                             *
- * IMPORTANT:                                                                  *
- * Every call to SWIG_csharp_string_callback MUST be followed by exactly       *
- * one call to StringFromPinnedGCHandle() on the returned pointer.             *
- * Failure to do so will result in memory leaks or double frees.               *
- ******************************************************************************/
+/******************************************************************************
+ * Marshaller for NULL terminated UTF-8 encoded strings                       *
+ * The managed Utf8StringHelper registers a callback function with the native *
+ * runtime which is used by the native runtime to create .NET strings. When   *
+ * called by the native runtime, the .NET function decodes the unmanaged      *
+ * memory into a managed string and returns a new pinned GCHandle for that    *
+ * string. A pointer to that GCHandle is returned. When the callback returns  *
+ * to managed .NET, the managed string is retrieved from the GCHandle and the *
+ * GCHandle is freed by calling StringFromPinnedGCHandle.                     *
+ *                                                                            *
+ * IMPORTANT:                                                                 *
+ * Every call to SWIG_csharp_string_callback MUST be followed by exactly      *
+ * one call to StringFromPinnedGCHandle() on the returned pointer.            *
+ * Failure to do so will result in memory leaks or double frees.              *
+ *****************************************************************************/
 
 %insert(runtime) %{
 /* Callback for returning strings to C# without leaking memory */
@@ -127,9 +126,9 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 }
 %}
 
-/******************************************************************************
- * Apply typemaps for all SWIG string types and for const char *utf8_string   *
- ******************************************************************************/
+/*****************************************************************************
+ * Apply typemaps for all SWIG string types and for const char *utf8_string  *
+ ****************************************************************************/
 
 %typemap(cstype) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) "string"
 %typemap(imtype, out="IntPtr") (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) "byte[]"
@@ -289,15 +288,13 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
     public static string[] DecodeStringArray(IntPtr pList) {
       int count = 0;
       if (pList != IntPtr.Zero) checked {
-        while (System.Runtime.InteropServices.Marshal.ReadIntPtr(pList, count*IntPtr.Size) != IntPtr.Zero)
+        while (System.Runtime.InteropServices.Marshal.ReadIntPtr(pList, count * IntPtr.Size) != IntPtr.Zero)
           count++;
       }
       string[] ret = new string[count];
-      if (count > 0) {
-        for(int cx = 0; cx < count; cx++) {
-          IntPtr objPtr = System.Runtime.InteropServices.Marshal.ReadIntPtr(pList, cx * IntPtr.Size);
-          ret[cx]= $module.StringEncoder?.FromNullTerminated(objPtr);
-        }
+      for(int cx = 0; cx < count; cx++) {
+        IntPtr objPtr = System.Runtime.InteropServices.Marshal.ReadIntPtr(pList, cx * IntPtr.Size);
+        ret[cx]= $module.StringEncoder?.FromNullTerminated(objPtr);
       }
       return ret;
     }

--- a/swig/include/csharp/csharp_strings.i
+++ b/swig/include/csharp/csharp_strings.i
@@ -149,11 +149,7 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 
 %typemap(cstype) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) "string"
 %typemap(imtype, out="IntPtr") (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) "byte[]"
-
-%typemap(in) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) %{
-  $1 = ($1_ltype)$input;
-%}
-
+%typemap(in) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) %{ $1 = ($1_ltype)$input; %}
 %typemap(out) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) %{
  /*
   * %typemap(out) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string)
@@ -162,32 +158,29 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
   $result = SWIG_csharp_string_callback((const char *)$1);
 %}
 
-%typemap(csin) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) %{
-  $module.StringEncoder?.ToNullTerminated($csinput)
-%}
-
-%typemap(csout, excode=SWIGEXCODE) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string)
-{
-  /* %typemap(csout) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) */
+%typemap(csin) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string)
+  "$module.StringEncoder?.ToNullTerminated($csinput)"
+  
+%define CS_RETURN_UTF8_STRING
   IntPtr cPtr = $imcall;
   string ret = $modulePINVOKE.StringFromPinnedGCHandle(cPtr);
   $excode
   return ret;
+%enddef
+
+%typemap(csout, excode=SWIGEXCODE) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) {
+  CS_RETURN_UTF8_STRING
 }
 
 /*
  * Typemap for UTF-8 char* string properties.
  */
 
-%typemap(csvarout, excode=SWIGEXCODE2) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) %{
+%typemap(csvarout, noblock=1, excode=SWIGEXCODE2) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) {
   get {
-    /* %typemap(csvarout) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) */
-    IntPtr cPtr = $imcall;
-    string ret = $modulePINVOKE.StringFromPinnedGCHandle(cPtr);
-    $excode
-    return ret;
+    CS_RETURN_UTF8_STRING
   }
-%}
+}
 
 /*
  * Typemaps for  (retStringAndCPLFree*)
@@ -198,13 +191,10 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
   * %typemap(out) (retStringAndCPLFree*)
   * GCHandle is released by %typemap(csout) (char *)
   */
-  if($1)
-  {
+  if($1) {
     $result = SWIG_csharp_string_callback((const char *)$1);
     CPLFree($1);
-  }
-  else
-  {
+  } else {
     $result = NULL;
   }
 %}
@@ -216,15 +206,13 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 %typemap(imtype) (char** argout), (char **username), (char **usrname), (char **type) "ref IntPtr"
 %typemap(cstype) (char** argout), (char **username), (char **usrname), (char **type) "out string"
 %typemap(in) (char **argout), (char **username), (char **usrname), (char **type) %{ $1 = ($1_ltype)$input; %}
-%typemap(csin,
+%typemap(csin, cshin="out $csinput",
   pre="    IntPtr temp$csinput = IntPtr.Zero;",
-  post="    $csinput = $modulePINVOKE.StringFromPinnedGCHandle(temp$csinput);",
-  cshin="out $csinput"
-  ) (char** argout), (char **username), (char **usrname), (char **type)
+  post="    $csinput = $modulePINVOKE.StringFromPinnedGCHandle(temp$csinput);")
+  (char** argout), (char **username), (char **usrname), (char **type)
   "ref temp$csinput"
 
-%typemap(argout) (char **argout)
-{
+%typemap(argout) (char **argout) {
  /*
   * %typemap(argout) (char **argout)
   * GCHandle is released by %typemap(csin)
@@ -235,8 +223,7 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
     CPLFree(*$1);
   *$1 = temp_string;
 }
-%typemap(argout) (char **username), (char **usrname), (char **type)
-{
+%typemap(argout) (char **username), (char **usrname), (char **type) {
  /*
   * %typemap(argout) (char **username), (char **usrname), (char **type)
   * GCHandle is released by %typemap(csin)
@@ -249,27 +236,10 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
  * caller doesn't want to see changes.
  */
 
-%typemap(imtype) (char **ignorechange) "ref byte[]"
+%typemap(imtype) (char **ignorechange) "byte[]"
 %typemap(cstype) (char **ignorechange) "ref string"
-%typemap(csin,
-  pre="    byte[] bts$csinput = $module.StringEncoder?.ToNullTerminated($csinput);",
-  cshin="$csinput"
-  ) (char** ignorechange)
-  "ref bts$csinput"
-
-%typemap(in, noblock="1") (char **ignorechange)
-{
-  /* %typemap(in) (char **ignorechange) */
-  $*1_type savearg = *(($1_type)$input);
-  $1 = ($1_ltype)$input;
-}
-%typemap(argout, noblock="1") (char **ignorechange)
-{
-  /* %typemap(argout) (char **ignorechange) */
-  if ((*$1 - savearg) > 0)
-     memmove(savearg, *$1, strlen(*$1)+1);
-  *$1 = savearg;
-}
+%typemap(in)     (char **ignorechange) %{ $1 = ($1_ltype)&$input; %}
+%typemap(csin)   (char **ignorechange) "$module.StringEncoder?.ToNullTerminated($csinput)"
 
 /******************************************************************************
  * Marshaller for NULL terminated lists of NULL terminated UTF-8 strings.     *
@@ -326,11 +296,10 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 %typemap(cstype) char **options, char **dict, char **dictAndCSLDestroy, char **CSL "string[]"
 %typemap(in) char **options, char **dict, char **dictAndCSLDestroy, char **CSL %{ $1 = ($1_ltype)$input; %}
 %typemap(out) char **options, char **dict, char **dictAndCSLDestroy, char **CSL %{ $result = $1; %}
-%typemap(csin,
+%typemap(csin, cshin="$csinput",
   pre="    using (var temp$csinput = new $modulePINVOKE.StringListMarshal($csinput)) { ",
-  terminator="    }",
-  cshin="$csinput"
-  ) char **options, char **dict, char **dictAndCSLDestroy, char **CSL
+  terminator="    }")
+  char **options, char **dict, char **dictAndCSLDestroy, char **CSL
   "temp$csinput._ar"
 
 /*

--- a/swig/include/csharp/csharp_strings.i
+++ b/swig/include/csharp/csharp_strings.i
@@ -56,7 +56,7 @@ static CSharpUtf8StringHelperCallback SWIG_csharp_string_callback = NULL;
   }
   internal class DefaultStringEncoder : IStringEncoder {
     public string FromNullTerminated(IntPtr pStr) {
-#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+#if NETCOREAPP1_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
       return System.Runtime.InteropServices.Marshal.PtrToStringUTF8(pStr);
 #else
       if (pStr == IntPtr.Zero) return null;

--- a/swig/include/csharp/csharp_strings.i
+++ b/swig/include/csharp/csharp_strings.i
@@ -439,7 +439,7 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 	  string message = e != null ? " Inner Exception: " + e.Message : Utf8UnmanagedToString(pMessage);
       SWIGPendingException.Set(new ArgumentOutOfRangeException(Utf8UnmanagedToString(pParamName), message));
     }
-    unsafe static string Utf8UnmanagedToString(IntPtr pUtf8Bts)
+    static string Utf8UnmanagedToString(IntPtr pUtf8Bts)
 	  => $module.StringEncoder?.FromNullTerminated(pUtf8Bts);
   }
   //Instantiate the helper class so that the static constructor executes

--- a/swig/include/csharp/csharp_strings.i
+++ b/swig/include/csharp/csharp_strings.i
@@ -36,38 +36,39 @@ static CSharpUtf8StringHelperCallback SWIG_csharp_string_callback = NULL;
 %}
 
 %pragma(csharp) modulecode=%{
-  /* Interface for marshalling string to/from Gdal unmanaged strings. */
-  public interface IStringMarshaller {
-    /* Convert a string to a null-terminated array of bytes to be sent to Gdal unmanaged */
+  /* Interface for encoding/decoding string to/from Gdal unmanaged strings. */
+  public interface IStringEncoder {
+    /* Encode a string to a null-terminated array of bytes to be sent to Gdal unmanaged */
     byte[] ToNullTerminated(string str);
-    /* Convert an unmanaged, null-terminated string from Gdal to a managed string */
+    /* Decode an unmanaged, null-terminated string from Gdal to a managed string */
     string FromNullTerminated(IntPtr pStr);
   }
-  internal static readonly IStringMarshaller s_DefaultStringMarshaller = new DefaultStringMarshaller();
-  internal static IStringMarshaller s_StringMarshaller;
-  public static IStringMarshaller StringMarshaller {
+  internal static readonly IStringEncoder s_DefaultStringEncoder = new DefaultStringEncoder();
+  internal static IStringEncoder s_StringEncoder;
+  public static IStringEncoder StringEncoder {
     get {
-      if (s_StringMarshaller == null)
-        s_StringMarshaller = s_DefaultStringMarshaller;
-      return s_StringMarshaller;
+      if (s_StringEncoder == null)
+        s_StringEncoder = s_DefaultStringEncoder;
+      return s_StringEncoder;
     }
     set {
-      s_StringMarshaller = value;
+      s_StringEncoder = value;
     }
   }
-  internal class DefaultStringMarshaller : IStringMarshaller {
-    public unsafe string FromNullTerminated(IntPtr pStr) {
-      if (pStr == IntPtr.Zero) return null;
-      byte* pBytes = (byte*)pStr.ToPointer();
-#if NET6_0_OR_GREATER
-      ReadOnlySpan<byte> nativeBytes = System.Runtime.InteropServices.MemoryMarshal.CreateReadOnlySpanFromNullTerminated(pBytes);
-      return System.Text.Encoding.UTF8.GetString(nativeBytes);
+  internal class DefaultStringEncoder : IStringEncoder {
+    public string FromNullTerminated(IntPtr pStr) {
+#if NETCOREAPP || NETSTANDARD2_1_OR_GREATER
+      return System.Runtime.InteropServices.Marshal.PtrToStringUTF8(pStr);
 #else
-      int len = 0;
-      checked {
-        while (pBytes[len] != 0) len++;
+      if (pStr == IntPtr.Zero) return null;
+      unsafe {
+        byte* pBytes = (byte*)pStr.ToPointer();
+        int len = 0;
+        checked {
+          while (pBytes[len] != 0) len++;
+        }
+        return System.Text.Encoding.UTF8.GetString(pBytes, len);
       }
-      return System.Text.Encoding.UTF8.GetString(pBytes, len);
 #endif
     }
     public byte[] ToNullTerminated(string str) {
@@ -94,21 +95,19 @@ static CSharpUtf8StringHelperCallback SWIG_csharp_string_callback = NULL;
       RegisterUtf8StringCallback_$module(stringDelegate);
     }
 
-    public unsafe static IntPtr DecodeStringToPinnedGCHandle(IntPtr pUtf8Bts)
-    {
-      string value = $module.StringMarshaller?.FromNullTerminated(pUtf8Bts);
-	  if (value == null) return IntPtr.Zero;	  
+    public static IntPtr DecodeStringToPinnedGCHandle(IntPtr pUtf8Bts) {
+      string value = $module.StringEncoder?.FromNullTerminated(pUtf8Bts);
+      if (value == null) return IntPtr.Zero;
       var handle = System.Runtime.InteropServices.GCHandle.Alloc(value,
                      System.Runtime.InteropServices.GCHandleType.Pinned);
       return System.Runtime.InteropServices.GCHandle.ToIntPtr(handle);
     }
   }
 
-  //Instantiate the helper class so that the static constructor executes
+  /* Instantiate the helper class so that the static constructor executes */
   public static readonly Utf8StringHelper utf8StringHelper = new Utf8StringHelper();
 
-  internal static string StringFromPinnedGCHandle(IntPtr pinnedHandle)
-  {
+  internal static string StringFromPinnedGCHandle(IntPtr pinnedHandle){
     if (pinnedHandle == IntPtr.Zero) return null;
     var handle = System.Runtime.InteropServices.GCHandle.FromIntPtr(pinnedHandle);
     string value = handle.Target as string;
@@ -147,9 +146,9 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 
 %typemap(csin,
   pre="
-  byte[] bts$csinput = $module.StringMarshaller?.ToNullTerminated($csinput);
-  unsafe {
-    fixed (byte* pBts$csinput = bts$csinput) {",
+    byte[] bts$csinput = $module.StringEncoder?.ToNullTerminated($csinput);
+    unsafe {
+      fixed (byte* pBts$csinput = bts$csinput) {",
   terminator="    }}",
   cshin="$csinput"
   ) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string)
@@ -171,7 +170,7 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 %typemap(csvarin, excode=SWIGEXCODE2) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) %{
   /* %typemap(csvarin) (char *), (char *&), (char[ANY]), (char[]), (const char *utf8_string) */
   set {
-    byte[] bts$csinput = $module.StringMarshaller?.ToNullTerminated($csinput);
+    byte[] bts$csinput = $module.StringEncoder?.ToNullTerminated($csinput);
     unsafe {
       fixed (byte* pBts$csinput = bts$csinput) {
         $imcall;$excode
@@ -254,8 +253,10 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 %typemap(cstype) (char **ignorechange) "ref string"
 %typemap(csin,
   pre="
-    byte[] bts$csinput = $module.StringMarshaller?.ToNullTerminated($csinput);
-    unsafe { fixed (byte* pBts$csinput = bts$csinput) { IntPtr temp$csinput = (IntPtr)pBts$csinput;",
+    byte[] bts$csinput = $module.StringEncoder?.ToNullTerminated($csinput);
+    unsafe {
+      fixed (byte* pBts$csinput = bts$csinput) {
+        IntPtr temp$csinput = (IntPtr)pBts$csinput;",
   terminator="    }}",
   cshin="$csinput"
   ) (char** ignorechange)
@@ -290,7 +291,7 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
       _handles = new System.Runtime.InteropServices.GCHandle[ar.Length];
       _ar = new IntPtr[ar.Length + 1];
       for (int cx = 0; cx < ar.Length; cx++) {
-        byte[] bts = $module.StringMarshaller?.ToNullTerminated(ar[cx]);
+        byte[] bts = $module.StringEncoder?.ToNullTerminated(ar[cx]);
         _handles[cx] = System.Runtime.InteropServices.GCHandle.Alloc(bts, System.Runtime.InteropServices.GCHandleType.Pinned);
         _ar[cx] = _handles[cx].AddrOfPinnedObject();
       }
@@ -340,7 +341,7 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
   if (count > 0) {
     for(int cx = 0; cx < count; cx++) {
       objPtr = System.Runtime.InteropServices.Marshal.ReadIntPtr(cPtr, cx * System.Runtime.InteropServices.Marshal.SizeOf(typeof(IntPtr)));
-      ret[cx]= $module.StringMarshaller?.FromNullTerminated(objPtr);
+      ret[cx]= $module.StringEncoder?.FromNullTerminated(objPtr);
     }
   }
 %enddef

--- a/swig/include/csharp/csharp_strings.i
+++ b/swig/include/csharp/csharp_strings.i
@@ -17,9 +17,9 @@
  * The managed Utf8StringHelper registers a callback function with the native *
  * runtime which is used by the native runtime to create .NET strings. When   *
  * called by the native runtime, the .NET function decodes the unmanaged      *
- * memory into a managed string and returns a new pinned GCHandle for that    *
- * string. A pointer to that GCHandle is returned. When the callback returns  *
- * to managed .NET, the managed string is retrieved from the GCHandle and the *
+ * memory into a managed string and returns a new GCHandle for that string.   *
+ * A pointer to that GCHandle is returned. When the callback returns to       *
+ * managed .NET, the managed string is retrieved from the GCHandle and the    *
  * GCHandle is freed by calling StringFromGCHandle.                           *
  *                                                                            *
  * IMPORTANT:                                                                 *

--- a/swig/include/csharp/csharp_strings.i
+++ b/swig/include/csharp/csharp_strings.i
@@ -20,11 +20,11 @@
  * memory into a managed string and returns a new pinned GCHandle for that    *
  * string. A pointer to that GCHandle is returned. When the callback returns  *
  * to managed .NET, the managed string is retrieved from the GCHandle and the *
- * GCHandle is freed by calling StringFromPinnedGCHandle.                     *
+ * GCHandle is freed by calling StringFromGCHandle.                           *
  *                                                                            *
  * IMPORTANT:                                                                 *
  * Every call to SWIG_csharp_string_callback MUST be followed by exactly      *
- * one call to StringFromPinnedGCHandle() on the returned pointer.            *
+ * one call to StringFromGCHandle() on the returned pointer.                  *
  * Failure to do so will result in memory leaks or double frees.              *
  *****************************************************************************/
 
@@ -100,7 +100,7 @@ struct CsharpDummyObject{};
 
     public delegate System.IntPtr Utf8StringDelegate(System.IntPtr message);
 
-    static Utf8StringDelegate stringDelegate = new Utf8StringDelegate(DecodeStringToPinnedGCHandle);
+    static Utf8StringDelegate stringDelegate = new Utf8StringDelegate(DecodeStringToGCHandle);
 
     [global::System.Runtime.InteropServices.DllImport("$dllimport", EntryPoint="RegisterUtf8StringCallback_$module")]
     public static extern void RegisterUtf8StringCallback_$module(Utf8StringDelegate stringDelegate);
@@ -109,12 +109,11 @@ struct CsharpDummyObject{};
       RegisterUtf8StringCallback_$module(stringDelegate);
     }
 
-    public static IntPtr DecodeStringToPinnedGCHandle(IntPtr pUtf8Bts) {
+    public static IntPtr DecodeStringToGCHandle(IntPtr pUtf8Bts) {
       string value = $module.StringEncoder?.FromNullTerminated(pUtf8Bts);
       if (value == null)
         return IntPtr.Zero;
-      var handle = System.Runtime.InteropServices.GCHandle.Alloc(value,
-                     System.Runtime.InteropServices.GCHandleType.Pinned);
+      var handle = System.Runtime.InteropServices.GCHandle.Alloc(value);
       return System.Runtime.InteropServices.GCHandle.ToIntPtr(handle);
     }
   }
@@ -122,10 +121,10 @@ struct CsharpDummyObject{};
   /* Instantiate the helper class so that the static constructor executes */
   public static readonly Utf8StringHelper utf8StringHelper = new Utf8StringHelper();
 
-  internal static string StringFromPinnedGCHandle(IntPtr pinnedHandle){
-    if (pinnedHandle == IntPtr.Zero)
+  internal static string StringFromGCHandle(IntPtr gcHandle){
+    if (gcHandle == IntPtr.Zero)
       return null;
-    var handle = System.Runtime.InteropServices.GCHandle.FromIntPtr(pinnedHandle);
+    var handle = System.Runtime.InteropServices.GCHandle.FromIntPtr(gcHandle);
     string value = handle.Target as string;
     handle.Free();
     return value;
@@ -162,7 +161,7 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 %define CS_RETURN_UTF8_STRING
 
   IntPtr cPtr = $imcall;
-  string ret = $modulePINVOKE.StringFromPinnedGCHandle(cPtr);
+  string ret = $modulePINVOKE.StringFromGCHandle(cPtr);
   $excode
   return ret;
 %enddef
@@ -207,7 +206,7 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 %typemap(in) (char **argout), (char **username), (char **usrname), (char **type) %{ $1 = ($1_ltype)$input; %}
 %typemap(csin, cshin="out $csinput",
   pre="    IntPtr temp$csinput = IntPtr.Zero;",
-  post="    $csinput = $modulePINVOKE.StringFromPinnedGCHandle(temp$csinput);")
+  post="    $csinput = $modulePINVOKE.StringFromGCHandle(temp$csinput);")
   (char** argout), (char **username), (char **usrname), (char **type)
   "ref temp$csinput"
 

--- a/swig/include/csharp/csharp_strings.i
+++ b/swig/include/csharp/csharp_strings.i
@@ -34,62 +34,14 @@ typedef char * (SWIGSTDCALL* CSharpUtf8StringHelperCallback)(const char *);
 static CSharpUtf8StringHelperCallback SWIG_csharp_string_callback = NULL;
 %}
 
-/*
- * Define a dummy type so that we can extend it to add custom types
- * inside the module namespace using the csimports typemap
- */
-%{
-typedef struct {} CsharpDummyObject;
-%}
-%typemap(csclassmodifiers) CsharpDummyObject "internal class";
-%typemap(csimports) CsharpDummyObject %{
-  using System;
-  using System.Text;
-  using System.Runtime.InteropServices;
-
-  /* Interface for encoding/decoding string to/from Gdal unmanaged strings. */
-  public interface I$moduleStringEncoder {
-    /* Encode a string to a null-terminated array of bytes to be sent to Gdal unmanaged */
-    byte[] ToNullTerminated(string str);
-    /* Decode an unmanaged, null-terminated string from Gdal to a managed string */
-    string FromNullTerminated(IntPtr pStr);
-  }
-  
-  public class Default$moduleStringEncoder : I$moduleStringEncoder {
-    public virtual string FromNullTerminated(IntPtr pStr) {
-#if NETCOREAPP1_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-      return Marshal.PtrToStringUTF8(pStr);
-#else
-      if (pStr == IntPtr.Zero) return null;
-      unsafe {
-        byte* pBytes = (byte*)pStr.ToPointer();
-        int len = 0;
-        checked {
-          while (pBytes[len] != 0) len++;
-        }
-        return Encoding.UTF8.GetString(pBytes, len);
-      }
-#endif
-    }
-    public virtual byte[] ToNullTerminated(string str) {
-      if (str == null) return null;
-      int byteCount = Encoding.UTF8.GetByteCount(str);
-      var bts = new byte[byteCount + 1];
-      Encoding.UTF8.GetBytes(str, 0, str.Length, bts, 0);
-      return bts;
-    }
-  }
-%}
-struct CsharpDummyObject{};
-
 %pragma(csharp) modulecode=%{
-  private static readonly I$moduleStringEncoder s_DefaultStringEncoder = new Default$moduleStringEncoder();
+  private static readonly OSR.IStringEncoder s_DefaultStringEncoder = new OSR.DefaultStringEncoder();
   [System.ThreadStatic]
-  private static I$moduleStringEncoder s_ThreadLocalStringEncoder;
-  public static I$moduleStringEncoder StringEncoder
+  private static OSR.IStringEncoder s_ThreadLocalStringEncoder;
+  public static OSR.IStringEncoder StringEncoder
     => ThreadLocalStringEncoder ?? GlobalStringEncoder ?? s_DefaultStringEncoder;
-  public static I$moduleStringEncoder GlobalStringEncoder { get; set; }
-  public static I$moduleStringEncoder ThreadLocalStringEncoder {    
+  public static OSR.IStringEncoder GlobalStringEncoder { get; set; }
+  public static OSR.IStringEncoder ThreadLocalStringEncoder {    
     get => s_ThreadLocalStringEncoder;
     set => s_ThreadLocalStringEncoder = value;
   }

--- a/swig/include/csharp/csharp_strings.i
+++ b/swig/include/csharp/csharp_strings.i
@@ -247,8 +247,7 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
 %pragma(csharp) imclasscode=%{
   public class StringListMarshal : IDisposable {
     public readonly IntPtr[] _ar;
-    private readonly System.Runtime.InteropServices.GCHandle[] _handles;
-    private int _isDisposed;
+    private System.Runtime.InteropServices.GCHandle[] _handles;
     public StringListMarshal(string[] ar) {
       if (ar == null)
         return;
@@ -263,9 +262,11 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
     }
     ~StringListMarshal() => Dispose();
     public virtual void Dispose() {
-      if (System.Threading.Interlocked.CompareExchange(ref _isDisposed, 1, 0) == 0 && _handles != null) {
-         for (int cx = 0; cx < _handles.Length; cx++) {
-           _handles[cx].Free();
+	  var handles = System.Threading.Interlocked.Exchange(ref _handles, null);
+      if (handles != null && _ar != null) {
+         for (int cx = 0; cx < handles.Length; cx++) {		   
+           if (handles[cx].IsAllocated)
+             handles[cx].Free();
            _ar[cx] = IntPtr.Zero;
         }
       }

--- a/swig/include/csharp/gdal_csharp.i
+++ b/swig/include/csharp/gdal_csharp.i
@@ -16,6 +16,7 @@
 %rename (GetMetadata) GetMetadata_List;
 %ignore GetMetadata_Dict;
 
+/* C# string encoder is located inside OSR (See csharp_string_encoder.i) */
 %include typemaps_csharp.i
 
 DEFINE_EXTERNAL_CLASS(OSRSpatialReferenceShadow, OSGeo.OSR.SpatialReference)

--- a/swig/include/csharp/ogr_csharp.i
+++ b/swig/include/csharp/ogr_csharp.i
@@ -71,7 +71,7 @@ DEFINE_EXTERNAL_CLASS(GDALMajorObjectShadow, OSGeo.GDAL.MajorObject)
      return new $csclassname(wkbGeometryType.wkbUnknown, null, 0, IntPtr.Zero, gml);
   }
 
-  public Geometry(wkbGeometryType type) : this(OgrPINVOKE.new_Geometry((int)type, IntPtr.Zero, 0, IntPtr.Zero, IntPtr.Zero), true, null) {
+  public Geometry(wkbGeometryType type) : this(OgrPINVOKE.new_Geometry((int)type, null, 0, IntPtr.Zero, null), true, null) {
     if (OgrPINVOKE.SWIGPendingException.Pending) throw OgrPINVOKE.SWIGPendingException.Retrieve();
   }
 }

--- a/swig/include/csharp/ogr_csharp.i
+++ b/swig/include/csharp/ogr_csharp.i
@@ -19,6 +19,7 @@
 %rename (SetGenerate_DB2_V72_BYTE_ORDER) OGRSetGenerate_DB2_V72_BYTE_ORDER;
 %rename (RegisterAll) OGRRegisterAll();
 
+/* C# string encoder is located inside OSR (See csharp_string_encoder.i) */
 %include typemaps_csharp.i
 
 DEFINE_EXTERNAL_CLASS(OSRSpatialReferenceShadow, OSGeo.OSR.SpatialReference)

--- a/swig/include/csharp/osr_csharp.i
+++ b/swig/include/csharp/osr_csharp.i
@@ -13,6 +13,7 @@
 
 %include cpl_exceptions.i
 
+%include csharp_string_encoder.i
 %include typemaps_csharp.i
 
 %apply (int *hasval) {int* pnListCount};

--- a/swig/include/csharp/typemaps_csharp.i
+++ b/swig/include/csharp/typemaps_csharp.i
@@ -89,23 +89,6 @@ OGRErrMessages( int rc ) {
 }
 %}
 
-/*
- * Helper to marshal utf8 strings.
- */
-
-%pragma(csharp) modulecode=%{
-  internal unsafe static string Utf8BytesToString(IntPtr pNativeData)
-  {
-    if (pNativeData == IntPtr.Zero)
-        return null;
-
-    byte* pStringUtf8 = (byte*) pNativeData;
-    int len = 0;
-    while (pStringUtf8[len] != 0) len++;
-    return System.Text.Encoding.UTF8.GetString(pStringUtf8, len);
-  }
-%}
-
 %typemap(out,fragment="OGRErrMessages",canthrow=1) OGRErr
 {
   /* %typemap(out,fragment="OGRErrMessages",canthrow=1) OGRErr */

--- a/swig/include/gdalconst.i
+++ b/swig/include/gdalconst.i
@@ -17,7 +17,6 @@
 
 #if defined(SWIGCSHARP)
 %module GdalConst
-%include csharp_strings.i
 #else
 %module gdalconst
 #endif

--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -534,6 +534,7 @@ typedef int CPLErr;
 #define OGRNullFID            -1
 #define OGRUnsetMarker        -21121
 
+%csconst(1);
 #define OLCRandomRead          "RandomRead"
 #define OLCSequentialWrite     "SequentialWrite"
 #define OLCRandomWrite         "RandomWrite"
@@ -581,6 +582,7 @@ typedef int CPLErr;
 #define ODrCDeleteDataSource   "DeleteDataSource"
 
 #define OLMD_FID64             "OLMD_FID64"
+%csconst(0);
 
 #define GEOS_PREC_NO_TOPO          1
 #define GEOS_PREC_KEEP_COLLAPSED   2


### PR DESCRIPTION
## What does this PR do?

Creates an interface for users to create custom string Encoder/Decoders for Gdal to use for all string operations. This serves a purpose similar to #3825 by allowing users to manage how strings are encoded/decoded to/from Gdal.

Expose `I$moduleStringEncoder` interfaces which have 2 methods:
 - `string FromNullTerminated(IntPtr pStr);` - Read native null-terminated data from a Gdal pointer and return a managed string.
 - `byte[] ToNullTerminated(string str);` - Create a null-terminated array of bytes from a managed string to send to Gdal.

It also simplifies string marshalling changes [made in recent PR](https://github.com/OSGeo/gdal/pull/14283) by no longer requires C# to allocate/free any unmanaged memory. All string/byte[] objects are managed.

------------
Here's an example of a custom StringEncoder.
  
```C#
class CustomGdalEncoder : OSGeo.GDAL.IGdalStringEncoder, OSGeo.OGR.IOgrStringEncoder, OSGeo.OSR.IOsrStringEncoder
{
    public string FromNullTerminated(IntPtr pStr)
      => Marshal.PtrToStringUTF8(pStr);

    public byte[] ToNullTerminated(string str)
    {
        if (str == null)
            return null;
        int byteCount = Encoding.UTF8.GetByteCount(str);
        var bts = new byte[byteCount + 1];
        Encoding.UTF8.GetBytes(str, 0, str.Length, bts, 0);
        return bts;
    }
}
var encoder = new CustomGdalEncoder();
OSGeo.GDAL.Gdal.GlobalStringEncoder = encoder;
OSGeo.OGR.Ogr.GlobalStringEncoder = encoder;
OSGeo.OSR.Osr.GlobalStringEncoder = encoder;
```

@runette

## What are related issues/pull requests?
#3825
#14283 

## Tasklist

 - [X] Make sure code is correctly formatted
 - [x] Review
 - [x] Adjust for comments

## Environment

Provide environment details, if relevant:
Mono and dotnet
