### PR TITLE
Doc: Add raster clip example and update error message

### DIFF
--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -1041,18 +1041,18 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
         {
             CPLErr eErr = bIsError ? CE_Failure : CE_Warning;
 
-            CPLError(eErr, CPLE_AppDefined,
-                     "%s-srcwin %g %g %g %g falls %s outside source raster "
-                     "extent.%s",
-                     (psOptions->dfULX != 0.0 || psOptions->dfULY != 0.0 ||
-                      psOptions->dfLRX != 0.0 || psOptions->dfLRY != 0.0)
-                         ? "Computed "
-                         : "",
-                     psOptions->srcWin.dfXOff, psOptions->srcWin.dfYOff,
-                     psOptions->srcWin.dfXSize, psOptions->srcWin.dfYSize,
-                     bCompletelyOutside ? "completely" : "partially",
-                     bIsError
-                         ? ""
+            CPLError(
+                eErr, CPLE_AppDefined,
+                "%ssource window %g %g %g %g falls %s outside source raster "
+                "extent.%s",
+                (psOptions->dfULX != 0.0 || psOptions->dfULY != 0.0 ||
+                 psOptions->dfLRX != 0.0 || psOptions->dfLRY != 0.0)
+                    ? "Computed "
+                    : "",
+                psOptions->srcWin.dfXOff, psOptions->srcWin.dfYOff,
+                psOptions->srcWin.dfXSize, psOptions->srcWin.dfYSize,
+                bCompletelyOutside ? "completely" : "partially",
+                bIsError ? ""
                          : " Pixels outside the source raster extent will be "
                            "set to the NoData value (if defined), or zero.");
         }

--- a/doc/source/programs/gdal_raster_clip.rst
+++ b/doc/source/programs/gdal_raster_clip.rst
@@ -177,3 +177,20 @@ Examples
    .. code-block:: bash
 
         $ gdal raster clip --window=1000,2000,500,600 in.tif out.tif --overwrite
+
+.. example::
+   :title: Clip a GeoTIFF using a bounding box extending beyond the source extent, and write the result as a COG
+
+   Use ``--allow-bbox-outside-source`` to suppress the error
+   ``ERROR 1: Computed source window -180 2943 6269 6235 falls partially outside source raster extent``
+   when the bounding box exceeds the raster extent.
+
+   .. code-block:: bash
+
+      $ gdal raster clip \
+          --bbox=3757032.814272985,-626172.1357121654,4383204.9499851465,0 \
+          --bbox-crs=EPSG:3857 \
+          --allow-bbox-outside-source \
+          in.tif out.tif \
+          --overwrite \
+          --output-format COG


### PR DESCRIPTION
Adds a raster clip example with `--allow-bbox-outside-source`.

Also updates the error message when this is not used, following the approach used in #13986. 

```
# old
ERROR 1: Computed -srcwin -180 2943 6269 6235 falls partially outside source raster extent.
# new
ERROR 1: Computed source window -180 2943 6269 6235 falls partially outside source raster extent
```

There was only a very minor change, but precommit reformatted the whole statement. 