### PR TITLE
Fix spelling errors.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6802,7 +6802,7 @@ netCDF driver:
  * fix crash on invalid layer (ossfuzz 58469)
 
 OpenFileGDB driver:
- * allows to modify a record with a GlobalID field without regenerating it
+ * allows modifying a record with a GlobalID field without regenerating it
  * correctly read POINT EMPTY (#7986)
 
 Parquet driver:

--- a/cmake/modules/packages/FindODBC.cmake
+++ b/cmake/modules/packages/FindODBC.cmake
@@ -10,7 +10,7 @@ Find an Open Database Connectivity (ODBC) include directory and library.
 On Windows, when building with Visual Studio, this module assumes the ODBC
 library is provided by the available Windows SDK.
 
-On Unix, this module allows to search for ODBC library provided by
+On Unix, this module allows searching for ODBC library provided by
 unixODBC or iODBC implementations of ODBC API.
 This module reads hint about location of the config program:
 

--- a/doc/source/programs/gdal_vector_create.rst
+++ b/doc/source/programs/gdal_vector_create.rst
@@ -41,7 +41,7 @@ Program-Specific Options
 
     Output layer name.
 
-    Only meaningful when creating a single layer dataset. It allows to define or override
+    Only meaningful when creating a single layer dataset. It allows defining or overriding
     the name of the created layer.
 
 .. option:: -i, --like, --input <TEMPLATE-DATASET>

--- a/frmts/miramon/miramon_band.cpp
+++ b/frmts/miramon/miramon_band.cpp
@@ -2239,7 +2239,7 @@ int MMRBand::WriteAttributeTable(GDALDataset &oSrcDS)
     if (!pBD_XP)
         return 1;
 
-    // Creating a simple REL that allows to MiraMon user to
+    // Creating a simple REL that allows MiraMon user to
     // document this RAT in case of need.
     auto pRATRel = std::make_unique<MMRRel>(m_osRATRELName);
     if (!pRATRel->OpenRELFile("wb"))

--- a/frmts/miramon/miramon_dataset.cpp
+++ b/frmts/miramon/miramon_dataset.cpp
@@ -931,7 +931,7 @@ bool MMRDataset::IsCategoricalBand(GDALDataset &oSrcDS,
 }
 
 // In the RGB case, a map (.mmm) is generated with the RGB information of the bands.
-// This allows to visualize the RGB composition in MiraMon without having to create
+// This allows visualizing the RGB composition in MiraMon without having to create
 // a map in MiraMon and set the RGB information.
 void MMRDataset::WriteRGBMap()
 {

--- a/frmts/miramon_common/mm_gdal_driver_structs.h
+++ b/frmts/miramon_common/mm_gdal_driver_structs.h
@@ -636,7 +636,7 @@ struct MiraMonPolygonLayer
     }
 */
 
-// Information that allows to reuse memory stuff when
+// Information that allows reusing memory stuff when
 // features are being read
 struct MiraMonFeature
 {

--- a/port/cpl_vsil.cpp
+++ b/port/cpl_vsil.cpp
@@ -4029,7 +4029,7 @@ void VSISetCredential(const char *pszPathPrefix, const char *pszKey,
  * virtual file system.
  *
  * That option may also be set as a configuration option with
- * CPLSetConfigOption(), but this function allows to specify them with a
+ * CPLSetConfigOption(), but this function allows specifying them with a
  * granularity at the level of a file path, which makes it easier if using the
  * same virtual file system but with different credentials (e.g. different
  * credentials for bucket "/vsis3/foo" and "/vsis3/bar")
@@ -4170,7 +4170,7 @@ const char *VSIGetPathSpecificOption(const char *pszPath, const char *pszKey,
  * identical or close to popular ones (typically AWS S3), but with slightly
  * different settings (at the very least the endpoint).
  *
- * This functions allows to duplicate the source virtual file system handler
+ * This functions allows duplicating the source virtual file system handler
  * as a new one with a different prefix (when the source virtual file system
  * handler supports the duplication operation).
  *


### PR DESCRIPTION
The lintian QA tool reported spelling errors for the Debian package build:

 * allows to -> allows &lt;verb&gt;ing