### PR TITLE
GDALAlgorithm::ParseCommandLineArguments(): fix for list-type of argument with max count = 1

### DIFF
--- a/autotest/cpp/test_gdal_algorithm.cpp
+++ b/autotest/cpp/test_gdal_algorithm.cpp
@@ -5136,6 +5136,171 @@ TEST_F(test_gdal_algorithm, duplicate_values)
     }
 }
 
+TEST_F(test_gdal_algorithm, list_single_valued_dataset_followed_by_positional)
+{
+    // Scenario of https://github.com/OSGeo/gdal/issues/14358
+
+    class MyAlgorithm : public MyAlgorithmWithDummyRun
+    {
+      public:
+        std::vector<GDALArgDatasetValue> m_inputDataset{};
+        GDALArgDatasetValue m_outputDataset{};
+
+        MyAlgorithm()
+        {
+            AddInputDatasetArg(&m_inputDataset, GDAL_OF_RASTER, true)
+                .SetMaxCount(1)
+                .SetAutoOpenDataset(false);
+            AddOutputDatasetArg(&m_outputDataset, GDAL_OF_RASTER, true)
+                .SetDatasetInputFlags(GADV_NAME | GADV_OBJECT);
+        }
+    };
+
+    {
+        MyAlgorithm alg;
+        EXPECT_TRUE(alg.ParseCommandLineArguments(
+            {"--input", "/vsimem/in.tif", "/vsimem/out.tif"}));
+        EXPECT_EQ(alg.m_inputDataset.size(), 1U);
+    }
+
+    {
+        MyAlgorithm alg;
+        EXPECT_TRUE(alg.ParseCommandLineArguments(
+            {"--input=/vsimem/in.tif", "/vsimem/out.tif"}));
+        EXPECT_EQ(alg.m_inputDataset.size(), 1U);
+    }
+
+    {
+        MyAlgorithm alg;
+        EXPECT_TRUE(alg.ParseCommandLineArguments(
+            {"/vsimem/in.tif", "/vsimem/out.tif"}));
+        EXPECT_EQ(alg.m_inputDataset.size(), 1U);
+    }
+
+    {
+        MyAlgorithm alg;
+        EXPECT_TRUE(alg.ParseCommandLineArguments(
+            {"--input", "/vsimem/in.tif", "--output", "/vsimem/out.tif"}));
+        EXPECT_EQ(alg.m_inputDataset.size(), 1U);
+    }
+
+    {
+        MyAlgorithm alg;
+        CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
+        EXPECT_FALSE(alg.ParseCommandLineArguments(
+            {"--input", "/vsimem/in.tif", "--input", "not_expected.tif",
+             "/vsimem/out.tif"}));
+        EXPECT_EQ(alg.m_inputDataset.size(), 1U);
+    }
+
+    {
+        MyAlgorithm alg;
+        CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
+        EXPECT_FALSE(
+            alg.ParseCommandLineArguments({"--input", "/vsimem/in.tif"}));
+        EXPECT_EQ(alg.m_inputDataset.size(), 1U);
+    }
+}
+
+TEST_F(test_gdal_algorithm, list_single_valued_str_followed_by_positional)
+{
+    // Scenario of https://github.com/OSGeo/gdal/issues/14358
+
+    class MyAlgorithm : public MyAlgorithmWithDummyRun
+    {
+      public:
+        std::vector<std::string> m_a{};
+        int m_b{};
+
+        MyAlgorithm()
+        {
+            AddArg("a", 0, "a", &m_a)
+                .SetPositional()
+                .SetRequired()
+                .SetMaxCount(1);
+            AddArg("b", 0, "b", &m_b).SetPositional().SetRequired();
+        }
+    };
+
+    {
+        MyAlgorithm alg;
+        EXPECT_TRUE(alg.ParseCommandLineArguments({"--a", "str", "1"}));
+        EXPECT_EQ(alg.m_a.size(), 1U);
+    }
+
+    {
+        MyAlgorithm alg;
+        EXPECT_TRUE(alg.ParseCommandLineArguments({"str", "1"}));
+        EXPECT_EQ(alg.m_a.size(), 1U);
+    }
+}
+
+TEST_F(test_gdal_algorithm, list_single_valued_int_followed_by_positional)
+{
+    // Scenario of https://github.com/OSGeo/gdal/issues/14358
+
+    class MyAlgorithm : public MyAlgorithmWithDummyRun
+    {
+      public:
+        std::vector<int> m_a{};
+        int m_b{};
+
+        MyAlgorithm()
+        {
+            AddArg("a", 0, "a", &m_a)
+                .SetPositional()
+                .SetRequired()
+                .SetMaxCount(1);
+            AddArg("b", 0, "b", &m_b).SetPositional().SetRequired();
+        }
+    };
+
+    {
+        MyAlgorithm alg;
+        EXPECT_TRUE(alg.ParseCommandLineArguments({"--a", "2", "1"}));
+        EXPECT_EQ(alg.m_a.size(), 1U);
+    }
+
+    {
+        MyAlgorithm alg;
+        EXPECT_TRUE(alg.ParseCommandLineArguments({"2", "1"}));
+        EXPECT_EQ(alg.m_a.size(), 1U);
+    }
+}
+
+TEST_F(test_gdal_algorithm, list_single_valued_real_followed_by_positional)
+{
+    // Scenario of https://github.com/OSGeo/gdal/issues/14358
+
+    class MyAlgorithm : public MyAlgorithmWithDummyRun
+    {
+      public:
+        std::vector<double> m_a{};
+        int m_b{};
+
+        MyAlgorithm()
+        {
+            AddArg("a", 0, "a", &m_a)
+                .SetPositional()
+                .SetRequired()
+                .SetMaxCount(1);
+            AddArg("b", 0, "b", &m_b).SetPositional().SetRequired();
+        }
+    };
+
+    {
+        MyAlgorithm alg;
+        EXPECT_TRUE(alg.ParseCommandLineArguments({"--a", "2.5", "1"}));
+        EXPECT_EQ(alg.m_a.size(), 1U);
+    }
+
+    {
+        MyAlgorithm alg;
+        EXPECT_TRUE(alg.ParseCommandLineArguments({"2.5", "1"}));
+        EXPECT_EQ(alg.m_a.size(), 1U);
+    }
+}
+
 }  // namespace test_gdal_algorithm
 
 #if defined(__clang__)

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -1921,7 +1921,8 @@ bool GDALAlgorithm::ParseArgument(
                      std::vector<double>, std::vector<GDALArgDatasetValue>>>
         &inConstructionValues)
 {
-    const bool isListArg = GDALAlgorithmArgTypeIsList(arg->GetType());
+    const bool isListArg =
+        GDALAlgorithmArgTypeIsList(arg->GetType()) && arg->GetMaxCount() > 1;
     if (arg->IsExplicitlySet() && !isListArg)
     {
         // Hack for "gdal info" to be able to pass an opened raster dataset
@@ -2028,6 +2029,13 @@ bool GDALAlgorithm::ParseArgument(
             {
                 valueVector.push_back(v);
             }
+            if (arg->GetMaxCount() == 1)
+            {
+                bool ret = arg->Set(std::move(valueVector));
+                inConstructionValues.erase(inConstructionValues.find(arg));
+                return ret;
+            }
+
             break;
         }
 
@@ -2066,6 +2074,13 @@ bool GDALAlgorithm::ParseArgument(
                     return false;
                 }
             }
+            if (arg->GetMaxCount() == 1)
+            {
+                bool ret = arg->Set(std::move(valueVector));
+                inConstructionValues.erase(inConstructionValues.find(arg));
+                return ret;
+            }
+
             break;
         }
 
@@ -2099,6 +2114,13 @@ bool GDALAlgorithm::ParseArgument(
                 }
                 valueVector.push_back(dfValue);
             }
+            if (arg->GetMaxCount() == 1)
+            {
+                bool ret = arg->Set(std::move(valueVector));
+                inConstructionValues.erase(inConstructionValues.find(arg));
+                return ret;
+            }
+
             break;
         }
 
@@ -2127,6 +2149,13 @@ bool GDALAlgorithm::ParseArgument(
                     valueVector.push_back(GDALArgDatasetValue(v));
                 }
             }
+            if (arg->GetMaxCount() == 1)
+            {
+                bool ret = arg->Set(std::move(valueVector));
+                inConstructionValues.erase(inConstructionValues.find(arg));
+                return ret;
+            }
+
             break;
         }
     }


### PR DESCRIPTION
Fixes #14358
