### PR TITLE
gdal raster create: replicate --like tiling when possible

### DIFF
--- a/apps/gdalalg_raster_create.cpp
+++ b/apps/gdalalg_raster_create.cpp
@@ -130,6 +130,8 @@ bool GDALRasterCreateAlgorithm::RunStep(GDALPipelineStepRunContext &)
     GDALGeoTransform gt;
     bool bGTValid = false;
 
+    CPLStringList aosCreationOptions(m_creationOptions);
+
     GDALDataset *poSrcDS = m_inputDataset.empty()
                                ? nullptr
                                : m_inputDataset.front().GetDatasetRef();
@@ -173,6 +175,58 @@ bool GDALRasterCreateAlgorithm::RunStep(GDALPipelineStepRunContext &)
                 poSrcDS->GetRasterBand(1)->GetNoDataValue(&bNoData);
             if (bNoData)
                 m_nodata = CPLSPrintf("%.17g", dfNoData);
+        }
+
+        // Replicate tiling of input datasets for a few popular output formats,
+        // when compatible, and when the user hasn't specified creation options
+        // affecting tiling.
+        int nBlockXSize = 0, nBlockYSize = 0;
+        if (m_bandCount > 0)
+            poSrcDS->GetRasterBand(1)->GetBlockSize(&nBlockXSize, &nBlockYSize);
+
+        if (EQUAL(m_format.c_str(), "GTIFF") &&
+            aosCreationOptions.FetchNameValue("TILED") == nullptr &&
+            aosCreationOptions.FetchNameValue("BLOCKXSIZE") == nullptr &&
+            aosCreationOptions.FetchNameValue("BLOCKYSIZE") == nullptr &&
+            m_bandCount > 0)
+        {
+            if (nBlockXSize != poSrcDS->GetRasterXSize() &&
+                (nBlockXSize % 16) == 0 && (nBlockYSize % 16) == 0)
+            {
+                aosCreationOptions.SetNameValue("TILED", "YES");
+                aosCreationOptions.SetNameValue("BLOCKXSIZE",
+                                                CPLSPrintf("%d", nBlockXSize));
+                aosCreationOptions.SetNameValue("BLOCKYSIZE",
+                                                CPLSPrintf("%d", nBlockYSize));
+            }
+        }
+        else if (EQUAL(m_format.c_str(), "COG") &&
+                 aosCreationOptions.FetchNameValue("BLOCKSIZE") == nullptr &&
+                 m_bandCount > 0)
+        {
+            if (nBlockXSize != poSrcDS->GetRasterXSize() &&
+                nBlockXSize == nBlockYSize && nBlockXSize >= 128 &&
+                (nBlockXSize % 16) == 0)
+            {
+                aosCreationOptions.SetNameValue("BLOCKSIZE",
+                                                CPLSPrintf("%d", nBlockXSize));
+            }
+        }
+        else if (EQUAL(m_format.c_str(), "GPKG") &&
+                 aosCreationOptions.FetchNameValue("BLOCKSIZE") == nullptr &&
+                 aosCreationOptions.FetchNameValue("BLOCKXSIZE") == nullptr &&
+                 aosCreationOptions.FetchNameValue("BLOCKYSIZE") == nullptr &&
+                 m_bandCount > 0)
+        {
+            if (nBlockXSize != poSrcDS->GetRasterXSize() &&
+                nBlockXSize >= 256 && nBlockXSize <= 4096 &&
+                nBlockYSize >= 256 && nBlockYSize <= 4096)
+            {
+                aosCreationOptions.SetNameValue("BLOCKXSIZE",
+                                                CPLSPrintf("%d", nBlockXSize));
+                aosCreationOptions.SetNameValue("BLOCKYSIZE",
+                                                CPLSPrintf("%d", nBlockYSize));
+            }
         }
     }
 
@@ -221,13 +275,12 @@ bool GDALRasterCreateAlgorithm::RunStep(GDALPipelineStepRunContext &)
                         poDriver->GetDescription());
             return false;
         }
-        m_creationOptions.push_back("APPEND_SUBDATASET=YES");
+        aosCreationOptions.SetNameValue("APPEND_SUBDATASET", "YES");
     }
 
     auto poRetDS = std::unique_ptr<GDALDataset>(poDriver->Create(
         m_outputDataset.GetName().c_str(), m_size[0], m_size[1], m_bandCount,
-        GDALGetDataTypeByName(m_type.c_str()),
-        CPLStringList(m_creationOptions).List()));
+        GDALGetDataTypeByName(m_type.c_str()), aosCreationOptions.List()));
     if (!poRetDS)
     {
         return false;

--- a/autotest/utilities/test_gdalalg_raster_create.py
+++ b/autotest/utilities/test_gdalalg_raster_create.py
@@ -15,7 +15,7 @@ import math
 
 import pytest
 
-from osgeo import gdal
+from osgeo import gdal, osr
 
 
 def get_alg():
@@ -564,3 +564,55 @@ def test_gdalalg_raster_create_like_not_positional(tmp_vsimem):
         "Positional values starting at '/vsimem/test_gdalalg_raster_create_like_not_positional/out.tif' are not expected"
         in err
     )
+
+
+@pytest.mark.parametrize(
+    "blockxsize,blockysize,output_format,expected_blockxsize,expected_blockysize,creation_option",
+    [
+        (16, 32, "GTiff", 16, 32, []),
+        (128, 128, "COG", 128, 128, []),
+        (512, 512, "GPKG", 512, 512, []),
+        (16, 32, "GTiff", 1000, 8, ["TILED=NO"]),
+        (128, 128, "COG", 256, 256, ["BLOCKSIZE=256"]),
+        (512, 512, "GPKG", 256, 256, ["BLOCKSIZE=256"]),
+        (16, 32, "GPKG", 256, 256, []),
+    ],
+)
+def test_gdalalg_raster_create_replicate_tiling(
+    tmp_vsimem,
+    blockxsize,
+    blockysize,
+    output_format,
+    expected_blockxsize,
+    expected_blockysize,
+    creation_option,
+):
+
+    if gdal.GetDriverByName(output_format) is None:
+        pytest.skip(f"{output_format} not available")
+
+    with gdal.GetDriverByName("GTIFF").Create(
+        tmp_vsimem / "src.tif",
+        1000,
+        1000,
+        1,
+        options=["TILED=YES", f"BLOCKXSIZE={blockxsize}", f"BLOCKYSIZE={blockysize}"],
+    ) as ds:
+        ds.SetGeoTransform([2, 1, 0, 49, 0, -1])
+        ds.SetSpatialRef(osr.SpatialReference(epsg=4326))
+
+    out_filename = str(tmp_vsimem / "out") + (
+        ".gpkg" if output_format == "GPKG" else ".tif"
+    )
+    gdal.alg.raster.create(
+        input=tmp_vsimem / "src.tif",
+        output=out_filename,
+        output_format=output_format,
+        creation_option=creation_option,
+    )
+
+    ds = gdal.Open(out_filename)
+    assert ds.GetRasterBand(1).GetBlockSize() == [
+        expected_blockxsize,
+        expected_blockysize,
+    ]

--- a/doc/source/programs/gdal_raster_create.rst
+++ b/doc/source/programs/gdal_raster_create.rst
@@ -91,6 +91,11 @@ Program-Specific Options
     :option:`--crs`, :option:`--bbox` and :option:`--nodata`.
     Note that the pixel values will *not* be copied.
 
+    Since GDAL 3.13, if the input dataset is tiled, and for output formats
+    ``GTiff``, ``COG`` and ``GPKG``, its tile dimensions are replicated to
+    the output file, when they are compatible of its capabilities, and if the
+    user hasn't specified any creation option related to tiling.
+
 .. option:: --metadata <KEY>=<VALUE>
 
     Adds a metadata item, at the dataset level.


### PR DESCRIPTION
    Since GDAL 3.13, if the input dataset is tiled, and for output formats
    ``GTiff``, ``COG`` and ``GPKG``, its tile dimensions are replicated to
    the output file, when they are compatible of its capabilities, and if the
    user hasn't specified any creation option related to tiling.
