### PR TITLE
OGRSpatialReference::GetAuthorityName()/GetAuthorityCode(): add default…

### DIFF
--- a/apps/gdalalg_raster_pixel_info.cpp
+++ b/apps/gdalalg_raster_pixel_info.cpp
@@ -580,8 +580,8 @@ bool GDALRasterPixelInfoAlgorithm::RunStep(GDALPipelineStepRunContext &)
     bool canOutputGeoJSONGeom = false;
     if (poSrcCRS && bHasGT)
     {
-        const char *pszAuthName = poSrcCRS->GetAuthorityName(nullptr);
-        const char *pszAuthCode = poSrcCRS->GetAuthorityCode(nullptr);
+        const char *pszAuthName = poSrcCRS->GetAuthorityName();
+        const char *pszAuthCode = poSrcCRS->GetAuthorityCode();
         if (pszAuthName && pszAuthCode && EQUAL(pszAuthName, "EPSG"))
         {
             canOutputGeoJSONGeom = true;

--- a/apps/gdalalg_raster_tile.cpp
+++ b/apps/gdalalg_raster_tile.cpp
@@ -2455,8 +2455,8 @@ GenerateSTAC(const std::string &osDirectory, const std::string &osTitle,
         std::move(oTilesTileMatrixLink);
     oProperties["tiles:tile_matrix_links"] = std::move(oTilesTileMatrixLinks);
 
-    const char *pszAuthName = oSRS.GetAuthorityName(nullptr);
-    const char *pszAuthCode = oSRS.GetAuthorityCode(nullptr);
+    const char *pszAuthName = oSRS.GetAuthorityName();
+    const char *pszAuthCode = oSRS.GetAuthorityCode();
     if (pszAuthName && pszAuthCode)
     {
         oProperties["proj:code"] =
@@ -2904,8 +2904,8 @@ static void GenerateOpenLayers(
     }
     else if (!oSRS_TMS.IsEmpty() && tms.identifier() != "GoogleMapsCompatible")
     {
-        const char *pszAuthName = oSRS_TMS.GetAuthorityName(nullptr);
-        const char *pszAuthCode = oSRS_TMS.GetAuthorityCode(nullptr);
+        const char *pszAuthName = oSRS_TMS.GetAuthorityName();
+        const char *pszAuthCode = oSRS_TMS.GetAuthorityCode();
         if (pszAuthName && pszAuthCode && EQUAL(pszAuthName, "EPSG"))
         {
             substs["epsg_code"] = pszAuthCode;
@@ -4634,8 +4634,8 @@ bool GDALRasterTileAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
         aosTO.SetNameValue("DST_SRS", oSRS_TMS.exportToWkt().c_str());
     }
 
-    const char *pszAuthName = oSRS_TMS.GetAuthorityName(nullptr);
-    const char *pszAuthCode = oSRS_TMS.GetAuthorityCode(nullptr);
+    const char *pszAuthName = oSRS_TMS.GetAuthorityName();
+    const char *pszAuthCode = oSRS_TMS.GetAuthorityCode();
     const int nEPSGCode =
         (pszAuthName && pszAuthCode && EQUAL(pszAuthName, "EPSG"))
             ? atoi(pszAuthCode)

--- a/apps/gdalalg_vector_index.cpp
+++ b/apps/gdalalg_vector_index.cpp
@@ -555,10 +555,8 @@ bool GDALVectorIndexAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
 
             if (nSourceCRSFieldIdx >= 0 && poSrcCRS)
             {
-                const char *pszAuthorityCode =
-                    poSrcCRS->GetAuthorityCode(nullptr);
-                const char *pszAuthorityName =
-                    poSrcCRS->GetAuthorityName(nullptr);
+                const char *pszAuthorityCode = poSrcCRS->GetAuthorityCode();
+                const char *pszAuthorityName = poSrcCRS->GetAuthorityName();
                 const std::string osWKT = poSrcCRS->exportToWkt();
                 if (m_sourceCrsFormat == "auto")
                 {

--- a/apps/gdalinfo_lib.cpp
+++ b/apps/gdalinfo_lib.cpp
@@ -403,8 +403,8 @@ void EmitTextDisplayOfCRS(
     const std::string &osIntroText,
     std::function<void(const std::string &)> printFunction)
 {
-    const char *pszAuthCode = poSRS->GetAuthorityCode(nullptr);
-    const char *pszAuthName = poSRS->GetAuthorityName(nullptr);
+    const char *pszAuthCode = poSRS->GetAuthorityCode();
+    const char *pszAuthName = poSRS->GetAuthorityName();
 
     bool bCRSAlreadyEmitted = false;
     if (pszAuthName && pszAuthCode && osCRSFormat == "AUTO")
@@ -778,8 +778,8 @@ char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
 
         const double dfCoordinateEpoch = poSRS->GetCoordinateEpoch();
 
-        const char *pszAuthCode = poSRS->GetAuthorityCode(nullptr);
-        const char *pszAuthName = poSRS->GetAuthorityName(nullptr);
+        const char *pszAuthCode = poSRS->GetAuthorityCode();
+        const char *pszAuthName = poSRS->GetAuthorityName();
         if (bJson)
         {
             json_object *poWkt = json_object_new_string(osWkt.c_str());

--- a/apps/gdalsrsinfo.cpp
+++ b/apps/gdalsrsinfo.cpp
@@ -202,8 +202,8 @@ MAIN_START(argc, argv)
                            panConfidence[i]);
                 }
 
-                const char *pszAuthorityName = oSRS.GetAuthorityName(nullptr);
-                const char *pszAuthorityCode = oSRS.GetAuthorityCode(nullptr);
+                const char *pszAuthorityName = oSRS.GetAuthorityName();
+                const char *pszAuthorityCode = oSRS.GetAuthorityCode();
                 if (pszAuthorityName && pszAuthorityCode)
                 {
                     osIdentifiedCode = pszAuthorityName;

--- a/apps/gdaltindex_lib.cpp
+++ b/apps/gdaltindex_lib.cpp
@@ -2587,9 +2587,9 @@ GDALDatasetH GDALTileIndexInternal(const char *pszDest,
             {
                 auto psArray = topArrays[iProjCode];
                 const char *pszSRSAuthName =
-                    poSrcSRS ? poSrcSRS->GetAuthorityName(nullptr) : nullptr;
+                    poSrcSRS ? poSrcSRS->GetAuthorityName() : nullptr;
                 const char *pszSRSAuthCode =
-                    poSrcSRS ? poSrcSRS->GetAuthorityCode(nullptr) : nullptr;
+                    poSrcSRS ? poSrcSRS->GetAuthorityCode() : nullptr;
                 if (pszSRSAuthName && pszSRSAuthCode)
                 {
                     std::string osCode(pszSRSAuthName);
@@ -2733,10 +2733,8 @@ GDALDatasetH GDALTileIndexInternal(const char *pszDest,
 
             if (i_SrcSRSName >= 0 && poSrcSRS)
             {
-                const char *pszAuthorityCode =
-                    poSrcSRS->GetAuthorityCode(nullptr);
-                const char *pszAuthorityName =
-                    poSrcSRS->GetAuthorityName(nullptr);
+                const char *pszAuthorityCode = poSrcSRS->GetAuthorityCode();
+                const char *pszAuthorityName = poSrcSRS->GetAuthorityName();
                 if (psOptions->eSrcSRSFormat == FORMAT_AUTO)
                 {
                     if (pszAuthorityName != nullptr &&

--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -960,10 +960,8 @@ static void ReportOnLayer(CPLString &osRet, CPLJSONObject &oLayer,
                         bool authIdSet{false};
                         if (psOptions->bExportOgrSchema)
                         {
-                            const char *pszAuthCode =
-                                poSRS->GetAuthorityCode(nullptr);
-                            const char *pszAuthName =
-                                poSRS->GetAuthorityName(nullptr);
+                            const char *pszAuthCode = poSRS->GetAuthorityCode();
+                            const char *pszAuthName = poSRS->GetAuthorityName();
                             if (pszAuthName && pszAuthCode)
                             {
                                 std::string oSRS{pszAuthName};
@@ -1029,9 +1027,9 @@ static void ReportOnLayer(CPLString &osRet, CPLJSONObject &oLayer,
                         for (const auto &poSupportedSRS : srsList)
                         {
                             const char *pszAuthName =
-                                poSupportedSRS->GetAuthorityName(nullptr);
+                                poSupportedSRS->GetAuthorityName();
                             const char *pszAuthCode =
-                                poSupportedSRS->GetAuthorityCode(nullptr);
+                                poSupportedSRS->GetAuthorityCode();
                             CPLJSONObject oSupportedSRS;
                             if (pszAuthName && pszAuthCode)
                             {
@@ -1317,9 +1315,9 @@ static void ReportOnLayer(CPLString &osRet, CPLJSONObject &oLayer,
                 for (const auto &poSupportedSRS : srsList)
                 {
                     const char *pszAuthName =
-                        poSupportedSRS->GetAuthorityName(nullptr);
+                        poSupportedSRS->GetAuthorityName();
                     const char *pszAuthCode =
-                        poSupportedSRS->GetAuthorityCode(nullptr);
+                        poSupportedSRS->GetAuthorityCode();
                     if (!bFirst)
                         Concat(osRet, psOptions->bStdoutOutput, ", ");
                     bFirst = false;

--- a/autotest/gcore/geoloc.py
+++ b/autotest/gcore/geoloc.py
@@ -470,7 +470,7 @@ def test_geoloc_GEOLOC_ARRAY_transformer_option():
     warped_ds = gdal.Warp(
         "", ds, format="MEM", transformerOptions=["GEOLOC_ARRAY=/vsimem/lonlat.tif"]
     )
-    assert warped_ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+    assert warped_ds.GetSpatialRef().GetAuthorityCode() == "32631"
 
     ds = None
 

--- a/autotest/gcore/hfa_srs.py
+++ b/autotest/gcore/hfa_srs.py
@@ -164,7 +164,7 @@ def test_hfa_srs(srs_def, failure_expected, read_with_pe_string):
     if (
         not isinstance(srs_def, str)
         and srs_def == 4326
-        and sr2.GetAuthorityCode(None) != "4326"
+        and sr2.GetAuthorityCode() != "4326"
     ) or sr.IsSame(sr2) != 1:
 
         if osr.GetPROJVersionMajor() * 100 + osr.GetPROJVersionMinor() < 630:
@@ -202,7 +202,7 @@ def test_hfa_srs_wisconsin_tmerc():
     wkt = ds.GetProjectionRef()
     sr = osr.SpatialReference()
     sr.SetFromUserInput(wkt)
-    assert sr.GetAuthorityCode(None) == "103300"
+    assert sr.GetAuthorityCode() == "103300"
 
 
 def test_hfa_srs_NAD83_UTM():
@@ -215,7 +215,7 @@ def test_hfa_srs_NAD83_UTM():
 
     ds = gdal.Open("/vsimem/TestHFASRS.img")
     wkt = ds.GetProjectionRef()
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "26915"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "26915"
     ds = None
 
     gdal.Unlink("/vsimem/TestHFASRS.img")
@@ -235,8 +235,8 @@ def test_hfa_srs_NAD83_CORS96_UTM():
 
     ds = gdal.Open("/vsimem/TestHFASRS.img")
     srs_got = ds.GetSpatialRef()
-    assert srs_got.GetAuthorityName(None) == "ESRI"
-    assert srs_got.GetAuthorityCode(None) == "102411"
+    assert srs_got.GetAuthorityName() == "ESRI"
+    assert srs_got.GetAuthorityCode() == "102411"
     assert srs_got.IsSame(sr), srs_got.ExportToWkt()
     ds = None
 
@@ -289,8 +289,8 @@ def test_hfa_srs_EPSG_2193(tmp_vsimem):
 
     ds = gdal.Open(filename)
     srs_got = ds.GetSpatialRef()
-    assert srs_got.GetAuthorityName(None) == "EPSG"
-    assert srs_got.GetAuthorityCode(None) == "2193"
+    assert srs_got.GetAuthorityName() == "EPSG"
+    assert srs_got.GetAuthorityCode() == "2193"
     assert srs_got.GetDataAxisToSRSAxisMapping() == [2, 1]
     assert srs_got.IsSame(sr)
     ds = None

--- a/autotest/gcore/libertiff.py
+++ b/autotest/gcore/libertiff.py
@@ -34,7 +34,7 @@ def libertiff_open(filename, open_options=[]):
 def test_libertiff_basic():
     ds = libertiff_open("data/byte.tif")
     assert ds.GetMetadataItem("AREA_OR_POINT") == "Area"
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "26711"
     assert ds.GetGeoTransform() == pytest.approx(
         (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0)
     )
@@ -889,7 +889,7 @@ def test_libertiff_srs_read_epsg4326_3855_geotiff1_1():
 def test_libertiff_srs_read_epsg4979_geotiff1_1():
     ds = libertiff_open("data/epsg4979_geotiff1_1.tif")
     sr = ds.GetSpatialRef()
-    assert sr.GetAuthorityCode(None) == "4979"
+    assert sr.GetAuthorityCode() == "4979"
 
 
 def test_libertiff_strip_block_size():

--- a/autotest/gcore/multidim.py
+++ b/autotest/gcore/multidim.py
@@ -194,7 +194,7 @@ def test_multidim_getresampled(resampling):
     assert resampled_ar.GetDataType() == ar.GetDataType()
     srs = resampled_ar.GetSpatialRef()
     assert srs is not None
-    assert srs.GetAuthorityCode(None) == srs_ds.GetAuthorityCode(None)
+    assert srs.GetAuthorityCode() == srs_ds.GetAuthorityCode()
     dims = resampled_ar.GetDimensions()
     assert len(dims) == 2
     assert dims[0].GetName() == "dimY"
@@ -276,7 +276,7 @@ def test_multidim_getresampled_new_dims_with_variables(
     assert resampled_ar
     srs = resampled_ar.GetSpatialRef()
     assert srs is not None
-    assert srs.GetAuthorityCode(None) == srs_ds.GetAuthorityCode(None)
+    assert srs.GetAuthorityCode() == srs_ds.GetAuthorityCode()
     dims = resampled_ar.GetDimensions()
     assert len(dims) == 2
     assert dims[0].GetSize() == ds.RasterYSize // 2
@@ -301,7 +301,7 @@ def test_multidim_getresampled_with_srs():
     assert resampled_ar
     got_srs = resampled_ar.GetSpatialRef()
     assert got_srs is not None
-    assert got_srs.GetAuthorityCode(None) == srs.GetAuthorityCode(None)
+    assert got_srs.GetAuthorityCode() == srs.GetAuthorityCode()
     dims = resampled_ar.GetDimensions()
 
     expected_ds = gdal.Warp("", ds, options="-of MEM -t_srs EPSG:4267 -r nearest")

--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -3439,7 +3439,7 @@ def test_tiff_read_arcgis93_geodataxform_gcp():
 def test_tiff_read_arcgis10_geodataxform_gcp_ignored():
 
     ds = gdal.Open("data/gtiff/esri_geodataxform_no_resolutionunit.tif")
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "3857"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "3857"
     assert ds.GetGCPCount() == 0
     assert ds.GetGeoTransform() == pytest.approx(
         (
@@ -5295,8 +5295,8 @@ def test_tiff_warning_get_metadata_item_PIXELTYPE():
 def test_tiff_read_projection_from_esri_xml():
 
     ds = gdal.Open("data/gtiff/projection_from_esri_xml.tif")
-    assert ds.GetSpatialRef().GetAuthorityName(None) == "EPSG"
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "25833"
+    assert ds.GetSpatialRef().GetAuthorityName() == "EPSG"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "25833"
     assert ds.GetGeoTransform() == pytest.approx((250000, 0.2, 0.0, 5887000, 0.0, -0.2))
 
 

--- a/autotest/gcore/tiff_srs.py
+++ b/autotest/gcore/tiff_srs.py
@@ -195,8 +195,8 @@ def test_tiff_srs_WGS_1984_Web_Mercator():
     sr = ds.GetSpatialRef()
     ds = None
 
-    assert sr.GetAuthorityName(None) == "ESRI"
-    assert sr.GetAuthorityCode(None) == "102113"
+    assert sr.GetAuthorityName() == "ESRI"
+    assert sr.GetAuthorityCode() == "102113"
 
 
 ###############################################################################
@@ -447,7 +447,7 @@ def test_tiff_srs_ProjectedCSTypeGeoKey_GeographicTypeGeoKey():
 
     ds = gdal.Open("data/utmsmall.tif")
     sr = ds.GetSpatialRef()
-    assert sr.GetAuthorityCode(None) == "26711"
+    assert sr.GetAuthorityCode() == "26711"
 
 
 def _test_tiff_srs(sr, expect_fail):
@@ -461,7 +461,7 @@ def _test_tiff_srs(sr, expect_fail):
     # The GeoTIFF driver is smart enough to figure out that a CRS with
     # '+proj=longlat +datum=WGS84' is EPSG:4326
     if (
-        sr.GetAuthorityCode(None) is None
+        sr.GetAuthorityCode() is None
         and "+proj=longlat +datum=WGS84" in sr.ExportToProj4()
     ):
         sr.ImportFromEPSG(4326)
@@ -601,7 +601,7 @@ def _create_geotiff1_1_from_copy_and_compare(srcfilename, options=[]):
 def test_tiff_srs_read_epsg4326_geotiff1_1():
     ds = gdal.Open("data/epsg4326_geotiff1_1.tif")
     sr = ds.GetSpatialRef()
-    assert sr.GetAuthorityCode(None) == "4326"
+    assert sr.GetAuthorityCode() == "4326"
 
 
 def test_tiff_srs_write_epsg4326_geotiff1_1():
@@ -613,7 +613,7 @@ def test_tiff_srs_write_epsg4326_geotiff1_1():
 def test_tiff_srs_read_epsg26711_geotiff1_1():
     ds = gdal.Open("data/epsg26711_geotiff1_1.tif")
     sr = ds.GetSpatialRef()
-    assert sr.GetAuthorityCode(None) == "26711"
+    assert sr.GetAuthorityCode() == "26711"
 
 
 def test_tiff_srs_write_epsg26711_geotiff1_1():
@@ -637,7 +637,7 @@ def test_tiff_srs_write_epsg4326_3855_geotiff1_1():
 def test_tiff_srs_read_epsg4979_geotiff1_1():
     ds = gdal.Open("data/epsg4979_geotiff1_1.tif")
     sr = ds.GetSpatialRef()
-    assert sr.GetAuthorityCode(None) == "4979"
+    assert sr.GetAuthorityCode() == "4979"
 
 
 def test_tiff_srs_write_epsg4979_geotiff1_1():
@@ -655,7 +655,7 @@ def test_tiff_srs_write_epsg4937_etrs89_3D_geotiff1_1():
     ds = None
     ds = gdal.Open(tmpfile)
     assert sr.GetName() == "ETRS89"
-    assert sr.GetAuthorityCode(None) == "4937"
+    assert sr.GetAuthorityCode() == "4937"
     ds = None
     gdal.Unlink(tmpfile)
 
@@ -664,7 +664,7 @@ def test_tiff_srs_write_epsg4937_etrs89_3D_geotiff1_1():
 def test_tiff_srs_read_epsg4326_5030_geotiff1_1():
     ds = gdal.Open("data/epsg4326_5030_geotiff1_1.tif")
     sr = ds.GetSpatialRef()
-    assert sr.GetAuthorityCode(None) == "4979"
+    assert sr.GetAuthorityCode() == "4979"
 
 
 def test_tiff_srs_read_epsg26711_3855_geotiff1_1():
@@ -689,7 +689,7 @@ def test_tiff_srs_read_epsg32631_4979_geotiff1_1():
     assert sr.GetName() == "WGS 84 / UTM zone 31N"
     sr_geog = osr.SpatialReference()
     sr_geog.CopyGeogCSFrom(sr)
-    assert sr_geog.GetAuthorityCode(None) == "4979"
+    assert sr_geog.GetAuthorityCode() == "4979"
 
 
 def test_tiff_srs_write_vertical_perspective():
@@ -830,7 +830,7 @@ def test_tiff_srs_write_epsg3857():
     ds = None
     ds = gdal.Open(tmpfile)
     assert sr.GetName() == "WGS 84 / Pseudo-Mercator"
-    assert sr.GetAuthorityCode(None) == "3857"
+    assert sr.GetAuthorityCode() == "3857"
     f = gdal.VSIFOpenL(tmpfile, "rb")
     data = gdal.VSIFReadL(1, 100000, f)
     gdal.VSIFCloseL(f)
@@ -841,7 +841,7 @@ def test_tiff_srs_write_epsg3857():
 def test_tiff_srs_read_epsg26730_with_linear_units_set():
     ds = gdal.Open("data/epsg26730_with_linear_units_set.tif")
     sr = ds.GetSpatialRef()
-    assert sr.GetAuthorityCode(None) == "26730"
+    assert sr.GetAuthorityCode() == "26730"
 
 
 def test_tiff_srs_read_user_defined_geokeys():
@@ -971,7 +971,7 @@ def test_tiff_srs_read_inconsistent_invflattening():
     with gdal.quiet_errors():
         srs = ds.GetSpatialRef()
     assert gdal.GetLastErrorMsg() != ""
-    assert srs.GetAuthorityCode(None) == "28992"
+    assert srs.GetAuthorityCode() == "28992"
     assert srs.GetAuthorityCode("GEOGCS") == "4289"
     assert srs.GetInvFlattening() == pytest.approx(
         299.1528131, abs=1e-7
@@ -982,7 +982,7 @@ def test_tiff_srs_read_inconsistent_invflattening():
     with gdaltest.config_option("GTIFF_SRS_SOURCE", "GEOKEYS"):
         srs = ds.GetSpatialRef()
     assert gdal.GetLastErrorMsg() == ""
-    assert srs.GetAuthorityCode(None) is None
+    assert srs.GetAuthorityCode() is None
     assert srs.GetAuthorityCode("GEOGCS") is None
     assert srs.GetInvFlattening() == pytest.approx(
         299.1528131, abs=1e-7
@@ -993,7 +993,7 @@ def test_tiff_srs_read_inconsistent_invflattening():
     with gdaltest.config_option("GTIFF_SRS_SOURCE", "EPSG"):
         srs = ds.GetSpatialRef()
     assert gdal.GetLastErrorMsg() == ""
-    assert srs.GetAuthorityCode(None) == "28992"
+    assert srs.GetAuthorityCode() == "28992"
     assert srs.GetAuthorityCode("GEOGCS") == "4289"
     assert srs.GetInvFlattening() == pytest.approx(
         299.1528128, abs=1e-7
@@ -1016,7 +1016,7 @@ def test_tiff_srs_dynamic_geodetic_crs():
     gdal.ErrorReset()
     srs = ds.GetSpatialRef()
     assert gdal.GetLastErrorMsg() == "", srs.ExportToWkt(["FORMAT=WKT2_2019"])
-    assert srs.GetAuthorityCode(None) == "8999"
+    assert srs.GetAuthorityCode() == "8999"
     assert srs.IsDynamic()
     ds = None
     gdal.Unlink("/vsimem/test_tiff_srs_dynamic_geodetic_crs.tif")
@@ -1040,7 +1040,7 @@ def test_tiff_srs_geographic_crs_3D(geotiff_version):
     srs = ds.GetSpatialRef()
     assert gdal.GetLastErrorMsg() == "", srs.ExportToWkt(["FORMAT=WKT2_2019"])
     if geotiff_version == "1.1":
-        assert srs.GetAuthorityCode(None) == "4959"
+        assert srs.GetAuthorityCode() == "4959"
     ds = None
     gdal.Unlink("/vsimem/test_tiff_srs_geographic_crs_3D.tif")
 
@@ -1058,7 +1058,7 @@ def test_tiff_srs_datum_name_with_space():
     gdal.ErrorReset()
     srs = ds.GetSpatialRef()
     assert gdal.GetLastErrorMsg() == "", srs.ExportToWkt(["FORMAT=WKT2_2019"])
-    assert srs.GetAuthorityCode(None) == "4312"
+    assert srs.GetAuthorityCode() == "4312"
     ds = None
     gdal.Unlink("/vsimem/test_tiff_srs_datum_name_with_space.tif")
 
@@ -1192,7 +1192,7 @@ def test_tiff_srs_epsg_2193_override():
     gdal.ErrorReset()
     srs = ds.GetSpatialRef()
     assert gdal.GetLastErrorMsg() == "", srs.ExportToWkt(["FORMAT=WKT2_2019"])
-    assert srs.GetAuthorityCode(None) == "2193"
+    assert srs.GetAuthorityCode() == "2193"
 
 
 def test_tiff_srs_projected_GTCitationGeoKey_with_underscore_and_GeogTOWGS84GeoKey():
@@ -1203,7 +1203,7 @@ def test_tiff_srs_projected_GTCitationGeoKey_with_underscore_and_GeogTOWGS84GeoK
     )
     gdal.ErrorReset()
     srs = ds.GetSpatialRef()
-    assert srs.GetAuthorityCode(None) == "2039"
+    assert srs.GetAuthorityCode() == "2039"
     assert "+proj=tmerc" in srs.ExportToProj4()
     if osr.GetPROJVersionMajor() >= 9:  # not necessarily the minimum version
         assert srs.GetName() == "Israel 1993 / Israeli TM Grid"
@@ -1296,7 +1296,7 @@ def test_tiff_srs_read_compound_with_EPSG_code(code):
     gdal.ErrorReset()
     got_srs = ds.GetSpatialRef()
     assert gdal.GetLastErrorMsg() == "", srs.ExportToWkt(["FORMAT=WKT2_2019"])
-    assert got_srs.GetAuthorityCode(None) == str(code)
+    assert got_srs.GetAuthorityCode() == str(code)
     assert got_srs.IsSame(srs)
     ds = None
     gdal.Unlink(filename)
@@ -1321,7 +1321,7 @@ def test_tiff_srs_read_compound_without_EPSG_code():
     gdal.ErrorReset()
     got_srs = ds.GetSpatialRef()
     assert gdal.GetLastErrorMsg() == "", srs.ExportToWkt(["FORMAT=WKT2_2019"])
-    assert got_srs.GetAuthorityCode(None) is None
+    assert got_srs.GetAuthorityCode() is None
     assert got_srs.GetAuthorityCode("GEOGCS") == "4326"
     assert got_srs.GetAuthorityCode("VERT_CS") == "5709"
     assert got_srs.IsSame(srs)
@@ -1343,7 +1343,7 @@ def test_tiff_srs_projection_method_unknown_of_geotiff_with_crs_code():
     ds = gdal.Open(filename)
     gdal.ErrorReset()
     srs = ds.GetSpatialRef()
-    assert srs.GetAuthorityCode(None) == "8857"
+    assert srs.GetAuthorityCode() == "8857"
     ds = None
     gdal.Unlink(filename)
 
@@ -1490,5 +1490,5 @@ def test_tiff_srs_infer_iau_code_from_srs_name():
 
     ds = gdal.Open("data/gtiff/tiff_srs_iau_2015_30110.tif")
     srs = ds.GetSpatialRef()
-    assert srs.GetAuthorityName(None) == "IAU_2015"
-    assert srs.GetAuthorityCode(None) == "30110"
+    assert srs.GetAuthorityName() == "IAU_2015"
+    assert srs.GetAuthorityCode() == "30110"

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -569,7 +569,7 @@ def test_tiff_write_16():
     ds = gdal.Open("tmp/tw_16.tif")
     assert ds.GetGeoTransform() == (10, 5, 0, 30, 0, -5)
     assert ds.GetSpatialRef() is not None
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
 
     md = ds.GetMetadata()
     assert "test" in md, "Metadata absent from .aux.xml file."
@@ -10041,7 +10041,7 @@ def test_tiff_write_setspatialref_read_only():
     ds = gdal.Open(filename)
     got_srs = ds.GetSpatialRef()
     assert got_srs
-    assert got_srs.GetAuthorityCode(None) == "4326"
+    assert got_srs.GetAuthorityCode() == "4326"
     ds = None
 
     gdal.GetDriverByName("GTiff").Delete(filename)
@@ -10071,7 +10071,7 @@ def test_tiff_write_setspatialref_read_only_override_tifftags():
     ds = gdal.Open(filename)
     got_srs = ds.GetSpatialRef()
     assert got_srs
-    assert got_srs.GetAuthorityCode(None) == "4326"
+    assert got_srs.GetAuthorityCode() == "4326"
     ds = None
 
     ds = gdal.Open(filename, gdal.GA_Update)
@@ -10085,7 +10085,7 @@ def test_tiff_write_setspatialref_read_only_override_tifftags():
     ds = gdal.Open(filename)
     got_srs = ds.GetSpatialRef()
     assert got_srs
-    assert got_srs.GetAuthorityCode(None) == "32632"
+    assert got_srs.GetAuthorityCode() == "32632"
     ds = None
 
     gdal.GetDriverByName("GTiff").Delete(filename)
@@ -10180,7 +10180,7 @@ def test_tiff_write_setgcps_read_only():
     assert got_gcps[0].GCPY == gcps[0].GCPY
     got_srs = ds.GetGCPSpatialRef()
     assert got_srs
-    assert got_srs.GetAuthorityCode(None) == "4326"
+    assert got_srs.GetAuthorityCode() == "4326"
     ds = None
 
     gdal.GetDriverByName("GTiff").Delete(filename)
@@ -10216,7 +10216,7 @@ def test_tiff_write_setgcps_read_only_override_tifftags():
     assert got_gcps[0].GCPY == gcps[0].GCPY
     got_srs = ds.GetGCPSpatialRef()
     assert got_srs
-    assert got_srs.GetAuthorityCode(None) == "4326"
+    assert got_srs.GetAuthorityCode() == "4326"
     ds = None
 
     ds = gdal.Open(filename, gdal.GA_Update)

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1487,7 +1487,7 @@ def test_vrt_protocol():
 
     ds = gdal.Open("vrt://data/byte.tif?bands=1&a_srs=EPSG:3031")
     crs = ds.GetSpatialRef()
-    assert crs.GetAuthorityCode(None) == "3031"
+    assert crs.GetAuthorityCode() == "3031"
 
     ds = gdal.Open("vrt://data/byte.tif?a_ullr=0,10,20,0")
     geotransform = ds.GetGeoTransform()

--- a/autotest/gdrivers/avif.py
+++ b/autotest/gdrivers/avif.py
@@ -293,8 +293,8 @@ def test_avif_geoheif_wkt2():
         [691000.0, 0.1, 0.0, 6090000.0, 0.0, -0.1]
     )
     assert ds.GetSpatialRef() is not None
-    assert ds.GetSpatialRef().GetAuthorityName(None) == "EPSG"
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "28355"
+    assert ds.GetSpatialRef().GetAuthorityName() == "EPSG"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "28355"
     assert ds.GetGCPCount() == 1
     gcp = ds.GetGCPs()[0]
     assert (
@@ -327,8 +327,8 @@ def test_avif_geoheif_uri():
         [691051.2, 0.1, 0.0, 6090000.0, 0.0, -0.1]
     )
     assert ds.GetSpatialRef() is not None
-    assert ds.GetSpatialRef().GetAuthorityName(None) == "EPSG"
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32755"
+    assert ds.GetSpatialRef().GetAuthorityName() == "EPSG"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "32755"
 
     assert ds.GetGCPCount() == 1
     gcp = ds.GetGCPs()[0]
@@ -358,8 +358,8 @@ def test_avif_geoheif_curie():
     )
     assert ds.GetMetadataItem("TAGS", "DESCRIPTION_en-AU") == "copyright"
     assert ds.GetSpatialRef() is not None
-    assert ds.GetSpatialRef().GetAuthorityName(None) == "EPSG"
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32755"
+    assert ds.GetSpatialRef().GetAuthorityName() == "EPSG"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "32755"
 
     assert ds.GetGeoTransform() is not None
     assert ds.GetGeoTransform() == pytest.approx(

--- a/autotest/gdrivers/avif_heif.py
+++ b/autotest/gdrivers/avif_heif.py
@@ -62,8 +62,8 @@ if __name__ == "__main__":
             [691000.0, 0.1, 0.0, 6090000.0, 0.0, -0.1]
         )
         assert ds.GetSpatialRef() is not None
-        assert ds.GetSpatialRef().GetAuthorityName(None) == "EPSG"
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "28355"
+        assert ds.GetSpatialRef().GetAuthorityName() == "EPSG"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "28355"
         assert ds.GetGCPCount() == 1
         gcp = ds.GetGCPs()[0]
         assert (

--- a/autotest/gdrivers/ecw.py
+++ b/autotest/gdrivers/ecw.py
@@ -2301,7 +2301,7 @@ def test_ecw_online_2():
     ds.GetRasterBand(1).Checksum()
     assert len(ds.GetGCPs()) == 15, "bad number of GCP"
 
-    assert ds.GetGCPSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ds.GetGCPSpatialRef().GetAuthorityCode() == "4326"
 
     ds = None
 

--- a/autotest/gdrivers/envi.py
+++ b/autotest/gdrivers/envi.py
@@ -590,7 +590,7 @@ def test_envi_edit_coordinate_system_string():
     ds = None
 
     ds = gdal.Open(filename, gdal.GA_Update)
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
     srs = osr.SpatialReference()
     srs.ImportFromEPSG(3261)
     ds.SetSpatialRef(srs)
@@ -606,7 +606,7 @@ def test_envi_edit_coordinate_system_string():
     ds = gdal.Open(filename)
     srs = ds.GetSpatialRef()
     assert srs.IsProjected()
-    assert srs.GetAuthorityCode(None) == "3261"
+    assert srs.GetAuthorityCode() == "3261"
     ds = None
 
     drv.Delete(filename)

--- a/autotest/gdrivers/esric.py
+++ b/autotest/gdrivers/esric.py
@@ -214,7 +214,7 @@ def test_tpkx_default_full_extent(extent_source):
     assert ds.RasterXSize == 2533
     assert ds.RasterYSize == 1922
     assert ds.RasterCount == 4
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "3857"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "3857"
     assert ds.GetGeoTransform() == pytest.approx(
         (
             -19841829.550377003848553,

--- a/autotest/gdrivers/gpkg.py
+++ b/autotest/gdrivers/gpkg.py
@@ -2385,7 +2385,7 @@ def test_gpkg_26_errors():
         "../gdrivers/data/small_world.tif",
         options="-of GPKG -co TILING_SCHEME=LINZAntarticaMapTileGrid -projwin -180 -50 180 -90",
     )
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "5482"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "5482"
     assert ds.GetGeoTransform() == pytest.approx(
         ((314023.27126670163, 28672, 0.0, 5685976.728733298, 0.0, -28672)), abs=1e-8
     )

--- a/autotest/gdrivers/gti.py
+++ b/autotest/gdrivers/gti.py
@@ -82,9 +82,10 @@ def check_basic(
     assert vrt_ds.RasterYSize == src_ds.RasterYSize
     assert vrt_ds.RasterCount == src_ds.RasterCount
     assert vrt_ds.GetGeoTransform() == pytest.approx(src_ds.GetGeoTransform())
-    assert vrt_ds.GetSpatialRef().GetAuthorityCode(
-        None
-    ) == src_ds.GetSpatialRef().GetAuthorityCode(None)
+    assert (
+        vrt_ds.GetSpatialRef().GetAuthorityCode()
+        == src_ds.GetSpatialRef().GetAuthorityCode()
+    )
     for iband in range(1, vrt_ds.RasterCount + 1):
         vrt_band = vrt_ds.GetRasterBand(iband)
         src_band = src_ds.GetRasterBand(iband)
@@ -841,7 +842,7 @@ def test_gti_valid_srs(tmp_path):
     del index_ds
 
     ds = gdal.Open(index_filename)
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "4267"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "4267"
 
 
 def test_gti_invalid_band_count(tmp_vsimem):
@@ -3130,7 +3131,7 @@ def test_gti_stac_geoparquet():
         pytest.skip("cannot open URL")
 
     ds = gdal.Open("GTI:/vsicurl/" + url)
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "26914"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "26914"
     assert ds.GetGeoTransform() == pytest.approx(
         (408231.0, 1.0, 0.0, 3873862.0, 0.0, -1.0), rel=1e-5
     )
@@ -3175,7 +3176,7 @@ def test_gti_stac_geoparquet_sentinel2(filename):
         ds = gdal.Open(f"GTI:data/gti/{filename}")
     assert ds.RasterXSize == 5556
     assert ds.RasterYSize == 5540
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32612"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "32612"
     assert ds.GetGeoTransform() == pytest.approx(
         (398760.0, 20.0, 0.0, 3900560.0, 0.0, -20.0), rel=1e-5
     )
@@ -3491,7 +3492,7 @@ def test_gti_srs_metadata_spatial_filter(tmp_vsimem):
     del index_ds
 
     ds = gdal.Open(index_filename)
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "3857"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "3857"
 
     assert ds.GetRasterBand(1).Checksum() != 0
 
@@ -3519,7 +3520,7 @@ def test_gti_srs_open_option_spatial_filter(tmp_vsimem):
         index_filename, open_options=["SRS=EPSG:3857", "SRS_BEHAVIOR=REPROJECT"]
     )
     assert ds is not None
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "3857"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "3857"
     assert ds.GetRasterBand(1).Checksum() != 0
 
 
@@ -3557,7 +3558,7 @@ def test_gti_srs_mismatch_no_behavior_warns(tmp_vsimem):
     with gdaltest.error_raised(gdal.CE_Warning, match="SRS_BEHAVIOR"):
         ds = gdal.OpenEx(index_filename, open_options=["SRS=EPSG:3857"])
     assert ds is not None
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "3857"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "3857"
 
 
 ###############################################################################
@@ -3578,7 +3579,7 @@ def test_gti_srs_behavior_override(tmp_vsimem):
             index_filename, open_options=["SRS=EPSG:3857", "SRS_BEHAVIOR=OVERRIDE"]
         )
     assert ds is not None
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "3857"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "3857"
 
 
 ###############################################################################
@@ -3598,4 +3599,4 @@ def test_gti_srs_no_layer_srs_silent(tmp_vsimem):
     with gdaltest.error_raised(gdal.CE_None):
         ds = gdal.OpenEx(index_filename, open_options=["SRS=EPSG:3857"])
     assert ds is not None
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "3857"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "3857"

--- a/autotest/gdrivers/hdf5.py
+++ b/autotest/gdrivers/hdf5.py
@@ -1795,7 +1795,7 @@ def test_hdf5_NISAR_level_2_epsg_code():
     assert ds.RasterXSize == 4
     assert ds.RasterYSize == 5
     assert ds.GetGeoTransform() == pytest.approx((5.0, 10.0, 0.0, 550.0, 0.0, -100.0))
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32611"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "32611"
 
 
 ###############################################################################
@@ -1835,4 +1835,4 @@ def test_hdf5_NISAR_level_2_spatial_ref():
     assert ds.RasterXSize == 4
     assert ds.RasterYSize == 5
     assert ds.GetGeoTransform() == pytest.approx((5.0, 10.0, 0.0, 550.0, 0.0, -100.0))
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32611"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "32611"

--- a/autotest/gdrivers/heif.py
+++ b/autotest/gdrivers/heif.py
@@ -831,8 +831,8 @@ def test_heif_geoheif_curie():
     )
     assert ds.GetMetadataItem("TAGS", "DESCRIPTION_en-AU") == "copyright"
     assert ds.GetSpatialRef() is not None
-    assert ds.GetSpatialRef().GetAuthorityName(None) == "EPSG"
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32755"
+    assert ds.GetSpatialRef().GetAuthorityName() == "EPSG"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "32755"
     assert ds.GetGeoTransform() is not None
     assert ds.GetGeoTransform() == pytest.approx(
         [691051.2, 0.1, 0.0, 6090000.0, 0.0, -0.1]
@@ -869,8 +869,8 @@ def test_heif_geoheif_curie_order():
         [691051.2, 0.1, 0.0, 6090000.0, 0.0, -0.1]
     )
     assert ds.GetSpatialRef() is not None
-    assert ds.GetSpatialRef().GetAuthorityName(None) == "EPSG"
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32755"
+    assert ds.GetSpatialRef().GetAuthorityName() == "EPSG"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "32755"
     assert ds.GetGCPCount() == 1
     gcp = ds.GetGCPs()[0]
     assert (

--- a/autotest/gdrivers/jp2grok.py
+++ b/autotest/gdrivers/jp2grok.py
@@ -1101,7 +1101,7 @@ def test_jp2grok_rewrite_boxes(tmp_path):
     # Check they were written into the file (not PAM)
     assert gdal.VSIStatL(tmp_path / ".aux.xml") is None
     ds = gdal.Open(tmpfile)
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
     assert ds.GetGeoTransform() == (0, 1, 0, 3, 0, -1)
     # Verify pixel data survived the transcode
     got = ds.GetRasterBand(1).ReadAsArray()
@@ -1134,7 +1134,7 @@ def test_jp2grok_rewrite_boxes(tmp_path):
     assert got_gcp.GCPZ == 2
     assert got_gcp.GCPPixel == 3
     assert got_gcp.GCPLine == 4
-    assert ds.GetGCPSpatialRef().GetAuthorityCode(None) == "32631"
+    assert ds.GetGCPSpatialRef().GetAuthorityCode() == "32631"
     ds = None
 
     # Add metadata
@@ -1244,7 +1244,7 @@ def test_jp2grok_transcode_markers(
     # Pixel data and georeferencing must survive transcode
     ds = gdal.Open(dst_jp2)
     assert ds is not None
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
     assert ds.GetGeoTransform() == (500000, 1, 0, 5000000, 0, -1)
     assert np.array_equal(ds.GetRasterBand(1).ReadAsArray(), pixel_data)
     ds = None

--- a/autotest/gdrivers/jp2metadata.py
+++ b/autotest/gdrivers/jp2metadata.py
@@ -244,7 +244,7 @@ def test_jp2metadata_5():
 
     ds = gdal.Open("data/jpeg2000/gmljp2_epsg3035_easting_northing.jp2")
     sr = ds.GetSpatialRef()
-    assert sr.GetAuthorityCode(None) == "3035"
+    assert sr.GetAuthorityCode() == "3035"
 
     gt = ds.GetGeoTransform()
     gte = (4895766.000000001, 2.0, 0.0, 2296946.0, 0.0, -2.0)

--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -3095,7 +3095,7 @@ def test_jp2openjpeg_online_2():
     ds.GetRasterBand(1).Checksum()
     assert len(ds.GetGCPs()) == 15, "bad number of GCP"
 
-    assert ds.GetGCPSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ds.GetGCPSpatialRef().GetAuthorityCode() == "4326"
 
     ds = None
 

--- a/autotest/gdrivers/jpeg.py
+++ b/autotest/gdrivers/jpeg.py
@@ -1856,7 +1856,7 @@ def test_jpeg_read_pix4d_xmp_crs_vertcs_ellipsoidal():
     # where pix4d_xmp_crs_vertcs_ellipsoidal.xml is the XMP content
     ds = gdal.Open("data/jpeg/pix4d_xmp_crs_vertcs_ellipsoidal.jpg")
     srs = ds.GetSpatialRef()
-    assert srs.GetAuthorityCode(None) == "6319"
+    assert srs.GetAuthorityCode() == "6319"
 
 
 ###############################################################################

--- a/autotest/gdrivers/mrf.py
+++ b/autotest/gdrivers/mrf.py
@@ -658,7 +658,7 @@ def test_mrf_setspatialref():
     ds = None
     gdal.Unlink(filename + ".aux.xml")
     ds = gdal.Open(filename)
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
     ds = None
     gdal.GetDriverByName("MRF").Delete(filename)
 

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -6300,7 +6300,7 @@ def test_netcdf_proj4string_geospatial_bounds_crs():
     assert ds.GetGeoTransform() == pytest.approx(
         (-5400000.0, 75000.0, 0.0, 5400000.0, 0.0, -75000.0)
     )
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "6931"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "6931"
 
 
 ###############################################################################

--- a/autotest/gdrivers/netcdf_multidim.py
+++ b/autotest/gdrivers/netcdf_multidim.py
@@ -1455,22 +1455,22 @@ def test_netcdf_multidim_create_several_arrays_with_srs():
         rg = ds.GetRootGroup()
 
         ar = rg.OpenMDArray("ar_longlat_4326_1")
-        assert ar.GetSpatialRef().GetAuthorityCode(None) == "4326"
+        assert ar.GetSpatialRef().GetAuthorityCode() == "4326"
 
         ar = rg.OpenMDArray("ar_longlat_4326_2")
-        assert ar.GetSpatialRef().GetAuthorityCode(None) == "4326"
+        assert ar.GetSpatialRef().GetAuthorityCode() == "4326"
 
         ar = rg.OpenMDArray("ar_longlat_4258")
-        assert ar.GetSpatialRef().GetAuthorityCode(None) == "4258"
+        assert ar.GetSpatialRef().GetAuthorityCode() == "4258"
 
         ar = rg.OpenMDArray("ar_longlat_32631_1")
-        assert ar.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert ar.GetSpatialRef().GetAuthorityCode() == "32631"
 
         ar = rg.OpenMDArray("ar_longlat_32631_2")
-        assert ar.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert ar.GetSpatialRef().GetAuthorityCode() == "32631"
 
         ar = rg.OpenMDArray("ar_longlat_32632")
-        assert ar.GetSpatialRef().GetAuthorityCode(None) == "32632"
+        assert ar.GetSpatialRef().GetAuthorityCode() == "32632"
 
     read()
 
@@ -3658,7 +3658,7 @@ def test_netcdf_multidim_getresampled_with_geoloc_EMIT_L2A():
     assert dims[2].GetSize() == 2
     assert resampled_ar.GetDataType() == ar.GetDataType()
     assert resampled_ar.GetBlockSize() == [3, 3, 2]
-    assert resampled_ar.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert resampled_ar.GetSpatialRef().GetAuthorityCode() == "4326"
     assert resampled_ar.GetNoDataValue() == ar.GetNoDataValue()
     assert resampled_ar.GetUnit() == ar.GetUnit()
     assert (
@@ -3747,7 +3747,7 @@ def test_netcdf_multidim_getresampled_with_geoloc_EMIT_L2A():
     assert dims[2].GetName() == "bands"
     assert dims[2].GetSize() == 1
     assert resampled_ar.GetDataType() == ar.GetDataType()
-    assert resampled_ar.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert resampled_ar.GetSpatialRef().GetAuthorityCode() == "4326"
     assert resampled_ar.GetNoDataValue() == ar.GetNoDataValue()
     assert resampled_ar.GetUnit() == ar.GetUnit()
     assert (
@@ -3915,7 +3915,7 @@ def test_netcdf_multidim_getresampled_with_geoloc_EMIT_L2B_MIN():
     assert dims[1].GetSize() == 3
     assert resampled_ar.GetDataType() == ar.GetDataType()
     assert resampled_ar.GetBlockSize() == [3, 3]
-    assert resampled_ar.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert resampled_ar.GetSpatialRef().GetAuthorityCode() == "4326"
     assert resampled_ar.GetNoDataValue() == ar.GetNoDataValue()
     assert resampled_ar.GetUnit() == ar.GetUnit()
     assert (
@@ -4194,14 +4194,14 @@ def test_netcdf_multidim_WGS84_and_EGM96_height(tmp_path):
         ds.SetGeoTransform([2, 1, 0, 49, 0, -1])
     with gdal.Open(tmp_filename) as ds:
         srs = ds.GetSpatialRef()
-        assert srs.GetAuthorityCode(None) == "9707"
+        assert srs.GetAuthorityCode() == "9707"
         # We currently report a 3rd axis, which is dubious
         assert srs.GetDataAxisToSRSAxisMapping()[0:2] == [2, 1]
     with gdal.OpenEx(tmp_filename, gdal.OF_MULTIDIM_RASTER) as ds:
         rg = ds.GetRootGroup()
         ar = rg.OpenMDArray("Band1")
         srs = ar.GetSpatialRef()
-        assert srs.GetAuthorityCode(None) == "9707"
+        assert srs.GetAuthorityCode() == "9707"
         assert srs.GetDataAxisToSRSAxisMapping() == [1, 2]
 
 

--- a/autotest/gdrivers/openfilegdb.py
+++ b/autotest/gdrivers/openfilegdb.py
@@ -230,7 +230,7 @@ def test_openfilegb_raster_int8():
     assert ds.RasterYSize == 20
     assert ds.RasterCount == 1
     assert ds.GetGeoTransform() == (440720, 60, 0, 3751320, 0, -60)
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "26711"
     assert ds.GetMetadata("IMAGE_STRUCTURE") == {"COMPRESSION": "DEFLATE"}
     assert ds.GetMetadata("xml:definition")[0].startswith("<DERasterDataset ")
     assert ds.GetMetadata("xml:documentation")[0].startswith("<metadata ")
@@ -286,7 +286,7 @@ def test_openfilegb_raster_rat():
     assert ds.RasterYSize == 20
     assert ds.RasterCount == 1
     assert ds.GetGeoTransform() == (440720, 60, 0, 3751320, 0, -60)
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "26711"
     assert ds.GetMetadata("IMAGE_STRUCTURE") == {"COMPRESSION": "DEFLATE"}
     band = ds.GetRasterBand(1)
     assert band.DataType == gdal.GDT_Int8

--- a/autotest/gdrivers/pdf.py
+++ b/autotest/gdrivers/pdf.py
@@ -3083,8 +3083,8 @@ def test_pdf_iso32000_esri_as_epsg():
     gdal.ErrorReset()
     ds = gdal.Open("data/pdf/esri_102422_as_epsg_code.pdf")
     sr = ds.GetSpatialRef()
-    assert sr.GetAuthorityName(None) == "ESRI"
-    assert sr.GetAuthorityCode(None) == "102422"
+    assert sr.GetAuthorityName() == "ESRI"
+    assert sr.GetAuthorityCode() == "102422"
     assert gdal.GetLastErrorMsg() == ""
 
 

--- a/autotest/gdrivers/rcm.py
+++ b/autotest/gdrivers/rcm.py
@@ -106,7 +106,7 @@ def test_rcm_open_from_product_xml():
         "SAMP_OFF": "0",
         "SAMP_SCALE": "0",
     }
-    assert ds.GetGCPSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ds.GetGCPSpatialRef().GetAuthorityCode() == "4326"
     assert ds.GetGCPCount() == 1
     assert ds.GetGCPs()[0].GCPPixel == 2
     assert ds.GetGCPs()[0].GCPLine == 1

--- a/autotest/gdrivers/rmf.py
+++ b/autotest/gdrivers/rmf.py
@@ -613,9 +613,9 @@ def test_rmf_29():
     wkt = test_ds.GetProjectionRef()
     sr = osr.SpatialReference()
     sr.SetFromUserInput(wkt)
-    assert (
-        str(sr.GetAuthorityCode(None)) == "3388"
-    ), "EPSG code is %s expected 3388." % str(sr.GetAuthorityCode(None))
+    assert str(sr.GetAuthorityCode()) == "3388", "EPSG code is %s expected 3388." % str(
+        sr.GetAuthorityCode()
+    )
 
 
 ###############################################################################

--- a/autotest/gdrivers/s102.py
+++ b/autotest/gdrivers/s102.py
@@ -37,7 +37,7 @@ def test_s102_basic(filename):
     assert ds.RasterCount == 2
     assert ds.RasterXSize == 3
     assert ds.RasterYSize == 2
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
     assert ds.GetGeoTransform() == pytest.approx((1.8, 0.4, 0.0, 48.75, 0.0, -0.5))
     assert ds.GetMetadata_Dict() == {
         "AREA_OR_POINT": "Point",
@@ -91,7 +91,7 @@ def test_s102_elevation():
     assert ds.RasterCount == 2
     assert ds.RasterXSize == 3
     assert ds.RasterYSize == 2
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
     assert ds.GetGeoTransform() == pytest.approx((1.8, 0.4, 0.0, 48.75, 0.0, -0.5))
 
     elevation = ds.GetRasterBand(1)
@@ -126,7 +126,7 @@ def test_s102_north_up_no():
     assert ds.RasterCount == 2
     assert ds.RasterXSize == 3
     assert ds.RasterYSize == 2
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
     assert ds.GetGeoTransform() == pytest.approx((1.8, 0.4, 0.0, 47.75, 0.0, 0.5))
 
     depth = ds.GetRasterBand(1)
@@ -176,7 +176,7 @@ def test_s102_multidim():
     ar = rg.OpenMDArrayFromFullname(
         "/BathymetryCoverage/BathymetryCoverage.01/Group_001/values"
     )
-    assert ar.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ar.GetSpatialRef().GetAuthorityCode() == "4326"
 
     assert ar.GetDimensions()[0].GetName() == "Y"
     y = ar.GetDimensions()[0].GetIndexingVariable()
@@ -238,7 +238,7 @@ def test_s102_QualityOfSurvey(filename, quality_group_name):
     assert ds.RasterCount == 1
     assert ds.RasterXSize == 3
     assert ds.RasterYSize == 2
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
     assert ds.GetGeoTransform() == pytest.approx((1.8, 0.4, 0.0, 48.75, 0.0, -0.5))
     band = ds.GetRasterBand(1)
     assert band.DataType == gdal.GDT_UInt32
@@ -294,7 +294,7 @@ def test_s102_QualityOfSurvey_multidim():
     ar = rg.OpenMDArrayFromFullname(
         "/QualityOfSurvey/QualityOfSurvey.01/Group_001/values"
     )
-    assert ar.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ar.GetSpatialRef().GetAuthorityCode() == "4326"
     assert ar.GetNoDataValue() == 0
 
     assert ar.GetDimensions()[0].GetName() == "Y"
@@ -755,7 +755,7 @@ def test_s102_write_basic(tmp_path):
             creationOptions={"VERTICAL_DATUM": "MLLW"},
         )
         assert out_ds.GetRasterBand(1).Checksum() == 4672
-        assert out_ds.GetSpatialRef().GetAuthorityCode(None) == "32611"
+        assert out_ds.GetSpatialRef().GetAuthorityCode() == "32611"
         assert out_ds.GetGeoTransform() == (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0)
 
         out_ds.Close()

--- a/autotest/gdrivers/s104.py
+++ b/autotest/gdrivers/s104.py
@@ -34,7 +34,7 @@ def test_s104_basic():
     assert ds.RasterCount == 0
     assert ds.RasterXSize == 3
     assert ds.RasterYSize == 2
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
     assert ds.GetGeoTransform() == pytest.approx((1.8, 0.4, 0.0, 48.75, 0.0, -0.5))
     assert ds.GetMetadata_Dict() == {
         "AREA_OR_POINT": "Point",
@@ -124,7 +124,7 @@ def test_s104_north_up_no():
     assert ds.RasterCount == 2
     assert ds.RasterXSize == 3
     assert ds.RasterYSize == 2
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
     assert ds.GetGeoTransform() == pytest.approx((1.8, 0.4, 0.0, 47.75, 0.0, 0.5))
 
     band = ds.GetRasterBand(1)
@@ -165,7 +165,7 @@ def test_s104_multidim():
     ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
     rg = ds.GetRootGroup()
     ar = rg.OpenMDArrayFromFullname("/WaterLevel/WaterLevel.01/Group_001/values")
-    assert ar.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ar.GetSpatialRef().GetAuthorityCode() == "4326"
 
     assert ar.GetDimensions()[0].GetName() == "Y"
     y = ar.GetDimensions()[0].GetIndexingVariable()
@@ -917,7 +917,7 @@ def test_s104_write_basic(tmp_path):
         )
 
     with gdal.Open(f'S104:"{tmp_path}/104xxxxyyyy.h5":Group_001') as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
         assert ds.GetGeoTransform() == pytest.approx(
             (500000, 1.1, 0, 4500000 + 1.2 * 3, 0, -1.2)
         )
@@ -1016,7 +1016,7 @@ def test_s104_write_with_uncertainty_band(tmp_path):
         )
 
     with gdal.Open(f'S104:"{tmp_path}/104xxxxyyyy.h5":Group_001') as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
         assert ds.GetGeoTransform() == pytest.approx(
             (500000, 1.1, 0, 4500000 + 1.2 * 3, 0, -1.2)
         )
@@ -1398,7 +1398,7 @@ def test_s104_write_multiple_timestamps(tmp_path):
         )
 
     with gdal.Open(f'S104:"{tmp_path}/104xxxxyyyy.h5":Group_001') as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
         assert ds.GetGeoTransform() == pytest.approx(
             (500000, 1.1, 0, 4500000 + 1.2 * 3, 0, -1.2)
         )
@@ -1469,7 +1469,7 @@ def test_s104_write_multiple_timestamps(tmp_path):
         )
 
     with gdal.Open(f'S104:"{tmp_path}/104xxxxyyyybis.h5":Group_001') as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
         assert ds.GetGeoTransform() == pytest.approx(
             (500000, 1.1, 0, 4500000 + 1.2 * 3, 0, -1.2)
         )
@@ -1603,7 +1603,7 @@ def test_s104_write_multiple_vertical_datums(tmp_path):
         )
 
     with gdal.Open(f'S104:"{tmp_path}/104xxxxyyyy.h5":WaterLevel.01:Group_001') as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
         assert ds.GetGeoTransform() == pytest.approx(
             (500000, 1.1, 0, 4500000 + 1.2 * 3, 0, -1.2)
         )
@@ -1661,7 +1661,7 @@ def test_s104_write_multiple_vertical_datums(tmp_path):
         assert ds.GetMetadata_Dict() == dict1
 
     with gdal.Open(f'S104:"{tmp_path}/104xxxxyyyy.h5":WaterLevel.02:Group_001') as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
         assert ds.GetGeoTransform() == pytest.approx(
             (500000, 1.1, 0, 4500000 + 1.2 * 3, 0, -1.2)
         )
@@ -1734,7 +1734,7 @@ def test_s104_write_multiple_vertical_datums(tmp_path):
     with gdal.Open(
         f'S104:"{tmp_path}/104xxxxyyyybis.h5":WaterLevel.01:Group_001'
     ) as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
         assert ds.GetGeoTransform() == pytest.approx(
             (500000, 1.1, 0, 4500000 + 1.2 * 3, 0, -1.2)
         )
@@ -1765,7 +1765,7 @@ def test_s104_write_multiple_vertical_datums(tmp_path):
     with gdal.Open(
         f'S104:"{tmp_path}/104xxxxyyyybis.h5":WaterLevel.02:Group_001'
     ) as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
         assert ds.GetGeoTransform() == pytest.approx(
             (500000, 1.1, 0, 4500000 + 1.2 * 3, 0, -1.2)
         )

--- a/autotest/gdrivers/s111.py
+++ b/autotest/gdrivers/s111.py
@@ -34,7 +34,7 @@ def test_s111_basic():
     assert ds.RasterCount == 0
     assert ds.RasterXSize == 3
     assert ds.RasterYSize == 2
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
     assert ds.GetGeoTransform() == pytest.approx((1.8, 0.4, 0.0, 48.75, 0.0, -0.5))
     assert ds.GetMetadata_Dict() == {
         "VERTICAL_DATUM_NAME": "meanLowerLowWater",
@@ -103,7 +103,7 @@ def test_s111_north_up_no():
     assert ds.RasterCount == 2
     assert ds.RasterXSize == 3
     assert ds.RasterYSize == 2
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
     assert ds.GetGeoTransform() == pytest.approx((1.8, 0.4, 0.0, 47.75, 0.0, 0.5))
 
     band = ds.GetRasterBand(1)
@@ -147,7 +147,7 @@ def test_s111_multidim():
     ar = rg.OpenMDArrayFromFullname(
         "/SurfaceCurrent/SurfaceCurrent.01/Group_001/values"
     )
-    assert ar.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ar.GetSpatialRef().GetAuthorityCode() == "4326"
 
     assert ar.GetDimensions()[0].GetName() == "Y"
     y = ar.GetDimensions()[0].GetIndexingVariable()
@@ -703,7 +703,7 @@ def test_s111_write_basic(tmp_path):
         )
 
     with gdal.Open(f'S111:"{tmp_path}/111xxxxyyyy.h5":Group_001') as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
         assert ds.GetGeoTransform() == pytest.approx(
             (500000, 1.1, 0, 4500000 + 1.2 * 3, 0, -1.2)
         )
@@ -817,7 +817,7 @@ def test_s111_write_with_uncertainty_bands(tmp_path):
         )
 
     with gdal.Open(f'S111:"{tmp_path}/111xxxxyyyy.h5":Group_001') as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
         assert ds.GetGeoTransform() == pytest.approx(
             (500000, 1.1, 0, 4500000 + 1.2 * 3, 0, -1.2)
         )
@@ -1350,7 +1350,7 @@ def test_s111_write_multiple_timestamps(tmp_path):
         )
 
     with gdal.Open(f'S111:"{tmp_path}/111xxxxyyyy.h5":Group_001') as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
         assert ds.GetGeoTransform() == pytest.approx(
             (500000, 1.1, 0, 4500000 + 1.2 * 3, 0, -1.2)
         )
@@ -1419,7 +1419,7 @@ def test_s111_write_multiple_timestamps(tmp_path):
         )
 
     with gdal.Open(f'S111:"{tmp_path}/111xxxxyyyybis.h5":Group_001') as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
         assert ds.GetGeoTransform() == pytest.approx(
             (500000, 1.1, 0, 4500000 + 1.2 * 3, 0, -1.2)
         )
@@ -1520,7 +1520,7 @@ def test_s111_write_multiple_instances(tmp_path):
     with gdal.Open(
         f'S111:"{tmp_path}/111xxxxyyyy.h5":SurfaceCurrent.01:Group_001'
     ) as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
         assert ds.GetGeoTransform() == pytest.approx(
             (500000, 1.1, 0, 4500000 + 1.2 * 3, 0, -1.2)
         )
@@ -1577,7 +1577,7 @@ def test_s111_write_multiple_instances(tmp_path):
     with gdal.Open(
         f'S111:"{tmp_path}/111xxxxyyyy.h5":SurfaceCurrent.02:Group_001'
     ) as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
         assert ds.GetGeoTransform() == pytest.approx(
             (500000, 1.1, 0, 4500000 + 1.2 * 3, 0, -1.2)
         )
@@ -1648,7 +1648,7 @@ def test_s111_write_multiple_instances(tmp_path):
     with gdal.Open(
         f'S111:"{tmp_path}/111xxxxyyyybis.h5":SurfaceCurrent.01:Group_001'
     ) as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
         assert ds.GetGeoTransform() == pytest.approx(
             (500000, 1.1, 0, 4500000 + 1.2 * 3, 0, -1.2)
         )
@@ -1679,7 +1679,7 @@ def test_s111_write_multiple_instances(tmp_path):
     with gdal.Open(
         f'S111:"{tmp_path}/111xxxxyyyybis.h5":SurfaceCurrent.02:Group_001'
     ) as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
         assert ds.GetGeoTransform() == pytest.approx(
             (500000, 1.1, 0, 4500000 + 1.2 * 3, 0, -1.2)
         )

--- a/autotest/gdrivers/snap_tiff.py
+++ b/autotest/gdrivers/snap_tiff.py
@@ -44,7 +44,7 @@ def test_snap_tiff():
     assert ds.RasterCount == 1
     assert ds.GetRasterBand(1).DataType == gdal.GDT_Float32
     assert ds.GetGCPCount() == 4
-    assert ds.GetGCPSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ds.GetGCPSpatialRef().GetAuthorityCode() == "4326"
     gcps = ds.GetGCPs()
     assert len(gcps) == 4
     assert gcps[0].GCPPixel == 0.5

--- a/autotest/gdrivers/tiledb_multidim.py
+++ b/autotest/gdrivers/tiledb_multidim.py
@@ -580,7 +580,7 @@ def test_tiledb_multidim_array_read_dim_label_and_spatial_ref(epsg_code, axis_ma
             60,
         ]
         srs = ar.GetSpatialRef()
-        assert srs.GetAuthorityCode(None) == str(epsg_code)
+        assert srs.GetAuthorityCode() == str(epsg_code)
         assert srs.GetDataAxisToSRSAxisMapping() == axis_mapping
 
         # Test that gdalmdiminfo can deal with dimensions whose indexing variable
@@ -645,7 +645,7 @@ def test_tiledb_multidim_array_read_gdal_raster_classic():
             [-179.55 + i * 0.90 for i in range(400)]
         )
         srs = ar.GetSpatialRef()
-        assert srs.GetAuthorityCode(None) == "4326"
+        assert srs.GetAuthorityCode() == "4326"
         assert srs.GetDataAxisToSRSAxisMapping() == [2, 3]
         ds_ref = gdal.Open("data/small_world.tif")
         assert ar.Read() == ds_ref.ReadRaster()

--- a/autotest/gdrivers/wmts.py
+++ b/autotest/gdrivers/wmts.py
@@ -2059,8 +2059,8 @@ def test_wmts_read_esri_code_disguised_as_epsg_and_wrong_axis_order():
             assert gdal.GetLastErrorMsg().startswith(
                 "Auto-correcting wrongly swapped TileMatrix.TopLeftCorner coordinates"
             )
-            assert ds.GetSpatialRef().GetAuthorityName(None) == "ESRI"
-            assert ds.GetSpatialRef().GetAuthorityCode(None) == "104905"
+            assert ds.GetSpatialRef().GetAuthorityName() == "ESRI"
+            assert ds.GetSpatialRef().GetAuthorityCode() == "104905"
             assert ds.GetGeoTransform() == pytest.approx(
                 (
                     -180.0,

--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -1079,7 +1079,7 @@ def test_zarr_read_crs(tmp_vsimem, crs_member):
     ar = rg.OpenMDArray(rg.GetMDArrayNames()[0])
     srs = ar.GetSpatialRef()
     assert srs is not None
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
     # Mapping is 1, 2 since the slowest varying axis in multidim
     # mode is the lines, which matches latitude as the first axis of the CRS.
     assert srs.GetDataAxisToSRSAxisMapping() == [1, 2]
@@ -1088,7 +1088,7 @@ def test_zarr_read_crs(tmp_vsimem, crs_member):
     # Open as classic CRS
     ds = gdal.Open(tmp_vsimem / "test.zarr")
     srs = ds.GetSpatialRef()
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
     # Inverted mapping in classic raster mode compared to multidim mode,
     # because the first "axis" in our data model is columns.
     assert srs.GetDataAxisToSRSAxisMapping() == [2, 1]
@@ -3819,7 +3819,7 @@ def test_zarr_pam_spatial_ref(tmp_vsimem):
         assert ar
         crs = ar.GetSpatialRef()
         assert crs is not None
-        assert crs.GetAuthorityCode(None) == "4326"
+        assert crs.GetAuthorityCode() == "4326"
         assert crs.GetDataAxisToSRSAxisMapping() == [1, 2]
         assert crs.GetCoordinateEpoch() == 2021.2
 
@@ -3829,7 +3829,7 @@ def test_zarr_pam_spatial_ref(tmp_vsimem):
         ds = gdal.Open(tmp_vsimem / "test.zarr")
         crs = ds.GetSpatialRef()
         assert crs is not None
-        assert crs.GetAuthorityCode(None) == "4326"
+        assert crs.GetAuthorityCode() == "4326"
         assert crs.GetDataAxisToSRSAxisMapping() == [2, 1]
 
     check_crs_classic_dataset()
@@ -5967,7 +5967,7 @@ def test_zarr_write_WGS84_and_EGM96_height(tmp_vsimem):
         ds.SetSpatialRef(srs)
     with gdal.Open(tmp_filename) as ds:
         srs = ds.GetSpatialRef()
-        assert srs.GetAuthorityCode(None) == "9707"
+        assert srs.GetAuthorityCode() == "9707"
         assert srs.GetDataAxisToSRSAxisMapping() == [2, 1]
 
 
@@ -6177,7 +6177,7 @@ def test_zarr_read_ossfuzz_444714656():
 def test_zarr_read_zarr_with_stac_proj_epsg():
 
     ds = gdal.Open("data/zarr/zarr_with_stac_proj_epsg.zarr")
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "26711"
 
 
 ###############################################################################
@@ -6188,7 +6188,7 @@ def test_zarr_read_zarr_with_stac_proj_epsg():
 def test_zarr_read_zarr_with_stac_proj_wkt2():
 
     ds = gdal.Open("data/zarr/zarr_with_stac_proj_wkt2.zarr")
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "26711"
 
 
 ###############################################################################
@@ -7638,7 +7638,7 @@ def test_zarr_read_spatial_proj_at_array_level():
 
     ds = gdal.Open("data/zarr/v3/spatial_proj_at_array_level.zarr")
     assert ds.GetGeoTransform() == (450000, 10, 0, 5000000, 0, -10)
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
     assert ds.GetMetadata() == {"AREA_OR_POINT": "Area"}
 
 
@@ -7651,7 +7651,7 @@ def test_zarr_read_spatial_proj_at_parent_level():
 
     ds = gdal.Open("data/zarr/v3/spatial_proj_at_parent_level.zarr")
     assert ds.GetGeoTransform() == (450000, 10, 0, 5000000, 0, -10)
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
     assert ds.GetMetadata() == {"AREA_OR_POINT": "Area"}
 
 
@@ -7664,7 +7664,7 @@ def test_zarr_read_spatial_proj_convention_at_root_level():
 
     ds = gdal.Open("data/zarr/v3/spatial_proj_convention_at_root_level.zarr")
     assert ds.GetGeoTransform() == (450000, 10, 0, 5000000, 0, -10)
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
     assert ds.GetMetadata() == {"AREA_OR_POINT": "Area"}
 
 
@@ -8117,7 +8117,7 @@ def test_zarr_read_srs_eopf_sample_service(tmp_vsimem, filename, j):
     gdal.FileFromMemBuffer(tmp_vsimem / filename / ".zgroup", '{"zarr_format": 2}')
 
     ds = gdal.Open(tmp_vsimem / filename)
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32632"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "32632"
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_adbc.py
+++ b/autotest/ogr/ogr_adbc.py
@@ -330,7 +330,7 @@ def test_ogr_adbc_duckdb_parquet_with_spatial(OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL)
                 float("inf"),
                 float("-inf"),
             )
-            assert lyr.GetSpatialRef().GetAuthorityCode(None) == "27700"
+            assert lyr.GetSpatialRef().GetAuthorityCode() == "27700"
             f = lyr.GetNextFeature()
             assert f.GetGeometryRef().ExportToWkt().startswith("POLYGON ((")
 

--- a/autotest/ogr/ogr_basic_test.py
+++ b/autotest/ogr/ogr_basic_test.py
@@ -1293,14 +1293,14 @@ def test_ogr_basic_dataset_get_spatial_ref():
 
     ds = gdal.GetDriverByName("MEM").CreateVector("")
     ds.CreateLayer("one", srs=srs)
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
 
     ds = gdal.GetDriverByName("MEM").CreateVector("")
     lyr = ds.CreateLayer("one", srs=srs)
     geom_field_defn = ogr.GeomFieldDefn("second")
     geom_field_defn.SetSpatialRef(srs)
     lyr.CreateGeomField(geom_field_defn)
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
 
     ds = gdal.GetDriverByName("MEM").CreateVector("")
     lyr = ds.CreateLayer("one", srs=srs)
@@ -1312,7 +1312,7 @@ def test_ogr_basic_dataset_get_spatial_ref():
     ds = gdal.GetDriverByName("MEM").CreateVector("")
     ds.CreateLayer("one", srs=srs)
     ds.CreateLayer("two", srs=srs)
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
 
     ds = gdal.GetDriverByName("MEM").CreateVector("")
     ds.CreateLayer("one", srs=srs)

--- a/autotest/ogr/ogr_csv.py
+++ b/autotest/ogr/ogr_csv.py
@@ -1107,9 +1107,9 @@ def test_ogr_csv_29(tmp_path):
     lyr = ds.GetLayerByName("test")
     assert lyr.GetLayerDefn().GetGeomFieldCount() == 2
     srs = lyr.GetLayerDefn().GetGeomFieldDefn(0).GetSpatialRef()
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
     srs = lyr.GetLayerDefn().GetGeomFieldDefn(1).GetSpatialRef()
-    assert srs.GetAuthorityCode(None) == "32632"
+    assert srs.GetAuthorityCode() == "32632"
     feat = lyr.GetNextFeature()
     geom = feat.GetGeomFieldRef("geom__WKT_lyr1_EPSG_4326")
     if geom.ExportToWkt() != "POINT (1 2)":

--- a/autotest/ogr/ogr_esrijson.py
+++ b/autotest/ogr/ogr_esrijson.py
@@ -706,7 +706,7 @@ def test_ogr_esrijson_identify_srs():
     lyr = ds.GetLayer(0)
     sr = lyr.GetSpatialRef()
     assert sr
-    assert sr.GetAuthorityCode(None) == "4326"
+    assert sr.GetAuthorityCode() == "4326"
 
 
 ###############################################################################
@@ -719,7 +719,7 @@ def test_ogr_esrijson_read_CadastralSpecialServices():
     lyr = ds.GetLayer(0)
     sr = lyr.GetSpatialRef()
     assert sr
-    assert sr.GetAuthorityCode(None) == "4326"
+    assert sr.GetAuthorityCode() == "4326"
     assert lyr.GetGeomType() != ogr.wkbNone
     f = lyr.GetNextFeature()
     assert f["landdescription"] == "WA330160N0260E0SN070"

--- a/autotest/ogr/ogr_fgdb.py
+++ b/autotest/ogr/ogr_fgdb.py
@@ -818,7 +818,7 @@ def test_ogr_filegdb_inconsistent_crs_feature_dataset_and_feature_table():
     lyr = ds.GetLayer(0)
     srs = lyr.GetSpatialRef()
     assert srs is not None
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_flatgeobuf.py
+++ b/autotest/ogr/ogr_flatgeobuf.py
@@ -333,8 +333,8 @@ def test_ogr_flatgeobuf_srs_epsg():
     lyr = ds.GetLayer(0)
     srs_got = lyr.GetSpatialRef()
     assert srs_got.IsSame(srs)
-    assert srs_got.GetAuthorityName(None) == "EPSG"
-    assert srs_got.GetAuthorityCode(None) == "32631"
+    assert srs_got.GetAuthorityName() == "EPSG"
+    assert srs_got.GetAuthorityCode() == "32631"
     ds = None
 
     ogr.GetDriverByName("FlatGeobuf").DeleteDataSource("/vsimem/test.fgb")
@@ -353,8 +353,8 @@ def test_ogr_flatgeobuf_srs_other_authority():
     lyr = ds.GetLayer(0)
     srs_got = lyr.GetSpatialRef()
     assert srs_got.IsSame(srs)
-    assert srs_got.GetAuthorityName(None) == "ESRI"
-    assert srs_got.GetAuthorityCode(None) == "104009"
+    assert srs_got.GetAuthorityName() == "ESRI"
+    assert srs_got.GetAuthorityCode() == "104009"
     ds = None
 
     ogr.GetDriverByName("FlatGeobuf").DeleteDataSource("/vsimem/test.fgb")
@@ -372,7 +372,7 @@ def test_ogr_flatgeobuf_srs_no_authority():
     lyr = ds.GetLayer(0)
     srs_got = lyr.GetSpatialRef()
     assert srs_got.IsSame(srs)
-    assert srs_got.GetAuthorityName(None) is None
+    assert srs_got.GetAuthorityName() is None
     ds = None
 
     ogr.GetDriverByName("FlatGeobuf").DeleteDataSource("/vsimem/test.fgb")
@@ -900,7 +900,7 @@ def test_ogr_flatgeobuf_coordinate_epoch():
     ds = gdal.OpenEx(filename)
     lyr = ds.GetLayer(0)
     srs = lyr.GetSpatialRef()
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
     assert srs.GetCoordinateEpoch() == 2021.3
     assert srs.GetDataAxisToSRSAxisMapping() == [2, 1]
     ds = None
@@ -1644,4 +1644,4 @@ def test_ogr_flatgeobuf_write_empty_file_no_spatial_index(tmp_vsimem):
         lyr = ds.GetLayer(0)
         assert lyr.GetFeatureCount() == 0
         assert lyr.GetExtent(can_return_null=True) is None
-        assert lyr.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert lyr.GetSpatialRef().GetAuthorityCode() == "32631"

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -2993,7 +2993,7 @@ def test_ogr_geojson_62():
     )
     lyr = ds.GetLayer(0)
     srs = lyr.GetSpatialRef()
-    assert srs.GetAuthorityCode(None) == "32631"
+    assert srs.GetAuthorityCode() == "32631"
     assert srs.GetDataAxisToSRSAxisMapping() == [1, 2]
 
     # See https://github.com/OSGeo/gdal/issues/2035
@@ -3002,7 +3002,7 @@ def test_ogr_geojson_62():
     )
     lyr = ds.GetLayer(0)
     srs = lyr.GetSpatialRef()
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
     assert srs.GetDataAxisToSRSAxisMapping() == [2, 1]
 
     # crs type=EPSG (not even documented in GJ2008 spec!) tests. Just for coverage completeness
@@ -4034,7 +4034,7 @@ def test_ogr_geojson_crs_4326(filename):
     ds = ogr.Open("data/geojson/" + filename)
     lyr = ds.GetLayer(0)
     srs = lyr.GetSpatialRef()
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
     assert srs.GetDataAxisToSRSAxisMapping() == [2, 1]
 
 
@@ -4047,7 +4047,7 @@ def test_ogr_geojson_crs_4979(filename):
     ds = ogr.Open("data/geojson/" + filename)
     lyr = ds.GetLayer(0)
     srs = lyr.GetSpatialRef()
-    assert srs.GetAuthorityCode(None) == "4979"
+    assert srs.GetAuthorityCode() == "4979"
     assert srs.GetDataAxisToSRSAxisMapping() == [2, 1, 3]
 
 

--- a/autotest/ogr/ogr_gml.py
+++ b/autotest/ogr/ogr_gml.py
@@ -4080,7 +4080,7 @@ def test_ogr_gml_srs_name_in_xsd(tmp_vsimem, gml_format):
     ds = ogr.Open(filename)
     lyr = ds.GetLayer(0)
     srs = lyr.GetSpatialRef()
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
     assert srs.GetDataAxisToSRSAxisMapping() == [2, 1]
     f = lyr.GetNextFeature()
     assert f.GetGeometryRef().ExportToWkt() == "MULTIPOLYGON (((2 49,2 50,3 50,2 49)))"
@@ -4136,11 +4136,11 @@ def test_ogr_gml_force_srs_detection_multiple_geom_fields():
     lyr = ds.GetLayer(0)
     assert lyr.GetLayerDefn().GetGeomFieldDefn(0).GetSpatialRef() is None
     assert (
-        lyr.GetLayerDefn().GetGeomFieldDefn(1).GetSpatialRef().GetAuthorityCode(None)
+        lyr.GetLayerDefn().GetGeomFieldDefn(1).GetSpatialRef().GetAuthorityCode()
         == "32631"
     )
     assert (
-        lyr.GetLayerDefn().GetGeomFieldDefn(2).GetSpatialRef().GetAuthorityCode(None)
+        lyr.GetLayerDefn().GetGeomFieldDefn(2).GetSpatialRef().GetAuthorityCode()
         == "32632"
     )
     assert lyr.GetLayerDefn().GetGeomFieldDefn(3).GetSpatialRef() is None

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -346,7 +346,7 @@ def test_ogr_gpkg_3(gpkg_ds, tmp_path):
     )
     assert lyr is not None
 
-    assert gpkg_ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert gpkg_ds.GetSpatialRef().GetAuthorityCode() == "4326"
 
     lyr = gpkg_ds.CreateLayer("a_layer", options=["SPATIAL_INDEX=NO"])
 
@@ -5328,7 +5328,7 @@ def test_ogr_gpkg_multiple_geom_columns(tmp_vsimem):
     lyr = ds.GetLayerByName("test (pt)")
     assert lyr.GetGeomType() == ogr.wkbPoint
     assert lyr.GetGeometryColumn() == "pt"
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "4326"
     assert lyr.GetLayerDefn().GetFieldCount() == 3
     f = lyr.GetNextFeature()
     assert f.GetFID() == 1
@@ -6047,7 +6047,7 @@ def test_ogr_gpkg_st_transform_no_record_spatial_ref_sys(tmp_vsimem):
         "SELECT ST_Transform(SetSRID(geom, 32631), 32731) FROM test"
     ) as sql_lyr:
         # Fails on a number of configs
-        # assert sql_lyr.GetSpatialRef().GetAuthorityCode(None) == '32731'
+        # assert sql_lyr.GetSpatialRef().GetAuthorityCode() == '32731'
         f = sql_lyr.GetNextFeature()
         assert f.GetGeometryRef().ExportToWkt() == "POINT (500000 10000000)"
         f = None
@@ -7038,7 +7038,7 @@ def test_ogr_gpkg_spatial_view_computed_geom_column(tmp_vsimem, tmp_path):
 
     lyr = ds.GetLayerByName("geom_view")
     assert lyr.GetGeomType() == ogr.wkbMultiPoint25D
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "4326"
     f = lyr.GetNextFeature()
     assert f.GetGeometryRef().ExportToIsoWkt() == "MULTIPOINT Z ((1 2 3))"
     assert lyr.GetExtent() == (1, 1, 2, 2)
@@ -8119,7 +8119,7 @@ def test_ogr_gpkg_alter_geom_field_defn(tmp_vsimem, tmp_path):
     assert lyr.GetGeometryColumn() == "new_geom_name"
     srs = lyr.GetSpatialRef()
     assert srs is not None
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
     ds = None
 
     ds = ogr.Open(filename, update=1)
@@ -8156,7 +8156,7 @@ def test_ogr_gpkg_alter_geom_field_defn(tmp_vsimem, tmp_path):
     lyr = ds.GetLayer(0)
     srs = lyr.GetSpatialRef()
     assert srs is not None
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
 
     new_geom_field_defn = ogr.GeomFieldDefn("", ogr.wkbNone)
     other_srs = osr.SpatialReference()
@@ -8174,7 +8174,7 @@ def test_ogr_gpkg_alter_geom_field_defn(tmp_vsimem, tmp_path):
     lyr = ds.GetLayer(0)
     srs = lyr.GetSpatialRef()
     assert srs is not None
-    assert srs.GetAuthorityCode(None) == "4269"
+    assert srs.GetAuthorityCode() == "4269"
 
     new_geom_field_defn = ogr.GeomFieldDefn("", ogr.wkbNone)
     srs = osr.SpatialReference()
@@ -8193,7 +8193,7 @@ def test_ogr_gpkg_alter_geom_field_defn(tmp_vsimem, tmp_path):
     lyr = ds.GetLayer(0)
     srs = lyr.GetSpatialRef()
     assert srs is not None
-    assert srs.GetAuthorityCode(None) == "4269"
+    assert srs.GetAuthorityCode() == "4269"
     assert srs.GetCoordinateEpoch() == 2022
     ds = None
 

--- a/autotest/ogr/ogr_hana.py
+++ b/autotest/ogr/ogr_hana.py
@@ -126,9 +126,10 @@ def test_ogr_hana_2():
     assert (
         layer.GetFeatureCount() == shp_layer.GetFeatureCount()
     ), "feature count does not match"
-    assert layer.GetSpatialRef().GetAuthorityCode(
-        None
-    ) == shp_layer.GetSpatialRef().GetAuthorityCode(None), "spatial ref does not match"
+    assert (
+        layer.GetSpatialRef().GetAuthorityCode()
+        == shp_layer.GetSpatialRef().GetAuthorityCode()
+    ), "spatial ref does not match"
 
     layer.SetAttributeFilter(None)
     field_count = layer.GetLayerDefn().GetFieldCount()
@@ -210,7 +211,7 @@ def test_ogr_hana_7():
     ds = open_datasource()
     layer = ds.ExecuteSQL("SELECT * FROM TPOLY")
     assert (
-        layer.GetSpatialRef().GetAuthorityCode(None) == "27700"
+        layer.GetSpatialRef().GetAuthorityCode() == "27700"
     ), "returned wrong spatial reference id"
     ds.ReleaseResultSet(layer)
 

--- a/autotest/ogr/ogr_jsonfg.py
+++ b/autotest/ogr/ogr_jsonfg.py
@@ -300,7 +300,7 @@ def test_jsonfg_read_crs(
     lyr_srs = lyr.GetSpatialRef()
     if epsg_code_lyr:
         assert lyr_srs
-        assert lyr_srs.GetAuthorityCode(None) == str(epsg_code_lyr)
+        assert lyr_srs.GetAuthorityCode() == str(epsg_code_lyr)
         assert lyr_srs.GetDataAxisToSRSAxisMapping() == mapping_lyr
     else:
         assert lyr_srs is None
@@ -315,7 +315,7 @@ def test_jsonfg_read_crs(
                 assert geom_srs
                 assert geom_srs.IsSame(lyr_srs)
             elif epsg_code_lyr is None and epsg_code_feat is not None:
-                assert geom_srs.GetAuthorityCode(None) == str(epsg_code_feat[i])
+                assert geom_srs.GetAuthorityCode() == str(epsg_code_feat[i])
                 assert geom_srs.GetDataAxisToSRSAxisMapping() == mapping_feat[i]
 
     else:
@@ -329,7 +329,7 @@ def test_jsonfg_read_crs(
             assert geom_srs.IsSame(lyr_srs)
         elif epsg_code_feat is not None:
             assert geom_srs
-            assert geom_srs.GetAuthorityCode(None) == str(epsg_code_feat)
+            assert geom_srs.GetAuthorityCode() == str(epsg_code_feat)
             assert geom_srs.GetDataAxisToSRSAxisMapping() == mapping_feat
 
 
@@ -404,7 +404,7 @@ def test_jsonfg_read_GEOMETRY_ELEMENT_open_option(
     lyr = ds.GetLayer(0)
     lyr_srs = lyr.GetSpatialRef()
     assert lyr_srs
-    assert lyr_srs.GetAuthorityCode(None) == str(epsg_code_lyr)
+    assert lyr_srs.GetAuthorityCode() == str(epsg_code_lyr)
     assert lyr_srs.GetDataAxisToSRSAxisMapping() == mapping_lyr
     f = lyr.GetNextFeature()
     geom = f.GetGeometryRef()
@@ -1707,7 +1707,7 @@ def test_jsonfg_read_ogc_crs84():
     ds = gdal.OpenEx(json.dumps(j))
     assert ds.GetDriver().GetDescription() == "JSONFG"
     lyr = ds.GetLayer(0)
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "4326"
     assert lyr.GetSpatialRef().GetDataAxisToSRSAxisMapping() == [2, 1]
     f = lyr.GetNextFeature()
     assert f.GetGeometryRef().ExportToIsoWkt() == "POINT (2 49)"

--- a/autotest/ogr/ogr_lvbag.py
+++ b/autotest/ogr/ogr_lvbag.py
@@ -245,8 +245,8 @@ def test_ogr_lvbag_dataset_pnd():
 
     sr = lyr.GetSpatialRef()
 
-    assert sr.GetAuthorityName(None) == "EPSG"
-    assert sr.GetAuthorityCode(None) == "28992"
+    assert sr.GetAuthorityName() == "EPSG"
+    assert sr.GetAuthorityCode() == "28992"
 
     feat = lyr.GetNextFeature()
     if feat.GetField("oorspronkelijkBouwjaar") != 2009:

--- a/autotest/ogr/ogr_mapml.py
+++ b/autotest/ogr/ogr_mapml.py
@@ -113,7 +113,7 @@ def test_ogr_mapml_basic():
     assert lyr.GetDataset().GetDescription() == ds.GetDescription()
     srs = lyr.GetSpatialRef()
     assert srs
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
     assert lyr.GetGeomType() == ogr.wkbUnknown
     assert lyr.GetName() == "test"
     assert lyr.TestCapability(ogr.OLCStringsAsUTF8)
@@ -378,7 +378,7 @@ def test_ogr_mapml_reprojection_to_wgs84():
     assert lyr.GetGeomType() == ogr.wkbPoint
     srs = lyr.GetSpatialRef()
     assert srs
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
     f = lyr.GetNextFeature()
     assert f.GetGeometryRef().ExportToWkt() == "POINT (3 0)"
     ds = None
@@ -402,7 +402,7 @@ def test_ogr_mapml_layer_srs_is_known():
     lyr = ds.GetLayer(0)
     srs = lyr.GetSpatialRef()
     assert srs
-    assert srs.GetAuthorityCode(None) == "3857"
+    assert srs.GetAuthorityCode() == "3857"
     f = lyr.GetNextFeature()
     assert f.GetGeometryRef().ExportToWkt() == "POINT (1 2)"
     ds = None

--- a/autotest/ogr/ogr_mem.py
+++ b/autotest/ogr/ogr_mem.py
@@ -617,7 +617,7 @@ def test_ogr_mem_coordinate_epoch():
     ds = ogr.GetDriverByName("MEM").CreateDataSource("")
     lyr = ds.CreateLayer("foo", srs=srs)
     srs = lyr.GetSpatialRef()
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
     assert srs.GetCoordinateEpoch() == 2021.3
     assert srs.GetDataAxisToSRSAxisMapping() == [2, 1]
 

--- a/autotest/ogr/ogr_mitab.py
+++ b/autotest/ogr/ogr_mitab.py
@@ -1616,7 +1616,7 @@ def test_ogr_mitab_35(tmp_vsimem):
         == 'CoordSys Earth Projection 3, 33, "m", 3, 46.5, 44, 49, 700000, 6600000'
     )
     srs = get_srs_from_coordsys(tmp_vsimem, coordsys)
-    assert srs.GetAuthorityCode(None) == "2154"
+    assert srs.GetAuthorityCode() == "2154"
     coordsys = get_coordsys_from_srs(tmp_vsimem, srs)
     assert (
         coordsys

--- a/autotest/ogr/ogr_mssqlspatial.py
+++ b/autotest/ogr/ogr_mssqlspatial.py
@@ -133,7 +133,7 @@ def tpoly(mssql_ds):
 
     got_srs = sql_lyr.GetSpatialRef()
     expected_srs = shp_lyr.GetSpatialRef()
-    assert got_srs.GetAuthorityCode(None) == expected_srs.GetAuthorityCode(
+    assert got_srs.GetAuthorityCode() == expected_srs.GetAuthorityCode(
         None
     ), "not matching spatial ref"
 

--- a/autotest/ogr/ogr_mysql.py
+++ b/autotest/ogr/ogr_mysql.py
@@ -176,9 +176,10 @@ def tpoly(mysql_ds):
         mysql_lyr.GetFeatureCount() == shp_lyr.GetFeatureCount()
     ), "not matching feature count"
 
-    assert mysql_lyr.GetSpatialRef().GetAuthorityCode(
-        None
-    ) == shp_lyr.GetSpatialRef().GetAuthorityCode(None), "not matching spatial ref"
+    assert (
+        mysql_lyr.GetSpatialRef().GetAuthorityCode()
+        == shp_lyr.GetSpatialRef().GetAuthorityCode()
+    ), "not matching spatial ref"
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_oapif.py
+++ b/autotest/ogr/ogr_oapif.py
@@ -1441,7 +1441,7 @@ def test_ogr_oapif_storage_crs_easting_northing():
 
     srs = lyr.GetSpatialRef()
     assert srs
-    assert srs.GetAuthorityCode(None) == "32631"
+    assert srs.GetAuthorityCode() == "32631"
     assert lyr.GetLayerDefn().GetFieldCount() == 1
 
     handler = webserver.SequentialHandler()
@@ -1541,7 +1541,7 @@ def test_ogr_oapif_storage_crs_latitude_longitude():
 
     srs = lyr.GetSpatialRef()
     assert srs
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
     assert srs.GetDataAxisToSRSAxisMapping() == [2, 1]
     assert srs.GetCoordinateEpoch() == 2022.5
     assert lyr.GetLayerDefn().GetFieldCount() == 1
@@ -1651,7 +1651,7 @@ def test_ogr_oapif_storage_crs_latitude_longitude_non_compliant_server():
 
     srs = lyr.GetSpatialRef()
     assert srs
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
     assert srs.GetDataAxisToSRSAxisMapping() == [2, 1]
     assert srs.GetCoordinateEpoch() == 2022.5
     assert lyr.GetLayerDefn().GetFieldCount() == 1
@@ -1747,13 +1747,13 @@ def test_ogr_oapif_crs_and_preferred_crs_open_options():
     supported_srs_list = lyr.GetSupportedSRSList()
     assert supported_srs_list
     assert len(supported_srs_list) == 2
-    assert supported_srs_list[0].GetAuthorityCode(None) == "32631"
+    assert supported_srs_list[0].GetAuthorityCode() == "32631"
     # Below doesn't work with early PROJ 6 versions
-    # assert supported_srs_list[1].GetAuthorityCode(None) == "CRS84"
+    # assert supported_srs_list[1].GetAuthorityCode() == "CRS84"
 
     srs = lyr.GetSpatialRef()
     assert srs
-    assert srs.GetAuthorityCode(None) == "32631"
+    assert srs.GetAuthorityCode() == "32631"
 
     json_info = gdal.VectorInfo(ds, format="json", featureCount=False)
     assert "supportedSRSList" in json_info["layers"][0]["geometryFields"][0]
@@ -1781,7 +1781,7 @@ def test_ogr_oapif_crs_and_preferred_crs_open_options():
     )
 
     assert lyr.SetActiveSRS(0, supported_srs_list[0]) == ogr.OGRERR_NONE
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "32631"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "32631"
     minx, maxx, miny, maxy = lyr.GetExtent()
     assert (minx, miny, maxx, maxy) == pytest.approx(
         (-611288.854779237, 4427761.561734099, 1525592.2813932528, 5620112.89047953),
@@ -1798,7 +1798,7 @@ def test_ogr_oapif_crs_and_preferred_crs_open_options():
     with webserver.install_http_handler(get_items_handler()):
         srs = lyr.GetSpatialRef()
         assert srs
-        assert srs.GetAuthorityCode(None) == "32631"
+        assert srs.GetAuthorityCode() == "32631"
 
     with webserver.install_http_handler(get_collections_handler()):
         ds = gdal.OpenEx(
@@ -1810,7 +1810,7 @@ def test_ogr_oapif_crs_and_preferred_crs_open_options():
     with webserver.install_http_handler(get_items_handler()):
         srs = lyr.GetSpatialRef()
         assert srs
-        assert srs.GetAuthorityCode(None) == "4326"
+        assert srs.GetAuthorityCode() == "4326"
 
     handler = webserver.SequentialHandler()
     handler.add(
@@ -1836,7 +1836,7 @@ def test_ogr_oapif_crs_and_preferred_crs_open_options():
             "", ds, format="MEM", dstSRS="EPSG:32631", reproject=True
         )
     out_lyr = out_ds.GetLayer(0)
-    assert out_lyr.GetSpatialRef().GetAuthorityCode(None) == "32631"
+    assert out_lyr.GetSpatialRef().GetAuthorityCode() == "32631"
     f = out_lyr.GetNextFeature()
     assert f.GetGeometryRef().ExportToWkt() == "POINT (500000 4500000)"
 

--- a/autotest/ogr/ogr_openfilegdb.py
+++ b/autotest/ogr/ogr_openfilegdb.py
@@ -2314,7 +2314,7 @@ def test_ogr_openfilegdb_inconsistent_crs_feature_dataset_and_feature_table():
     lyr = ds.GetLayer(0)
     srs = lyr.GetSpatialRef()
     assert srs is not None
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_openfilegdb_write.py
+++ b/autotest/ogr/ogr_openfilegdb_write.py
@@ -1442,7 +1442,7 @@ def test_ogr_openfilegdb_write_feature_dataset_crs(tmp_vsimem):
     lyr = ds.GetLayerByName("inherited_srs")
     srs = lyr.GetSpatialRef()
     assert srs is not None
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
 
 
 ###############################################################################
@@ -3896,7 +3896,7 @@ def test_ogr_openfilegdb_write_alter_geom_field_defn(tmp_vsimem):
     assert "WKID" in xml
 
     assert lyr.GetGeometryColumn() == "shape_renamed"
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "4326"
 
     # Set SRS to None
     fld_defn = ogr.GeomFieldDefn("shape_renamed", ogr.wkbLineString)
@@ -3953,13 +3953,13 @@ def test_ogr_openfilegdb_write_alter_geom_field_defn(tmp_vsimem):
         == ogr.OGRERR_NONE
     )
     assert lyr.GetSpatialRef() is not None
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4269"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "4269"
     ds = None
 
     ds = ogr.Open(dirname, update=1)
     lyr = ds.GetLayer(0)
     assert lyr.GetSpatialRef() is not None
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4269"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "4269"
 
     sql_lyr = ds.ExecuteSQL("GetLayerDefinition test")
     assert sql_lyr

--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -153,7 +153,7 @@ def _check_test_parquet(
     assert lyr_defn.GetGeomFieldDefn(0).GetName() == "geometry"
     srs = lyr_defn.GetGeomFieldDefn(0).GetSpatialRef()
     assert srs is not None
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
     if expect_layer_geom_type:
         assert lyr_defn.GetGeomFieldDefn(0).GetType() == ogr.wkbPoint
     # import pprint
@@ -921,7 +921,7 @@ def test_ogr_parquet_coordinate_epoch(epsg_code):
 
     srs = lyr.GetSpatialRef()
     assert srs is not None
-    assert int(srs.GetAuthorityCode(None)) == epsg_code
+    assert int(srs.GetAuthorityCode()) == epsg_code
     assert srs.GetCoordinateEpoch() == 2022.3
     lyr = None
     ds = None
@@ -958,7 +958,7 @@ def test_ogr_parquet_missing_crs_member():
 
     srs = lyr.GetSpatialRef()
     assert srs is not None
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
     lyr = None
     ds = None
 
@@ -1012,7 +1012,7 @@ def test_ogr_parquet_crs_identification_on_write(input_definition, expected_crs)
 
     srs = lyr.GetSpatialRef()
     assert srs is not None
-    assert srs.GetAuthorityCode(None) == expected_crs
+    assert srs.GetAuthorityCode() == expected_crs
     lyr = None
     ds = None
 
@@ -1948,7 +1948,7 @@ def test_ogr_parquet_write_crs_without_id_in_datum_ensemble_members():
 
     srs = lyr.GetSpatialRef()
     assert srs is not None
-    assert int(srs.GetAuthorityCode(None)) == 32631
+    assert int(srs.GetAuthorityCode()) == 32631
     lyr = None
     ds = None
 
@@ -3068,7 +3068,7 @@ def test_ogr_parquet_recognize_geo_from_geom_possible_names(geom_col_name, is_wk
         lyr = ds.GetLayer(0)
         assert lyr.GetGeometryColumn() == geom_col_name
         assert lyr.GetGeomType() == ogr.wkbUnknown
-        assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+        assert lyr.GetSpatialRef().GetAuthorityCode() == "4326"
         ds = None
 
     finally:
@@ -4489,7 +4489,7 @@ def test_ogr_parquet_write_use_geo_type(tmp_vsimem):
 
     with gdal.OpenEx(tmp_vsimem / "out.parquet") as ds:
         lyr = ds.GetLayer(0)
-        assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+        assert lyr.GetSpatialRef().GetAuthorityCode() == "4326"
         assert lyr.GetMetadataItem("EDGES") == "SPHERICAL"
 
     with gdal.GetDriverByName("Parquet").CreateVector(tmp_vsimem / "out.parquet") as ds:
@@ -4501,7 +4501,7 @@ def test_ogr_parquet_write_use_geo_type(tmp_vsimem):
 
     with gdal.OpenEx(tmp_vsimem / "out.parquet") as ds:
         lyr = ds.GetLayer(0)
-        assert lyr.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert lyr.GetSpatialRef().GetAuthorityCode() == "32631"
         assert lyr.GetMetadataItem("EDGES") is None
 
 
@@ -4609,7 +4609,7 @@ def test_ogr_parquet_update(tmp_path):
         assert lyr.GetFIDColumn() == ""
         assert lyr.GetGeometryColumn() == "geometry"
         assert lyr.GetGeomType() == ogr.wkbPoint
-        assert lyr.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert lyr.GetSpatialRef().GetAuthorityCode() == "32631"
         assert lyr.TestCapability(ogr.OLCSequentialWrite)
         assert lyr.TestCapability(ogr.OLCRandomWrite)
         assert lyr.TestCapability(ogr.OLCCreateField)
@@ -4626,7 +4626,7 @@ def test_ogr_parquet_update(tmp_path):
         assert lyr.GetFIDColumn() == ""
         assert lyr.GetGeometryColumn() == "geometry"
         assert lyr.GetGeomType() == ogr.wkbPoint
-        assert lyr.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert lyr.GetSpatialRef().GetAuthorityCode() == "32631"
         assert lyr.GetFeatureCount() == 2
         f = lyr.GetNextFeature()
         assert f["str"] == "foo"
@@ -4689,7 +4689,7 @@ def test_ogr_parquet_update_with_creation_options_implicit(tmp_path):
         assert lyr.GetFIDColumn() == "my_fid"
         assert lyr.GetGeometryColumn() == "my_geom"
         assert lyr.GetGeomType() == ogr.wkbPoint
-        assert lyr.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert lyr.GetSpatialRef().GetAuthorityCode() == "32631"
         f = ogr.Feature(lyr.GetLayerDefn())
         f["str"] = "bar"
         f["int"] = 456
@@ -4704,7 +4704,7 @@ def test_ogr_parquet_update_with_creation_options_implicit(tmp_path):
         assert lyr.GetFIDColumn() == "my_fid"
         assert lyr.GetGeometryColumn() == "my_geom"
         assert lyr.GetGeomType() == ogr.wkbPoint
-        assert lyr.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert lyr.GetSpatialRef().GetAuthorityCode() == "32631"
         assert lyr.GetFeatureCount() == 2
         f = lyr.GetNextFeature()
         assert f["str"] == "foo"
@@ -5052,4 +5052,4 @@ def test_ogr_parquet_read_geoparquet_1_1_no_explicit_crs_but_geoarrow_wkb_declar
         "data/parquet/geoparquet_1_1_no_explicit_crs_but_geoarrow_wkb_declared.parquet"
     )
     lyr = ds.GetLayer(0)
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "4326"

--- a/autotest/ogr/ogr_pg.py
+++ b/autotest/ogr/ogr_pg.py
@@ -2478,7 +2478,7 @@ def test_ogr_pg_47(pg_ds, pg_postgis_version, pg_postgis_schema):
     lyr = pg_ds.GetLayerByName("test_geog")
     assert lyr.GetExtent() == (2.0, 2.0, 49.0, 49.0), "bad extent for test_geog"
 
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == str(srid)
+    assert lyr.GetSpatialRef().GetAuthorityCode() == str(srid)
 
     feat = lyr.GetNextFeature()
     geom = feat.GetGeometryRef()
@@ -5501,14 +5501,14 @@ def test_ogr_pg_alter_geom_field_defn(pg_ds):
     )
     assert lyr.GetGeometryColumn() == "new_geomfield_name"
     assert lyr.GetGeomType() == ogr.wkbPoint
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4269"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "4269"
     assert not lyr.GetLayerDefn().GetGeomFieldDefn(0).IsNullable()
 
     test_ds = reconnect(pg_ds, update=0)
     test_lyr = test_ds.GetLayer("ogr_pg_alter_geom_field_defn")
     assert test_lyr.GetGeometryColumn() == "new_geomfield_name"
     assert test_lyr.GetGeomType() == ogr.wkbPoint
-    assert test_lyr.GetSpatialRef().GetAuthorityCode(None) == "4269"
+    assert test_lyr.GetSpatialRef().GetAuthorityCode() == "4269"
     assert not test_lyr.GetLayerDefn().GetGeomFieldDefn(0).IsNullable()
     test_ds = None
 
@@ -5538,13 +5538,13 @@ def test_ogr_pg_alter_geom_field_defn(pg_ds):
         )
         == ogr.OGRERR_NONE
     )
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4269"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "4269"
 
     test_ds = reconnect(pg_ds, update=0)
     test_lyr = test_ds.GetLayer("ogr_pg_alter_geom_field_defn")
     assert test_lyr.GetGeometryColumn() == "new_geomfield_name"
     assert test_lyr.GetGeomType() == ogr.wkbPoint
-    assert test_lyr.GetSpatialRef().GetAuthorityCode(None) == "4269"
+    assert test_lyr.GetSpatialRef().GetAuthorityCode() == "4269"
     assert test_lyr.GetLayerDefn().GetGeomFieldDefn(0).IsNullable()
     test_ds = None
 
@@ -5585,7 +5585,7 @@ def test_ogr_pg_alter_geom_field_defn(pg_ds):
     test_lyr = test_ds.GetLayer("ogr_pg_alter_geom_field_defn")
     assert test_lyr.GetGeometryColumn() == "new_geomfield_name"
     assert test_lyr.GetGeomType() == ogr.wkbPoint
-    assert test_lyr.GetSpatialRef().GetAuthorityCode(None) == "4269"
+    assert test_lyr.GetSpatialRef().GetAuthorityCode() == "4269"
     assert test_lyr.GetLayerDefn().GetGeomFieldDefn(0).IsNullable()
     test_ds = None
 

--- a/autotest/ogr/ogr_pmtiles.py
+++ b/autotest/ogr/ogr_pmtiles.py
@@ -55,7 +55,7 @@ def test_ogr_pmtiles_read_basic():
             5318507.966831126,
         )
     )
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "3857"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "3857"
     assert len([f for f in lyr]) == 8
     assert lyr.GetNextFeature() is None
     lyr.ResetReading()

--- a/autotest/ogr/ogr_rfc41.py
+++ b/autotest/ogr/ogr_rfc41.py
@@ -786,7 +786,7 @@ def test_ogr_rfc41_8(require_ogr_sql_sqlite):  # noqa
     assert sql_lyr.GetLayerDefn().GetGeomFieldDefn(0).GetSpatialRef() is None
     assert sql_lyr.GetLayerDefn().GetGeomFieldDefn(1).GetType() == ogr.wkbPoint25D
     srs = sql_lyr.GetLayerDefn().GetGeomFieldDefn(1).GetSpatialRef()
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
     ds.ReleaseResultSet(sql_lyr)
 
     # Test INSERT INTO request

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -507,7 +507,7 @@ def test_ogr_shape_18():
 
     assert srs_lyr is not None, "Missing projection definition."
 
-    assert srs_lyr.GetAuthorityCode(None) == "27700"
+    assert srs_lyr.GetAuthorityCode() == "27700"
 
 
 ###############################################################################
@@ -4306,7 +4306,7 @@ def test_ogr_shape_etrs89_with_zero_TOWGS84(tmp_vsimem):
     ds = ogr.Open(tmp_vsimem / "test_ogr_shape_etrs89_with_zero_TOWGS84.shp")
     lyr = ds.GetLayer(0)
     srs = lyr.GetSpatialRef()
-    assert srs.GetAuthorityCode(None) == "3763"
+    assert srs.GetAuthorityCode() == "3763"
     assert "BOUNDCRS" not in srs.ExportToWkt(["FORMAT=WKT2"])
     ds = None
 
@@ -5672,7 +5672,7 @@ def test_ogr_shape_alter_geom_field_defn(tmp_vsimem):
     lyr = ds.GetLayer(0)
     srs = lyr.GetSpatialRef()
     assert srs is not None
-    assert srs.GetAuthorityCode(None) == "4269"
+    assert srs.GetAuthorityCode() == "4269"
 
     new_geom_field_defn = ogr.GeomFieldDefn("", ogr.wkbPoint)
     assert (
@@ -5703,7 +5703,7 @@ def test_ogr_shape_alter_geom_field_defn(tmp_vsimem):
     lyr = ds.GetLayer(0)
     srs = lyr.GetSpatialRef()
     assert srs is not None
-    assert srs.GetAuthorityCode(None) == "4326"
+    assert srs.GetAuthorityCode() == "4326"
 
     # Wrong index
     new_geom_field_defn = ogr.GeomFieldDefn("", ogr.wkbPoint)
@@ -5800,7 +5800,7 @@ def test_ogr_shape_prj_with_wrong_axis_order(tmp_vsimem):
     lyr = ds.GetLayer(0)
     # Axis order has been changed
     assert lyr.GetSpatialRef().GetAxisName(None, 0) == "Latitude"
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "4326"
     assert lyr.GetSpatialRef().GetDataAxisToSRSAxisMapping() == [2, 1]
 
 

--- a/autotest/ogr/ogr_sqlite.py
+++ b/autotest/ogr/ogr_sqlite.py
@@ -2777,7 +2777,7 @@ def test_ogr_spatialite_point_sql_check_srs(sqlite_test_db):
     lyr.CreateFeature(feat)
     with sqlite_test_db.ExecuteSQL("SELECT * FROM point") as sql_lyr:
         assert sql_lyr.GetLayerDefn().GetGeomFieldCount() == 1
-        assert sql_lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+        assert sql_lyr.GetSpatialRef().GetAuthorityCode() == "4326"
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_topojson.py
+++ b/autotest/ogr/ogr_topojson.py
@@ -186,7 +186,7 @@ def test_ogr_topojson_crs():
 
     ds = ogr.Open("data/topojson/topojson_with_crs.topojson")
     lyr = ds.GetLayer(0)
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "4326"
 
     lyr = ds.GetLayer(1)
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "4326"

--- a/autotest/ogr/ogr_wfs.py
+++ b/autotest/ogr/ogr_wfs.py
@@ -5178,9 +5178,9 @@ def test_ogr_wfs_vsimem_wfs200_supported_crs():
         supported_srs_list = lyr.GetSupportedSRSList()
         assert supported_srs_list is not None
         assert len(supported_srs_list) == 3
-        assert supported_srs_list[0].GetAuthorityCode(None) == "4326"
-        assert supported_srs_list[1].GetAuthorityCode(None) == "3857"
-        assert supported_srs_list[2].GetAuthorityCode(None) == "4258"
+        assert supported_srs_list[0].GetAuthorityCode() == "4326"
+        assert supported_srs_list[1].GetAuthorityCode() == "3857"
+        assert supported_srs_list[2].GetAuthorityCode() == "4258"
 
         # Test changing active SRS
         assert lyr.SetActiveSRS(0, supported_srs_list[1]) == ogr.OGRERR_NONE
@@ -5230,7 +5230,7 @@ def test_ogr_wfs_vsimem_wfs200_supported_crs():
                 (-10.0, 40.0, 15.0, 50.0),
                 abs=1e-3,
             )
-            assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4258"
+            assert lyr.GetSpatialRef().GetAuthorityCode() == "4258"
             f = lyr.GetNextFeature()
             assert f is not None
             assert f.GetGeometryRef().ExportToWkt() == "POINT (2 49)"

--- a/autotest/osr/osr_basic.py
+++ b/autotest/osr/osr_basic.py
@@ -1443,9 +1443,7 @@ def test_osr_basic_set_from_user_input_IGNF():
     srs = osr.SpatialReference()
     assert srs.SetFromUserInput("IGNF:LAMB93") == 0
 
-    assert (
-        srs.GetAuthorityName(None) == "IGNF" and srs.GetAuthorityCode(None) == "LAMB93"
-    )
+    assert srs.GetAuthorityName() == "IGNF" and srs.GetAuthorityCode() == "LAMB93"
 
 
 def test_osr_basic_set_from_user_input_IGNF_non_existing_code():
@@ -1822,10 +1820,10 @@ def test_osr_promote_to_3D():
     sr.SetFromUserInput("WGS84")
 
     assert sr.PromoteTo3D() == 0
-    assert sr.GetAuthorityCode(None) == "4979"
+    assert sr.GetAuthorityCode() == "4979"
 
     assert sr.DemoteTo2D() == 0
-    assert sr.GetAuthorityCode(None) == "4326"
+    assert sr.GetAuthorityCode() == "4326"
 
 
 def test_osr_strip_vertical():
@@ -1836,9 +1834,7 @@ def test_osr_strip_vertical():
 
     assert sr.StripVertical() == 0
     assert not sr.IsCompound()
-    assert (
-        sr.GetAuthorityCode(None) == "2393"
-    )  # KKJ / Finland Uniform Coordinate System
+    assert sr.GetAuthorityCode() == "2393"  # KKJ / Finland Uniform Coordinate System
 
 
 def test_osr_SetVerticalPerspective():

--- a/autotest/osr/osr_cf1.py
+++ b/autotest/osr/osr_cf1.py
@@ -80,7 +80,7 @@ def test_osr_cf1_import_from_spatial_ref_attribute():
     wkt = """GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4326"]]"""
     sr = osr.SpatialReference()
     assert sr.ImportFromCF1({"spatial_ref": wkt}) == ogr.OGRERR_NONE
-    assert sr.GetAuthorityCode(None) == "4326"
+    assert sr.GetAuthorityCode() == "4326"
 
 
 ###############################################################################
@@ -91,4 +91,4 @@ def test_osr_cf1_import_from_crs_wkt_attribute():
     wkt = """GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4326"]]"""
     sr = osr.SpatialReference()
     assert sr.ImportFromCF1({"crs_wkt": wkt}) == ogr.OGRERR_NONE
-    assert sr.GetAuthorityCode(None) == "4326"
+    assert sr.GetAuthorityCode() == "4326"

--- a/autotest/osr/osr_compd.py
+++ b/autotest/osr/osr_compd.py
@@ -354,5 +354,5 @@ def test_osr_compd_vert_datum_2002():
     assert sr.IsProjected()
     assert sr.GetAuthorityCode("PROJCS") == "26930"
     assert sr.GetAuthorityName("PROJCS") == "EPSG"
-    assert sr.GetAuthorityCode(None) is None
-    assert sr.GetAuthorityName(None) is None
+    assert sr.GetAuthorityCode() is None
+    assert sr.GetAuthorityName() is None

--- a/autotest/osr/osr_epsg.py
+++ b/autotest/osr/osr_epsg.py
@@ -29,7 +29,7 @@ def test_osr_epsg_1():
     with gdal.quiet_errors():
         srs.ImportFromEPSG(26591)
         assert "OSR_USE_NON_DEPRECATED" in gdal.GetLastErrorMsg()
-    assert srs.GetAuthorityCode(None) == "3003"
+    assert srs.GetAuthorityCode() == "3003"
 
 
 ###############################################################################
@@ -162,7 +162,7 @@ def test_osr_epsg_10():
 
     assert srs.AutoIdentifyEPSG() == 0
 
-    assert srs.GetAuthorityCode(None) == "3031", srs.ExportToWkt()
+    assert srs.GetAuthorityCode() == "3031", srs.ExportToWkt()
 
     srs_ref = osr.SpatialReference()
     srs_ref.ImportFromEPSG(3031)
@@ -192,7 +192,7 @@ def test_osr_epsg_10():
 
     assert srs.AutoIdentifyEPSG() == 0
 
-    assert srs.GetAuthorityCode(None) == "3995", srs.ExportToWkt()
+    assert srs.GetAuthorityCode() == "3995", srs.ExportToWkt()
 
     srs_ref = osr.SpatialReference()
     srs_ref.ImportFromEPSG(3995)
@@ -286,11 +286,11 @@ def test_osr_epsg_13():
     #    gdaltest.post_reason('fail')
     #    print(matches)
     #    return 'fail'
-    # if matches[0][0].GetAuthorityCode(None) != '4126' or matches[0][1] != 90:
+    # if matches[0][0].GetAuthorityCode() != '4126' or matches[0][1] != 90:
     #    gdaltest.post_reason('fail')
     #    print(matches)
     #    return 'fail'
-    # if matches[1][0].GetAuthorityCode(None) != '4669' or matches[1][1] != 90:
+    # if matches[1][0].GetAuthorityCode() != '4669' or matches[1][1] != 90:
     #    gdaltest.post_reason('fail')
     #    print(matches)
     #    return 'fail'
@@ -399,7 +399,7 @@ def test_osr_epsg_find_matches_wrong_axis_order():
 """)
     matches = sr.FindMatches()
     assert len(matches) == 1 and matches[0][1] == 90
-    assert matches[0][0].GetAuthorityCode(None) == "2193"
+    assert matches[0][0].GetAuthorityCode() == "2193"
     assert matches[0][0].GetDataAxisToSRSAxisMapping() == [2, 1]
 
 
@@ -495,7 +495,7 @@ def test_osr_epsg_auto_identify_epsg_nad83_cors96():
             ORDER[2],
             ANGLEUNIT["degree",0.0174532925199433]]]""")
     srs.AutoIdentifyEPSG()
-    assert srs.GetAuthorityCode(None) == "6783"
+    assert srs.GetAuthorityCode() == "6783"
 
 
 ###############################################################################
@@ -528,7 +528,7 @@ def test_osr_epsg_auto_identify_epsg_projcrs_with_geogcrs_without_axis_roder():
     )
     with pytest.raises(Exception):
         srs.AutoIdentifyEPSG()
-    assert srs.CloneGeogCS().GetAuthorityCode(None) is None
+    assert srs.CloneGeogCS().GetAuthorityCode() is None
 
 
 ###############################################################################
@@ -553,8 +553,8 @@ def test_osr_epsg_import_esri_code():
     with gdal.quiet_errors():
         srs.ImportFromEPSG(104905)
 
-    assert srs.GetAuthorityName(None) == "ESRI"
-    assert srs.GetAuthorityCode(None) == "104905"
+    assert srs.GetAuthorityName() == "ESRI"
+    assert srs.GetAuthorityCode() == "104905"
 
 
 ###############################################################################

--- a/autotest/osr/osr_usgs.py
+++ b/autotest/osr/osr_usgs.py
@@ -111,4 +111,4 @@ def test_osr_usgs_wgs84():
     srs2.ImportFromUSGS(proj_code, zone, params, datum_code)
 
     assert srs2.IsSame(srs)
-    assert srs2.GetAuthorityCode(None) == "32631"
+    assert srs2.GetAuthorityCode() == "32631"

--- a/autotest/pyscripts/test_ogrmerge.py
+++ b/autotest/pyscripts/test_ogrmerge.py
@@ -549,16 +549,16 @@ def test_ogrmerge_gpkg(
     assert lyr.GetExtent() == src_lyr.GetExtent()
     if a_srs:
         assert (
-            lyr.GetSpatialRef().GetAuthorityName(None)
+            lyr.GetSpatialRef().GetAuthorityName()
             + ":"
-            + lyr.GetSpatialRef().GetAuthorityCode(None)
+            + lyr.GetSpatialRef().GetAuthorityCode()
             == a_srs
         )
     elif t_srs:
         assert (
-            lyr.GetSpatialRef().GetAuthorityName(None)
+            lyr.GetSpatialRef().GetAuthorityName()
             + ":"
-            + lyr.GetSpatialRef().GetAuthorityCode(None)
+            + lyr.GetSpatialRef().GetAuthorityCode()
             == t_srs
         )
     else:

--- a/autotest/utilities/test_gdal.py
+++ b/autotest/utilities/test_gdal.py
@@ -726,7 +726,7 @@ def test_gdal_run():
         output_format="MEM",
         dst_crs="EPSG:4326",
     ) as alg:
-        assert alg.Output().GetSpatialRef().GetAuthorityCode(None) == "4326"
+        assert alg.Output().GetSpatialRef().GetAuthorityCode() == "4326"
 
     with gdal.Run(
         ["raster", "reproject"],
@@ -736,7 +736,7 @@ def test_gdal_run():
             "dst-crs": "EPSG:4326",
         },
     ) as alg:
-        assert alg.Output().GetSpatialRef().GetAuthorityCode(None) == "4326"
+        assert alg.Output().GetSpatialRef().GetAuthorityCode() == "4326"
 
 
 def test_gdal_drivers():

--- a/autotest/utilities/test_gdal_footprint_lib.py
+++ b/autotest/utilities/test_gdal_footprint_lib.py
@@ -33,7 +33,7 @@ def test_gdal_footprint_lib_basic():
     out_ds = gdal.Footprint("", "../gcore/data/byte.tif", format="MEM")
     assert out_ds is not None
     lyr = out_ds.GetLayer(0)
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "26711"
     assert lyr.GetFeatureCount() == 1
     f = lyr.GetNextFeature()
     assert f["location"] == "../gcore/data/byte.tif"
@@ -74,7 +74,7 @@ def test_gdal_footprint_lib_targetCoordinateSystem_georef():
     )
     assert out_ds is not None
     lyr = out_ds.GetLayer(0)
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "26711"
     assert lyr.GetFeatureCount() == 1
     f = lyr.GetNextFeature()
     ogrtest.check_feature_geometry(
@@ -94,7 +94,7 @@ def test_gdal_footprint_lib_destSRS():
     )
     assert out_ds is not None
     lyr = out_ds.GetLayer(0)
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4267"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "4267"
     f = lyr.GetNextFeature()
     ogrtest.check_feature_geometry(
         f,

--- a/autotest/utilities/test_gdalalg_driver_gti_create.py
+++ b/autotest/utilities/test_gdalalg_driver_gti_create.py
@@ -37,7 +37,7 @@ def test_gdalalg_driver_gti_create_xml_filename(tmp_vsimem):
 
     ds = alg["output"].GetDataset()
     lyr = ds.GetLayerByName("my_layer")
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "26711"
     assert lyr.GetLayerDefn().GetFieldCount() == 2
     assert lyr.GetLayerDefn().GetFieldDefn(0).GetName() == "location"
     assert lyr.GetLayerDefn().GetFieldDefn(0).GetType() == ogr.OFTString

--- a/autotest/utilities/test_gdalalg_raster_clip.py
+++ b/autotest/utilities/test_gdalalg_raster_clip.py
@@ -71,7 +71,7 @@ def test_gdalalg_raster_clip_bbox():
     ds = alg["output"].GetDataset()
     assert ds.RasterXSize == 18
     assert ds.RasterYSize == 18
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "26711"
     assert ds.GetGeoTransform() == pytest.approx(
         (440780, 60, 0, 3751260, 0, -60), rel=1e-8
     )
@@ -97,7 +97,7 @@ def test_gdalalg_raster_clip_like():
     ds = alg["output"].GetDataset()
     assert ds.RasterXSize == 18
     assert ds.RasterYSize == 18
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "26711"
     assert ds.GetGeoTransform() == pytest.approx(
         (440780, 60, 0, 3751260, 0, -60), rel=1e-8
     )
@@ -209,7 +209,7 @@ def test_gdalalg_raster_clip_bbox_crs():
     ds = alg["output"].GetDataset()
     assert ds.RasterXSize == 6
     assert ds.RasterYSize == 20
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "26711"
     assert ds.GetGeoTransform() == pytest.approx(
         (441620.0, 60.0, 0.0, 3751140.0, 0.0, -60.0), rel=1e-8
     )
@@ -231,7 +231,7 @@ def test_gdalgalg_raster_clip_geometry(tmp_vsimem):
     ds = alg["output"].GetDataset()
     assert ds.RasterXSize == 16
     assert ds.RasterYSize == 17
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "26711"
     assert ds.GetGeoTransform() == pytest.approx(
         (440840, 60.0, 0.0, 3751260, 0.0, -60.0), rel=1e-8
     )
@@ -253,7 +253,7 @@ def test_gdalalg_raster_clip_geometry_add_alpha():
     ds = alg["output"].GetDataset()
     assert ds.RasterXSize == 20
     assert ds.RasterYSize == 20
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "26711"
     assert ds.GetGeoTransform() == pytest.approx(src_ds.GetGeoTransform(), rel=1e-8)
     assert ds.GetRasterBand(1).ReadRaster(0, 0, 10, 10) == b"\x00" * 100
     assert ds.GetRasterBand(1).ReadRaster(10, 10, 10, 10) == src_ds.ReadRaster(

--- a/autotest/utilities/test_gdalalg_raster_create.py
+++ b/autotest/utilities/test_gdalalg_raster_create.py
@@ -210,7 +210,7 @@ def test_gdalalg_raster_create_full():
     assert (
         ds.GetRasterBand(2).ReadRaster(0, 0, 1, 1, buf_type=gdal.GDT_UInt8) == b"\xfe"
     )
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
     assert ds.GetGeoTransform() == (2.0, 0.5, 0.0, 50.0, 0.0, -0.25)
     assert ds.GetMetadataItem("key") == "value"
 
@@ -234,7 +234,7 @@ def test_gdalalg_raster_create_copy():
     assert (
         ds.GetRasterBand(2).ReadRaster(0, 0, 1, 1, buf_type=gdal.GDT_UInt8) == b"\x00"
     )
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
     assert ds.GetGeoTransform() == (2.0, 0.5, 0.0, 50.0, 0.0, -0.25)
     assert ds.GetMetadataItem("key") is None
     assert ds.GetRasterBand(1).GetMetadataItem("foo") is None
@@ -409,7 +409,7 @@ def test_gdalalg_raster_create_copy_override_crs():
     alg["crs"] = "EPSG:32631"
     assert alg.Run()
     ds = alg["output"].GetDataset()
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32631"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "32631"
 
 
 def test_gdalalg_raster_create_copy_override_bbox():

--- a/autotest/utilities/test_gdalalg_raster_edit.py
+++ b/autotest/utilities/test_gdalalg_raster_edit.py
@@ -49,7 +49,7 @@ def test_gdalalg_raster_edit_crs(tmp_vsimem):
     )
 
     with gdal.OpenEx(tmp_filename) as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "32611"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "32611"
 
 
 def test_gdalalg_raster_edit_crs_none(tmp_vsimem):
@@ -277,7 +277,7 @@ def test_gdalalg_raster_pipeline_edit_crs(tmp_vsimem):
     )
 
     with gdal.OpenEx(out_filename) as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "32611"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "32611"
         assert ds.GetRasterBand(1).Checksum() == 4672
 
 
@@ -402,7 +402,7 @@ def test_gdalalg_raster_pipeline_complex():
         pipeline="create --size=1,1 --crs EPSG:4269 --bbox=-126,22,-65,50 ! reproject --dst-crs EPSG:4326 ! edit --metadata DESC=stuff"
     ) as alg:
         ds = alg.Output()
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
         assert ds.GetMetadataItem("DESC") == "stuff"
 
 
@@ -419,7 +419,7 @@ def test_gdalalg_raster_edit_gcp_from_list_of_values():
     )
 
     assert mem_ds.GetGCPCount() == 2
-    assert mem_ds.GetGCPSpatialRef().GetAuthorityCode(None) == "4326"
+    assert mem_ds.GetGCPSpatialRef().GetAuthorityCode() == "4326"
 
     assert mem_ds.GetGCPs()[0].GCPPixel == 1.5
     assert mem_ds.GetGCPs()[0].GCPLine == 2.5

--- a/autotest/utilities/test_gdalalg_raster_footprint.py
+++ b/autotest/utilities/test_gdalalg_raster_footprint.py
@@ -36,7 +36,7 @@ def test_gdalalg_raster_footprint():
     assert last_pct[0] == 1.0
     ds = alg["output"].GetDataset()
     lyr = ds.GetLayerByName("footprint")
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "26711"
     assert lyr.GetFeatureCount() == 1
     f = lyr.GetNextFeature()
     assert f["location"] == "../gcore/data/byte.tif"
@@ -326,7 +326,7 @@ def test_gdalalg_raster_dst_crs():
     assert alg.Run()
     ds = alg["output"].GetDataset()
     lyr = ds.GetLayer(0)
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4267"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "4267"
     f = lyr.GetNextFeature()
     assert f.GetGeometryRef().ExportToWkt().startswith("MULTIPOLYGON (((-117.6411")
 

--- a/autotest/utilities/test_gdalalg_raster_index.py
+++ b/autotest/utilities/test_gdalalg_raster_index.py
@@ -51,7 +51,7 @@ def test_gdalalg_raster_index():
     assert last_pct[0] == 1.0
     ds = alg["output"].GetDataset()
     lyr = ds.GetLayerByName("my_layer")
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "26711"
     assert lyr.GetLayerDefn().GetFieldCount() == 1
     assert lyr.GetLayerDefn().GetFieldDefn(0).GetName() == "location"
     assert lyr.GetLayerDefn().GetFieldDefn(0).GetType() == ogr.OFTString
@@ -86,7 +86,7 @@ def test_gdalalg_raster_index_overwrite(tmp_vsimem):
     assert alg.Run()
     ds = alg["output"].GetDataset()
     lyr = ds.GetLayer(0)
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "26711"
     assert lyr.GetFeatureCount() == 1
     assert alg.Finalize()
     ds.Close()
@@ -117,7 +117,7 @@ def test_gdalalg_raster_index_overwrite(tmp_vsimem):
     assert alg.Run()
     ds = alg["output"].GetDataset()
     lyr = ds.GetLayer(0)
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "26711"
     assert lyr.GetFeatureCount() == 2
     assert alg.Finalize()
     ds.Close()
@@ -129,7 +129,7 @@ def test_gdalalg_raster_index_overwrite(tmp_vsimem):
     assert alg.Run()
     ds = alg["output"].GetDataset()
     lyr = ds.GetLayer(0)
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "26711"
     assert lyr.GetFeatureCount() == 1
     assert alg.Finalize()
     ds.Close()
@@ -141,7 +141,7 @@ def test_gdalalg_raster_index_overwrite(tmp_vsimem):
     assert alg.Run()
     ds = alg["output"].GetDataset()
     lyr = ds.GetLayer(0)
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "26711"
     assert lyr.GetFeatureCount() == 2
     assert alg.Finalize()
     ds.Close()
@@ -153,7 +153,7 @@ def test_gdalalg_raster_index_overwrite(tmp_vsimem):
     assert alg.Run()
     ds = alg["output"].GetDataset()
     lyr = ds.GetLayer(0)
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "26711"
     assert lyr.GetFeatureCount() == 1
     assert alg.Finalize()
     ds.Close()
@@ -227,7 +227,7 @@ def test_gdalalg_raster_index_crs():
     assert alg.Run()
     ds = alg["output"].GetDataset()
     lyr = ds.GetLayer(0)
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4267"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "4267"
     f = lyr.GetNextFeature()
     assert f["source_crs"] == "EPSG:26711"
     # The polygon is an axis-aligned rectangle computed via GDALWarp(),
@@ -435,7 +435,7 @@ def test_gdalalg_raster_index_stac_geoparquet_base_url(tmp_vsimem):
 
     with ogr.Open(tmp_vsimem / "out.parquet") as ds:
         lyr = ds.GetLayer(0)
-        assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+        assert lyr.GetSpatialRef().GetAuthorityCode() == "4326"
         f = lyr.GetNextFeature()
         assert f["assets.image.href"] == "http://example.com/byte.tif"
 

--- a/autotest/utilities/test_gdalalg_raster_pipeline.py
+++ b/autotest/utilities/test_gdalalg_raster_pipeline.py
@@ -512,7 +512,7 @@ def test_gdalalg_raster_pipeline_reproject_no_args(tmp_vsimem):
     )
 
     with gdal.OpenEx(out_filename) as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "26711"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "26711"
         assert ds.GetRasterBand(1).Checksum() == 4672
 
 
@@ -561,7 +561,7 @@ def test_gdalalg_raster_pipeline_reproject_bbox_arg(tmp_vsimem):
     )
 
     with gdal.OpenEx(out_filename) as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
         assert ds.GetGeoTransform() == pytest.approx(
             (-117.641, 0.0005909090909093286, 0.0, 33.9005, 0.0, -0.0005833333333333554)
         )
@@ -592,7 +592,7 @@ def test_gdalalg_raster_pipeline_reproject_almost_all_args(tmp_vsimem):
     )
 
     with gdal.OpenEx(out_filename) as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
         assert ds.GetGeoTransform() == pytest.approx(
             (-117.641, 0.0005, 0.0, 33.9008, 0.0, -0.0004), rel=1e-8
         )

--- a/autotest/utilities/test_gdalalg_raster_pixel_info.py
+++ b/autotest/utilities/test_gdalalg_raster_pixel_info.py
@@ -655,7 +655,7 @@ def test_gdalalg_raster_pixel_info_from_to_vector_dataset(tmp_vsimem, include_fi
     with ogr.Open(tmp_vsimem / "out.gpkg") as out_ds:
         out_lyr = out_ds.GetLayer(0)
         assert out_lyr.GetGeomType() == ogr.wkbPoint
-        assert out_lyr.GetSpatialRef().GetAuthorityCode(None) == "4267"
+        assert out_lyr.GetSpatialRef().GetAuthorityCode() == "4267"
         f = out_lyr.GetNextFeature()
         assert f["line"] == pytest.approx(9.5)
         assert f["column"] == pytest.approx(10.5)
@@ -811,7 +811,7 @@ def test_gdalalg_raster_pixel_info_from_to_vector_dataset_with_pos_crs_user_crs(
     with ogr.Open(tmp_vsimem / "out.gpkg") as out_ds:
         out_lyr = out_ds.GetLayer(0)
         assert out_lyr.GetGeomType() == ogr.wkbPoint
-        assert out_lyr.GetSpatialRef().GetAuthorityCode(None) == "4267"
+        assert out_lyr.GetSpatialRef().GetAuthorityCode() == "4267"
         f = out_lyr.GetNextFeature()
         assert f["line"] == pytest.approx(9.5)
         assert f["column"] == pytest.approx(10.5)
@@ -844,7 +844,7 @@ def test_gdalalg_raster_pixel_info_from_to_vector_dataset_with_pos_crs_pixel(
     with ogr.Open(tmp_vsimem / "out.gpkg") as out_ds:
         out_lyr = out_ds.GetLayer(0)
         assert out_lyr.GetGeomType() == ogr.wkbPoint
-        assert out_lyr.GetSpatialRef().GetAuthorityCode(None) == "26711"
+        assert out_lyr.GetSpatialRef().GetAuthorityCode() == "26711"
         f = out_lyr.GetNextFeature()
         assert f["line"] == pytest.approx(9.5)
         assert f["column"] == pytest.approx(10.5)
@@ -874,7 +874,7 @@ def test_gdalalg_raster_pixel_info_from_to_vector_dataset_complex(tmp_vsimem):
     with ogr.Open(tmp_vsimem / "out.gpkg") as out_ds:
         out_lyr = out_ds.GetLayer(0)
         assert out_lyr.GetGeomType() == ogr.wkbPoint
-        assert out_lyr.GetSpatialRef().GetAuthorityCode(None) == "26711"
+        assert out_lyr.GetSpatialRef().GetAuthorityCode() == "26711"
         f = out_lyr.GetNextFeature()
         assert f["line"] == pytest.approx(10)
         assert f["column"] == pytest.approx(5)
@@ -964,7 +964,7 @@ def test_gdalalg_raster_pixel_info_in_pipeline(tmp_vsimem):
         out_ds = alg.Output()
         out_lyr = out_ds.GetLayer(0)
         assert out_lyr.GetGeomType() == ogr.wkbPoint
-        assert out_lyr.GetSpatialRef().GetAuthorityCode(None) == "26711"
+        assert out_lyr.GetSpatialRef().GetAuthorityCode() == "26711"
         f = out_lyr.GetNextFeature()
         assert f["line"] == pytest.approx(9.5)
         assert f["column"] == pytest.approx(10.5)

--- a/autotest/utilities/test_gdalalg_raster_polygonize.py
+++ b/autotest/utilities/test_gdalalg_raster_polygonize.py
@@ -36,7 +36,7 @@ def test_gdalalg_raster_polygonize():
     assert last_pct[0] == 1.0
     ds = alg["output"].GetDataset()
     lyr = ds.GetLayerByName("polygonize")
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "26711"
     assert lyr.GetFeatureCount() == 281
     assert lyr.GetLayerDefn().GetFieldDefn(0).GetName() == "DN"
     assert lyr.GetLayerDefn().GetFieldDefn(0).GetType() == ogr.OFTInteger

--- a/autotest/utilities/test_gdalalg_raster_tile.py
+++ b/autotest/utilities/test_gdalalg_raster_tile.py
@@ -122,7 +122,7 @@ def test_gdalalg_raster_tile_basic(tmp_vsimem, tiling_scheme, tilesize):
         ds = gdal.Open(tmp_vsimem / "stacta.json")
         assert ds.RasterXSize == 256
         assert ds.RasterYSize == 256
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "3857"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "3857"
         assert ds.GetGeoTransform() == pytest.approx(
             (
                 -13110479.09147343,
@@ -1621,7 +1621,7 @@ def test_gdalalg_raster_tile_output_format_gtiff(tmp_vsimem, output_format, tile
     with gdal.Open(tmp_vsimem / "10/177/409.tif") as ds:
         assert ds.RasterXSize == tile_size
         assert ds.RasterYSize == tile_size
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "3857"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "3857"
         assert list(ds.GetGeoTransform()) == pytest.approx(
             [
                 -13110479.09147343,
@@ -1639,7 +1639,7 @@ def test_gdalalg_raster_tile_output_format_gtiff(tmp_vsimem, output_format, tile
         )
 
     with gdal.Open(tmp_vsimem / "11/354/818.tif") as ds:
-        assert ds.GetSpatialRef().GetAuthorityCode(None) == "3857"
+        assert ds.GetSpatialRef().GetAuthorityCode() == "3857"
         assert list(ds.GetGeoTransform()) == pytest.approx(
             [
                 -13110479.09147343,

--- a/autotest/utilities/test_gdalalg_vector_buffer.py
+++ b/autotest/utilities/test_gdalalg_vector_buffer.py
@@ -104,8 +104,6 @@ def test_gdalalg_vector_buffer(input_wkt, options, output_wkt):
     assert out_lyr.GetGeomType() == out_f.GetGeometryRef().GetGeometryType()
     # print(out_f.GetGeometryRef().ExportToIsoWkt())
     ogrtest.check_feature_geometry(out_f, output_wkt)
-    assert (
-        out_f.GetGeometryRef().GetSpatialReference().GetAuthorityCode(None) == "32631"
-    )
+    assert out_f.GetGeometryRef().GetSpatialReference().GetAuthorityCode() == "32631"
     out_f = out_lyr.GetNextFeature()
     assert out_f.GetGeometryRef() is None

--- a/autotest/utilities/test_gdalalg_vector_clip.py
+++ b/autotest/utilities/test_gdalalg_vector_clip.py
@@ -184,7 +184,7 @@ def test_gdalalg_vector_clip_bbox_srs():
 
     out_ds = clip["output"].GetDataset()
     out_lyr = out_ds.GetLayer(0)
-    assert out_lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert out_lyr.GetSpatialRef().GetAuthorityCode() == "4326"
     out_f = out_lyr.GetNextFeature()
     assert out_f["foo"] == "bar"
 

--- a/autotest/utilities/test_gdalalg_vector_concat.py
+++ b/autotest/utilities/test_gdalalg_vector_concat.py
@@ -49,7 +49,7 @@ def test_gdalalg_vector_concat(GDAL_VECTOR_CONCAT_MAX_OPENED_DATASETS):
     assert ds.GetLayer(-1) is None
     assert ds.GetLayer(1) is None
     lyr = ds.GetLayerByName("poly")
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "27700"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "27700"
     assert len(lyr) == 20
     f = lyr.GetNextFeature()
     assert lyr.GetLayerDefn().GetFieldCount() == 3
@@ -112,7 +112,7 @@ def test_gdalalg_vector_concat_dst_crs():
     assert alg.Run()
     ds = alg["output"].GetDataset()
     lyr = ds.GetLayerByName("test")
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "4326"
     f = lyr.GetNextFeature()
     assert f.GetGeometryRef().ExportToWkt() == "POINT (2 49)"
     f = lyr.GetNextFeature()
@@ -126,7 +126,7 @@ def test_gdalalg_vector_concat_dst_crs():
     assert alg.Run()
     ds = alg["output"].GetDataset()
     lyr = ds.GetLayerByName("test")
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "4326"
     f = lyr.GetNextFeature()
     assert f.GetGeometryRef().ExportToWkt() == "POINT (2 49)"
     f = lyr.GetNextFeature()
@@ -140,7 +140,7 @@ def test_gdalalg_vector_concat_dst_crs():
     assert alg.Run()
     ds = alg["output"].GetDataset()
     lyr = ds.GetLayerByName("test")
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "32631"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "32631"
     f = lyr.GetNextFeature()
     ogrtest.check_feature_geometry(f, "POINT (426857.9877172817 5427937.523464922)")
     f = lyr.GetNextFeature()
@@ -171,7 +171,7 @@ def test_gdalalg_vector_concat_dst_crs():
     assert alg.Run()
     ds = alg["output"].GetDataset()
     lyr = ds.GetLayerByName("test")
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "4326"
     f = lyr.GetNextFeature()
     ogrtest.check_feature_geometry(f, "POINT (3 0)")
 

--- a/autotest/utilities/test_gdalalg_vector_concave_hull.py
+++ b/autotest/utilities/test_gdalalg_vector_concave_hull.py
@@ -65,9 +65,7 @@ def test_gdalalg_vector_concave_hull_basic(alg, input_wkt, ratio, output_wkt):
     assert out_lyr.GetGeomType() == ogr.wkbUnknown
 
     ogrtest.check_feature_geometry(out_f, output_wkt)
-    assert (
-        out_f.GetGeometryRef().GetSpatialReference().GetAuthorityCode(None) == "32631"
-    )
+    assert out_f.GetGeometryRef().GetSpatialReference().GetAuthorityCode() == "32631"
     out_f = out_lyr.GetNextFeature()
     assert out_f is None
 

--- a/autotest/utilities/test_gdalalg_vector_convex_hull.py
+++ b/autotest/utilities/test_gdalalg_vector_convex_hull.py
@@ -55,8 +55,6 @@ def test_gdalalg_vector_convex_hull(alg, input_wkt, output_wkt):
     assert out_lyr.GetGeomType() == ogr.wkbUnknown
 
     ogrtest.check_feature_geometry(out_f, output_wkt)
-    assert (
-        out_f.GetGeometryRef().GetSpatialReference().GetAuthorityCode(None) == "32631"
-    )
+    assert out_f.GetGeometryRef().GetSpatialReference().GetAuthorityCode() == "32631"
     out_f = out_lyr.GetNextFeature()
     assert out_f is None

--- a/autotest/utilities/test_gdalalg_vector_create.py
+++ b/autotest/utilities/test_gdalalg_vector_create.py
@@ -240,7 +240,7 @@ def test_gdalalg_vector_create_overwrite_update_overwrite_layer(tmp_vsimem):
     assert lyr is not None, "Layer not found after overwrite"
     geom_defn = lyr.GetLayerDefn().GetGeomFieldDefn(0)
     assert (
-        geom_defn.GetSpatialRef().GetAuthorityCode(None) == "3857"
+        geom_defn.GetSpatialRef().GetAuthorityCode() == "3857"
     ), "Unexpected CRS after overwrite"
 
 
@@ -339,7 +339,7 @@ def test_gdalalg_vector_create_ogr_schema(tmp_vsimem):
     geom_defn = layer.GetLayerDefn().GetGeomFieldDefn(0)
     assert geom_defn.GetName() == "geom", "Unexpected geometry field name"
     assert geom_defn.GetType() == ogr.wkbPoint, "Unexpected geometry type"
-    assert geom_defn.GetSpatialRef().GetAuthorityCode(None) == "3857", "Unexpected CRS"
+    assert geom_defn.GetSpatialRef().GetAuthorityCode() == "3857", "Unexpected CRS"
 
     # Cleanup
     out_ds = None
@@ -370,7 +370,7 @@ def test_gdalalg_vector_create_ogr_schema(tmp_vsimem):
     assert geom_defn.GetName() == "geom", "Unexpected geometry field name with --like"
     assert geom_defn.GetType() == ogr.wkbPoint, "Unexpected geometry type with --like"
     assert (
-        geom_defn.GetSpatialRef().GetAuthorityCode(None) == "3857"
+        geom_defn.GetSpatialRef().GetAuthorityCode() == "3857"
     ), "Unexpected CRS with --like"
 
 
@@ -698,4 +698,4 @@ def test_gdal_vector_create_compact_crs(tmp_vsimem):
     geom_defn = layer.GetLayerDefn().GetGeomFieldDefn(0)
     assert geom_defn.GetName() == "geom1", "Unexpected geometry field name"
     assert geom_defn.GetType() == ogr.wkbPoint, "Unexpected geometry type"
-    assert geom_defn.GetSpatialRef().GetAuthorityCode(None) == "32632", "Unexpected CRS"
+    assert geom_defn.GetSpatialRef().GetAuthorityCode() == "32632", "Unexpected CRS"

--- a/autotest/utilities/test_gdalalg_vector_edit.py
+++ b/autotest/utilities/test_gdalalg_vector_edit.py
@@ -41,9 +41,9 @@ def test_gdalalg_vector_edit_crs():
 
     out_ds = alg["output"].GetDataset()
     out_lyr = out_ds.GetLayer(0)
-    assert out_lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert out_lyr.GetSpatialRef().GetAuthorityCode() == "4326"
     out_f = out_lyr.GetNextFeature()
-    assert out_f.GetGeometryRef().GetSpatialReference().GetAuthorityCode(None) == "4326"
+    assert out_f.GetGeometryRef().GetSpatialReference().GetAuthorityCode() == "4326"
     assert out_f["foo"] == "bar"
     ogrtest.check_feature_geometry(out_f, "POINT (1 2)")
 

--- a/autotest/utilities/test_gdalalg_vector_grid.py
+++ b/autotest/utilities/test_gdalalg_vector_grid.py
@@ -504,7 +504,7 @@ def test_gdalalg_vector_grid_crs():
     alg["crs"] = "EPSG:4326"
     assert alg.Run()
     ds = alg["output"].GetDataset()
-    assert ds.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
 
 
 def test_gdalalg_vector_grid_overwrite(tmp_vsimem):

--- a/autotest/utilities/test_gdalalg_vector_index.py
+++ b/autotest/utilities/test_gdalalg_vector_index.py
@@ -42,7 +42,7 @@ def test_gdalalg_vector_index_new_file():
         lyr = ds.GetLayer(0)
         assert lyr.GetName() == "tileindex"
         assert lyr.GetFeatureCount() == 1
-        assert lyr.GetSpatialRef().GetAuthorityCode(None) == "27700"
+        assert lyr.GetSpatialRef().GetAuthorityCode() == "27700"
         assert lyr.GetLayerDefn().GetFieldCount() == 1
         f = lyr.GetNextFeature()
         assert f["location"] == "../ogr/data/poly.shp,0"
@@ -66,7 +66,7 @@ def test_gdalalg_vector_index_absolute_path():
         lyr = ds.GetLayer(0)
         assert lyr.GetName() == "tileindex"
         assert lyr.GetFeatureCount() == 1
-        assert lyr.GetSpatialRef().GetAuthorityCode(None) == "27700"
+        assert lyr.GetSpatialRef().GetAuthorityCode() == "27700"
         assert lyr.GetLayerDefn().GetFieldCount() == 1
         f = lyr.GetNextFeature()
         assert (
@@ -137,7 +137,7 @@ def test_gdalalg_vector_index_new_file_dst_crs(tmp_vsimem):
         ds = alg.Output()
         lyr = ds.GetLayer(0)
         assert lyr.GetFeatureCount() == 1
-        assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+        assert lyr.GetSpatialRef().GetAuthorityCode() == "4326"
         assert lyr.GetLayerDefn().GetFieldCount() == 1
         f = lyr.GetNextFeature()
         ogrtest.check_feature_geometry(f, "POLYGON ((3 0,3 0,3 0,3 0,3 0))")

--- a/autotest/utilities/test_gdalalg_vector_make_valid.py
+++ b/autotest/utilities/test_gdalalg_vector_make_valid.py
@@ -53,9 +53,7 @@ def test_gdalalg_vector_make_valid():
     out_lyr = out_ds.GetLayer(0)
     out_f = out_lyr.GetNextFeature()
     assert out_f.GetGeometryRef().GetGeometryType() == ogr.wkbMultiPolygon
-    assert (
-        out_f.GetGeometryRef().GetSpatialReference().GetAuthorityCode(None) == "32631"
-    )
+    assert out_f.GetGeometryRef().GetSpatialReference().GetAuthorityCode() == "32631"
     out_f = out_lyr.GetNextFeature()
     assert out_f.GetGeometryRef().ExportToIsoWkt() == "POINT (1 2)"
     out_f = out_lyr.GetNextFeature()

--- a/autotest/utilities/test_gdalalg_vector_pipeline.py
+++ b/autotest/utilities/test_gdalalg_vector_pipeline.py
@@ -810,7 +810,7 @@ def test_gdalalg_vector_pipeline_reproject_nominal(tmp_vsimem):
     )
 
     with gdal.OpenEx(out_filename) as ds:
-        assert ds.GetLayer(0).GetSpatialRef().GetAuthorityCode(None) == "4326"
+        assert ds.GetLayer(0).GetSpatialRef().GetAuthorityCode() == "4326"
         assert ds.GetLayer(0).GetFeatureCount() == 10
 
 
@@ -836,7 +836,7 @@ def test_gdalalg_vector_pipeline_reproject_with_src_crs(tmp_vsimem):
 
     with gdal.OpenEx(out_filename) as ds:
         lyr = ds.GetLayer(0)
-        assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+        assert lyr.GetSpatialRef().GetAuthorityCode() == "4326"
         f = lyr.GetNextFeature()
         assert f.GetGeometryRef().GetEnvelope() == pytest.approx(
             (2.750130423614134, 2.759262932833617, 43.0361359661472, 43.0429263707128)

--- a/autotest/utilities/test_gdalalg_vector_segmentize.py
+++ b/autotest/utilities/test_gdalalg_vector_segmentize.py
@@ -49,9 +49,7 @@ def test_gdalalg_vector_segmentize():
         out_f.GetGeometryRef().ExportToWkt()
         == "LINESTRING (0 0,0.0 0.25,0.0 0.5,0.0 0.75,0 1)"
     )
-    assert (
-        out_f.GetGeometryRef().GetSpatialReference().GetAuthorityCode(None) == "32631"
-    )
+    assert out_f.GetGeometryRef().GetSpatialReference().GetAuthorityCode() == "32631"
     out_f = out_lyr.GetNextFeature()
     assert out_f.GetGeometryRef() is None
     assert out_lyr.GetFeatureCount() == 2

--- a/autotest/utilities/test_gdalalg_vector_simplify.py
+++ b/autotest/utilities/test_gdalalg_vector_simplify.py
@@ -48,9 +48,7 @@ def test_gdalalg_vector_simplify():
     out_lyr = out_ds.GetLayer(0)
     out_f = out_lyr.GetNextFeature()
     assert out_f.GetGeometryRef().ExportToWkt() == "LINESTRING (0 0,2 0)"
-    assert (
-        out_f.GetGeometryRef().GetSpatialReference().GetAuthorityCode(None) == "32631"
-    )
+    assert out_f.GetGeometryRef().GetSpatialReference().GetAuthorityCode() == "32631"
     out_f = out_lyr.GetNextFeature()
     assert out_f.GetGeometryRef() is None
     assert out_lyr.GetFeatureCount() == 2

--- a/autotest/utilities/test_gdalalg_vector_swap_xy.py
+++ b/autotest/utilities/test_gdalalg_vector_swap_xy.py
@@ -43,9 +43,7 @@ def test_gdalalg_vector_swap_xy():
     out_lyr = out_ds.GetLayer(0)
     out_f = out_lyr.GetNextFeature()
     assert out_f.GetGeometryRef().ExportToIsoWkt() == "POINT (2 1)"
-    assert (
-        out_f.GetGeometryRef().GetSpatialReference().GetAuthorityCode(None) == "32631"
-    )
+    assert out_f.GetGeometryRef().GetSpatialReference().GetAuthorityCode() == "32631"
     out_f = out_lyr.GetNextFeature()
     assert out_f.GetGeometryRef() is None
     assert out_lyr.GetFeatureCount() == 2

--- a/autotest/utilities/test_gdalmdimtranslate_lib.py
+++ b/autotest/utilities/test_gdalmdimtranslate_lib.py
@@ -908,7 +908,7 @@ def test_gdalmdimtranslate_array_resample():
     assert dims[2].GetName() == "bands"
     assert dims[2].GetSize() == 2
     assert resampled_ar.GetDataType() == gdal.ExtendedDataType.Create(gdal.GDT_Float32)
-    assert resampled_ar.GetSpatialRef().GetAuthorityCode(None) == "4326"
+    assert resampled_ar.GetSpatialRef().GetAuthorityCode() == "4326"
     assert struct.unpack("f" * (3 * 3 * 2), resampled_ar.Read()) == (
         -9999.0,
         -9999.0,

--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -647,7 +647,7 @@ def test_ogr2ogr_lib_ct_no_srs():
         coordinateOperation="+proj=affine +s11=-1",
     )
     lyr = ds.GetLayer(0)
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "27700"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "27700"
     f = lyr.GetNextFeature()
     # f.DumpReadable()
     ogrtest.check_feature_geometry(
@@ -3047,7 +3047,7 @@ def test_ogr2ogr_lib_reproject_arrow_optim_ct(tmp_vsimem):
     assert "OGR2OGR: Using WriteArrowBatch()" in got_msg
 
     lyr = ds.GetLayer(0)
-    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "32632"
+    assert lyr.GetSpatialRef().GetAuthorityCode() == "32632"
     f = lyr.GetNextFeature()
     assert f.GetGeometryRef().ExportToWkt() == "POINT (-1 2)"
 

--- a/autotest/utilities/test_ogrtindex.py
+++ b/autotest/utilities/test_ogrtindex.py
@@ -168,7 +168,7 @@ def test_ogrtindex_3(ogrtindex_path, tmp_path, src_srs_format, expected_srss):
     assert ds.GetLayer(0).GetFeatureCount() == 2, "did not get expected feature count"
 
     assert (
-        ds.GetLayer(0).GetSpatialRef().GetAuthorityCode(None) == "4326"
+        ds.GetLayer(0).GetSpatialRef().GetAuthorityCode() == "4326"
     ), "did not get expected spatial ref"
 
     expected_wkts = [

--- a/frmts/daas/daasdataset.cpp
+++ b/frmts/daas/daasdataset.cpp
@@ -1142,8 +1142,8 @@ bool GDALDAASDataset::SetupServerSideReprojection(const char *pszTargetSRS)
 
     // Check that we can find the EPSG code as we will need to
     // provide as a urn to getBuffer
-    const char *pszAuthorityCode = oSRS.GetAuthorityCode(nullptr);
-    const char *pszAuthorityName = oSRS.GetAuthorityName(nullptr);
+    const char *pszAuthorityCode = oSRS.GetAuthorityCode();
+    const char *pszAuthorityName = oSRS.GetAuthorityName();
     if (pszAuthorityName == nullptr || !EQUAL(pszAuthorityName, "EPSG") ||
         pszAuthorityCode == nullptr)
     {

--- a/frmts/eeda/eedacommon.cpp
+++ b/frmts/eeda/eedacommon.cpp
@@ -196,8 +196,8 @@ BuildBandDescArray(json_object *poBands,
             dfResX == 1.0 && dfResY == 1.0 )
         {
             // e.g. EEDAI:LT5_L1T_8DAY_EVI/19840109
-            const char* pszAuthorityName = oSRS.GetAuthorityName(nullptr);
-            const char* pszAuthorityCode = oSRS.GetAuthorityCode(nullptr);
+            const char* pszAuthorityName = oSRS.GetAuthorityName();
+            const char* pszAuthorityCode = oSRS.GetAuthorityCode();
             if( pszAuthorityName && pszAuthorityCode &&
                 EQUAL(pszAuthorityName, "EPSG") &&
                 EQUAL(pszAuthorityCode, "4326") )

--- a/frmts/eeda/eedadataset.cpp
+++ b/frmts/eeda/eedadataset.cpp
@@ -555,8 +555,8 @@ OGRFeature *GDALEEDALayer::GetNextRawFeature()
                 oSRS.SetFromUserInput(
                     osSRS,
                     OGRSpatialReference::SET_FROM_USER_INPUT_LIMITATIONS_get());
-                const char *pszAuthName = oSRS.GetAuthorityName(nullptr);
-                const char *pszAuthCode = oSRS.GetAuthorityCode(nullptr);
+                const char *pszAuthName = oSRS.GetAuthorityName();
+                const char *pszAuthCode = oSRS.GetAuthorityCode();
                 if (pszAuthName && pszAuthCode)
                 {
                     poFeature->SetField(

--- a/frmts/gtiff/cogdriver.cpp
+++ b/frmts/gtiff/cogdriver.cpp
@@ -171,8 +171,8 @@ static bool COGGetTargetSRS(const char *const *papszOptions,
         oTargetSRS.SetFromUserInput(
             osTargetSRS,
             OGRSpatialReference::SET_FROM_USER_INPUT_LIMITATIONS_get());
-        const char *pszAuthCode = oTargetSRS.GetAuthorityCode(nullptr);
-        const char *pszAuthName = oTargetSRS.GetAuthorityName(nullptr);
+        const char *pszAuthCode = oTargetSRS.GetAuthorityCode();
+        const char *pszAuthName = oTargetSRS.GetAuthorityName();
         if (pszAuthName && pszAuthCode)
         {
             osTargetSRS = pszAuthName;
@@ -222,7 +222,7 @@ static bool COGGetWarpingCharacteristics(
     oTargetSRS.SetFromUserInput(
         osTargetSRS,
         OGRSpatialReference::SET_FROM_USER_INPUT_LIMITATIONS_get());
-    const char *pszAuthCode = oTargetSRS.GetAuthorityCode(nullptr);
+    const char *pszAuthCode = oTargetSRS.GetAuthorityCode();
     const int nEPSGCode = pszAuthCode ? atoi(pszAuthCode) : 0;
 
     // Hack to compensate for GDALSuggestedWarpOutput2() failure (or not
@@ -842,8 +842,8 @@ GDALCOGCreator::Create(const char *pszFilename, GDALDataset *const poSrcDS,
         const auto poSrcSRS = poCurDS->GetSpatialRef();
         if (poSrcSRS)
         {
-            const char *pszAuthName = poSrcSRS->GetAuthorityName(nullptr);
-            const char *pszAuthCode = poSrcSRS->GetAuthorityCode(nullptr);
+            const char *pszAuthName = poSrcSRS->GetAuthorityName();
+            const char *pszAuthCode = poSrcSRS->GetAuthorityCode();
             if (pszAuthName && pszAuthCode)
             {
                 osSrcSRS = pszAuthName;

--- a/frmts/gtiff/gt_wkt_srs.cpp
+++ b/frmts/gtiff/gt_wkt_srs.cpp
@@ -1672,8 +1672,7 @@ OGRSpatialReferenceH GTIFGetOGISDefnAsOSR(GTIF *hGTIF, GTIFDefn *psDefn)
     }
 
     if ((bIs2DProjCRS || oSRS.IsGeographic()) &&
-        oSRS.GetAuthorityCode(nullptr) == nullptr &&
-        psDefn->UOMAngleInDegrees == 1.0)
+        oSRS.GetAuthorityCode() == nullptr && psDefn->UOMAngleInDegrees == 1.0)
     {
         const PJ_TYPE type = bIs2DProjCRS ? PJ_TYPE_PROJECTED_CRS
                              : oSRS.GetAxesCount() == 2
@@ -1797,8 +1796,7 @@ OGRSpatialReferenceH GTIFGetOGISDefnAsOSR(GTIF *hGTIF, GTIFDefn *psDefn)
 
         if (bCanBuildCompoundCRS)
         {
-            const bool bHorizontalHasCode =
-                oSRS.GetAuthorityCode(nullptr) != nullptr;
+            const bool bHorizontalHasCode = oSRS.GetAuthorityCode() != nullptr;
             const char *pszHorizontalName = oSRS.GetName();
             const std::string osHorizontalName(
                 pszHorizontalName ? pszHorizontalName : "unnamed");
@@ -3423,8 +3421,8 @@ int GTIFSetFromOGISDefnEx(GTIF *psGTIF, OGRSpatialReferenceH hSRS,
         // of the current SRS object and the one coming from the EPSG code
         // are the same, then by default, do not write them.
         bool bUseReferenceTOWGS84 = false;
-        const char *pszAuthName = poSRS->GetAuthorityName(nullptr);
-        const char *pszAuthCode = poSRS->GetAuthorityCode(nullptr);
+        const char *pszAuthName = poSRS->GetAuthorityName();
+        const char *pszAuthCode = poSRS->GetAuthorityCode();
         if (pszAuthName && EQUAL(pszAuthName, "EPSG") && pszAuthCode)
         {
             CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -3787,8 +3787,8 @@ static bool IsSRSCompatibleOfGeoTIFF(const OGRSpatialReference *poSRS,
     char *pszWKT = nullptr;
     if ((poSRS->IsGeographic() || poSRS->IsProjected()) && !poSRS->IsCompound())
     {
-        const char *pszAuthName = poSRS->GetAuthorityName(nullptr);
-        const char *pszAuthCode = poSRS->GetAuthorityCode(nullptr);
+        const char *pszAuthName = poSRS->GetAuthorityName();
+        const char *pszAuthCode = poSRS->GetAuthorityCode();
         if (pszAuthName && pszAuthCode && EQUAL(pszAuthName, "EPSG"))
             return true;
     }

--- a/frmts/hdf5/s100.cpp
+++ b/frmts/hdf5/s100.cpp
@@ -1303,8 +1303,8 @@ bool S100BaseWriter::BaseChecks(const char *pszDriverName, bool crsMustBeEPSG,
         return false;
     }
 
-    const char *pszAuthName = m_poSRS->GetAuthorityName(nullptr);
-    const char *pszAuthCode = m_poSRS->GetAuthorityCode(nullptr);
+    const char *pszAuthName = m_poSRS->GetAuthorityName();
+    const char *pszAuthCode = m_poSRS->GetAuthorityCode();
     if (pszAuthName && pszAuthCode && EQUAL(pszAuthName, "EPSG"))
     {
         m_nEPSGCode = atoi(pszAuthCode);

--- a/frmts/hfa/hfadataset.cpp
+++ b/frmts/hfa/hfadataset.cpp
@@ -4474,7 +4474,7 @@ CPLErr HFADataset::ReadProjection()
     // If we got a valid projection and managed to identify a EPSG code,
     // then do not use the ESRI PE String.
     const bool bTryReadingPEString =
-        poSRS == nullptr || poSRS->GetAuthorityCode(nullptr) == nullptr;
+        poSRS == nullptr || poSRS->GetAuthorityCode() == nullptr;
 
     // Special logic for PE string in ProjectionX node.
     char *pszPE_COORDSYS = nullptr;

--- a/frmts/mbtiles/mbtilesdataset.cpp
+++ b/frmts/mbtiles/mbtilesdataset.cpp
@@ -1314,10 +1314,10 @@ CPLErr MBTilesDataset::SetSpatialRef(const OGRSpatialReference *poSRS)
         return CE_Failure;
     }
 
-    if (poSRS == nullptr || poSRS->GetAuthorityName(nullptr) == nullptr ||
-        !EQUAL(poSRS->GetAuthorityName(nullptr), "EPSG") ||
-        poSRS->GetAuthorityCode(nullptr) == nullptr ||
-        !EQUAL(poSRS->GetAuthorityCode(nullptr), "3857"))
+    if (poSRS == nullptr || poSRS->GetAuthorityName() == nullptr ||
+        !EQUAL(poSRS->GetAuthorityName(), "EPSG") ||
+        poSRS->GetAuthorityCode() == nullptr ||
+        !EQUAL(poSRS->GetAuthorityCode(), "3857"))
     {
         CPLError(CE_Failure, CPLE_NotSupported,
                  "Only EPSG:3857 supported on MBTiles dataset");
@@ -3328,8 +3328,8 @@ GDALDataset *MBTilesDataset::CreateCopy(const char *pszFilename,
         OGRSpatialReference oSrcSRS;
         oSrcSRS.SetFromUserInput(poSrcDS->GetProjectionRef());
         oSrcSRS.AutoIdentifyEPSG();
-        if (oSrcSRS.GetAuthorityCode(nullptr) == nullptr ||
-            atoi(oSrcSRS.GetAuthorityCode(nullptr)) != 3857)
+        if (oSrcSRS.GetAuthorityCode() == nullptr ||
+            atoi(oSrcSRS.GetAuthorityCode()) != 3857)
         {
             nTargetBands++;
         }

--- a/frmts/rmf/rmfdataset.cpp
+++ b/frmts/rmf/rmfdataset.cpp
@@ -851,11 +851,11 @@ CPLErr RMFDataset::WriteHeader()
         sHeader.dfStdP2 = adfPrjParams[1];
         sHeader.dfCenterLat = adfPrjParams[2];
         sHeader.dfCenterLong = adfPrjParams[3];
-        if (m_oSRS.GetAuthorityName(nullptr) != nullptr &&
-            m_oSRS.GetAuthorityCode(nullptr) != nullptr &&
-            EQUAL(m_oSRS.GetAuthorityName(nullptr), "EPSG"))
+        if (m_oSRS.GetAuthorityName() != nullptr &&
+            m_oSRS.GetAuthorityCode() != nullptr &&
+            EQUAL(m_oSRS.GetAuthorityName(), "EPSG"))
         {
-            sHeader.iEPSGCode = atoi(m_oSRS.GetAuthorityCode(nullptr));
+            sHeader.iEPSGCode = atoi(m_oSRS.GetAuthorityCode());
         }
 
         sExtHeader.nEllipsoid = static_cast<GInt32>(iEllips);

--- a/frmts/wcs/wcsdataset100.cpp
+++ b/frmts/wcs/wcsdataset100.cpp
@@ -330,10 +330,10 @@ bool WCSDataset100::ExtractGridInfo()
     /* -------------------------------------------------------------------- */
     if (!m_oSRS.IsEmpty() && osCRS == "")
     {
-        const char *pszAuth = m_oSRS.GetAuthorityName(nullptr);
+        const char *pszAuth = m_oSRS.GetAuthorityName();
         if (pszAuth != nullptr && EQUAL(pszAuth, "EPSG"))
         {
-            pszAuth = m_oSRS.GetAuthorityCode(nullptr);
+            pszAuth = m_oSRS.GetAuthorityCode();
             if (pszAuth)
             {
                 osCRS = "EPSG:";

--- a/frmts/wms/wmsdriver.cpp
+++ b/frmts/wms/wmsdriver.cpp
@@ -665,8 +665,8 @@ static CPLXMLNode *GDALWMSDatasetGetConfigFromArcGISJSON(const char *pszURL,
         {
             oSRS = *poSRSMatch;
             poSRSMatch->Release();
-            const char *pszAuthName = oSRS.GetAuthorityName(nullptr);
-            const char *pszCode = oSRS.GetAuthorityCode(nullptr);
+            const char *pszAuthName = oSRS.GetAuthorityName();
+            const char *pszCode = oSRS.GetAuthorityCode();
             if (pszAuthName && EQUAL(pszAuthName, "EPSG") && pszCode)
                 nWKID = atoi(pszCode);
         }

--- a/frmts/zarr/zarr_array.cpp
+++ b/frmts/zarr/zarr_array.cpp
@@ -309,8 +309,8 @@ CPLJSONObject ZarrArray::SerializeSpecialAttributes()
 
             oZarrConventionsArray.Add(oConventionProj);
 
-            const char *pszAuthorityName = m_poSRS->GetAuthorityName(nullptr);
-            const char *pszAuthorityCode = m_poSRS->GetAuthorityCode(nullptr);
+            const char *pszAuthorityName = m_poSRS->GetAuthorityName();
+            const char *pszAuthorityCode = m_poSRS->GetAuthorityCode();
             if (pszAuthorityName && pszAuthorityCode)
             {
                 oAttrs.Set("proj:code", CPLSPrintf("%s:%s", pszAuthorityName,
@@ -488,8 +488,8 @@ CPLJSONObject ZarrArray::SerializeSpecialAttributes()
         CPLJSONObject oCRS;
         ExportToWkt2AndPROJJSON(oCRS, "wkt", "projjson");
 
-        const char *pszAuthorityCode = m_poSRS->GetAuthorityCode(nullptr);
-        const char *pszAuthorityName = m_poSRS->GetAuthorityName(nullptr);
+        const char *pszAuthorityCode = m_poSRS->GetAuthorityCode();
+        const char *pszAuthorityName = m_poSRS->GetAuthorityName();
         if (pszAuthorityCode && pszAuthorityName &&
             EQUAL(pszAuthorityName, "EPSG"))
         {

--- a/ogr/ogr_spatialref.h
+++ b/ogr/ogr_spatialref.h
@@ -460,8 +460,8 @@ class CPL_DLL OGRSpatialReference
 
     int GetEPSGGeogCS() const;
 
-    const char *GetAuthorityCode(const char *pszTargetKey) const;
-    const char *GetAuthorityName(const char *pszTargetKey) const;
+    const char *GetAuthorityCode(const char *pszTargetKey = nullptr) const;
+    const char *GetAuthorityName(const char *pszTargetKey = nullptr) const;
     char *GetOGCURN() const;
 
     bool GetAreaOfUse(double *pdfWestLongitudeDeg, double *pdfSouthLatitudeDeg,

--- a/ogr/ogr_srs_esri.cpp
+++ b/ogr/ogr_srs_esri.cpp
@@ -637,7 +637,7 @@ OGRErr OGRSpatialReference::importFromESRI(char **papszPrj)
         const CPLString osValue = OSR_GDS(papszPrj, "Units", "");
         CPLString osOldAuth;
         {
-            const char *pszOldAuth = GetAuthorityCode(nullptr);
+            const char *pszOldAuth = GetAuthorityCode();
             if (pszOldAuth)
                 osOldAuth = pszOldAuth;
         }

--- a/ogr/ogr_srs_usgs.cpp
+++ b/ogr/ogr_srs_usgs.cpp
@@ -766,8 +766,8 @@ OGRErr OGRSpatialReference::importFromUSGS(long iProjSys, long iZone,
     {
         if (AutoIdentifyEPSG() == OGRERR_NONE)
         {
-            const char *pszAuthName = GetAuthorityName(nullptr);
-            const char *pszAuthCode = GetAuthorityCode(nullptr);
+            const char *pszAuthName = GetAuthorityName();
+            const char *pszAuthCode = GetAuthorityCode();
             if (pszAuthName && pszAuthCode && EQUAL(pszAuthName, "EPSG"))
                 CPL_IGNORE_RET_VAL(importFromEPSG(atoi(pszAuthCode)));
         }

--- a/ogr/ogrct.cpp
+++ b/ogr/ogrct.cpp
@@ -240,8 +240,8 @@ static char *GetTextRepresentation(const OGRSpatialReference *poSRS)
     // definition in case a trip to WKT1 has lost the area of use.
     // unless OGR_CT_PREFER_OFFICIAL_SRS_DEF=NO (see
     // https://github.com/OSGeo/PROJ/issues/2955)
-    const char *pszAuth = poSRS->GetAuthorityName(nullptr);
-    const char *pszCode = poSRS->GetAuthorityCode(nullptr);
+    const char *pszAuth = poSRS->GetAuthorityName();
+    const char *pszCode = poSRS->GetAuthorityCode();
     if (pszAuth && pszCode &&
         CPLTestBool(
             CPLGetConfigOption("OGR_CT_PREFER_OFFICIAL_SRS_DEF", "YES")))
@@ -254,8 +254,8 @@ static char *GetTextRepresentation(const OGRSpatialReference *poSRS)
         OGRSpatialReference oTmpSRS;
         if (oTmpSRS.SetFromUserInput(osAuthCode) == OGRERR_NONE)
         {
-            const char *pszAuthAfter = oTmpSRS.GetAuthorityName(nullptr);
-            const char *pszCodeAfter = oTmpSRS.GetAuthorityCode(nullptr);
+            const char *pszAuthAfter = oTmpSRS.GetAuthorityName();
+            const char *pszCodeAfter = oTmpSRS.GetAuthorityCode();
             if (pszAuthAfter && pszCodeAfter && EQUAL(pszAuthAfter, pszAuth) &&
                 EQUAL(pszCodeAfter, pszCode))
             {
@@ -1416,10 +1416,10 @@ void OGRProjCT::DetectWebMercatorToWGS84()
         // Examine SRS ID before going to Proj4 string for faster execution
         // This assumes that the SRS definition is "not lying", that is, it
         // is equivalent to the resolution of the official EPSG code.
-        const char *pszSourceAuth = poSRSSource->GetAuthorityName(nullptr);
-        const char *pszSourceCode = poSRSSource->GetAuthorityCode(nullptr);
-        const char *pszTargetAuth = poSRSTarget->GetAuthorityName(nullptr);
-        const char *pszTargetCode = poSRSTarget->GetAuthorityCode(nullptr);
+        const char *pszSourceAuth = poSRSSource->GetAuthorityName();
+        const char *pszSourceCode = poSRSSource->GetAuthorityCode();
+        const char *pszTargetAuth = poSRSTarget->GetAuthorityName();
+        const char *pszTargetCode = poSRSTarget->GetAuthorityCode();
         if (pszSourceAuth && pszSourceCode && pszTargetAuth && pszTargetCode &&
             EQUAL(pszSourceAuth, "EPSG") && EQUAL(pszTargetAuth, "EPSG"))
         {

--- a/ogr/ogrmitabspatialref.cpp
+++ b/ogr/ogrmitabspatialref.cpp
@@ -2247,11 +2247,9 @@ int TABFileGetTABProjFromSpatialRef(const OGRSpatialReference *poSpatialRef,
     const char *pszAuthorityName = nullptr;
     const char *pszAuthorityCode = nullptr;
     const char *pszExtension = nullptr;
-    if (((pszAuthorityName = poSpatialRef->GetAuthorityName(nullptr)) !=
-             nullptr &&
+    if (((pszAuthorityName = poSpatialRef->GetAuthorityName()) != nullptr &&
          EQUAL(pszAuthorityName, "EPSG") &&
-         (pszAuthorityCode = poSpatialRef->GetAuthorityCode(nullptr)) !=
-             nullptr &&
+         (pszAuthorityCode = poSpatialRef->GetAuthorityCode()) != nullptr &&
          atoi(pszAuthorityCode) == 3857) ||
         ((pszExtension = poSpatialRef->GetExtension(nullptr, "PROJ4")) !=
              nullptr &&

--- a/ogr/ogrsf_frmts/amigocloud/ogramigoclouddatasource.cpp
+++ b/ogr/ogrsf_frmts/amigocloud/ogramigoclouddatasource.cpp
@@ -308,7 +308,7 @@ int OGRAmigoCloudDataSource::FetchSRSId(OGRSpatialReference *poSRS)
     // cppcheck-suppress uselessAssignmentPtrArg
     poSRS = nullptr;
 
-    const char *pszAuthorityName = oSRS.GetAuthorityName(nullptr);
+    const char *pszAuthorityName = oSRS.GetAuthorityName();
 
     if (pszAuthorityName == nullptr || strlen(pszAuthorityName) == 0)
     {
@@ -319,16 +319,16 @@ int OGRAmigoCloudDataSource::FetchSRSId(OGRSpatialReference *poSRS)
          */
         oSRS.AutoIdentifyEPSG();
 
-        pszAuthorityName = oSRS.GetAuthorityName(nullptr);
+        pszAuthorityName = oSRS.GetAuthorityName();
         if (pszAuthorityName != nullptr && EQUAL(pszAuthorityName, "EPSG"))
         {
-            const char *pszAuthorityCode = oSRS.GetAuthorityCode(nullptr);
+            const char *pszAuthorityCode = oSRS.GetAuthorityCode();
             if (pszAuthorityCode != nullptr && strlen(pszAuthorityCode) > 0)
             {
                 /* Import 'clean' SRS */
                 oSRS.importFromEPSG(atoi(pszAuthorityCode));
 
-                pszAuthorityName = oSRS.GetAuthorityName(nullptr);
+                pszAuthorityName = oSRS.GetAuthorityName();
             }
         }
     }
@@ -341,7 +341,7 @@ int OGRAmigoCloudDataSource::FetchSRSId(OGRSpatialReference *poSRS)
         /* For the root authority name 'EPSG', the authority code
          * should always be integral
          */
-        const int nAuthorityCode = atoi(oSRS.GetAuthorityCode(nullptr));
+        const int nAuthorityCode = atoi(oSRS.GetAuthorityCode());
 
         return nAuthorityCode;
     }

--- a/ogr/ogrsf_frmts/arrow/ogrfeatherlayer.cpp
+++ b/ogr/ogrsf_frmts/arrow/ogrfeatherlayer.cpp
@@ -285,10 +285,8 @@ void OGRFeatherLayer::EstablishFeatureDefn()
                                 SET_FROM_USER_INPUT_LIMITATIONS_get()) ==
                         OGRERR_NONE)
                     {
-                        const char *pszAuthName =
-                            poSRS->GetAuthorityName(nullptr);
-                        const char *pszAuthCode =
-                            poSRS->GetAuthorityCode(nullptr);
+                        const char *pszAuthName = poSRS->GetAuthorityName();
+                        const char *pszAuthCode = poSRS->GetAuthorityCode();
                         if (pszAuthName && pszAuthCode &&
                             EQUAL(pszAuthName, "OGC") &&
                             EQUAL(pszAuthCode, "CRS84"))

--- a/ogr/ogrsf_frmts/carto/ogrcartodatasource.cpp
+++ b/ogr/ogrsf_frmts/carto/ogrcartodatasource.cpp
@@ -335,7 +335,7 @@ int OGRCARTODataSource::FetchSRSId(const OGRSpatialReference *poSRS)
     // cppcheck-suppress uselessAssignmentPtrArg
     poSRS = nullptr;
 
-    pszAuthorityName = oSRS.GetAuthorityName(nullptr);
+    pszAuthorityName = oSRS.GetAuthorityName();
 
     if (pszAuthorityName == nullptr || strlen(pszAuthorityName) == 0)
     {
@@ -346,16 +346,16 @@ int OGRCARTODataSource::FetchSRSId(const OGRSpatialReference *poSRS)
          */
         oSRS.AutoIdentifyEPSG();
 
-        pszAuthorityName = oSRS.GetAuthorityName(nullptr);
+        pszAuthorityName = oSRS.GetAuthorityName();
         if (pszAuthorityName != nullptr && EQUAL(pszAuthorityName, "EPSG"))
         {
-            const char *pszAuthorityCode = oSRS.GetAuthorityCode(nullptr);
+            const char *pszAuthorityCode = oSRS.GetAuthorityCode();
             if (pszAuthorityCode != nullptr && strlen(pszAuthorityCode) > 0)
             {
                 /* Import 'clean' SRS */
                 oSRS.importFromEPSG(atoi(pszAuthorityCode));
 
-                pszAuthorityName = oSRS.GetAuthorityName(nullptr);
+                pszAuthorityName = oSRS.GetAuthorityName();
             }
         }
     }
@@ -368,7 +368,7 @@ int OGRCARTODataSource::FetchSRSId(const OGRSpatialReference *poSRS)
         /* For the root authority name 'EPSG', the authority code
          * should always be integral
          */
-        const int nAuthorityCode = atoi(oSRS.GetAuthorityCode(nullptr));
+        const int nAuthorityCode = atoi(oSRS.GetAuthorityCode());
 
         return nAuthorityCode;
     }

--- a/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
@@ -399,23 +399,22 @@ void OGRFlatGeobufLayer::writeHeader(VSILFILE *poFp, uint64_t featuresCount,
     if (m_poSRS)
     {
         int nAuthorityCode = 0;
-        const char *pszAuthorityName = m_poSRS->GetAuthorityName(nullptr);
+        const char *pszAuthorityName = m_poSRS->GetAuthorityName();
         if (pszAuthorityName == nullptr || strlen(pszAuthorityName) == 0)
         {
             // Try to force identify an EPSG code.
             m_poSRS->AutoIdentifyEPSG();
 
-            pszAuthorityName = m_poSRS->GetAuthorityName(nullptr);
+            pszAuthorityName = m_poSRS->GetAuthorityName();
             if (pszAuthorityName != nullptr && EQUAL(pszAuthorityName, "EPSG"))
             {
-                const char *pszAuthorityCode =
-                    m_poSRS->GetAuthorityCode(nullptr);
+                const char *pszAuthorityCode = m_poSRS->GetAuthorityCode();
                 if (pszAuthorityCode != nullptr && strlen(pszAuthorityCode) > 0)
                 {
                     /* Import 'clean' SRS */
                     m_poSRS->importFromEPSG(atoi(pszAuthorityCode));
 
-                    pszAuthorityName = m_poSRS->GetAuthorityName(nullptr);
+                    pszAuthorityName = m_poSRS->GetAuthorityName();
                 }
             }
         }
@@ -423,7 +422,7 @@ void OGRFlatGeobufLayer::writeHeader(VSILFILE *poFp, uint64_t featuresCount,
         {
             // For the root authority name 'EPSG', the authority code
             // should always be integral
-            nAuthorityCode = atoi(m_poSRS->GetAuthorityCode(nullptr));
+            nAuthorityCode = atoi(m_poSRS->GetAuthorityCode());
         }
 
         // Translate SRS to WKT.

--- a/ogr/ogrsf_frmts/georss/ogrgeorsslayer.cpp
+++ b/ogr/ogrsf_frmts/georss/ogrgeorsslayer.cpp
@@ -1472,8 +1472,8 @@ OGRErr OGRGeoRSSLayer::ICreateFeature(OGRFeature *poFeatureIn)
         {
             if (poSRS != nullptr)
             {
-                const char *pszAuthorityName = poSRS->GetAuthorityName(nullptr);
-                const char *pszAuthorityCode = poSRS->GetAuthorityCode(nullptr);
+                const char *pszAuthorityName = poSRS->GetAuthorityName();
+                const char *pszAuthorityCode = poSRS->GetAuthorityCode();
                 if (pszAuthorityName != nullptr &&
                     EQUAL(pszAuthorityName, "EPSG") &&
                     pszAuthorityCode != nullptr)

--- a/ogr/ogrsf_frmts/gmlutils/gmlutils.cpp
+++ b/ogr/ogrsf_frmts/gmlutils/gmlutils.cpp
@@ -328,8 +328,8 @@ char *GML_GetSRSName(const OGRSpatialReference *poSRS,
         *pbCoordSwap = true;
     }
 
-    const char *pszAuthName = poSRS->GetAuthorityName(nullptr);
-    const char *pszAuthCode = poSRS->GetAuthorityCode(nullptr);
+    const char *pszAuthName = poSRS->GetAuthorityName();
+    const char *pszAuthCode = poSRS->GetAuthorityCode();
     if (nullptr != pszAuthName && nullptr != pszAuthCode)
     {
         if (eSRSNameFormat == SRSNAME_SHORT)

--- a/ogr/ogrsf_frmts/gmlutils/ogrwfsfilter.cpp
+++ b/ogr/ogrsf_frmts/gmlutils/ogrwfsfilter.cpp
@@ -151,14 +151,14 @@ static const char *WFS_ExprGetSRSName(const swq_expr_node *poExpr,
     else if (poExpr->nSubExprCount == iSubArgIndex &&
              psOptions->poSRS != nullptr)
     {
-        if (psOptions->poSRS->GetAuthorityName(nullptr) &&
-            EQUAL(psOptions->poSRS->GetAuthorityName(nullptr), "EPSG") &&
-            psOptions->poSRS->GetAuthorityCode(nullptr) &&
-            oSRS.importFromEPSGA(atoi(
-                psOptions->poSRS->GetAuthorityCode(nullptr))) == OGRERR_NONE)
+        if (psOptions->poSRS->GetAuthorityName() &&
+            EQUAL(psOptions->poSRS->GetAuthorityName(), "EPSG") &&
+            psOptions->poSRS->GetAuthorityCode() &&
+            oSRS.importFromEPSGA(atoi(psOptions->poSRS->GetAuthorityCode())) ==
+                OGRERR_NONE)
         {
             return CPLSPrintf("urn:ogc:def:crs:EPSG::%s",
-                              psOptions->poSRS->GetAuthorityCode(nullptr));
+                              psOptions->poSRS->GetAuthorityCode());
         }
     }
     return nullptr;

--- a/ogr/ogrsf_frmts/gmt/ogrgmtdatasource.cpp
+++ b/ogr/ogrsf_frmts/gmt/ogrgmtdatasource.cpp
@@ -151,10 +151,10 @@ OGRGmtDataSource::ICreateLayer(const char *pszLayerName,
     /* -------------------------------------------------------------------- */
     if (poSRS != nullptr)
     {
-        if (poSRS->GetAuthorityName(nullptr) &&
-            EQUAL(poSRS->GetAuthorityName(nullptr), "EPSG"))
+        if (poSRS->GetAuthorityName() &&
+            EQUAL(poSRS->GetAuthorityName(), "EPSG"))
         {
-            VSIFPrintfL(fp, "# @Je%s\n", poSRS->GetAuthorityCode(nullptr));
+            VSIFPrintfL(fp, "# @Je%s\n", poSRS->GetAuthorityCode());
         }
 
         char *pszValue = nullptr;

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -140,8 +140,8 @@ GetTilingScheme(const char *pszName)
     }
     else
     {
-        const char *pszAuthName = oSRS.GetAuthorityName(nullptr);
-        const char *pszAuthCode = oSRS.GetAuthorityCode(nullptr);
+        const char *pszAuthName = oSRS.GetAuthorityName();
+        const char *pszAuthCode = oSRS.GetAuthorityCode();
         if (pszAuthName == nullptr || !EQUAL(pszAuthName, "EPSG") ||
             pszAuthCode == nullptr)
         {
@@ -594,23 +594,23 @@ int GDALGeoPackageDataset::GetSrsId(const OGRSpatialReference *poSRSIn)
         }
     }
 
-    const char *pszAuthorityName = poSRS->GetAuthorityName(nullptr);
+    const char *pszAuthorityName = poSRS->GetAuthorityName();
 
     if (pszAuthorityName == nullptr || strlen(pszAuthorityName) == 0)
     {
         // Try to force identify an EPSG code.
         poSRS->AutoIdentifyEPSG();
 
-        pszAuthorityName = poSRS->GetAuthorityName(nullptr);
+        pszAuthorityName = poSRS->GetAuthorityName();
         if (pszAuthorityName != nullptr && EQUAL(pszAuthorityName, "EPSG"))
         {
-            const char *pszAuthorityCode = poSRS->GetAuthorityCode(nullptr);
+            const char *pszAuthorityCode = poSRS->GetAuthorityCode();
             if (pszAuthorityCode != nullptr && strlen(pszAuthorityCode) > 0)
             {
                 /* Import 'clean' SRS */
                 poSRS->importFromEPSG(atoi(pszAuthorityCode));
 
-                pszAuthorityName = poSRS->GetAuthorityName(nullptr);
+                pszAuthorityName = poSRS->GetAuthorityName();
             }
         }
 
@@ -629,7 +629,7 @@ int GDALGeoPackageDataset::GetSrsId(const OGRSpatialReference *poSRSIn)
         "IGNORE_COORDINATE_EPOCH=YES", nullptr};
     if (pszAuthorityName != nullptr && strlen(pszAuthorityName) > 0)
     {
-        const char *pszAuthorityCode = poSRS->GetAuthorityCode(nullptr);
+        const char *pszAuthorityCode = poSRS->GetAuthorityCode();
         if (pszAuthorityCode)
         {
             if (CPLGetValueType(pszAuthorityCode) == CPL_VALUE_INTEGER)
@@ -6184,8 +6184,8 @@ GDALDataset *GDALGeoPackageDataset::CreateCopy(const char *pszFilename,
         OGRSpatialReference oSrcSRS;
         oSrcSRS.SetFromUserInput(poSrcDS->GetProjectionRef());
         oSrcSRS.AutoIdentifyEPSG();
-        if (oSrcSRS.GetAuthorityCode(nullptr) == nullptr ||
-            atoi(oSrcSRS.GetAuthorityCode(nullptr)) != nEPSGCode)
+        if (oSrcSRS.GetAuthorityCode() == nullptr ||
+            atoi(oSrcSRS.GetAuthorityCode()) != nEPSGCode)
         {
             nTargetBands++;
         }

--- a/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
@@ -888,18 +888,18 @@ int OGRHanaDataSource::GetSrsId(const OGRSpatialReference *srs)
     /* -------------------------------------------------------------------- */
     OGRSpatialReference srsLocal(*srs);
 
-    const char *authorityName = srsLocal.GetAuthorityName(nullptr);
+    const char *authorityName = srsLocal.GetAuthorityName();
     if (authorityName == nullptr || strlen(authorityName) == 0)
     {
         srsLocal.AutoIdentifyEPSG();
-        authorityName = srsLocal.GetAuthorityName(nullptr);
+        authorityName = srsLocal.GetAuthorityName();
         if (authorityName != nullptr && EQUAL(authorityName, "EPSG"))
         {
-            const char *authorityCode = srsLocal.GetAuthorityCode(nullptr);
+            const char *authorityCode = srsLocal.GetAuthorityCode();
             if (authorityCode != nullptr && strlen(authorityCode) > 0)
             {
                 srsLocal.importFromEPSG(atoi(authorityCode));
-                authorityName = srsLocal.GetAuthorityName(nullptr);
+                authorityName = srsLocal.GetAuthorityName();
             }
         }
     }
@@ -907,7 +907,7 @@ int OGRHanaDataSource::GetSrsId(const OGRSpatialReference *srs)
     int authorityCode = 0;
     if (authorityName != nullptr)
     {
-        authorityCode = atoi(srsLocal.GetAuthorityCode(nullptr));
+        authorityCode = atoi(srsLocal.GetAuthorityCode());
         if (authorityCode > 0)
         {
             int ret = GetSridWithFilter(

--- a/ogr/ogrsf_frmts/jml/ogrjmlwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/jml/ogrjmlwriterlayer.cpp
@@ -35,8 +35,8 @@ OGRJMLWriterLayer::OGRJMLWriterLayer(const char *pszLayerName,
 
     if (poSRS)
     {
-        const char *pszAuthName = poSRS->GetAuthorityName(nullptr);
-        const char *pszAuthCode = poSRS->GetAuthorityCode(nullptr);
+        const char *pszAuthName = poSRS->GetAuthorityName();
+        const char *pszAuthCode = poSRS->GetAuthorityCode();
         if (pszAuthName != nullptr && EQUAL(pszAuthName, "EPSG") &&
             pszAuthCode != nullptr)
         {

--- a/ogr/ogrsf_frmts/jsonfg/ogrjsonfgdataset.cpp
+++ b/ogr/ogrsf_frmts/jsonfg/ogrjsonfgdataset.cpp
@@ -754,7 +754,7 @@ OGRJSONFGDataset::ICreateLayer(const char *pszNameIn,
         };
 
         const double dfCoordEpoch = poSRS->GetCoordinateEpoch();
-        const char *pszAuthName = poSRS->GetAuthorityName(nullptr);
+        const char *pszAuthName = poSRS->GetAuthorityName();
         if (!pszAuthName)
         {
             auto poBestMatch = poSRS->FindBestMatch();
@@ -766,10 +766,10 @@ OGRJSONFGDataset::ICreateLayer(const char *pszNameIn,
                 poSRSTmp->SetDataAxisToSRSAxisMapping(
                     poSRS->GetDataAxisToSRSAxisMapping());
                 poSRS = poSRSTmp.get();
-                pszAuthName = poSRS->GetAuthorityName(nullptr);
+                pszAuthName = poSRS->GetAuthorityName();
             }
         }
-        const char *pszAuthCode = poSRS->GetAuthorityCode(nullptr);
+        const char *pszAuthCode = poSRS->GetAuthorityCode();
         json_object *poObj = nullptr;
         if (pszAuthName && pszAuthCode)
         {

--- a/ogr/ogrsf_frmts/jsonfg/ogrjsonfgreader.cpp
+++ b/ogr/ogrsf_frmts/jsonfg/ogrjsonfgreader.cpp
@@ -526,8 +526,8 @@ void OGRJSONFGReader::FinalizeBuildContext(LayerDefnBuildContext &oBuildContext,
         }
         else if (poSRSLayer)
         {
-            const char *pszAuthName = poSRSLayer->GetAuthorityName(nullptr);
-            const char *pszAuthCode = poSRSLayer->GetAuthorityCode(nullptr);
+            const char *pszAuthName = poSRSLayer->GetAuthorityName();
+            const char *pszAuthCode = poSRSLayer->GetAuthorityCode();
             if (pszAuthName && pszAuthCode && EQUAL(pszAuthName, "OGC") &&
                 EQUAL(pszAuthCode, "CRS84"))
             {

--- a/ogr/ogrsf_frmts/mapml/ogrmapmldataset.cpp
+++ b/ogr/ogrsf_frmts/mapml/ogrmapmldataset.cpp
@@ -1000,8 +1000,8 @@ OGRMapMLWriterDataset::ICreateLayer(const char *pszLayerName,
 
     if (m_oSRS.IsEmpty())
     {
-        const char *pszAuthName = poSRS->GetAuthorityName(nullptr);
-        const char *pszAuthCode = poSRS->GetAuthorityCode(nullptr);
+        const char *pszAuthName = poSRS->GetAuthorityName();
+        const char *pszAuthCode = poSRS->GetAuthorityCode();
         if (pszAuthName && pszAuthCode && EQUAL(pszAuthName, "EPSG"))
         {
             const int nEPSGCode = atoi(pszAuthCode);

--- a/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
@@ -1442,10 +1442,8 @@ OGRSpatialReference *OGRMSSQLSpatialDataSource::FetchSRS(int nId)
                 const char *pszWKT = oStmt.GetColData(0);
                 if (poSRS->importFromWkt(pszWKT) == OGRERR_NONE)
                 {
-                    const char *pszAuthorityName =
-                        poSRS->GetAuthorityName(nullptr);
-                    const char *pszAuthorityCode =
-                        poSRS->GetAuthorityCode(nullptr);
+                    const char *pszAuthorityName = poSRS->GetAuthorityName();
+                    const char *pszAuthorityCode = poSRS->GetAuthorityCode();
                     if (pszAuthorityName && pszAuthorityCode &&
                         EQUAL(pszAuthorityName, "EPSG"))
                     {
@@ -1524,7 +1522,7 @@ int OGRMSSQLSpatialDataSource::FetchSRSId(const OGRSpatialReference *poSRS)
     // cppcheck-suppress uselessAssignmentPtrArg
     poSRS = nullptr;
 
-    pszAuthorityName = oSRS.GetAuthorityName(nullptr);
+    pszAuthorityName = oSRS.GetAuthorityName();
 
     if (pszAuthorityName == nullptr || strlen(pszAuthorityName) == 0)
     {
@@ -1535,16 +1533,16 @@ int OGRMSSQLSpatialDataSource::FetchSRSId(const OGRSpatialReference *poSRS)
          */
         oSRS.AutoIdentifyEPSG();
 
-        pszAuthorityName = oSRS.GetAuthorityName(nullptr);
+        pszAuthorityName = oSRS.GetAuthorityName();
         if (pszAuthorityName != nullptr && EQUAL(pszAuthorityName, "EPSG"))
         {
-            const char *pszAuthorityCode = oSRS.GetAuthorityCode(nullptr);
+            const char *pszAuthorityCode = oSRS.GetAuthorityCode();
             if (pszAuthorityCode != nullptr && strlen(pszAuthorityCode) > 0)
             {
                 /* Import 'clean' SRS */
                 oSRS.importFromEPSG(atoi(pszAuthorityCode));
 
-                pszAuthorityName = oSRS.GetAuthorityName(nullptr);
+                pszAuthorityName = oSRS.GetAuthorityName();
             }
         }
     }
@@ -1558,7 +1556,7 @@ int OGRMSSQLSpatialDataSource::FetchSRSId(const OGRSpatialReference *poSRS)
         /* For the root authority name 'EPSG', the authority code
          * should always be integral
          */
-        nAuthorityCode = atoi(oSRS.GetAuthorityCode(nullptr));
+        nAuthorityCode = atoi(oSRS.GetAuthorityCode());
 
         CPLODBCStatement oStmt(&oSession);
         oStmt.Appendf("SELECT srid FROM spatial_ref_sys WHERE "

--- a/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
@@ -306,8 +306,8 @@ CPLErr OGRMSSQLSpatialTableLayer::Initialize(const char *pszSchema,
         }
         else
         {
-            const char *pszAuthorityName = poSRS->GetAuthorityName(nullptr);
-            const char *pszAuthorityCode = poSRS->GetAuthorityCode(nullptr);
+            const char *pszAuthorityName = poSRS->GetAuthorityName();
+            const char *pszAuthorityCode = poSRS->GetAuthorityCode();
             if (pszAuthorityName && pszAuthorityCode &&
                 EQUAL(pszAuthorityName, "EPSG"))
             {

--- a/ogr/ogrsf_frmts/mvt/ogrmvtdataset.cpp
+++ b/ogr/ogrsf_frmts/mvt/ogrmvtdataset.cpp
@@ -5659,8 +5659,8 @@ bool OGRMVTWriterDataset::GenerateMetadata(
     // GDAL extension for custom tiling schemes
     if (!bIsStandardTilingScheme)
     {
-        const char *pszAuthName = m_poSRS->GetAuthorityName(nullptr);
-        const char *pszAuthCode = m_poSRS->GetAuthorityCode(nullptr);
+        const char *pszAuthName = m_poSRS->GetAuthorityName();
+        const char *pszAuthCode = m_poSRS->GetAuthorityCode();
         if (pszAuthName && pszAuthCode)
         {
             WriteMetadataItem("crs",

--- a/ogr/ogrsf_frmts/mysql/ogrmysqldatasource.cpp
+++ b/ogr/ogrsf_frmts/mysql/ogrmysqldatasource.cpp
@@ -592,8 +592,8 @@ OGRSpatialReferenceRefCountedPtr OGRMySQLDataSource::FetchSRS(int nId)
     {
         // The WKT found in MySQL 8 ST_SPATIAL_REFERENCE_SYSTEMS is not
         // compatible of what GDAL understands.
-        const char *pszAuthorityName = poSRS->GetAuthorityName(nullptr);
-        const char *pszAuthorityCode = poSRS->GetAuthorityCode(nullptr);
+        const char *pszAuthorityName = poSRS->GetAuthorityName();
+        const char *pszAuthorityCode = poSRS->GetAuthorityCode();
         if (pszAuthorityName != nullptr && EQUAL(pszAuthorityName, "EPSG") &&
             pszAuthorityCode != nullptr && strlen(pszAuthorityCode) > 0)
         {
@@ -626,7 +626,7 @@ int OGRMySQLDataSource::FetchSRSId(const OGRSpatialReference *poSRSIn)
     // cppcheck-suppress uselessAssignmentPtrArg
     poSRSIn = nullptr;
 
-    const char *pszAuthorityName = oSRS.GetAuthorityName(nullptr);
+    const char *pszAuthorityName = oSRS.GetAuthorityName();
     int nAuthorityCode = 0;
     if (pszAuthorityName == nullptr || strlen(pszAuthorityName) == 0)
     {
@@ -637,23 +637,23 @@ int OGRMySQLDataSource::FetchSRSId(const OGRSpatialReference *poSRSIn)
          */
         oSRS.AutoIdentifyEPSG();
 
-        pszAuthorityName = oSRS.GetAuthorityName(nullptr);
+        pszAuthorityName = oSRS.GetAuthorityName();
         if (pszAuthorityName != nullptr && EQUAL(pszAuthorityName, "EPSG"))
         {
-            const char *pszAuthorityCode = oSRS.GetAuthorityCode(nullptr);
+            const char *pszAuthorityCode = oSRS.GetAuthorityCode();
             if (pszAuthorityCode != nullptr && strlen(pszAuthorityCode) > 0)
             {
                 /* Import 'clean' SRS */
                 nAuthorityCode = atoi(pszAuthorityCode);
                 oSRS.importFromEPSG(nAuthorityCode);
 
-                pszAuthorityName = oSRS.GetAuthorityName(nullptr);
+                pszAuthorityName = oSRS.GetAuthorityName();
             }
         }
     }
     else
     {
-        const char *pszAuthorityCode = oSRS.GetAuthorityCode(nullptr);
+        const char *pszAuthorityCode = oSRS.GetAuthorityCode();
         if (pszAuthorityCode)
             nAuthorityCode = atoi(pszAuthorityCode);
     }

--- a/ogr/ogrsf_frmts/ngw/gdalngwdataset.cpp
+++ b/ogr/ogrsf_frmts/ngw/gdalngwdataset.cpp
@@ -792,7 +792,7 @@ OGRLayer *OGRNGWDataset::ICreateLayer(const char *pszNameIn,
 
     OGRSpatialReference *poSRSClone = poSpatialRef->Clone();
     poSRSClone->AutoIdentifyEPSG();
-    const char *pszEPSG = poSRSClone->GetAuthorityCode(nullptr);
+    const char *pszEPSG = poSRSClone->GetAuthorityCode();
     int nEPSG = -1;
     if (pszEPSG != nullptr)
     {

--- a/ogr/ogrsf_frmts/ngw/ogrngwlayer.cpp
+++ b/ogr/ogrsf_frmts/ngw/ogrngwlayer.cpp
@@ -1296,7 +1296,7 @@ std::string OGRNGWLayer::CreateNGWResourceJson()
     {
         OGRSpatialReference oSRS(*poSRSConst);
         oSRS.AutoIdentifyEPSG();
-        const char *pszEPSG = oSRS.GetAuthorityCode(nullptr);
+        const char *pszEPSG = oSRS.GetAuthorityCode();
         if (pszEPSG != nullptr)
         {
             nEPSG = atoi(pszEPSG);

--- a/ogr/ogrsf_frmts/oci/ogrocidatasource.cpp
+++ b/ogr/ogrsf_frmts/oci/ogrocidatasource.cpp
@@ -892,8 +892,8 @@ int OGROCIDataSource::FetchSRSId(const OGRSpatialReference *poSRS)
 
     if (poSRS->IsGeographic() || poSRS->IsProjected())
     {
-        pszAuthName = poSRS->GetAuthorityName(nullptr);
-        pszAuthCode = poSRS->GetAuthorityCode(nullptr);
+        pszAuthName = poSRS->GetAuthorityName();
+        pszAuthCode = poSRS->GetAuthorityCode();
     }
 
     OGROCIStatement oCmdStatement(GetSession());

--- a/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
@@ -511,8 +511,8 @@ bool OGRParquetLayerBase::DealWithArrow21GeometryGeographyNativeTypes(
                 OGRSpatialReference::SET_FROM_USER_INPUT_LIMITATIONS_get()) ==
             OGRERR_NONE)
         {
-            const char *pszAuthName = poSRS->GetAuthorityName(nullptr);
-            const char *pszAuthCode = poSRS->GetAuthorityCode(nullptr);
+            const char *pszAuthName = poSRS->GetAuthorityName();
+            const char *pszAuthCode = poSRS->GetAuthorityCode();
             if (pszAuthName && pszAuthCode && EQUAL(pszAuthName, "OGC") &&
                 EQUAL(pszAuthCode, "CRS84"))
                 poSRS->importFromEPSG(4326);

--- a/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
@@ -603,10 +603,8 @@ std::string OGRParquetWriterLayer::GetGeoMetadata() const
                 {
                     OGRSpatialReference oSRSIdentified(IdentifyCRS(poSRS));
 
-                    const char *pszAuthName =
-                        oSRSIdentified.GetAuthorityName(nullptr);
-                    const char *pszAuthCode =
-                        oSRSIdentified.GetAuthorityCode(nullptr);
+                    const char *pszAuthName = oSRSIdentified.GetAuthorityName();
+                    const char *pszAuthCode = oSRSIdentified.GetAuthorityCode();
 
                     bool bOmitCRS = false;
                     if (pszAuthName != nullptr && pszAuthCode != nullptr &&

--- a/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -2409,7 +2409,7 @@ int OGRPGDataSource::FetchSRSId(const OGRSpatialReference *poSRS)
     // cppcheck-suppress uselessAssignmentPtrArg
     poSRS = nullptr;
 
-    const char *pszAuthorityName = oSRS.GetAuthorityName(nullptr);
+    const char *pszAuthorityName = oSRS.GetAuthorityName();
 
     if (pszAuthorityName == nullptr || strlen(pszAuthorityName) == 0)
     {
@@ -2420,16 +2420,16 @@ int OGRPGDataSource::FetchSRSId(const OGRSpatialReference *poSRS)
          */
         oSRS.AutoIdentifyEPSG();
 
-        pszAuthorityName = oSRS.GetAuthorityName(nullptr);
+        pszAuthorityName = oSRS.GetAuthorityName();
         if (pszAuthorityName != nullptr && EQUAL(pszAuthorityName, "EPSG"))
         {
-            const char *pszAuthorityCode = oSRS.GetAuthorityCode(nullptr);
+            const char *pszAuthorityCode = oSRS.GetAuthorityCode();
             if (pszAuthorityCode != nullptr && strlen(pszAuthorityCode) > 0)
             {
                 /* Import 'clean' SRS */
                 oSRS.importFromEPSG(atoi(pszAuthorityCode));
 
-                pszAuthorityName = oSRS.GetAuthorityName(nullptr);
+                pszAuthorityName = oSRS.GetAuthorityName();
             }
         }
     }
@@ -2442,7 +2442,7 @@ int OGRPGDataSource::FetchSRSId(const OGRSpatialReference *poSRS)
     if (pszAuthorityName != nullptr)
     {
         /* Check that the authority code is integral */
-        nAuthorityCode = atoi(oSRS.GetAuthorityCode(nullptr));
+        nAuthorityCode = atoi(oSRS.GetAuthorityCode());
         if (nAuthorityCode > 0)
         {
             osCommand.Printf("SELECT srid FROM spatial_ref_sys WHERE "
@@ -2540,7 +2540,7 @@ int OGRPGDataSource::FetchSRSId(const OGRSpatialReference *poSRS)
 
     if (pszAuthorityName != nullptr && nAuthorityCode > 0)
     {
-        nAuthorityCode = atoi(oSRS.GetAuthorityCode(nullptr));
+        nAuthorityCode = atoi(oSRS.GetAuthorityCode());
 
         osCommand.Printf("INSERT INTO spatial_ref_sys "
                          "(srid,srtext,proj4text,auth_name,auth_srid) "

--- a/ogr/ogrsf_frmts/pgdump/ogrpgdumpdatasource.cpp
+++ b/ogr/ogrsf_frmts/pgdump/ogrpgdumpdatasource.cpp
@@ -418,11 +418,11 @@ OGRPGDumpDataSource::ICreateLayer(const char *pszLayerName,
     {
         if (poSRS)
         {
-            const char *pszAuthorityName = poSRS->GetAuthorityName(nullptr);
+            const char *pszAuthorityName = poSRS->GetAuthorityName();
             if (pszAuthorityName != nullptr && EQUAL(pszAuthorityName, "EPSG"))
             {
                 /* Assume the EPSG Id is the SRS ID. Might be a wrong guess ! */
-                nSRSId = atoi(poSRS->GetAuthorityCode(nullptr));
+                nSRSId = atoi(poSRS->GetAuthorityCode());
             }
             else
             {

--- a/ogr/ogrsf_frmts/pgdump/ogrpgdumplayer.cpp
+++ b/ogr/ogrsf_frmts/pgdump/ogrpgdumplayer.cpp
@@ -1871,11 +1871,11 @@ OGRErr OGRPGDumpLayer::CreateGeomField(const OGRGeomFieldDefn *poGeomFieldIn,
         nSRSId = m_nForcedSRSId;
     else if (poSRS != nullptr)
     {
-        const char *pszAuthorityName = poSRS->GetAuthorityName(nullptr);
+        const char *pszAuthorityName = poSRS->GetAuthorityName();
         if (pszAuthorityName != nullptr && EQUAL(pszAuthorityName, "EPSG"))
         {
             /* Assume the EPSG Id is the SRS ID. Might be a wrong guess ! */
-            nSRSId = atoi(poSRS->GetAuthorityCode(nullptr));
+            nSRSId = atoi(poSRS->GetAuthorityCode());
         }
         else
         {

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
@@ -4373,7 +4373,7 @@ int OGRSQLiteDataSource::FetchSRSId(const OGRSpatialReference *poSRSIn)
     /* -------------------------------------------------------------------- */
     auto poSRS = OGRSpatialReferenceRefCountedPtr::makeClone(poSRSIn);
 
-    const char *pszAuthorityName = poSRS->GetAuthorityName(nullptr);
+    const char *pszAuthorityName = poSRS->GetAuthorityName();
     const char *pszAuthorityCode = nullptr;
 
     if (pszAuthorityName == nullptr || strlen(pszAuthorityName) == 0)
@@ -4385,17 +4385,17 @@ int OGRSQLiteDataSource::FetchSRSId(const OGRSpatialReference *poSRSIn)
          */
         poSRS->AutoIdentifyEPSG();
 
-        pszAuthorityName = poSRS->GetAuthorityName(nullptr);
+        pszAuthorityName = poSRS->GetAuthorityName();
         if (pszAuthorityName != nullptr && EQUAL(pszAuthorityName, "EPSG"))
         {
-            pszAuthorityCode = poSRS->GetAuthorityCode(nullptr);
+            pszAuthorityCode = poSRS->GetAuthorityCode();
             if (pszAuthorityCode != nullptr && strlen(pszAuthorityCode) > 0)
             {
                 /* Import 'clean' SRS */
                 poSRS->importFromEPSG(atoi(pszAuthorityCode));
 
-                pszAuthorityName = poSRS->GetAuthorityName(nullptr);
-                pszAuthorityCode = poSRS->GetAuthorityCode(nullptr);
+                pszAuthorityName = poSRS->GetAuthorityName();
+                pszAuthorityCode = poSRS->GetAuthorityCode();
             }
         }
     }
@@ -4412,7 +4412,7 @@ int OGRSQLiteDataSource::FetchSRSId(const OGRSpatialReference *poSRSIn)
 
     if (pszAuthorityName != nullptr && strlen(pszAuthorityName) > 0)
     {
-        pszAuthorityCode = poSRS->GetAuthorityCode(nullptr);
+        pszAuthorityCode = poSRS->GetAuthorityCode();
 
         if (pszAuthorityCode != nullptr && strlen(pszAuthorityCode) > 0)
         {

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitevirtualogr.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitevirtualogr.cpp
@@ -289,10 +289,10 @@ int OGR2SQLITEModule::FetchSRSId(const OGRSpatialReference *poSRS)
     {
         if (poSRS != nullptr)
         {
-            const char *pszAuthorityName = poSRS->GetAuthorityName(nullptr);
+            const char *pszAuthorityName = poSRS->GetAuthorityName();
             if (pszAuthorityName != nullptr && EQUAL(pszAuthorityName, "EPSG"))
             {
-                const char *pszAuthorityCode = poSRS->GetAuthorityCode(nullptr);
+                const char *pszAuthorityCode = poSRS->GetAuthorityCode();
                 if (pszAuthorityCode != nullptr && strlen(pszAuthorityCode) > 0)
                 {
                     nSRSId = atoi(pszAuthorityCode);

--- a/ogr/ogrspatialreference.cpp
+++ b/ogr/ogrspatialreference.cpp
@@ -1471,7 +1471,7 @@ const char *OGRSpatialReference::GetCelestialBodyName() const
     if (std::fabs(GetSemiMajor(nullptr) - SRS_WGS84_SEMIMAJOR) <=
         0.05 * SRS_WGS84_SEMIMAJOR)
         return "Earth";
-    const char *pszAuthName = GetAuthorityName(nullptr);
+    const char *pszAuthName = GetAuthorityName();
     if (pszAuthName && EQUAL(pszAuthName, "EPSG"))
         return "Earth";
     return nullptr;
@@ -8901,8 +8901,8 @@ char *OGRSpatialReference::GetOGCURN() const
 {
     TAKE_OPTIONAL_LOCK();
 
-    const char *pszAuthName = GetAuthorityName(nullptr);
-    const char *pszAuthCode = GetAuthorityCode(nullptr);
+    const char *pszAuthName = GetAuthorityName();
+    const char *pszAuthCode = GetAuthorityCode();
     if (pszAuthName && pszAuthCode)
         return CPLStrdup(
             CPLSPrintf("urn:ogc:def:crs:%s::%s", pszAuthName, pszAuthCode));
@@ -10370,16 +10370,14 @@ OGRSpatialReference::FindBestMatch(int nMinimumMatchConfidence,
             const char *pszBaseAuthorityCode = nullptr;
             const char *pszBaseName = poBaseGeogCRS->GetName();
             if (adfTOWGS84 == std::vector<double>(7) &&
-                (pszAuthorityName = poSRS->GetAuthorityName(nullptr)) !=
-                    nullptr &&
+                (pszAuthorityName = poSRS->GetAuthorityName()) != nullptr &&
                 EQUAL(pszAuthorityName, "EPSG") &&
-                (pszAuthorityCode = poSRS->GetAuthorityCode(nullptr)) !=
+                (pszAuthorityCode = poSRS->GetAuthorityCode()) != nullptr &&
+                (pszBaseAuthorityName = poBaseGeogCRS->GetAuthorityName()) !=
                     nullptr &&
-                (pszBaseAuthorityName =
-                     poBaseGeogCRS->GetAuthorityName(nullptr)) != nullptr &&
                 EQUAL(pszBaseAuthorityName, "EPSG") &&
-                (pszBaseAuthorityCode =
-                     poBaseGeogCRS->GetAuthorityCode(nullptr)) != nullptr &&
+                (pszBaseAuthorityCode = poBaseGeogCRS->GetAuthorityCode()) !=
+                    nullptr &&
                 (EQUAL(pszBaseAuthorityCode, "4326") ||
                  EQUAL(pszBaseAuthorityCode, "4258") ||
                  // For ETRS89-XXX [...] new CRS added in EPSG 12.033+
@@ -10405,7 +10403,7 @@ OGRSpatialReference::FindBestMatch(int nMinimumMatchConfidence,
             {
                 const char *pszAuthName =
                     OGRSpatialReference::FromHandle(pahSRS[i])
-                        ->GetAuthorityName(nullptr);
+                        ->GetAuthorityName();
                 if (pszAuthName != nullptr &&
                     EQUAL(pszAuthName, pszPreferredAuthority))
                 {

--- a/swig/include/osr.i
+++ b/swig/include/osr.i
@@ -468,11 +468,11 @@ public:
     return (const char*)name;
   }
 
-  const char *GetAuthorityCode( const char *target_key ) {
+  const char *GetAuthorityCode( const char *target_key = NULL ) {
     return OSRGetAuthorityCode( self, target_key );
   }
 
-  const char *GetAuthorityName( const char *target_key ) {
+  const char *GetAuthorityName( const char *target_key = NULL ) {
     return OSRGetAuthorityName( self, target_key );
   }
 


### PR DESCRIPTION
… nullptr value for pszTarget argument

Fixing a many-year-long small frustration :-)
