### PR TITLE
gdal CLI: add mention in --help when argument not available in a pipeline step

### DIFF
--- a/apps/data/gdal_algorithm.schema.json
+++ b/apps/data/gdal_algorithm.schema.json
@@ -120,6 +120,10 @@
           "type": "string",
           "$comment": "Hint on the expected value of the argument"
         },
+        "available_in_pipeline_step": {
+          "type": "boolean",
+          "$comment": "Whether this argument is available when the algorithm is used in a pipeline step. Only present when its value is false."
+        },
         "choices": {
           "type": "array",
           "items": {

--- a/apps/gdalalg_abstract_pipeline.h
+++ b/apps/gdalalg_abstract_pipeline.h
@@ -150,6 +150,7 @@ class GDALPipelineStepAlgorithm /* non final */ : public GDALAlgorithm
         bool addUpsertArgument = true;                // only for vector output
         bool addSkipErrorsArgument = true;            // only for vector output
         bool addOutputLayerNameArgument = true;       // only for vector output
+        bool outputLayerNameAvailableInPipelineStep = false;
         int inputDatasetMaxCount = 1;
         std::string inputDatasetHelpMsg{};
         std::string inputDatasetAlias{};
@@ -275,6 +276,13 @@ class GDALPipelineStepAlgorithm /* non final */ : public GDALAlgorithm
         inline ConstructorOptions &SetAddOutputLayerNameArgument(bool b)
         {
             addOutputLayerNameArgument = b;
+            return *this;
+        }
+
+        inline ConstructorOptions &
+        SetOutputLayerNameAvailableInPipelineStep(bool b)
+        {
+            outputLayerNameAvailableInPipelineStep = b;
             return *this;
         }
     };

--- a/apps/gdalalg_pipeline.cpp
+++ b/apps/gdalalg_pipeline.cpp
@@ -85,8 +85,11 @@ void GDALPipelineStepAlgorithm::AddRasterInputArgs(
             openForMixedRasterVector
                 ? std::vector<std::string>{GDAL_DCAP_RASTER, GDAL_DCAP_VECTOR}
                 : std::vector<std::string>{GDAL_DCAP_RASTER})
-        .SetHiddenForCLI(hiddenForCLI);
-    AddOpenOptionsArg(&m_openOptions).SetHiddenForCLI(hiddenForCLI);
+        .SetHiddenForCLI(hiddenForCLI)
+        .SetAvailableInPipelineStep(false);
+    AddOpenOptionsArg(&m_openOptions)
+        .SetHiddenForCLI(hiddenForCLI)
+        .SetAvailableInPipelineStep(false);
     auto &arg =
         AddInputDatasetArg(
             &m_inputDataset,
@@ -97,7 +100,8 @@ void GDALPipelineStepAlgorithm::AddRasterInputArgs(
             .SetMaxCount(m_constructorOptions.inputDatasetMaxCount)
             .SetAutoOpenDataset(m_constructorOptions.autoOpenInputDatasets)
             .SetMetaVar(m_constructorOptions.inputDatasetMetaVar)
-            .SetHiddenForCLI(hiddenForCLI);
+            .SetHiddenForCLI(hiddenForCLI)
+            .SetAvailableInPipelineStep(false);
     if (m_constructorOptions.inputDatasetPositional && !hiddenForCLI)
         arg.SetPositional();
     if (m_constructorOptions.inputDatasetRequired && !hiddenForCLI)
@@ -119,23 +123,29 @@ void GDALPipelineStepAlgorithm::AddRasterOutputArgs(bool hiddenForCLI)
                   GAAMDI_REQUIRED_CAPABILITIES,
                   {GDAL_DCAP_RASTER,
                    m_constructorOptions.outputFormatCreateCapability.c_str()})
-              .SetHiddenForCLI(hiddenForCLI));
+              .SetHiddenForCLI(hiddenForCLI))
+             .SetAvailableInPipelineStep(false);
     AddOutputDatasetArg(&m_outputDataset, GDAL_OF_RASTER,
                         /* positionalAndRequired = */ !hiddenForCLI,
                         m_constructorOptions.outputDatasetHelpMsg.c_str())
         .SetHiddenForCLI(hiddenForCLI)
-        .SetDatasetInputFlags(GADV_NAME | GADV_OBJECT);
-    AddCreationOptionsArg(&m_creationOptions).SetHiddenForCLI(hiddenForCLI);
+        .SetDatasetInputFlags(GADV_NAME | GADV_OBJECT)
+        .SetAvailableInPipelineStep(false);
+    AddCreationOptionsArg(&m_creationOptions)
+        .SetHiddenForCLI(hiddenForCLI)
+        .SetAvailableInPipelineStep(false);
     constexpr const char *MUTUAL_EXCLUSION_GROUP_OVERWRITE_APPEND =
         "overwrite-append";
     AddOverwriteArg(&m_overwrite)
         .SetHiddenForCLI(hiddenForCLI)
-        .SetMutualExclusionGroup(MUTUAL_EXCLUSION_GROUP_OVERWRITE_APPEND);
+        .SetMutualExclusionGroup(MUTUAL_EXCLUSION_GROUP_OVERWRITE_APPEND)
+        .SetAvailableInPipelineStep(false);
     AddArg(GDAL_ARG_NAME_APPEND, 0,
            _("Append as a subdataset to existing output"), &m_appendRaster)
         .SetDefault(false)
         .SetHiddenForCLI(hiddenForCLI)
-        .SetMutualExclusionGroup(MUTUAL_EXCLUSION_GROUP_OVERWRITE_APPEND);
+        .SetMutualExclusionGroup(MUTUAL_EXCLUSION_GROUP_OVERWRITE_APPEND)
+        .SetAvailableInPipelineStep(false);
 }
 
 /************************************************************************/
@@ -160,14 +170,18 @@ void GDALPipelineStepAlgorithm::AddVectorInputArgs(bool hiddenForCLI)
 {
     AddInputFormatsArg(&m_inputFormats)
         .AddMetadataItem(GAAMDI_REQUIRED_CAPABILITIES, {GDAL_DCAP_VECTOR})
-        .SetHiddenForCLI(hiddenForCLI);
-    AddOpenOptionsArg(&m_openOptions).SetHiddenForCLI(hiddenForCLI);
+        .SetHiddenForCLI(hiddenForCLI)
+        .SetAvailableInPipelineStep(false);
+    AddOpenOptionsArg(&m_openOptions)
+        .SetHiddenForCLI(hiddenForCLI)
+        .SetAvailableInPipelineStep(false);
     auto &datasetArg =
         AddInputDatasetArg(&m_inputDataset, GDAL_OF_VECTOR, false)
             .SetMinCount(m_constructorOptions.inputDatasetRequired ? 1 : 0)
             .SetMaxCount(m_constructorOptions.inputDatasetMaxCount)
             .SetAutoOpenDataset(m_constructorOptions.autoOpenInputDatasets)
-            .SetHiddenForCLI(hiddenForCLI);
+            .SetHiddenForCLI(hiddenForCLI)
+            .SetAvailableInPipelineStep(false);
     if (!m_constructorOptions.inputDatasetAlias.empty())
         datasetArg.AddAlias(m_constructorOptions.inputDatasetAlias);
     if (!m_constructorOptions.inputDatasetMetaVar.empty())
@@ -181,7 +195,8 @@ void GDALPipelineStepAlgorithm::AddVectorInputArgs(bool hiddenForCLI)
         auto &layerArg = AddArg(GDAL_ARG_NAME_INPUT_LAYER, 'l',
                                 _("Input layer name(s)"), &m_inputLayerNames)
                              .AddAlias("layer")
-                             .SetHiddenForCLI(hiddenForCLI);
+                             .SetHiddenForCLI(hiddenForCLI)
+                             .SetAvailableInPipelineStep(false);
         SetAutoCompleteFunctionForLayerName(layerArg, datasetArg);
     }
 }
@@ -197,30 +212,43 @@ void GDALPipelineStepAlgorithm::AddVectorOutputArgs(
                        /* bGDALGAllowed = */ true)
         .AddMetadataItem(GAAMDI_REQUIRED_CAPABILITIES,
                          {GDAL_DCAP_VECTOR, GDAL_DCAP_CREATE})
-        .SetHiddenForCLI(hiddenForCLI);
-    AddOutputOpenOptionsArg(&m_outputOpenOptions).SetHiddenForCLI(hiddenForCLI);
+        .SetHiddenForCLI(hiddenForCLI)
+        .SetAvailableInPipelineStep(false);
+    AddOutputOpenOptionsArg(&m_outputOpenOptions)
+        .SetHiddenForCLI(hiddenForCLI)
+        .SetAvailableInPipelineStep(false);
     auto &outputDatasetArg =
         AddOutputDatasetArg(&m_outputDataset, GDAL_OF_VECTOR,
                             /* positionalAndRequired = */ false)
             .SetHiddenForCLI(hiddenForCLI)
-            .SetDatasetInputFlags(GADV_NAME | GADV_OBJECT);
+            .SetDatasetInputFlags(GADV_NAME | GADV_OBJECT)
+            .SetAvailableInPipelineStep(false);
     if (!hiddenForCLI)
         outputDatasetArg.SetPositional();
     if (!hiddenForCLI && m_constructorOptions.outputDatasetRequired)
         outputDatasetArg.SetRequired();
 
-    AddCreationOptionsArg(&m_creationOptions).SetHiddenForCLI(hiddenForCLI);
+    AddCreationOptionsArg(&m_creationOptions)
+        .SetHiddenForCLI(hiddenForCLI)
+        .SetAvailableInPipelineStep(false);
     AddLayerCreationOptionsArg(&m_layerCreationOptions)
-        .SetHiddenForCLI(hiddenForCLI);
-    AddOverwriteArg(&m_overwrite).SetHiddenForCLI(hiddenForCLI);
+        .SetHiddenForCLI(hiddenForCLI)
+        .SetAvailableInPipelineStep(false);
+    AddOverwriteArg(&m_overwrite)
+        .SetHiddenForCLI(hiddenForCLI)
+        .SetAvailableInPipelineStep(false);
     GDALInConstructionAlgorithmArg *updateArg = nullptr;
     if (m_constructorOptions.addUpdateArgument)
     {
-        updateArg = &AddUpdateArg(&m_update).SetHiddenForCLI(hiddenForCLI);
+        updateArg = &AddUpdateArg(&m_update)
+                         .SetHiddenForCLI(hiddenForCLI)
+                         .SetAvailableInPipelineStep(false);
     }
     if (m_constructorOptions.addOverwriteLayerArgument)
     {
-        AddOverwriteLayerArg(&m_overwriteLayer).SetHiddenForCLI(hiddenForCLI);
+        AddOverwriteLayerArg(&m_overwriteLayer)
+            .SetHiddenForCLI(hiddenForCLI)
+            .SetAvailableInPipelineStep(false);
     }
     constexpr const char *MUTUAL_EXCLUSION_GROUP_APPEND_UPSERT =
         "append-upsert";
@@ -228,13 +256,16 @@ void GDALPipelineStepAlgorithm::AddVectorOutputArgs(
     {
         AddAppendLayerArg(&m_appendLayer)
             .SetHiddenForCLI(hiddenForCLI)
-            .SetMutualExclusionGroup(MUTUAL_EXCLUSION_GROUP_APPEND_UPSERT);
+            .SetMutualExclusionGroup(MUTUAL_EXCLUSION_GROUP_APPEND_UPSERT)
+            .SetAvailableInPipelineStep(false);
     }
     if (m_constructorOptions.addUpsertArgument)
     {
         AddArg("upsert", 0, _("Upsert features (implies 'append')"), &m_upsert)
             .SetHiddenForCLI(hiddenForCLI)
             .SetMutualExclusionGroup(MUTUAL_EXCLUSION_GROUP_APPEND_UPSERT)
+
+            .SetAvailableInPipelineStep(false)
             .AddAction(
                 [updateArg, this]()
                 {
@@ -251,13 +282,15 @@ void GDALPipelineStepAlgorithm::AddVectorOutputArgs(
     {
         AddArg("skip-errors", 0, _("Skip errors when writing features"),
                &m_skipErrors)
-            .AddHiddenAlias("skip-failures");  // For ogr2ogr nostalgic people
+            .AddHiddenAlias("skip-failures")  // For ogr2ogr nostalgic people
+            .SetAvailableInPipelineStep(false);
     }
     if (m_constructorOptions.addNoCreateEmptyLayersArgument)
     {
         AddArg("no-create-empty-layers", 0,
                _("Avoid creating layers to which no features will be written"),
-               &m_noCreateEmptyLayers);
+               &m_noCreateEmptyLayers)
+            .SetAvailableInPipelineStep(false);
     }
 }
 
@@ -272,7 +305,9 @@ void GDALPipelineStepAlgorithm::AddOutputLayerNameArg(
            _("Output layer name"),
            &m_outputLayerName)
         .AddHiddenAlias("nln")  // For ogr2ogr nostalgic people
-        .SetHiddenForCLI(hiddenForCLI);
+        .SetHiddenForCLI(hiddenForCLI)
+        .SetAvailableInPipelineStep(
+            m_constructorOptions.outputLayerNameAvailableInPipelineStep);
 }
 
 /************************************************************************/

--- a/apps/gdalalg_raster_edit.cpp
+++ b/apps/gdalalg_raster_edit.cpp
@@ -54,13 +54,15 @@ GDALRasterEditAlgorithm::GDALRasterEditAlgorithm(bool standaloneStep)
                _("Dataset (to be updated in-place, unless --auxiliary)"),
                &m_dataset, GDAL_OF_RASTER | GDAL_OF_UPDATE)
             .SetPositional()
-            .SetRequired();
-        AddOpenOptionsArg(&m_openOptions);
+            .SetRequired()
+            .SetAvailableInPipelineStep(false);
+        AddOpenOptionsArg(&m_openOptions).SetAvailableInPipelineStep(false);
         AddArg("auxiliary", 0,
                _("Ask for an auxiliary .aux.xml file to be edited"),
                &m_readOnly)
             .AddHiddenAlias("ro")
-            .AddHiddenAlias(GDAL_ARG_NAME_READ_ONLY);
+            .AddHiddenAlias(GDAL_ARG_NAME_READ_ONLY)
+            .SetAvailableInPipelineStep(false);
     }
     else
     {

--- a/apps/gdalalg_raster_footprint.cpp
+++ b/apps/gdalalg_raster_footprint.cpp
@@ -38,23 +38,30 @@ GDALRasterFootprintAlgorithm::GDALRasterFootprintAlgorithm(bool standaloneStep)
 
     if (standaloneStep)
     {
-        AddOpenOptionsArg(&m_openOptions);
+        AddOpenOptionsArg(&m_openOptions).SetAvailableInPipelineStep(false);
         AddInputFormatsArg(&m_inputFormats)
-            .AddMetadataItem(GAAMDI_REQUIRED_CAPABILITIES, {GDAL_DCAP_RASTER});
-        AddInputDatasetArg(&m_inputDataset, GDAL_OF_RASTER);
+            .AddMetadataItem(GAAMDI_REQUIRED_CAPABILITIES, {GDAL_DCAP_RASTER})
+            .SetAvailableInPipelineStep(false);
+        AddInputDatasetArg(&m_inputDataset, GDAL_OF_RASTER)
+            .SetAvailableInPipelineStep(false);
 
         AddOutputDatasetArg(&m_outputDataset, GDAL_OF_VECTOR)
-            .SetDatasetInputFlags(GADV_NAME | GADV_OBJECT);
+            .SetDatasetInputFlags(GADV_NAME | GADV_OBJECT)
+            .SetAvailableInPipelineStep(false);
         AddOutputFormatArg(&m_format, /* bStreamAllowed = */ false,
                            /* bGDALGAllowed = */ false)
             .AddMetadataItem(GAAMDI_REQUIRED_CAPABILITIES,
-                             {GDAL_DCAP_VECTOR, GDAL_DCAP_CREATE});
-        AddCreationOptionsArg(&m_creationOptions);
-        AddLayerCreationOptionsArg(&m_layerCreationOptions);
+                             {GDAL_DCAP_VECTOR, GDAL_DCAP_CREATE})
+            .SetAvailableInPipelineStep(false);
+        AddCreationOptionsArg(&m_creationOptions)
+            .SetAvailableInPipelineStep(false);
+        AddLayerCreationOptionsArg(&m_layerCreationOptions)
+            .SetAvailableInPipelineStep(false);
         AddUpdateArg(&m_update)
+            .SetAvailableInPipelineStep(false)
             .SetHidden();  // needed for correct append execution
-        AddAppendLayerArg(&m_appendLayer);
-        AddOverwriteArg(&m_overwrite);
+        AddAppendLayerArg(&m_appendLayer).SetAvailableInPipelineStep(false);
+        AddOverwriteArg(&m_overwrite).SetAvailableInPipelineStep(false);
     }
     else
     {

--- a/apps/gdalalg_raster_pixel_info.cpp
+++ b/apps/gdalalg_raster_pixel_info.cpp
@@ -53,10 +53,12 @@ GDALRasterPixelInfoAlgorithm::GDALRasterPixelInfoAlgorithm(bool standaloneStep)
                            _("Output format (default is 'GeoJSON' if "
                              "'position-dataset' not specified)"))
             .AddMetadataItem(GAAMDI_REQUIRED_CAPABILITIES,
-                             {GDAL_DCAP_VECTOR, GDAL_DCAP_CREATE});
-        AddOpenOptionsArg(&m_openOptions);
+                             {GDAL_DCAP_VECTOR, GDAL_DCAP_CREATE})
+            .SetAvailableInPipelineStep(false);
+        AddOpenOptionsArg(&m_openOptions).SetAvailableInPipelineStep(false);
         AddInputFormatsArg(&m_inputFormats)
-            .AddMetadataItem(GAAMDI_REQUIRED_CAPABILITIES, {GDAL_DCAP_RASTER});
+            .AddMetadataItem(GAAMDI_REQUIRED_CAPABILITIES, {GDAL_DCAP_RASTER})
+            .SetAvailableInPipelineStep(false);
     }
 
     AddInputDatasetArg(&m_inputDataset, GDAL_OF_RASTER)
@@ -88,10 +90,14 @@ GDALRasterPixelInfoAlgorithm::GDALRasterPixelInfoAlgorithm(bool standaloneStep)
         .SetHiddenForCLI(!standaloneStep);
     if (standaloneStep)
     {
-        AddCreationOptionsArg(&m_creationOptions);
-        AddLayerCreationOptionsArg(&m_layerCreationOptions);
-        AddOverwriteArg(&m_overwrite);
-        AddOutputStringArg(&m_output).SetHiddenForCLI();
+        AddCreationOptionsArg(&m_creationOptions)
+            .SetAvailableInPipelineStep(false);
+        AddLayerCreationOptionsArg(&m_layerCreationOptions)
+            .SetAvailableInPipelineStep(false);
+        AddOverwriteArg(&m_overwrite).SetAvailableInPipelineStep(false);
+        AddOutputStringArg(&m_output)
+            .SetHiddenForCLI()
+            .SetAvailableInPipelineStep(false);
     }
 
     AddBandArg(&m_band);

--- a/apps/gdalalg_vector_edit.cpp
+++ b/apps/gdalalg_vector_edit.cpp
@@ -26,10 +26,19 @@
 /************************************************************************/
 
 GDALVectorEditAlgorithm::GDALVectorEditAlgorithm(bool standaloneStep)
-    : GDALVectorPipelineStepAlgorithm(NAME, DESCRIPTION, HELP_URL,
-                                      standaloneStep)
+    : GDALVectorPipelineStepAlgorithm(
+          NAME, DESCRIPTION, HELP_URL,
+          ConstructorOptions()
+              .SetStandaloneStep(standaloneStep)
+              .SetOutputLayerNameAvailableInPipelineStep(true))
 {
     AddActiveLayerArg(&m_activeLayer);
+    if (!standaloneStep)
+    {
+        AddOutputLayerNameArg(/* hiddenForCLI = */ false,
+                              /* shortNameOutputLayerAllowed = */ false);
+    }
+
     AddGeometryTypeArg(&m_geometryType, _("Layer geometry type"));
 
     AddArg("crs", 0, _("Override CRS (without reprojection)"), &m_overrideCrs)
@@ -67,6 +76,25 @@ GDALVectorEditAlgorithm::GDALVectorEditAlgorithm(bool standaloneStep)
     AddArg("unset-fid", 0,
            _("Unset the identifier of each feature and the FID column name"),
            &m_unsetFID);
+
+    AddValidationAction(
+        [this]()
+        {
+            if (!m_outputLayerName.empty() && m_activeLayer.empty() &&
+                m_inputDataset.size() == 1)
+            {
+                auto poSrcDS = m_inputDataset[0].GetDatasetRef();
+                if (poSrcDS && poSrcDS->GetLayerCount() > 1)
+                {
+                    ReportError(CE_Failure, CPLE_IllegalArg,
+                                "Argument 'output-layer' cannot be used when "
+                                "the input dataset has multiple layers, unless "
+                                "argument 'active-layer' is specified");
+                    return false;
+                }
+            }
+            return true;
+        });
 }
 
 namespace
@@ -81,19 +109,23 @@ class GDALVectorEditAlgorithmLayer final : public GDALVectorPipelineOutputLayer
   public:
     GDALVectorEditAlgorithmLayer(
         OGRLayer &oSrcLayer, const std::string &activeLayer,
-        bool bChangeGeomType, OGRwkbGeometryType eType,
-        const std::string &overrideCrs,
+        const std::string &outputLayerName, bool bChangeGeomType,
+        OGRwkbGeometryType eType, const std::string &overrideCrs,
         const std::vector<std::string> &layerMetadata,
         const std::vector<std::string> &unsetLayerMetadata, bool unsetFID)
         : GDALVectorPipelineOutputLayer(oSrcLayer),
           m_bOverrideCrs(!overrideCrs.empty()), m_unsetFID(unsetFID),
           m_poFeatureDefn(oSrcLayer.GetLayerDefn()->Clone())
     {
-        SetDescription(oSrcLayer.GetDescription());
         SetMetadata(oSrcLayer.GetMetadata());
 
-        if (activeLayer.empty() || activeLayer == GetDescription())
+        if (activeLayer.empty() || activeLayer == oSrcLayer.GetDescription())
         {
+            if (!outputLayerName.empty())
+            {
+                m_poFeatureDefn->SetName(outputLayerName.c_str());
+            }
+
             const CPLStringList aosMD(layerMetadata);
             for (const auto &[key, value] : cpl::IterateNameValue(aosMD))
             {
@@ -115,9 +147,9 @@ class GDALVectorEditAlgorithmLayer final : public GDALVectorPipelineOutputLayer
 
             if (bChangeGeomType)
             {
-                for (int i = 0; i < m_poFeatureDefn->GetGeomFieldCount(); ++i)
+                for (auto *poGeomFieldDefns : m_poFeatureDefn->GetGeomFields())
                 {
-                    m_poFeatureDefn->GetGeomFieldDefn(i)->SetType(eType);
+                    poGeomFieldDefns->SetType(eType);
                 }
             }
 
@@ -132,13 +164,14 @@ class GDALVectorEditAlgorithmLayer final : public GDALVectorPipelineOutputLayer
                     CPL_IGNORE_RET_VAL(
                         m_poSRS->SetFromUserInput(overrideCrs.c_str()));
                 }
-                for (int i = 0; i < m_poFeatureDefn->GetGeomFieldCount(); ++i)
+                for (auto *poGeomFieldDefns : m_poFeatureDefn->GetGeomFields())
                 {
-                    m_poFeatureDefn->GetGeomFieldDefn(i)->SetSpatialRef(
-                        m_poSRS.get());
+                    poGeomFieldDefns->SetSpatialRef(m_poSRS.get());
                 }
             }
         }
+
+        SetDescription(m_poFeatureDefn->GetName());
     }
 
     const char *GetFIDColumn() const override
@@ -277,9 +310,10 @@ bool GDALVectorEditAlgorithm::RunStep(GDALPipelineStepRunContext &)
         {
             outDS->AddLayer(*poSrcLayer,
                             std::make_unique<GDALVectorEditAlgorithmLayer>(
-                                *poSrcLayer, m_activeLayer, bChangeGeomType,
-                                eType, m_overrideCrs, m_layerMetadata,
-                                m_unsetLayerMetadata, m_unsetFID));
+                                *poSrcLayer, m_activeLayer, m_outputLayerName,
+                                bChangeGeomType, eType, m_overrideCrs,
+                                m_layerMetadata, m_unsetLayerMetadata,
+                                m_unsetFID));
         }
     }
 

--- a/apps/gdalalg_vector_select.cpp
+++ b/apps/gdalalg_vector_select.cpp
@@ -29,8 +29,11 @@
 /************************************************************************/
 
 GDALVectorSelectAlgorithm::GDALVectorSelectAlgorithm(bool standaloneStep)
-    : GDALVectorPipelineStepAlgorithm(NAME, DESCRIPTION, HELP_URL,
-                                      standaloneStep)
+    : GDALVectorPipelineStepAlgorithm(
+          NAME, DESCRIPTION, HELP_URL,
+          ConstructorOptions()
+              .SetStandaloneStep(standaloneStep)
+              .SetOutputLayerNameAvailableInPipelineStep(true))
 {
     if (!standaloneStep)
     {

--- a/apps/gdalalg_vector_select.cpp
+++ b/apps/gdalalg_vector_select.cpp
@@ -35,12 +35,12 @@ GDALVectorSelectAlgorithm::GDALVectorSelectAlgorithm(bool standaloneStep)
               .SetStandaloneStep(standaloneStep)
               .SetOutputLayerNameAvailableInPipelineStep(true))
 {
+    AddActiveLayerArg(&m_activeLayer);
     if (!standaloneStep)
     {
         AddOutputLayerNameArg(/* hiddenForCLI = */ false,
                               /* shortNameOutputLayerAllowed = */ false);
     }
-    AddActiveLayerArg(&m_activeLayer);
     AddArg("fields", 0, _("Fields to select (or exclude if --exclude)"),
            &m_fields)
         .SetDuplicateValuesAllowed(false)
@@ -52,6 +52,25 @@ GDALVectorSelectAlgorithm::GDALVectorSelectAlgorithm(bool standaloneStep)
     AddArg("ignore-missing-fields", 0, _("Ignore missing fields"),
            &m_ignoreMissingFields)
         .SetMutualExclusionGroup("exclude-ignore");
+
+    AddValidationAction(
+        [this]()
+        {
+            if (!m_outputLayerName.empty() && m_activeLayer.empty() &&
+                m_inputDataset.size() == 1)
+            {
+                auto poSrcDS = m_inputDataset[0].GetDatasetRef();
+                if (poSrcDS && poSrcDS->GetLayerCount() > 1)
+                {
+                    ReportError(CE_Failure, CPLE_IllegalArg,
+                                "Argument 'output-layer' cannot be used when "
+                                "the input dataset has multiple layers, unless "
+                                "argument 'active-layer' is specified");
+                    return false;
+                }
+            }
+            return true;
+        });
 }
 
 namespace

--- a/autotest/cpp/test_gdal_algorithm.cpp
+++ b/autotest/cpp/test_gdal_algorithm.cpp
@@ -4270,7 +4270,8 @@ TEST_F(test_gdal_algorithm, algorithm_c_api)
                 .SetDefault(std::vector<double>{1.5, 2.5});
             AddArg("intlist", 0, "intlist", &m_intlist)
                 .SetDefault(std::vector<int>{1, 2});
-            AddArg("dataset", 0, "dataset", &m_dsValue);
+            AddArg("dataset", 0, "dataset", &m_dsValue)
+                .SetAvailableInPipelineStep(false);
         }
 
         bool
@@ -4437,6 +4438,7 @@ TEST_F(test_gdal_algorithm, algorithm_c_api)
             CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
             EXPECT_EQ(GDALAlgorithmArgGetDefaultAsBoolean(hArg), false);
         }
+        EXPECT_TRUE(GDALAlgorithmArgIsAvailableInPipelineStep(hArg));
         {
             size_t nCount = 0;
             const double *ret =
@@ -4464,6 +4466,7 @@ TEST_F(test_gdal_algorithm, algorithm_c_api)
         EXPECT_EQ(GDALAlgorithmArgGetDatasetInputFlags(hArg),
                   GADV_NAME | GADV_OBJECT);
         EXPECT_EQ(GDALAlgorithmArgGetDatasetOutputFlags(hArg), GADV_OBJECT);
+        EXPECT_FALSE(GDALAlgorithmArgIsAvailableInPipelineStep(hArg));
         GDALArgDatasetValueH hVal = GDALArgDatasetValueCreate();
         GDALArgDatasetValueSetName(hVal, "foo");
 

--- a/autotest/utilities/test_gdalalg_vector_edit.py
+++ b/autotest/utilities/test_gdalalg_vector_edit.py
@@ -220,3 +220,41 @@ def test_error_message_leak():
                 out_filename,
             ],
         )
+
+
+def test_gdalalg_vector_edit_pipeline_output_layer():
+
+    with gdal.alg.vector.pipeline(
+        pipeline="read ../ogr/data/poly.shp ! edit --output-layer foo"
+    ) as alg:
+        ds = alg.Output()
+        lyr = ds.GetLayer(0)
+        assert lyr.GetDescription() == "foo"
+        assert lyr.GetLayerDefn().GetName() == "foo"
+
+
+def test_gdalalg_vector_edit_pipeline_output_layer_multiple_input_layers():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 0, 0, 0, gdal.GDT_Unknown)
+    src_ds.CreateLayer("a")
+    src_ds.CreateLayer("b")
+
+    with pytest.raises(
+        Exception,
+        match="Argument 'output-layer' cannot be used when the input dataset has multiple layers, unless argument 'active-layer' is specified",
+    ):
+        gdal.alg.vector.pipeline(
+            input=src_ds, pipeline="read ! edit --output-layer foo"
+        )
+
+    with gdal.alg.vector.pipeline(
+        input=src_ds, pipeline="read ! edit --active-layer a --output-layer foo"
+    ) as alg:
+        ds = alg.Output()
+        lyr = ds.GetLayer(0)
+        assert lyr.GetDescription() == "foo"
+        assert lyr.GetLayerDefn().GetName() == "foo"
+
+        lyr = ds.GetLayer(1)
+        assert lyr.GetDescription() == "b"
+        assert lyr.GetLayerDefn().GetName() == "b"

--- a/autotest/utilities/test_gdalalg_vector_select.py
+++ b/autotest/utilities/test_gdalalg_vector_select.py
@@ -252,3 +252,31 @@ def test_gdalalg_vector_select_pipeline_output_layer():
         lyr = ds.GetLayer(0)
         assert lyr.GetDescription() == "foo"
         assert lyr.GetLayerDefn().GetName() == "foo"
+
+
+def test_gdalalg_vector_select_pipeline_output_layer_multiple_input_layers():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 0, 0, 0, gdal.GDT_Unknown)
+    src_ds.CreateLayer("a").CreateField(ogr.FieldDefn("x"))
+    src_ds.CreateLayer("b")
+
+    with pytest.raises(
+        Exception,
+        match="Argument 'output-layer' cannot be used when the input dataset has multiple layers, unless argument 'active-layer' is specified",
+    ):
+        gdal.alg.vector.pipeline(
+            input=src_ds, pipeline="read ! select --output-layer foo --fields x"
+        )
+
+    with gdal.alg.vector.pipeline(
+        input=src_ds,
+        pipeline="read ! select --active-layer a --output-layer foo --fields x",
+    ) as alg:
+        ds = alg.Output()
+        lyr = ds.GetLayer(0)
+        assert lyr.GetDescription() == "foo"
+        assert lyr.GetLayerDefn().GetName() == "foo"
+
+        lyr = ds.GetLayer(1)
+        assert lyr.GetDescription() == "b"
+        assert lyr.GetLayerDefn().GetName() == "b"

--- a/gcore/gdal_rasterband.h
+++ b/gcore/gdal_rasterband.h
@@ -24,6 +24,9 @@
 #include <complex>
 #include <iterator>
 #include <memory>
+#if __cplusplus >= 201703L
+#include <optional>
+#endif
 #if __cplusplus >= 202002L
 #include <span>
 #endif
@@ -475,6 +478,40 @@ class CPL_DLL GDALRasterBand : public GDALMajorObject
     virtual double GetNoDataValue(int *pbSuccess = nullptr);
     virtual int64_t GetNoDataValueAsInt64(int *pbSuccess = nullptr);
     virtual uint64_t GetNoDataValueAsUInt64(int *pbSuccess = nullptr);
+
+#if __cplusplus >= 201703L
+    template <class T> inline std::optional<T> GetNoDataValue() const
+    {
+        int bSuccess = false;
+        if constexpr (std::is_same_v<T, int64_t>)
+        {
+            const int64_t v =
+                const_cast<GDALRasterBand *>(this)->GetNoDataValueAsInt64(
+                    &bSuccess);
+            if (!bSuccess)
+                return {};
+            return v;
+        }
+        else if constexpr (std::is_same_v<T, uint64_t>)
+        {
+            const uint64_t v =
+                const_cast<GDALRasterBand *>(this)->GetNoDataValueAsUInt64(
+                    &bSuccess);
+            if (!bSuccess)
+                return {};
+            return v;
+        }
+        else
+        {
+            const double v =
+                const_cast<GDALRasterBand *>(this)->GetNoDataValue(&bSuccess);
+            if (!bSuccess)
+                return {};
+            return v;
+        }
+    }
+#endif
+
     virtual double GetMinimum(int *pbSuccess = nullptr);
     virtual double GetMaximum(int *pbSuccess = nullptr);
     virtual double GetOffset(int *pbSuccess = nullptr);

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -8199,6 +8199,23 @@ bool GDALAlgorithmArgIsOnlyForCLI(GDALAlgorithmArgH hArg)
 }
 
 /************************************************************************/
+/*             GDALAlgorithmArgIsAvailableInPipelineStep()              */
+/************************************************************************/
+
+/** Return whether the argument is available in a pipeline step.
+ *
+ * If false, it is only available in standalone mode.
+ *
+ * @param hArg Handle to an argument. Must NOT be null.
+ * @since 3.13
+ */
+bool GDALAlgorithmArgIsAvailableInPipelineStep(GDALAlgorithmArgH hArg)
+{
+    VALIDATE_POINTER1(hArg, __func__, false);
+    return hArg->ptr->IsAvailableInPipelineStep();
+}
+
+/************************************************************************/
 /*                      GDALAlgorithmArgIsInput()                       */
 /************************************************************************/
 

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -6061,10 +6061,12 @@ void GDALAlgorithm::AddProgressArg()
 {
     AddArg(GDAL_ARG_NAME_QUIET, 'q',
            _("Quiet mode (no progress bar or warning message)"), &m_quiet)
+        .SetAvailableInPipelineStep(false)
         .SetCategory(GAAC_COMMON)
         .AddAction([this]() { m_progressBarRequested = false; });
 
     AddArg("progress", 0, _("Display progress bar"), &m_progressBarRequested)
+        .SetAvailableInPipelineStep(false)
         .SetHidden();
 }
 
@@ -6414,8 +6416,8 @@ GDALAlgorithm::GetUsageForCLI(bool shortUsage,
             maxOptLen = std::max(maxOptLen, userProvidedOpt.size());
 
         const auto OutputArg =
-            [this, maxOptLen, &osRet](const GDALAlgorithmArg *arg,
-                                      const std::string &opt)
+            [this, maxOptLen, &osRet,
+             &usageOptions](const GDALAlgorithmArg *arg, const std::string &opt)
         {
             osRet += "  ";
             osRet += opt;
@@ -6533,6 +6535,12 @@ GDALAlgorithm::GetUsageForCLI(bool shortUsage,
             if (arg->IsRequired())
             {
                 osRet += " [required]";
+            }
+
+            if (!arg->IsAvailableInPipelineStep() &&
+                !usageOptions.isPipelineStep)
+            {
+                osRet += " [not available in pipelines]";
             }
 
             osRet += '\n';
@@ -6755,6 +6763,11 @@ std::string GDALAlgorithm::GetUsageAsJSON() const
                 jArg.Add("metavar", metaVar.substr(1, metaVar.size() - 2));
             else
                 jArg.Add("metavar", metaVar);
+        }
+
+        if (!arg->IsAvailableInPipelineStep())
+        {
+            jArg.Add("available_in_pipeline_step", false);
         }
 
         const auto &choices = arg->GetChoices();

--- a/gcore/gdalalgorithm_c.h
+++ b/gcore/gdalalgorithm_c.h
@@ -186,6 +186,8 @@ bool CPL_DLL GDALAlgorithmArgIsHiddenForCLI(GDALAlgorithmArgH);
 
 bool CPL_DLL GDALAlgorithmArgIsHiddenForAPI(GDALAlgorithmArgH);
 
+bool CPL_DLL GDALAlgorithmArgIsAvailableInPipelineStep(GDALAlgorithmArgH);
+
 #ifndef DOXYGEN_SKIP
 bool CPL_DLL GDALAlgorithmArgIsOnlyForCLI(GDALAlgorithmArgH)
     CPL_WARN_DEPRECATED("Use GDALAlgorithmArgIsHiddenForAPI() instead");

--- a/gcore/gdalalgorithm_cpp.h
+++ b/gcore/gdalalgorithm_cpp.h
@@ -1133,6 +1133,24 @@ class CPL_DLL GDALAlgorithmArgDecl final
         m_datasetOutputFlags = flags;
     }
 
+    /** Set whether the argument is available in a pipeline step.
+     *
+     * If false, it is only available in standalone mode.
+     */
+    void SetAvailableInPipelineStep(bool available)
+    {
+        m_availableInPipelineStep = available;
+    }
+
+    /** Return whether the argument is available in a pipeline step.
+     *
+     * If false, it is only available in standalone mode.
+     */
+    bool IsAvailableInPipelineStep() const
+    {
+        return m_availableInPipelineStep;
+    }
+
   private:
     const std::string m_longName;
     const std::string m_shortName;
@@ -1158,6 +1176,7 @@ class CPL_DLL GDALAlgorithmArgDecl final
     bool m_autoOpenDataset = true;
     bool m_userProvided = false;
     bool m_duplicateValuesAllowed = true;
+    bool m_availableInPipelineStep = true;
     std::map<std::string, std::vector<std::string>> m_metadata{};
     std::vector<std::string> m_aliases{};
     std::vector<std::string> m_hiddenAliases{};
@@ -1492,6 +1511,12 @@ class CPL_DLL GDALAlgorithmArg /* non-final */
     inline int GetDatasetOutputFlags() const
     {
         return m_decl.GetDatasetOutputFlags();
+    }
+
+    /** Alias for GDALAlgorithmArgDecl::IsAvailableInPipelineStep() */
+    inline bool IsAvailableInPipelineStep() const
+    {
+        return m_decl.IsAvailableInPipelineStep();
     }
 
     /** Return the value of the argument, which is by decreasing order of priority:
@@ -2185,6 +2210,13 @@ class CPL_DLL GDALInConstructionAlgorithmArg final : public GDALAlgorithmArg
     SetIsCRSArg(bool noneAllowed = false,
                 const std::vector<std::string> &specialValues =
                     std::vector<std::string>());
+
+    /** Alias for GDALAlgorithmArgDecl::SetAvailableInPipelineStep() */
+    GDALInConstructionAlgorithmArg &SetAvailableInPipelineStep(bool available)
+    {
+        m_decl.SetAvailableInPipelineStep(available);
+        return *this;
+    }
 
     /** Alias for GDALAlgorithmArgDecl::SetUserProvided() */
     GDALInConstructionAlgorithmArg &SetUserProvided()

--- a/swig/include/Algorithm.i
+++ b/swig/include/Algorithm.i
@@ -182,6 +182,10 @@ public:
     return GDALAlgorithmArgIsHiddenForAPI(self);
   }
 
+  bool IsAvailableInPipelineStep() {
+    return GDALAlgorithmArgIsAvailableInPipelineStep(self);
+  }
+
   bool IsInput() {
     return GDALAlgorithmArgIsInput(self);
   }


### PR DESCRIPTION
and gdal vector edit: add --output-layer in pipeline mode too

Fixes #14389

```bash
$ gdal vector edit --help
Usage: gdal vector edit [OPTIONS] <INPUT> <OUTPUT>

Edit metadata of a vector dataset.

Positional arguments:
  -i, --input <INPUT>                                  Input vector datasets [required] [not in pipelines]
  -o, --output <OUTPUT>                                Output vector dataset [required] [not in pipelines]

Common Options:
  -h, --help                                           Display help message and exit
  --json-usage                                         Display usage as JSON document and exit
  --config <KEY>=<VALUE>                               Configuration option [may be repeated]
  -q, --quiet                                          Quiet mode (no progress bar or warning message) [not in pipelines]

Options:
  -l, --layer, --input-layer <INPUT-LAYER>             Input layer name(s) [may be repeated] [not in pipelines]
  -f, --of, --format, --output-format <OUTPUT-FORMAT>  Output format ("GDALG" allowed) [not in pipelines]
  --co, --creation-option <KEY>=<VALUE>                Creation option [may be repeated] [not in pipelines]
  --lco, --layer-creation-option <KEY>=<VALUE>         Layer creation option [may be repeated] [not in pipelines]
  --overwrite                                          Whether overwriting existing output dataset is allowed [not in pipelines]
  --update                                             Whether to open existing dataset in update mode [not in pipelines]
  --overwrite-layer                                    Whether overwriting existing output layer is allowed [not in pipelines]
  --append                                             Whether appending to existing layer is allowed [not in pipelines]
                                                       Mutually exclusive with --upsert
  --output-layer <OUTPUT-LAYER>                        Output layer name
  --skip-errors                                        Skip errors when writing features [not in pipelines]
  --active-layer <ACTIVE-LAYER>                        Set active layer (if not specified, all)
  --geometry-type <GEOMETRY-TYPE>                      Layer geometry type
  --crs <CRS>                                          Override CRS (without reprojection)
  --metadata <KEY>=<VALUE>                             Add/update dataset metadata item [may be repeated]
  --unset-metadata <KEY>                               Remove dataset metadata item [may be repeated]
  --layer-metadata <KEY>=<VALUE>                       Add/update layer metadata item [may be repeated]
  --unset-layer-metadata <KEY>                         Remove layer metadata item [may be repeated]
  --unset-fid                                          Unset the identifier of each feature and the FID column name

Advanced Options:
  --if, --input-format <INPUT-FORMAT>                  Input formats [may be repeated] [not in pipelines]
  --oo, --open-option <KEY>=<VALUE>                    Open options [may be repeated] [not in pipelines]
  --output-oo, --output-open-option <KEY>=<VALUE>      Output open options [may be repeated] [not in pipelines]
  --upsert                                             Upsert features (implies 'append') [not in pipelines]
                                                       Mutually exclusive with --append
```
