### PR TITLE
CSharp bindings: add support for file/buffer sizes larger than 2GB

### DIFF
--- a/swig/csharp/CMakeLists.txt
+++ b/swig/csharp/CMakeLists.txt
@@ -594,8 +594,20 @@ if (CSHARP_BUILD_SAMPLES)
         OSGeo.OSR)
 
     gdal_build_csharp_sample(
-      OUTPUT OGRLayerAlg.exe
-      SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/apps/OGRLayerAlg.cs
+      OUTPUT
+      VSIMem.exe
+      SOURCE
+      ${CMAKE_CURRENT_SOURCE_DIR}/apps/VSIMem.cs
+      DEPENDS
+      gdal_csharp
+      SYSTEM_DEPENDS
+      OSGeo.GDAL)
+
+    gdal_build_csharp_sample(
+      OUTPUT
+      OGRLayerAlg.exe
+      SOURCE
+      ${CMAKE_CURRENT_SOURCE_DIR}/apps/OGRLayerAlg.cs
       DEPENDS
         osr_csharp
         ogr_csharp
@@ -655,6 +667,7 @@ if (CSHARP_BUILD_SAMPLES)
               OSGeo.GDAL.Samples.GDALTest
               OSGeo.GDAL.Samples.OGRLayerAlg
               OSGeo.GDAL.Samples.GDALCsharpWarp
+              OSGeo.GDAL.Samples.VSIMem
               OSGeo.GDAL.Samples.OGRFeatureEdit
               OSGeo.GDAL.Samples.GetCRSInfo.exe)
 
@@ -747,4 +760,10 @@ if (CSHARP_RUN_TESTS)
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GDALTestUtf8/GDALTestUtf8)
     set_property(TEST csharp_testutf8 PROPERTY ENVIRONMENT "${TEST_ENV}")
+    add_test(
+      NAME csharp_vsimem
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      COMMAND ${CSHARP_INTERPRETER} VSIMem/VSIMem${_ex} Data/sample.tif)
+    set_property(TEST csharp_vsimem PROPERTY ENVIRONMENT "${TEST_ENV}")
+    set_property(TEST csharp_vsimem PROPERTY DEPENDS csharp_createdata)
 endif(CSHARP_RUN_TESTS)

--- a/swig/csharp/apps/VSIMem.cs
+++ b/swig/csharp/apps/VSIMem.cs
@@ -151,5 +151,20 @@ class VSIMem
         {
             ErrorAndQuit("Failed to create copied in-memory file.");
         }
+
+        if (!Gdal.VSIStatExL(inMemFilename, out long size, out int mode, nFlags: 0))
+        {
+            ErrorAndQuit("Failed to stat in-memory file.");
+        }
+
+        if (size != imageCopy.Length)
+        {
+            ErrorAndQuit("In-memory file size differs from source buffer size");
+        }
+
+        if ((mode & 0x8000) != 0x8000)
+        {
+            ErrorAndQuit("In-memory is not 'Regular'");
+        }
     }
 }

--- a/swig/csharp/apps/VSIMem.cs
+++ b/swig/csharp/apps/VSIMem.cs
@@ -124,7 +124,7 @@ class VSIMem
         //Create an in-memory file from a managed buffer.
         //The managed buffer is used to read/write and is not copied to GDAL.
         //Must dispose of the file to unpin the managed buffer and unlink the filename.
-        using (var inMemFile = Gdal.FileFromMemBufferNoCopy(inMemFilename, imageCopy, 0, imageCopy.Length))
+        using (var inMemFile = Gdal.FileFromMemBuffer(inMemFilename, imageCopy, 0, imageCopy.Length, vsiTakeOwnership: false))
         {
             if (inMemFile == null)
             {

--- a/swig/csharp/apps/VSIMem.cs
+++ b/swig/csharp/apps/VSIMem.cs
@@ -51,15 +51,47 @@ class VSIMem
 
         byte[] imageBuffer;
 
-        using (FileStream fs = new FileStream(args[0], FileMode.Open, FileAccess.Read))
+        try
         {
-            using (BinaryReader br = new BinaryReader(fs))
+            IntPtr vfInput = Gdal.VSIFOpenL(args[0], "r");
+            if (vfInput == IntPtr.Zero)
             {
-                long numBytes = new FileInfo(args[0]).Length;
-                imageBuffer = br.ReadBytes((int)numBytes);
-                br.Close();
-                fs.Close();
+                Console.WriteLine($"Failed to {nameof(Gdal.VSIFOpenL)} input file");
+                System.Environment.Exit(-1);
             }
+            if (!Gdal.VSIFSeekL(vfInput, 0, SeekOrigin.End))
+            {
+                Console.WriteLine($"{nameof(Gdal.VSIFSeekL)} failed to seek to end of input file");
+                System.Environment.Exit(-1);
+            }
+            long vfInputLength = Gdal.VSIFTellL(vfInput);
+            if (vfInputLength <= 0)
+            {
+                Console.WriteLine($"{nameof(Gdal.VSIFTellL)} reports incorrect location");
+                System.Environment.Exit(-1);
+            }
+            if (!Gdal.VSIFSeekL(vfInput, 0, SeekOrigin.Begin) || Gdal.VSIFTellL(vfInput) != 0)
+            {
+                Console.WriteLine($"{nameof(Gdal.VSIFSeekL)} failed to seek to beginning of input file");
+                System.Environment.Exit(-1);
+            }
+
+            imageBuffer = new byte[vfInputLength];
+            if (Gdal.VSIFReadL(imageBuffer, 0, imageBuffer.Length, vfInput) != imageBuffer.Length)
+            {
+                Console.WriteLine($"Failed to {nameof(Gdal.VSIFReadL)} from input file");
+                System.Environment.Exit(-1);
+            }
+            if (Gdal.VSIFCloseL(vfInput) != 0)
+            {
+                Console.WriteLine($"Failed to {nameof(Gdal.VSIFCloseL)} input file");
+                System.Environment.Exit(-1);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.Message);
+            throw;
         }
 
         Gdal.AllRegister();
@@ -67,36 +99,40 @@ class VSIMem
         string memFilename = "/vsimem/inmemfile";
         try
         {
-            Gdal.FileFromMemBuffer(memFilename, imageBuffer);
-            using (Dataset ds = Gdal.Open(memFilename, Access.GA_ReadOnly))
+            using (var file = Gdal.FileFromMemBufferNoCopy(memFilename, imageBuffer, 0, imageBuffer.Length))
             {
-                if (ds == null)
+                if (file == null)
                 {
-                    Console.WriteLine("Can't open in-memory file.");
+                    Console.WriteLine("Failed to open in-memory file.");
                     System.Environment.Exit(-1);
                 }
-                Console.WriteLine("Raster dataset parameters:");
-                Console.WriteLine("  RasterCount: " + ds.RasterCount);
-                Console.WriteLine("  RasterSize (" + ds.RasterXSize + "," + ds.RasterYSize + ")");
-
-                Driver drv = Gdal.GetDriverByName("GTiff");
-
-                if (drv == null)
+                using (Dataset ds = Gdal.Open(memFilename, Access.GA_ReadOnly))
                 {
-                    Console.WriteLine("Can't get driver.");
-                    System.Environment.Exit(-1);
-                }
+                    if (ds == null)
+                    {
+                        Console.WriteLine("Can't open in-memory file.");
+                        System.Environment.Exit(-1);
+                    }
+                    Console.WriteLine("Raster dataset parameters:");
+                    Console.WriteLine("  RasterCount: " + ds.RasterCount);
+                    Console.WriteLine("  RasterSize (" + ds.RasterXSize + "," + ds.RasterYSize + ")");
 
-                drv.CreateCopy("sample.tif", ds, 0, null, null, null);
+                    Driver drv = Gdal.GetDriverByName("GTiff");
+
+                    if (drv == null)
+                    {
+                        Console.WriteLine("Can't get driver.");
+                        System.Environment.Exit(-1);
+                    }
+
+                    drv.CreateCopy("sample.tif", ds, 0, null, null, null).Dispose();
+                }
             }
         }
         catch (Exception ex)
         {
             Console.WriteLine(ex.Message);
-        }
-        finally
-        {
-            Gdal.Unlink(memFilename);
+            throw;
         }
     }
 }

--- a/swig/csharp/apps/VSIMem.cs
+++ b/swig/csharp/apps/VSIMem.cs
@@ -36,103 +36,120 @@ using OSGeo.GDAL;
 
 class VSIMem
 {
-
     public static void usage()
+        => ErrorAndQuit("usage example: vsimem [image file]");
 
+    private static void ErrorAndQuit(string errorMessage)
     {
-        Console.WriteLine("usage example: vsimem [image file]");
-        System.Environment.Exit(-1);
+        Console.Error.WriteLine(errorMessage);
+        Environment.Exit(-1);
     }
 
     public static void Main(string[] args)
     {
-
         if (args.Length != 1) usage();
 
-        byte[] imageBuffer;
-
-        try
-        {
-            IntPtr vfInput = Gdal.VSIFOpenL(args[0], "r");
-            if (vfInput == IntPtr.Zero)
-            {
-                Console.WriteLine($"Failed to {nameof(Gdal.VSIFOpenL)} input file");
-                System.Environment.Exit(-1);
-            }
-            if (!Gdal.VSIFSeekL(vfInput, 0, SeekOrigin.End))
-            {
-                Console.WriteLine($"{nameof(Gdal.VSIFSeekL)} failed to seek to end of input file");
-                System.Environment.Exit(-1);
-            }
-            long vfInputLength = Gdal.VSIFTellL(vfInput);
-            if (vfInputLength <= 0)
-            {
-                Console.WriteLine($"{nameof(Gdal.VSIFTellL)} reports incorrect location");
-                System.Environment.Exit(-1);
-            }
-            if (!Gdal.VSIFSeekL(vfInput, 0, SeekOrigin.Begin) || Gdal.VSIFTellL(vfInput) != 0)
-            {
-                Console.WriteLine($"{nameof(Gdal.VSIFSeekL)} failed to seek to beginning of input file");
-                System.Environment.Exit(-1);
-            }
-
-            imageBuffer = new byte[vfInputLength];
-            if (Gdal.VSIFReadL(imageBuffer, 0, imageBuffer.Length, vfInput) != imageBuffer.Length)
-            {
-                Console.WriteLine($"Failed to {nameof(Gdal.VSIFReadL)} from input file");
-                System.Environment.Exit(-1);
-            }
-            if (Gdal.VSIFCloseL(vfInput) != 0)
-            {
-                Console.WriteLine($"Failed to {nameof(Gdal.VSIFCloseL)} input file");
-                System.Environment.Exit(-1);
-            }
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine(ex.Message);
-            throw;
-        }
-
         Gdal.AllRegister();
-
         string memFilename = "/vsimem/inmemfile";
+
         try
         {
-            using (var file = Gdal.FileFromMemBufferNoCopy(memFilename, imageBuffer, 0, imageBuffer.Length))
+            byte[] imageBytes = ReadInputFile(args[0]);
+            CopyToInMemoryFile(memFilename, imageBytes);
+            using (Dataset ds = Gdal.Open(memFilename, Access.GA_ReadOnly))
             {
-                if (file == null)
+                if (ds == null)
                 {
-                    Console.WriteLine("Failed to open in-memory file.");
-                    System.Environment.Exit(-1);
+                    ErrorAndQuit("Can't open in-memory file.");
                 }
-                using (Dataset ds = Gdal.Open(memFilename, Access.GA_ReadOnly))
+                Console.WriteLine("Raster dataset parameters:");
+                Console.WriteLine("  RasterCount: " + ds.RasterCount);
+                Console.WriteLine("  RasterSize (" + ds.RasterXSize + "," + ds.RasterYSize + ")");
+
+                Driver drv = Gdal.GetDriverByName("GTiff");
+
+                if (drv == null)
                 {
-                    if (ds == null)
-                    {
-                        Console.WriteLine("Can't open in-memory file.");
-                        System.Environment.Exit(-1);
-                    }
-                    Console.WriteLine("Raster dataset parameters:");
-                    Console.WriteLine("  RasterCount: " + ds.RasterCount);
-                    Console.WriteLine("  RasterSize (" + ds.RasterXSize + "," + ds.RasterYSize + ")");
-
-                    Driver drv = Gdal.GetDriverByName("GTiff");
-
-                    if (drv == null)
-                    {
-                        Console.WriteLine("Can't get driver.");
-                        System.Environment.Exit(-1);
-                    }
-
-                    drv.CreateCopy("sample.tif", ds, 0, null, null, null).Dispose();
+                    ErrorAndQuit("Can't get driver.");
                 }
+
+                drv.CreateCopy("sample.tif", ds, 0, null, null, null).Dispose();
             }
         }
-        catch (Exception ex)
+        finally
         {
-            Console.WriteLine(ex.Message);
-            throw;
+            Gdal.Unlink(memFilename);
+        }
+    }
+
+    /// <summary> Test VSIFOpenL, VSIFSeekL, VSIFTellL, VSIFReadL, and VSIFCloseL. </summary>
+    private static byte[] ReadInputFile(string inputFilename)
+    {
+        IntPtr vfInput = Gdal.VSIFOpenL(inputFilename, "r");
+        if (vfInput == IntPtr.Zero)
+        {
+            ErrorAndQuit($"Failed to {nameof(Gdal.VSIFOpenL)} input file: '{inputFilename}'");
+        }
+        if (!Gdal.VSIFSeekL(vfInput, 0, SeekOrigin.End))
+        {
+            ErrorAndQuit($"{nameof(Gdal.VSIFSeekL)} failed to seek to end of input file");
+        }
+
+        long vfInputLength = Gdal.VSIFTellL(vfInput);
+        if (vfInputLength <= 0)
+        {
+            ErrorAndQuit($"{nameof(Gdal.VSIFTellL)} reports incorrect location");
+        }
+        if (!Gdal.VSIFSeekL(vfInput, 0, SeekOrigin.Begin) || Gdal.VSIFTellL(vfInput) != 0)
+        {
+            ErrorAndQuit($"{nameof(Gdal.VSIFSeekL)} failed to seek to beginning of input file");
+        }
+
+        byte[] inputFileBuffer = new byte[vfInputLength];
+        if (Gdal.VSIFReadL(inputFileBuffer, 0, inputFileBuffer.Length, vfInput) != inputFileBuffer.Length)
+        {
+            ErrorAndQuit($"Failed to {nameof(Gdal.VSIFReadL)} from input file");
+        }
+        if (Gdal.VSIFCloseL(vfInput) != 0)
+        {
+            ErrorAndQuit($"Failed to {nameof(Gdal.VSIFCloseL)} input file");
+        }
+        return inputFileBuffer;
+    }
+
+    /// <summary> Test in-memory file methods and VSIFWriteL </summary>
+    private static void CopyToInMemoryFile(string inMemFilename, byte[] data)
+    {
+        byte[] imageCopy = new byte[data.Length];
+        //Create an in-memory file from a managed buffer.
+        //The managed buffer is used to read/write and is not copied to GDAL.
+        //Must dispose of the file to unpin the managed buffer and unlink the filename.
+        using (var inMemFile = Gdal.FileFromMemBufferNoCopy(inMemFilename, imageCopy, 0, imageCopy.Length))
+        {
+            if (inMemFile == null)
+            {
+                ErrorAndQuit("Failed to create no-copy in-memory file.");
+            }
+            IntPtr fpCopy = Gdal.VSIFOpenL(inMemFilename, "w");
+            if (fpCopy == IntPtr.Zero)
+            {
+                ErrorAndQuit("Failed to open in-memory file.");
+            }
+            if (Gdal.VSIFWriteL(data, 0, data.Length, fpCopy) != data.Length)
+            {
+                ErrorAndQuit("Failed to write to in-memory file.");
+            }
+            if (Gdal.VSIFCloseL(fpCopy) != 0)
+            {
+                ErrorAndQuit("Failed to close in-memory file.");
+            }
+        }
+
+        //Create an in-memory file by copying the data into an unmanaged buffer owed by GDAL.
+        //Must call Gdal.Unlink() on the file to free the unmanaged buffer.
+        if (!Gdal.FileFromMemBuffer(inMemFilename, imageCopy))
+        {
+            ErrorAndQuit("Failed to create copied in-memory file.");
         }
     }
 }

--- a/swig/include/cpl.i
+++ b/swig/include/cpl.i
@@ -593,9 +593,13 @@ GByte *CPLHexToBinary( const char *pszHex, int *pnBytes );
 %apply Pointer NONNULL {const char * pszFilename};
 
 
+#if defined(SWIGPYTHON) || defined(SWIGCSHARP)
 #if defined(SWIGPYTHON)
 
 %apply (GIntBig nLen, char *pBuf) {( GIntBig nBytes, const char *pabyData )};
+#elif defined(SWIGCSHARP)
+%apply (void *buffer_ptr) { const char *pabyData };
+#endif
 %inline {
 VSI_RETVAL wrapper_VSIFileFromMemBuffer( const char* path, GIntBig nBytes, const char *pabyData)
 {
@@ -615,7 +619,15 @@ VSI_RETVAL wrapper_VSIFileFromMemBuffer( const char* path, GIntBig nBytes, const
     }
 }
 }
-%clear ( GIntBig nBytes, const GByte *pabyData );
+#if defined(SWIGPYTHON)
+%clear ( GIntBig nBytes, const char *pabyData );
+#elif defined(SWIGCSHARP)
+%csmethodmodifiers VSIFileFromMemBuffer "private";
+%inline {
+ VSILFILE *VSIFileFromMemBuffer(const char *path, GByte *pabyData, GUIntBig nDataLength, int bTakeOwnership);
+}
+%clear (const char *pabyData);
+#endif
 #else
 #if defined(SWIGJAVA)
 %apply (int nLen, unsigned char *pBuf ) {( int nBytes, const GByte *pabyData )};
@@ -938,6 +950,8 @@ VSI_RETVAL VSIFCloseL( VSILFILE* fp );
 %inline {
 #if defined(SWIGPYTHON)
 int wrapper_VSIFSeekL( VSILFILE* fp, GIntBig offset, int whence) {
+#elif defined(SWIGCSHARP)
+VSI_RETVAL wrapper_VSIFSeekL( VSILFILE* fp, GIntBig offset, int whence) {
 #else
 VSI_RETVAL wrapper_VSIFSeekL( VSILFILE* fp, long offset, int whence) {
 #endif
@@ -970,6 +984,9 @@ int     VSISupportsSparseFiles( const char* path );
 #define VSI_RANGE_STATUS_HOLE       2
 
 int     VSIFGetRangeStatusL( VSILFILE* fp, GIntBig offset, GIntBig length );
+#elif defined(SWIGCSHARP)
+GIntBig VSIFTellL( VSILFILE* fp );
+VSI_RETVAL VSIFTruncateL( VSILFILE* fp, GIntBig length );
 #else
 long    VSIFTellL( VSILFILE* fp );
 VSI_RETVAL VSIFTruncateL( VSILFILE* fp, long length );
@@ -988,8 +1005,14 @@ int wrapper_VSIFWriteL( int nLen, char *pBuf, int size, int memb, VSILFILE* fp)
     return static_cast<int>(VSIFWriteL(pBuf, size, memb, fp));
 }
 }
+#elif defined(SWIGCSHARP)
+%apply (void *buffer_ptr) { (void *pBuffer) };
+%apply (size_t native_size) { (size_t nSize), (size_t nCount), (size_t VSIFWriteL), (size_t VSIFReadL)};
+size_t VSIFWriteL( const void *pBuffer, size_t nSize, size_t nCount, VSILFILE *fp );
+size_t VSIFReadL ( void *pBuffer, size_t nSize, size_t nCount, VSILFILE *fp );
+%clear (void *pBuffer), (size_t nSize), (size_t nCount), (size_t VSIFWriteL), (size_t VSIFReadL);
 #else
-int     VSIFWriteL( const char *, int, int, VSILFILE *fp );
+int     VSIFWriteL( const char *pBuffer, int nSize, int nCount, VSILFILE *fp );
 #endif
 
 /* VSIFReadL() handled specially in python/gdal_python.i */

--- a/swig/include/cpl.i
+++ b/swig/include/cpl.i
@@ -1009,7 +1009,7 @@ int wrapper_VSIFWriteL( int nLen, char *pBuf, int size, int memb, VSILFILE* fp)
 %apply (void *buffer_ptr) { (void *pBuffer) };
 %apply (size_t native_size) { (size_t nSize), (size_t nCount), (size_t VSIFWriteL), (size_t VSIFReadL)};
 size_t VSIFWriteL( const void *pBuffer, size_t nSize, size_t nCount, VSILFILE *fp );
-size_t VSIFReadL ( void *pBuffer, size_t nSize, size_t nCount, VSILFILE *fp );
+size_t VSIFReadL (       void *pBuffer, size_t nSize, size_t nCount, VSILFILE *fp );
 %clear (void *pBuffer), (size_t nSize), (size_t nCount), (size_t VSIFWriteL), (size_t VSIFReadL);
 #else
 int     VSIFWriteL( const char *pBuffer, int nSize, int nCount, VSILFILE *fp );

--- a/swig/include/cpl.i
+++ b/swig/include/cpl.i
@@ -972,6 +972,21 @@ return VSIFSeekL(fp, (vsi_l_offset)offset, whence);
 }
 }
 
+#if defined(SWIGCSHARP)
+%rename (VSIStatExL) wrapper_VSIStatExL;
+%apply (long long *OUTPUT) { (GIntBig *size) };
+%apply (int *OUTPUT) { (unsigned short *mode) };
+%inline {
+bool wrapper_VSIStatExL( const char * pszFilename, GIntBig *size, unsigned short *mode, int nFlags = 0 ) {
+  VSIStatBufL stats{};
+  int result = VSIStatExL(pszFilename, &stats, nFlags);
+  *size = static_cast<GIntBig>(stats.st_size);
+  *mode = stats.st_mode;
+  return result == 0;
+}
+}
+%clear (GIntBig *size), (unsigned short *mode);
+#endif
 
 #if defined(SWIGPYTHON)
 GIntBig    VSIFTellL( VSILFILE* fp );

--- a/swig/include/csharp/gdal_csharp.i
+++ b/swig/include/csharp/gdal_csharp.i
@@ -308,7 +308,7 @@ public CPLErr SetGCPs(GCP[] pGCPs, string pszGCPProjection) {
       throw new ArgumentOutOfRangeException(nameof(offset), "Non-negative number required");
     else if (count < 0)
       throw new ArgumentOutOfRangeException(nameof(count), "Non-negative number required");
-   else if (count > buffer.LongLength - offset)
+    else if (count > buffer.LongLength - offset)
       throw new ArgumentOutOfRangeException(nameof(offset), "Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
   }
 
@@ -316,30 +316,38 @@ public CPLErr SetGCPs(GCP[] pGCPs, string pszGCPProjection) {
     => IntPtr.Size == sizeof(long) ? new IntPtr(checked(ptr.ToInt64() + offset))
      : new IntPtr(checked(ptr.ToInt32() + (int)offset));
 
-  private class OwnedMemoryFileHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid {
-    private readonly GCHandle dataHandle;
-    public string FileName { get; }
-    public OwnedMemoryFileHandle(string path, byte[] buffer, long offset, long count)
-      : base(ownsHandle: true) {
-      FileName = path;
-      dataHandle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
-      ValidateBufferArgs(buffer, offset, count);
-      IntPtr ptr = AddOffset(dataHandle.AddrOfPinnedObject(), offset);
-      handle = VSIFileFromMemBuffer(FileName, ptr, (ulong)buffer.LongLength, bTakeOwnership: 0);
+  public sealed class OwnedMemoryFile : IDisposable {
+    private readonly GCHandle m_dataHandle;
+    private int m_disposed;
+    public string Filename { get; }
+    public bool IsDisposed => m_disposed != 0;
+    internal OwnedMemoryFile(string filename, GCHandle dataHandle) {
+      Filename = filename;
+      m_dataHandle = dataHandle;
     }
-    protected override void Dispose(bool disposing){
-      base.Dispose(disposing);
-      dataHandle.Free();
+    public void Dispose() {
+      if (System.Threading.Interlocked.CompareExchange(ref m_disposed, 1, 0) == 0) {
+        m_dataHandle.Free();
+        Unlink(Filename);
+      }
+      GC.SuppressFinalize(this);
     }
-    protected override bool ReleaseHandle() {
-      bool success = VSIFCloseL(handle) == 0;
-      success &= Unlink(FileName) == 0;
-      return success;
-    }
+    ~OwnedMemoryFile() => Dispose();
   }
 
-  public static SafeHandle FileFromMemBufferNoCopy(string utf8_string, byte[] buffer, long offset, long count)
-    => new OwnedMemoryFileHandle(utf8_string, buffer, offset, count);
+  public static OwnedMemoryFile FileFromMemBufferNoCopy(string utf8_string, byte[] buffer, long offset, long count) {
+    ValidateBufferArgs(buffer, offset, count);
+    GCHandle dataHandle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+    IntPtr ptr = AddOffset(dataHandle.AddrOfPinnedObject(), offset);
+    IntPtr fp = VSIFileFromMemBuffer(utf8_string, ptr, (ulong)buffer.LongLength, bTakeOwnership: 0);
+    if (fp == IntPtr.Zero) {
+      dataHandle.Free();
+      return null;
+    } else {
+      VSIFCloseL(fp);
+      return new OwnedMemoryFile(utf8_string, dataHandle);
+    }
+  }
 
   public static bool FileFromMemBuffer(string utf8_string, byte[] buffer, long offset, long count) {
     ValidateBufferArgs(buffer, offset, count);
@@ -347,8 +355,7 @@ public CPLErr SetGCPs(GCP[] pGCPs, string pszGCPProjection) {
     try {
       IntPtr addr = AddOffset(handle.AddrOfPinnedObject(), offset);
       return FileFromMemBuffer(utf8_string, count, addr) == 0;
-    }
-    finally {
+    } finally {
       handle.Free();
     }
   }
@@ -434,7 +441,7 @@ public CPLErr SetGCPs(GCP[] pGCPs, string pszGCPProjection) {
   }
 
   /* To maintain compatability with old VSIFWriteL definition */
-  [Obsolete("Use VSIFWriteL(byte[] data, int offset, int count, IntPtr fp)")]
+  [Obsolete("Use VSIFWriteL(byte[] buffer, int offset, int count, IntPtr fp)")]
   public static int VSIFWriteL(string data, int objectSize, int numObjects, IntPtr fp) {
     IntPtr handle = Marshal.StringToHGlobalAnsi(data);
     try {

--- a/swig/include/csharp/gdal_csharp.i
+++ b/swig/include/csharp/gdal_csharp.i
@@ -465,7 +465,7 @@ public CPLErr SetGCPs(GCP[] pGCPs, string pszGCPProjection) {
     }
   }
 
-  public static int VSIFReadL(byte[] buffer, int offset, int count, IntPtr fp) {
+  public static int VSIFReadL(byte[] buffer, long offset, int count, IntPtr fp) {
     ValidateBufferArgs(buffer, offset, count);
     GCHandle handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
     try {
@@ -476,7 +476,7 @@ public CPLErr SetGCPs(GCP[] pGCPs, string pszGCPProjection) {
     }
   }
 
-  public static int VSIFWriteL(byte[] buffer, int offset, int count, IntPtr fp) {
+  public static int VSIFWriteL(byte[] buffer, long offset, int count, IntPtr fp) {
     ValidateBufferArgs(buffer, offset, count);
     GCHandle handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
     try {

--- a/swig/include/csharp/gdal_csharp.i
+++ b/swig/include/csharp/gdal_csharp.i
@@ -332,9 +332,9 @@ public CPLErr SetGCPs(GCP[] pGCPs, string pszGCPProjection) {
     }
     public void Dispose() {
       if (System.Threading.Interlocked.CompareExchange(ref m_disposed, 1, 0) == 0) {
+        Unlink(Filename);
         if (!VsiOwned)
           m_dataHandle.Free();
-        Unlink(Filename);
       }
       GC.SuppressFinalize(this);
     }
@@ -349,7 +349,7 @@ public CPLErr SetGCPs(GCP[] pGCPs, string pszGCPProjection) {
       GCHandle dataHandle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
       try {
         IntPtr ptr = AddOffset(dataHandle.AddrOfPinnedObject(), offset);
-        IntPtr fp = VSIFileFromMemBuffer(utf8_string, ptr, (ulong)buffer.LongLength, bTakeOwnership: 0);
+        IntPtr fp = VSIFileFromMemBuffer(utf8_string, ptr, (ulong)count, bTakeOwnership: 0);
         if (fp == IntPtr.Zero) {
           return null;
         }

--- a/swig/include/csharp/gdal_csharp.i
+++ b/swig/include/csharp/gdal_csharp.i
@@ -351,6 +351,7 @@ public CPLErr SetGCPs(GCP[] pGCPs, string pszGCPProjection) {
         IntPtr ptr = AddOffset(dataHandle.AddrOfPinnedObject(), offset);
         IntPtr fp = VSIFileFromMemBuffer(utf8_string, ptr, (ulong)count, bTakeOwnership: 0);
         if (fp == IntPtr.Zero) {
+          dataHandle.Free();
           return null;
         }
         VSIFCloseL(fp);

--- a/swig/include/csharp/gdal_csharp.i
+++ b/swig/include/csharp/gdal_csharp.i
@@ -294,13 +294,63 @@ public CPLErr SetGCPs(GCP[] pGCPs, string pszGCPProjection) {
      return ret;
    }
 
- public static void FileFromMemBuffer(string utf8_string, byte[] bytes) {
-     GCHandle handle = GCHandle.Alloc(bytes, GCHandleType.Pinned);
-     try {
-          FileFromMemBuffer(utf8_string, bytes.Length, handle.AddrOfPinnedObject());
-     } finally {
-        handle.Free();
-     }
+  /*
+   *  Keep this seemingly redundant overload to maintain
+   * compatability with old FileFromMemBuffer definition
+   */
+  public static bool FileFromMemBuffer(string utf8_string, byte[] bytes)
+    => FileFromMemBuffer(utf8_string, bytes, 0, bytes.LongLength);
+
+  private static void ValidateBufferArgs(byte[] buffer, long offset, long count) {
+    if (buffer == null)
+      throw new ArgumentNullException(nameof(buffer));
+    else if (offset < 0)
+      throw new ArgumentOutOfRangeException(nameof(offset), "Non-negative number required");
+    else if (count < 0)
+      throw new ArgumentOutOfRangeException(nameof(count), "Non-negative number required");
+   else if (count > buffer.LongLength - offset)
+      throw new ArgumentOutOfRangeException(nameof(offset), "Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
+  }
+
+  private static IntPtr AddOffset(IntPtr ptr, long offset)
+    => IntPtr.Size == sizeof(long) ? new IntPtr(checked(ptr.ToInt64() + offset))
+     : new IntPtr(checked(ptr.ToInt32() + (int)offset));
+
+  private class OwnedMemoryFileHandle : Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid {
+    private readonly GCHandle dataHandle;
+    public string FileName { get; }
+    public OwnedMemoryFileHandle(string path, byte[] buffer, long offset, long count)
+      : base(ownsHandle: true) {
+      FileName = path;
+      dataHandle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+      ValidateBufferArgs(buffer, offset, count);
+      IntPtr ptr = AddOffset(dataHandle.AddrOfPinnedObject(), offset);
+      handle = VSIFileFromMemBuffer(FileName, ptr, (ulong)buffer.LongLength, bTakeOwnership: 0);
+    }
+    protected override void Dispose(bool disposing){
+      base.Dispose(disposing);
+      dataHandle.Free();
+    }
+    protected override bool ReleaseHandle() {
+      bool success = VSIFCloseL(handle) == 0;
+      success &= Unlink(FileName) == 0;
+      return success;
+    }
+  }
+
+  public static SafeHandle FileFromMemBufferNoCopy(string utf8_string, byte[] buffer, long offset, long count)
+    => new OwnedMemoryFileHandle(utf8_string, buffer, offset, count);
+
+  public static bool FileFromMemBuffer(string utf8_string, byte[] buffer, long offset, long count) {
+    ValidateBufferArgs(buffer, offset, count);
+    GCHandle handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+    try {
+      IntPtr addr = AddOffset(handle.AddrOfPinnedObject(), offset);
+      return FileFromMemBuffer(utf8_string, count, addr) == 0;
+    }
+    finally {
+      handle.Free();
+    }
   }
 
   public static int Warp(Dataset dstDS, Dataset[] poObjects, GDALWarpAppOptions warpAppOptions, $module.GDALProgressFuncDelegate callback, string callback_data) {
@@ -379,6 +429,42 @@ public CPLErr SetGCPs(GCP[] pGCPs, string pszGCPProjection) {
       return retval;
    }
 
+  public static bool VSIFSeekL(IntPtr fp, long offset, System.IO.SeekOrigin origin) {
+    return VSIFSeekL(fp, offset, (int)origin) == 0;
+  }
+
+  /* To maintain compatability with old VSIFWriteL definition */
+  [Obsolete("Use VSIFWriteL(byte[] data, int offset, int count, IntPtr fp)")]
+  public static int VSIFWriteL(string data, int objectSize, int numObjects, IntPtr fp) {
+    IntPtr handle = Marshal.StringToHGlobalAnsi(data);
+    try {
+      return VSIFWriteL(handle, (IntPtr)1, (IntPtr)data.Length, fp).ToInt32();
+    } finally {
+      Marshal.FreeHGlobal(handle);
+    }
+  }
+
+  public static int VSIFReadL(byte[] buffer, int offset, int count, IntPtr fp) {
+    ValidateBufferArgs(buffer, offset, count);
+    GCHandle handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+    try {
+      IntPtr addr = AddOffset(handle.AddrOfPinnedObject(), offset);
+      return VSIFReadL(addr, (IntPtr)sizeof(byte), (IntPtr)count, fp).ToInt32();
+    } finally {
+      handle.Free();
+    }
+  }
+
+  public static int VSIFWriteL(byte[] buffer, int offset, int count, IntPtr fp) {
+    ValidateBufferArgs(buffer, offset, count);
+    GCHandle handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+    try {
+      IntPtr addr = AddOffset(handle.AddrOfPinnedObject(), offset);
+      return VSIFWriteL(addr, (IntPtr)sizeof(byte), (IntPtr)count, fp).ToInt32();
+    } finally {
+      handle.Free();
+    }
+  }
 %}
 
 %rename (GetMemFileBuffer) wrapper_VSIGetMemFileBuffer;

--- a/swig/include/csharp/gdal_csharp.i
+++ b/swig/include/csharp/gdal_csharp.i
@@ -316,36 +316,49 @@ public CPLErr SetGCPs(GCP[] pGCPs, string pszGCPProjection) {
     => IntPtr.Size == sizeof(long) ? new IntPtr(checked(ptr.ToInt64() + offset))
      : new IntPtr(checked(ptr.ToInt32() + (int)offset));
 
-  public sealed class OwnedMemoryFile : IDisposable {
+  public sealed class VsiMemoryFile : IDisposable {
     private readonly GCHandle m_dataHandle;
     private int m_disposed;
     public string Filename { get; }
+    public bool VsiOwned { get; }
     public bool IsDisposed => m_disposed != 0;
-    internal OwnedMemoryFile(string filename, GCHandle dataHandle) {
+    internal VsiMemoryFile(string filename, GCHandle dataHandle) {
       Filename = filename;
       m_dataHandle = dataHandle;
     }
+    internal VsiMemoryFile(string filename) {
+      Filename = filename;
+      VsiOwned = true;
+    }
     public void Dispose() {
       if (System.Threading.Interlocked.CompareExchange(ref m_disposed, 1, 0) == 0) {
-        m_dataHandle.Free();
+        if (!VsiOwned)
+          m_dataHandle.Free();
         Unlink(Filename);
       }
       GC.SuppressFinalize(this);
     }
-    ~OwnedMemoryFile() => Dispose();
+    ~VsiMemoryFile() => Dispose();
   }
 
-  public static OwnedMemoryFile FileFromMemBufferNoCopy(string utf8_string, byte[] buffer, long offset, long count) {
-    ValidateBufferArgs(buffer, offset, count);
-    GCHandle dataHandle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
-    IntPtr ptr = AddOffset(dataHandle.AddrOfPinnedObject(), offset);
-    IntPtr fp = VSIFileFromMemBuffer(utf8_string, ptr, (ulong)buffer.LongLength, bTakeOwnership: 0);
-    if (fp == IntPtr.Zero) {
-      dataHandle.Free();
-      return null;
+  public static VsiMemoryFile FileFromMemBuffer(string utf8_string, byte[] buffer, long offset, long count, bool vsiTakeOwnership) {
+    if (vsiTakeOwnership) {
+      return FileFromMemBuffer(utf8_string, buffer, offset, count) ? new VsiMemoryFile(utf8_string) : null;
     } else {
-      VSIFCloseL(fp);
-      return new OwnedMemoryFile(utf8_string, dataHandle);
+      ValidateBufferArgs(buffer, offset, count);
+      GCHandle dataHandle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+      try {
+        IntPtr ptr = AddOffset(dataHandle.AddrOfPinnedObject(), offset);
+        IntPtr fp = VSIFileFromMemBuffer(utf8_string, ptr, (ulong)buffer.LongLength, bTakeOwnership: 0);
+        if (fp == IntPtr.Zero) {
+          return null;
+        }
+        VSIFCloseL(fp);
+        return new VsiMemoryFile(utf8_string, dataHandle);
+      } catch {
+        dataHandle.Free();
+        throw;
+      }
     }
   }
 

--- a/swig/include/csharp/typemaps_csharp.i
+++ b/swig/include/csharp/typemaps_csharp.i
@@ -181,6 +181,19 @@ OPTIONAL_POD(int, int);
 }
 
 /*
+ * Typemap for size_t native_size
+ */
+%typemap(ctype)  (size_t native_size), (const size_t &native_size) "size_t"
+%typemap(imtype) (size_t native_size), (const size_t &native_size) "IntPtr"
+%typemap(cstype) (size_t native_size), (const size_t &native_size) "IntPtr"
+%typemap(in)     (size_t native_size), (const size_t &native_size) "$1 = $input;"
+%typemap(out)    (size_t native_size), (const size_t &native_size) "$result = $1;"
+%typemap(csout, excode=SWIGEXCODE) (size_t native_size), (const size_t &native_size) {
+    IntPtr res = $imcall;$excode
+    return res;
+}
+
+/*
  * Typemap for PINNED arrays
  */
 

--- a/swig/include/gdal.i
+++ b/swig/include/gdal.i
@@ -751,7 +751,7 @@ void GDALDestroyDriverManager();
 %rename (ClearMemoryCaches) GDALClearMemoryCaches;
 void GDALClearMemoryCaches();
 
-#if defined(SWIGPYTHON)
+#if defined(SWIGPYTHON) || defined(SWIGCSHARP)
 %inline {
 GIntBig wrapper_GDALGetCacheMax()
 {


### PR DESCRIPTION
## What does this PR do?
- Adjust FileFromMemBuffer and VSIF* function definitions to work with buffers and files larger than 2GB.
- Add FileFromMemBuffer overload which takes `vsiTakeOwnership` as an option. Returns a `VsiMemoryFile` object which is `IDisposable`. When disposed, the in-memory file is unlinked the buffer is unpinned (if the VSI didn't take ownership).
- Add helper overloads to VSIF* funcitons
- Use Int64 for GetCacheMax(), GetCacheUsed(), and SetCacheMax()
- Add tests

@runette

## What are related issues/pull requests?

Fixes #6413

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [X] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [X] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Windows
* Compiler: VS 2016 / dotnet 10
