### PR TITLE
gdal raster zonal stats: add --include-geom, enhance --include-field

### DIFF
--- a/.github/workflows/ubuntu_26.04/reference_arg_names.txt
+++ b/.github/workflows/ubuntu_26.04/reference_arg_names.txt
@@ -121,6 +121,7 @@ id-metadata-item
 id-method
 ignore-missing-fields
 include-field
+include-geom
 include-row-col
 include-valid
 include-xy

--- a/alg/zonal.cpp
+++ b/alg/zonal.cpp
@@ -58,13 +58,24 @@ struct GDALZonalStatsOptions
             }
             else if (EQUAL(key, "INCLUDE_FIELDS"))
             {
-                CPLStringList aosFields(CSLTokenizeString2(
-                    value, ",",
-                    CSLT_HONOURSTRINGS | CSLT_STRIPLEADSPACES |
-                        CSLT_STRIPENDSPACES));
-                for (const char *pszField : aosFields)
+                if (EQUAL(value, "NONE"))
                 {
-                    include_fields.push_back(pszField);
+                    // do nothing
+                }
+                else if (EQUAL(value, "ALL"))
+                {
+                    include_all_fields = true;
+                }
+                else
+                {
+                    CPLStringList aosFields(CSLTokenizeString2(
+                        value, ",",
+                        CSLT_HONOURSTRINGS | CSLT_STRIPLEADSPACES |
+                            CSLT_STRIPENDSPACES));
+                    for (const char *pszField : aosFields)
+                    {
+                        include_fields.push_back(pszField);
+                    }
                 }
             }
             else if (EQUAL(key, "OUTPUT_LAYER"))
@@ -191,6 +202,7 @@ struct GDALZonalStatsOptions
     PixelIntersection pixels{DEFAULT};
     Strategy strategy{FEATURE_SEQUENTIAL};
     std::vector<std::string> stats{};
+    bool include_all_fields{false};
     std::vector<std::string> include_fields{};
     std::vector<int> bands{};
     std::string zones_layer{};
@@ -488,6 +500,15 @@ class GDALZonalStatsImpl
             const OGRFeatureDefn *poSrcDefn = poSrcLayer->GetLayerDefn();
             poZonesSRS = poSrcLayer->GetSpatialRef();
 
+            if (m_options.include_all_fields)
+            {
+                for (int i = 0; i < poSrcDefn->GetFieldCount(); i++)
+                {
+                    m_options.include_fields.emplace_back(
+                        poSrcDefn->GetFieldDefn(i)->GetNameRef());
+                }
+            }
+
             for (const auto &field : m_options.include_fields)
             {
                 if (poSrcDefn->GetFieldIndex(field.c_str()) == -1)
@@ -504,7 +525,8 @@ class GDALZonalStatsImpl
                              ->GetDataset()
                              ->GetSpatialRefRasterOnly();
 
-            if (!m_options.include_fields.empty())
+            if (m_options.include_all_fields ||
+                !m_options.include_fields.empty())
             {
                 CPLError(CE_Failure, CPLE_AppDefined,
                          "Cannot include fields from raster zones");
@@ -2110,7 +2132,8 @@ static CPLErr GDALZonalStats(GDALDataset &srcDataset, GDALDataset *poWeights,
  *   BANDS: a comma-separated list of band indices to be processed from the
  *          source dataset. If not present, all bands will be processed.
  *   INCLUDE_FIELDS: a comma-separated list of field names from the zones
- *          dataset to be included in output features.
+ *          dataset to be included in output features. Since GDAL 3.13, the
+ *          special values "ALL" and "NONE" can be used.
  *   PIXEL_INTERSECTION: controls which pixels are included in calculations:
  *          - DEFAULT: use default options to GDALRasterize
  *          - ALL_TOUCHED: use ALL_TOUCHED option of GDALRasterize

--- a/alg/zonal.cpp
+++ b/alg/zonal.cpp
@@ -78,6 +78,10 @@ struct GDALZonalStatsOptions
                     }
                 }
             }
+            else if (EQUAL(key, "INCLUDE_GEOM"))
+            {
+                include_geom = CPLTestBool(value);
+            }
             else if (EQUAL(key, "OUTPUT_LAYER"))
             {
                 output_layer = value;
@@ -204,6 +208,7 @@ struct GDALZonalStatsOptions
     std::vector<std::string> stats{};
     bool include_all_fields{false};
     std::vector<std::string> include_fields{};
+    bool include_geom{false};
     std::vector<int> bands{};
     std::string zones_layer{};
     std::size_t memory{0};
@@ -532,6 +537,13 @@ class GDALZonalStatsImpl
                          "Cannot include fields from raster zones");
                 return false;
             }
+
+            if (m_options.include_geom)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Cannot include geometry from raster zones");
+                return false;
+            }
         }
 
         CPLStringList aosOptions;
@@ -568,8 +580,16 @@ class GDALZonalStatsImpl
 
     OGRLayer *GetOutputLayer(bool createValueField)
     {
+        const OGRGeomFieldDefn *poGeomDefn = nullptr;
+        if (m_options.include_geom)
+        {
+            const OGRFeatureDefn *poSrcDefn =
+                std::get<OGRLayer *>(m_zones)->GetLayerDefn();
+            poGeomDefn = poSrcDefn->GetGeomFieldDefn(0);
+        }
+
         OGRLayer *poLayer =
-            m_dst.CreateLayer(m_options.output_layer.c_str(), nullptr,
+            m_dst.CreateLayer(m_options.output_layer.c_str(), poGeomDefn,
                               m_options.layer_creation_options.List());
         if (!poLayer)
             return nullptr;
@@ -2134,6 +2154,8 @@ static CPLErr GDALZonalStats(GDALDataset &srcDataset, GDALDataset *poWeights,
  *   INCLUDE_FIELDS: a comma-separated list of field names from the zones
  *          dataset to be included in output features. Since GDAL 3.13, the
  *          special values "ALL" and "NONE" can be used.
+ *   INCLUDE_GEOM: whether to include polygon zone geometry in the output
+ *                 features (since GDAL 3.13; default is "NO").
  *   PIXEL_INTERSECTION: controls which pixels are included in calculations:
  *          - DEFAULT: use default options to GDALRasterize
  *          - ALL_TOUCHED: use ALL_TOUCHED option of GDALRasterize

--- a/apps/gdalalg_raster_zonal_stats.cpp
+++ b/apps/gdalalg_raster_zonal_stats.cpp
@@ -72,6 +72,8 @@ GDALRasterZonalStatsAlgorithm::GDALRasterZonalStatsAlgorithm(bool bStandalone)
     AddArg("include-field", 0,
            _("Fields from polygon zones to include in output"),
            &m_includeFields);
+    AddArg("include-geom", 0, _("Include polygon zone geometry in the output"),
+           &m_includeZoneGeom);
     AddArg("strategy", 0,
            _("For polygon zones, whether to iterate over input features or "
              "raster chunks"),
@@ -186,6 +188,10 @@ bool GDALRasterZonalStatsAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
     {
         aosOptions.AddNameValue("INCLUDE_FIELDS",
                                 Join(m_includeFields, ",").c_str());
+    }
+    if (m_includeZoneGeom)
+    {
+        aosOptions.AddNameValue("INCLUDE_GEOM", "YES");
     }
     if (!m_outputLayerName.empty())
     {

--- a/apps/gdalalg_raster_zonal_stats.h
+++ b/apps/gdalalg_raster_zonal_stats.h
@@ -54,6 +54,7 @@ class GDALRasterZonalStatsAlgorithm /* non final */
     std::vector<int> m_bands{};
     std::vector<std::string> m_stats{};
     std::vector<std::string> m_includeFields{};
+    bool m_includeZoneGeom{false};
     std::string m_strategy{};
     std::string m_memoryStr{"5%"};
     std::string m_pixels{"default"};

--- a/autotest/utilities/test_gdalalg_raster_zonal_stats.py
+++ b/autotest/utilities/test_gdalalg_raster_zonal_stats.py
@@ -611,8 +611,9 @@ def test_gdalalg_raster_zonal_stats_output_format_detection(
     assert out_ds.GetDriver().GetName() == "CSV"
 
 
+@pytest.mark.parametrize("include_field", ["ALL", "NONE", ["PRFEDEA", "EAS_ID"]])
 def test_gdalalg_raster_zonal_stats_polygon_zones_include_fields(
-    zonal, strategy, polyrast
+    zonal, strategy, polyrast, include_field
 ):
 
     zonal["input"] = polyrast
@@ -626,7 +627,14 @@ def test_gdalalg_raster_zonal_stats_polygon_zones_include_fields(
     with pytest.raises(Exception, match="Field .* not found"):
         zonal.Run()
 
-    zonal["include-field"] = ["PRFEDEA", "EAS_ID"]
+    zonal["include-field"] = include_field
+
+    if include_field == "ALL":
+        expected_fields = ["AREA", "EAS_ID", "PRFEDEA", "sum"]
+    elif include_field == "NONE":
+        expected_fields = ["sum"]
+    else:
+        expected_fields = ["PRFEDEA", "EAS_ID", "sum"]
 
     assert zonal.Run()
 
@@ -634,10 +642,14 @@ def test_gdalalg_raster_zonal_stats_polygon_zones_include_fields(
 
     f = out_ds.GetLayer(0).GetNextFeature()
 
-    assert field_names(f) == ["PRFEDEA", "EAS_ID", "sum"]
+    assert field_names(f) == expected_fields
 
-    assert f["PRFEDEA"] == "35043411"
-    assert f["EAS_ID"] == 168
+    if "PRFEDEA" in expected_fields:
+        assert f["PRFEDEA"] == "35043411"
+    if "EAS_ID" in expected_fields:
+        assert f["EAS_ID"] == 168
+    if "AREA" in expected_fields:
+        assert f["AREA"] == 215229.266
     assert f["sum"] == 369.0
 
 

--- a/autotest/utilities/test_gdalalg_raster_zonal_stats.py
+++ b/autotest/utilities/test_gdalalg_raster_zonal_stats.py
@@ -653,6 +653,36 @@ def test_gdalalg_raster_zonal_stats_polygon_zones_include_fields(
     assert f["sum"] == 369.0
 
 
+def test_gdalalg_raster_zonal_stats_polygon_zones_include_geom(
+    zonal, strategy, polyrast
+):
+
+    zonal["input"] = polyrast
+    zonal["output"] = ""
+    zonal["output-format"] = "MEM"
+    zonal["strategy"] = strategy
+    zonal["stat"] = "sum"
+    zonal["include-geom"] = True
+    zonal["zones"] = "../ogr/data/poly.shp"
+
+    assert zonal.Run()
+
+    out_ds = zonal.Output()
+    out_lyr = out_ds.GetLayer(0)
+
+    src_ds = gdal.OpenEx("../ogr/data/poly.shp")
+    src_lyr = src_ds.GetLayer(0)
+
+    assert out_lyr.GetSpatialRef().IsSame(src_lyr.GetSpatialRef())
+
+    for src_feat, dst_feat in zip(src_lyr, out_lyr):
+        src_geom = src_feat.GetGeometryRef()
+        dst_geom = dst_feat.GetGeometryRef()
+
+        assert src_geom.GetSpatialReference().IsSame(dst_geom.GetSpatialReference())
+        ogrtest.check_feature_geometry(dst_feat, src_geom)
+
+
 def test_gdalalg_raster_zonal_stats_raster_zones_include_fields(zonal):
 
     zonal["input"] = "../gcore/data/byte.tif"
@@ -663,6 +693,19 @@ def test_gdalalg_raster_zonal_stats_raster_zones_include_fields(zonal):
     zonal["include-field"] = "id"
 
     with pytest.raises(Exception, match="Cannot include fields"):
+        zonal.Run()
+
+
+def test_gdalalg_raster_zonal_stats_raster_zones_include_geom(zonal):
+
+    zonal["input"] = "../gcore/data/byte.tif"
+    zonal["zones"] = "../gcore/data/byte.tif"
+    zonal["output"] = ""
+    zonal["output-format"] = "MEM"
+    zonal["stat"] = "sum"
+    zonal["include-geom"] = True
+
+    with pytest.raises(Exception, match="Cannot include geometry"):
         zonal.Run()
 
 

--- a/doc/source/programs/gdal_raster_zonal_stats.rst
+++ b/doc/source/programs/gdal_raster_zonal_stats.rst
@@ -123,6 +123,12 @@ Program-Specific Options
    Specifies one or more fields from the zones to be copied to the output. Only
    available when vector zones are used. Since GDAL 3.13, the special values "ALL" and "NONE" can be used.
 
+.. option:: --include-geom
+
+   Include the zone geometry in the output feature. Only available when vector zones are used.
+
+   .. versionadded:: 3.13
+
 .. option:: --pixels <PIXELS>
 
    Method to determine which pixels should be included in the calculation: ``default``, ``all-touched``, or ``fractional``.
@@ -214,7 +220,8 @@ Examples
 
    .. code-block:: bash
 
-      gdal pipeline read points.geojson ! buffer 200 ! \
+      gdal pipeline read points.geojson ! \
+          buffer 200 ! \
           zonal-stats \
             --input dem.tif
             --zones _ \
@@ -233,9 +240,9 @@ Examples
           zonal-stats \
             --zones watersheds.shp \
             --stat max_center_x \
-            --stat max_center_y !
+            --stat max_center_y ! \
           make-point \
             --x max_center_x \
             --y max_center_y \
-            --dst-crs EPSG:4326 !
+            --dst-crs EPSG:4326 ! \
           write out.geojson

--- a/doc/source/programs/gdal_raster_zonal_stats.rst
+++ b/doc/source/programs/gdal_raster_zonal_stats.rst
@@ -121,7 +121,7 @@ Program-Specific Options
 .. option:: --include-field <INCLUDE-FIELD>
 
    Specifies one or more fields from the zones to be copied to the output. Only
-   available when vector zones are used.
+   available when vector zones are used. Since GDAL 3.13, the special values "ALL" and "NONE" can be used.
 
 .. option:: --pixels <PIXELS>
 


### PR DESCRIPTION
- Make `--include-field` argument accept `ALL` and `NONE`, consistent with other utilities.
- Add `--include-geom` argument