### PR TITLE
OGR C++ API: replace all uses of 'OGRBoolean' (aliased to 'int') with 'bool'

### DIFF
--- a/alg/gdalwarper.cpp
+++ b/alg/gdalwarper.cpp
@@ -392,7 +392,7 @@ CPLErr GDALWarpNoDataMasker(void *pMaskFuncArg, int nBandCount,
         {
             const float fNoData = static_cast<float>(padfNoData[0]);
             const float *pafData = reinterpret_cast<float *>(*ppImageData);
-            const bool bIsNoDataNan = CPL_TO_BOOL(std::isnan(fNoData));
+            const bool bIsNoDataNan = std::isnan(fNoData);
 
             // Nothing to do if value is out of range.
             if (padfNoData[1] != 0.0)
@@ -420,7 +420,7 @@ CPLErr GDALWarpNoDataMasker(void *pMaskFuncArg, int nBandCount,
         {
             const double dfNoData = padfNoData[0];
             const double *padfData = reinterpret_cast<double *>(*ppImageData);
-            const bool bIsNoDataNan = CPL_TO_BOOL(std::isnan(dfNoData));
+            const bool bIsNoDataNan = std::isnan(dfNoData);
 
             // Nothing to do if value is out of range.
             if (padfNoData[1] != 0.0)
@@ -448,8 +448,7 @@ CPLErr GDALWarpNoDataMasker(void *pMaskFuncArg, int nBandCount,
         {
             const int nWordSize = GDALGetDataTypeSizeBytes(eType);
 
-            const bool bIsNoDataRealNan =
-                CPL_TO_BOOL(std::isnan(padfNoData[0]));
+            const bool bIsNoDataRealNan = std::isnan(padfNoData[0]);
 
             eErr = CE_Failure;
             double *padfWrk = static_cast<double *>(

--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -2032,11 +2032,11 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
                 pszMin != nullptr && pszMax != nullptr)
             {
                 const bool bSrcIsInteger =
-                    CPL_TO_BOOL(GDALDataTypeIsInteger(eSrcBandType) &&
-                                !GDALDataTypeIsComplex(eSrcBandType));
+                    CPL_TO_BOOL(GDALDataTypeIsInteger(eSrcBandType)) &&
+                    !CPL_TO_BOOL(GDALDataTypeIsComplex(eSrcBandType));
                 const bool bDstIsInteger =
-                    CPL_TO_BOOL(GDALDataTypeIsInteger(eBandType) &&
-                                !GDALDataTypeIsComplex(eBandType));
+                    CPL_TO_BOOL(GDALDataTypeIsInteger(eBandType)) &&
+                    !CPL_TO_BOOL(GDALDataTypeIsComplex(eBandType));
                 if (bSrcIsInteger && bDstIsInteger)
                 {
                     std::int64_t nDstMin = 0;

--- a/apps/gdalalg_vector_make_valid.cpp
+++ b/apps/gdalalg_vector_make_valid.cpp
@@ -100,7 +100,7 @@ std::unique_ptr<OGRFeature> GDALVectorMakeValidAlgorithmLayer::TranslateFeature(
                     wkbFlatten(poGeom->getGeometryType()) ==
                     wkbGeometryCollection;
 #if GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR <= 11
-                const bool bSrcIs3D = CPL_TO_BOOL(poGeom->Is3D());
+                const bool bSrcIs3D = poGeom->Is3D();
 #endif
                 poGeom.reset(poGeom->MakeValid(m_aosMakeValidOptions.List()));
                 if (poGeom)

--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -4629,8 +4629,7 @@ SetupTargetLayer::Setup(OGRLayer *poSrcLayer, const char *pszNewLayerName,
                 eGType = wkbNone;
             }
 
-            bool bHasZ =
-                CPL_TO_BOOL(wkbHasZ(static_cast<OGRwkbGeometryType>(eGType)));
+            const bool bHasZ = wkbHasZ(static_cast<OGRwkbGeometryType>(eGType));
             eGType = ConvertType(m_eGeomTypeConversion,
                                  static_cast<OGRwkbGeometryType>(eGType));
 

--- a/autotest/cpp/test_ogr.cpp
+++ b/autotest/cpp/test_ogr.cpp
@@ -271,7 +271,7 @@ template <class T> void testCopyEquals()
 
     T value2(*poOrigin);
 
-    ASSERT_TRUE(CPL_TO_BOOL(poOrigin->Equals(&value2)))
+    ASSERT_TRUE(poOrigin->Equals(&value2))
         << poOrigin->getGeometryName() << ": copy constructor changed a value";
 
     T value3;
@@ -288,7 +288,7 @@ template <class T> void testCopyEquals()
     CPLFree(wkt1);
     CPLFree(wkt2);
 #endif
-    ASSERT_TRUE(CPL_TO_BOOL(poOrigin->Equals(&value3)))
+    ASSERT_TRUE(poOrigin->Equals(&value3))
         << poOrigin->getGeometryName()
         << ": assignment operator changed a value";
 
@@ -389,7 +389,7 @@ template <class T> void testMove()
         T fromMoved(std::move(*poOrigin));
         EXPECT_EQ(poSRS->GetReferenceCount(), refCountBefore);
 
-        ASSERT_TRUE(CPL_TO_BOOL(fromMoved.Equals(&valueCopy)))
+        ASSERT_TRUE(fromMoved.Equals(&valueCopy))
             << valueCopy.getGeometryName()
             << ": move constructor changed a value";
         EXPECT_EQ(fromMoved.getSpatialReference(), poSRS);
@@ -401,7 +401,7 @@ template <class T> void testMove()
         value3 = std::move(valueCopy);
         EXPECT_EQ(poSRS->GetReferenceCount(), refCountBefore2);
 
-        ASSERT_TRUE(CPL_TO_BOOL(value3.Equals(&valueCopy2)))
+        ASSERT_TRUE(value3.Equals(&valueCopy2))
             << valueCopy2.getGeometryName()
             << ": move assignment operator changed a value";
         EXPECT_EQ(value3.getSpatialReference(), poSRS);

--- a/doc/source/user/migration_guide.rst
+++ b/doc/source/user/migration_guide.rst
@@ -4,6 +4,14 @@
 Migration guide
 ================================================================================
 
+From GDAL 3.13 to GDAL 3.14
+---------------------------
+
+- Changes impacting C++ users:
+
+    * All methods accepting or returning ``OGRBoolean`` (aliased to ``int``)
+      have been changed to use ``bool`` instead.
+
 From GDAL 3.12 to GDAL 3.13
 ---------------------------
 

--- a/frmts/gtiff/gt_wkt_srs.cpp
+++ b/frmts/gtiff/gt_wkt_srs.cpp
@@ -2079,7 +2079,7 @@ int GTIFSetFromOGISDefnEx(GTIF *psGTIF, OGRSpatialReferenceH hSRS,
         {
             OGRSpatialReference oSRSTmp(*poSRS);
             oSRSTmp.StripVertical();
-            bHasEllipsoid = CPL_TO_BOOL(!oSRSTmp.IsLocal());
+            bHasEllipsoid = !oSRSTmp.IsLocal();
         }
         if (bHasEllipsoid)
         {

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -525,8 +525,7 @@ inline bool GTiffDataset::IsFirstPixelEqualToNoData(const void *pBuffer)
     if (m_nBitsPerSample == 32 && eDT == GDT_Float32)
     {
         if (std::isnan(m_dfNoDataValue))
-            return CPL_TO_BOOL(
-                std::isnan(*(static_cast<const float *>(pBuffer))));
+            return std::isnan(*(static_cast<const float *>(pBuffer)));
         return GDALIsValueInRange<float>(dfEffectiveNoData) &&
                *(static_cast<const float *>(pBuffer)) ==
                    static_cast<float>(dfEffectiveNoData);
@@ -534,8 +533,7 @@ inline bool GTiffDataset::IsFirstPixelEqualToNoData(const void *pBuffer)
     if (m_nBitsPerSample == 64 && eDT == GDT_Float64)
     {
         if (std::isnan(dfEffectiveNoData))
-            return CPL_TO_BOOL(
-                std::isnan(*(static_cast<const double *>(pBuffer))));
+            return std::isnan(*(static_cast<const double *>(pBuffer)));
         return *(static_cast<const double *>(pBuffer)) == dfEffectiveNoData;
     }
     return false;

--- a/frmts/heif/heifdataset.cpp
+++ b/frmts/heif/heifdataset.cpp
@@ -457,7 +457,7 @@ void GDALHEIFDataset::ReadMetadata()
 
             const bool bLittleEndianTIFF = data[nTIFFFileOffset] == 'I' &&
                                            data[nTIFFFileOffset + 1] == 'I';
-            constexpr bool bLSBPlatform = CPL_IS_LSB != 0;
+            constexpr bool bLSBPlatform = CPL_IS_LSB;
             const bool bSwabflag = bLittleEndianTIFF != bLSBPlatform;
 
             uint32_t nTIFFDirOff;
@@ -866,16 +866,28 @@ CPLErr GDALHEIFRasterBand::IReadBlock(int nBlockXOff, int nBlockYOff,
     struct heif_decoding_options *decode_options =
         heif_decoding_options_alloc();
 
+    const auto interleaveRRGGBB = []()
+    {
+        if constexpr (CPL_IS_LSB)
+            return heif_chroma_interleaved_RRGGBB_LE;
+        else
+            return heif_chroma_interleaved_RRGGBB_BE;
+    }();
+
+    const auto interleaveRRGGBBAA = []()
+    {
+        if constexpr (CPL_IS_LSB)
+            return heif_chroma_interleaved_RRGGBBAA_LE;
+        else
+            return heif_chroma_interleaved_RRGGBBAA_BE;
+    }();
+
     auto err = heif_image_handle_decode_image_tile(
         poGDS->m_hImageHandle, &hImage, heif_colorspace_RGB,
-        nBands == 3 ? (eDataType == GDT_UInt16
-                           ? (CPL_IS_LSB ? heif_chroma_interleaved_RRGGBB_LE
-                                         : heif_chroma_interleaved_RRGGBB_BE)
-                           : heif_chroma_interleaved_RGB)
-                    : (eDataType == GDT_UInt16
-                           ? (CPL_IS_LSB ? heif_chroma_interleaved_RRGGBBAA_LE
-                                         : heif_chroma_interleaved_RRGGBBAA_BE)
-                           : heif_chroma_interleaved_RGBA),
+        nBands == 3 ? (eDataType == GDT_UInt16 ? interleaveRRGGBB
+                                               : heif_chroma_interleaved_RGB)
+                    : (eDataType == GDT_UInt16 ? interleaveRRGGBBAA
+                                               : heif_chroma_interleaved_RGBA),
         decode_options, nBlockXOff, nBlockYOff);
 
     if (err.code != heif_error_Ok)
@@ -933,25 +945,37 @@ CPLErr GDALHEIFRasterBand::IReadBlock(int, int nBlockYOff, void *pImage)
     const int nBands = poGDS->GetRasterCount();
     if (poGDS->m_hImage == nullptr)
     {
+#if LIBHEIF_NUMERIC_VERSION >= BUILD_LIBHEIF_VERSION(1, 4, 0)
+        const auto interleaveRRGGBB = []()
+        {
+            if constexpr (CPL_IS_LSB)
+                return heif_chroma_interleaved_RRGGBB_LE;
+            else
+                return heif_chroma_interleaved_RRGGBB_BE;
+        }();
+
+        const auto interleaveRRGGBBAA = []()
+        {
+            if constexpr (CPL_IS_LSB)
+                return heif_chroma_interleaved_RRGGBBAA_LE;
+            else
+                return heif_chroma_interleaved_RRGGBBAA_BE;
+        }();
+#endif
+
         auto err = heif_decode_image(
             poGDS->m_hImageHandle, &(poGDS->m_hImage), heif_colorspace_RGB,
             nBands == 3
                 ? (
 #if LIBHEIF_NUMERIC_VERSION >= BUILD_LIBHEIF_VERSION(1, 4, 0)
-                      eDataType == GDT_UInt16
-                          ? (CPL_IS_LSB ? heif_chroma_interleaved_RRGGBB_LE
-                                        : heif_chroma_interleaved_RRGGBB_BE)
-                          :
+                      eDataType == GDT_UInt16 ? interleaveRRGGBB :
 #endif
-                          heif_chroma_interleaved_RGB)
+                                              heif_chroma_interleaved_RGB)
                 : (
 #if LIBHEIF_NUMERIC_VERSION >= BUILD_LIBHEIF_VERSION(1, 4, 0)
-                      eDataType == GDT_UInt16
-                          ? (CPL_IS_LSB ? heif_chroma_interleaved_RRGGBBAA_LE
-                                        : heif_chroma_interleaved_RRGGBBAA_BE)
-                          :
+                      eDataType == GDT_UInt16 ? interleaveRRGGBBAA :
 #endif
-                          heif_chroma_interleaved_RGBA),
+                                              heif_chroma_interleaved_RGBA),
             nullptr);
         if (err.code != heif_error_Ok)
         {

--- a/frmts/raw/byndataset.cpp
+++ b/frmts/raw/byndataset.cpp
@@ -334,7 +334,7 @@ GDALDataset *BYNDataset::Open(GDALOpenInfo *poOpenInfo)
 
     const int nDTSize = GDALGetDataTypeSizeBytes(eDT);
 
-    int bIsLSB = poDS->hHeader.nByteOrder == 1 ? 1 : 0;
+    const bool bIsLSB = poDS->hHeader.nByteOrder == 1;
 
     auto poBand = std::make_unique<BYNRasterBand>(
         poDS.get(), 1, poDS->fpImage, BYN_HDR_SZ, nDTSize,

--- a/frmts/raw/envidataset.cpp
+++ b/frmts/raw/envidataset.cpp
@@ -2270,7 +2270,7 @@ ENVIDataset *ENVIDataset::Open(GDALOpenInfo *poOpenInfo, bool bFileSizeCheck)
     const char *pszMapInfo = poDS->m_aosHeader["map_info"];
     if (pszMapInfo != nullptr)
     {
-        poDS->bFoundMapinfo = CPL_TO_BOOL(poDS->ProcessMapinfo(pszMapInfo));
+        poDS->bFoundMapinfo = poDS->ProcessMapinfo(pszMapInfo);
     }
 
     // Look for RPC.

--- a/frmts/raw/rrasterdataset.cpp
+++ b/frmts/raw/rrasterdataset.cpp
@@ -1150,11 +1150,11 @@ GDALDataset *RRASTERDataset::Open(GDALOpenInfo *poOpenInfo)
     bool bNativeOrder = true;
     if (EQUAL(osByteOrder, "little"))
     {
-        bNativeOrder = CPL_TO_BOOL(CPL_IS_LSB);
+        bNativeOrder = CPL_IS_LSB;
     }
     else if (EQUAL(osByteOrder, "big"))
     {
-        bNativeOrder = CPL_TO_BOOL(!CPL_IS_LSB);
+        bNativeOrder = !CPL_IS_LSB;
     }
     else if (!EQUAL(osByteOrder, ""))
     {

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -2635,8 +2635,7 @@ CPLErr VRTDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
         }
     }
 
-    bool bLocalCompatibleForDatasetIO =
-        CPL_TO_BOOL(CheckCompatibleForDatasetIO());
+    bool bLocalCompatibleForDatasetIO = CheckCompatibleForDatasetIO();
     if (bLocalCompatibleForDatasetIO && eRWFlag == GF_Read &&
         (nBufXSize < nXSize || nBufYSize < nYSize) && m_apoOverviews.empty())
     {

--- a/gcore/gdaljp2metadata.cpp
+++ b/gcore/gdaljp2metadata.cpp
@@ -140,8 +140,8 @@ int GDALJP2Metadata::ReadAndParse(const char *pszFilename, int nGEOJP2Index,
          !m_bHaveGeoTransform))
     {
         m_bHaveGeoTransform =
-            CPL_TO_BOOL(GDALReadWorldFile(pszFilename, nullptr, m_gt.data()) ||
-                        GDALReadWorldFile(pszFilename, ".wld", m_gt.data()));
+            CPL_TO_BOOL(GDALReadWorldFile(pszFilename, nullptr, m_gt.data())) ||
+            CPL_TO_BOOL(GDALReadWorldFile(pszFilename, ".wld", m_gt.data()));
         bRet |= m_bHaveGeoTransform;
     }
 

--- a/gcore/overview.cpp
+++ b/gcore/overview.cpp
@@ -1238,7 +1238,7 @@ GDALResampleChunk_AverageOrRMS_T(const GDALOverviewResampleArgs &args,
     const GDALColorTable *const poColorTable =
         !bQuadraticMean &&
                 // AVERAGE_BIT2GRAYSCALE
-                CPL_TO_BOOL(STARTS_WITH_CI(pszResampling, "AVERAGE_BIT2G"))
+                STARTS_WITH_CI(pszResampling, "AVERAGE_BIT2G")
             ? nullptr
             : args.poColorTable;
     const bool bPropagateNoData = args.bPropagateNoData;

--- a/ogr/ogr2gmlgeometry.cpp
+++ b/ogr/ogr2gmlgeometry.cpp
@@ -101,7 +101,7 @@ static void AppendCoordinateList(const OGRLineString *poLine, char **ppszText,
                                  const OGRWktOptions &coordOpts)
 
 {
-    const bool b3D = wkbHasZ(poLine->getGeometryType()) != FALSE;
+    const bool b3D = wkbHasZ(poLine->getGeometryType());
 
     *pnLength += strlen(*ppszText + *pnLength);
     _GrowBuffer(*pnLength + 20, ppszText, pnMaxLength);

--- a/ogr/ogr2kmlgeometry.cpp
+++ b/ogr/ogr2kmlgeometry.cpp
@@ -141,7 +141,7 @@ static bool AppendCoordinateList(const OGRLineString *poLine, char **ppszText,
 
 {
     char szCoordinate[256] = {0};
-    const bool b3D = CPL_TO_BOOL(wkbHasZ(poLine->getGeometryType()));
+    const bool b3D = wkbHasZ(poLine->getGeometryType());
 
     AppendString(ppszText, pnLength, pnMaxLength, "<coordinates>");
 

--- a/ogr/ogr_api.cpp
+++ b/ogr/ogr_api.cpp
@@ -1953,7 +1953,7 @@ bool OGR_G_IsClockwise(OGRGeometryH hGeom)
     const OGRwkbGeometryType eGType = wkbFlatten(poGeom->getGeometryType());
     if (OGR_GT_IsCurve(eGType))
     {
-        return CPL_TO_BOOL(poGeom->toCurve()->isClockwise());
+        return poGeom->toCurve()->isClockwise();
     }
     else
     {

--- a/ogr/ogr_feature.h
+++ b/ogr/ogr_feature.h
@@ -1377,7 +1377,7 @@ class CPL_DLL OGRFeature
     void Reset();
 
     OGRFeature *Clone() const CPL_WARN_UNUSED_RESULT;
-    virtual OGRBoolean Equal(const OGRFeature *poFeature) const;
+    virtual bool Equal(const OGRFeature *poFeature) const;
 
     int GetFieldCount() const
     {

--- a/ogr/ogr_geometry.h
+++ b/ogr/ogr_geometry.h
@@ -1366,7 +1366,7 @@ class CPL_DLL OGRCurve : public OGRGeometry
         const OGRSpatialReference *poSRSOverride = nullptr) const = 0;
     virtual double get_GeodesicLength(
         const OGRSpatialReference *poSRSOverride = nullptr) const = 0;
-    virtual int isClockwise() const;
+    virtual bool isClockwise() const;
     virtual void reversePoints() = 0;
 
     /** Down-cast to OGRSimpleCurve*.
@@ -1776,7 +1776,7 @@ class CPL_DLL OGRLineString : public OGRSimpleCurve
     // Non-standard from OGRGeometry.
     OGRwkbGeometryType getGeometryType() const override;
     const char *getGeometryName() const override;
-    int isClockwise() const override;
+    bool isClockwise() const override;
 
     /** Return pointer of this in upper class */
     inline OGRSimpleCurve *toUpperClass()

--- a/ogr/ogr_geometry.h
+++ b/ogr/ogr_geometry.h
@@ -1350,7 +1350,7 @@ class CPL_DLL OGRCurve : public OGRGeometry
     virtual double get_Length() const = 0;
     virtual void StartPoint(OGRPoint *) const = 0;
     virtual void EndPoint(OGRPoint *) const = 0;
-    virtual int get_IsClosed() const;
+    virtual bool get_IsClosed() const;
     virtual void Value(double, OGRPoint *) const = 0;
     virtual OGRLineString *
     CurveToLine(double dfMaxAngleStepSizeDegrees = 0,

--- a/ogr/ogr_geometry.h
+++ b/ogr/ogr_geometry.h
@@ -380,7 +380,7 @@ class CPL_DLL OGRGeometry
                                              int &nGeomCount,
                                              OGRwkbVariant eWkbVariant);
     OGRErr PointOnSurfaceInternal(OGRPoint *poPoint) const;
-    OGRBoolean IsSFCGALCompatible() const;
+    bool IsSFCGALCompatible() const;
 
     void HomogenizeDimensionalityWith(OGRGeometry *poOtherGeom);
     std::string wktTypeString(OGRwkbVariant variant) const;
@@ -412,38 +412,38 @@ class CPL_DLL OGRGeometry
     /** Returns if two geometries are equal. */
     bool operator==(const OGRGeometry &other) const
     {
-        return CPL_TO_BOOL(Equals(&other));
+        return Equals(&other);
     }
 
     /** Returns if two geometries are different. */
     bool operator!=(const OGRGeometry &other) const
     {
-        return !CPL_TO_BOOL(Equals(&other));
+        return !Equals(&other);
     }
 
     // Standard IGeometry.
     virtual int getDimension() const = 0;
     virtual int getCoordinateDimension() const;
     int CoordinateDimension() const;
-    virtual OGRBoolean IsEmpty() const = 0;
-    virtual OGRBoolean IsValid(std::string *posReason = nullptr) const;
+    virtual bool IsEmpty() const = 0;
+    virtual bool IsValid(std::string *posReason = nullptr) const;
     virtual OGRGeometry *MakeValid(CSLConstList papszOptions = nullptr) const;
     virtual OGRGeometry *Normalize() const;
-    virtual OGRBoolean IsSimple() const;
+    virtual bool IsSimple() const;
 
     /*! Returns whether the geometry has a Z component. */
-    OGRBoolean Is3D() const
+    bool Is3D() const
     {
         return (flags & OGR_G_3D) != 0;
     }
 
     /*! Returns whether the geometry has a M component. */
-    OGRBoolean IsMeasured() const
+    bool IsMeasured() const
     {
         return (flags & OGR_G_MEASURED) != 0;
     }
 
-    virtual OGRBoolean IsRing() const;
+    virtual bool IsRing() const;
     virtual void empty() = 0;
     virtual OGRGeometry *clone() const CPL_WARN_UNUSED_RESULT = 0;
     virtual void getEnvelope(OGREnvelope *psEnvelope) const = 0;
@@ -508,7 +508,7 @@ class CPL_DLL OGRGeometry
     GEOSGeom
     exportToGEOS(GEOSContextHandle_t hGEOSCtxt, bool bRemoveEmptyParts = false,
                  bool bAddPointsIfNeeded = false) const CPL_WARN_UNUSED_RESULT;
-    virtual OGRBoolean hasCurveGeometry(int bLookForNonLinear = FALSE) const;
+    virtual bool hasCurveGeometry(int bLookForNonLinear = FALSE) const;
     virtual OGRGeometry *getCurveGeometry(
         const char *const *papszOptions = nullptr) const CPL_WARN_UNUSED_RESULT;
     virtual OGRGeometry *getLinearGeometry(
@@ -527,8 +527,8 @@ class CPL_DLL OGRGeometry
     virtual void closeRings();
 
     virtual bool setCoordinateDimension(int nDimension);
-    virtual bool set3D(OGRBoolean bIs3D);
-    virtual bool setMeasured(OGRBoolean bIsMeasured);
+    virtual bool set3D(bool bIs3D);
+    virtual bool setMeasured(bool bIsMeasured);
 
     virtual void assignSpatialReference(const OGRSpatialReference *poSR);
 
@@ -543,14 +543,14 @@ class CPL_DLL OGRGeometry
     virtual bool segmentize(double dfMaxLength);
 
     // ISpatialRelation
-    virtual OGRBoolean Intersects(const OGRGeometry *) const;
-    virtual OGRBoolean Equals(const OGRGeometry *) const = 0;
-    OGRBoolean Disjoint(const OGRGeometry *) const;
-    OGRBoolean Touches(const OGRGeometry *) const;
-    OGRBoolean Crosses(const OGRGeometry *) const;
-    virtual OGRBoolean Within(const OGRGeometry *) const;
-    virtual OGRBoolean Contains(const OGRGeometry *) const;
-    OGRBoolean Overlaps(const OGRGeometry *) const;
+    virtual bool Intersects(const OGRGeometry *) const;
+    virtual bool Equals(const OGRGeometry *) const = 0;
+    bool Disjoint(const OGRGeometry *) const;
+    bool Touches(const OGRGeometry *) const;
+    bool Crosses(const OGRGeometry *) const;
+    virtual bool Within(const OGRGeometry *) const;
+    virtual bool Contains(const OGRGeometry *) const;
+    bool Overlaps(const OGRGeometry *) const;
 
     OGRGeometry *Boundary() const CPL_WARN_UNUSED_RESULT;
 
@@ -612,12 +612,11 @@ class CPL_DLL OGRGeometry
 
     //! @cond Doxygen_Suppress
     // backward compatibility to non-standard method names.
-    OGRBoolean Intersect(OGRGeometry *) const
+    bool Intersect(OGRGeometry *) const
         CPL_WARN_DEPRECATED("Non standard method. "
                             "Use Intersects() instead");
-    OGRBoolean Equal(OGRGeometry *) const
-        CPL_WARN_DEPRECATED("Non standard method. "
-                            "Use Equals() instead");
+    bool Equal(OGRGeometry *) const CPL_WARN_DEPRECATED("Non standard method. "
+                                                        "Use Equals() instead");
     OGRGeometry *SymmetricDifference(const OGRGeometry *) const
         CPL_WARN_DEPRECATED("Non standard method. "
                             "Use SymDifference() instead");
@@ -1156,7 +1155,7 @@ class CPL_DLL OGRPoint : public OGRGeometry
     void getEnvelope(OGREnvelope *psEnvelope) const override;
     void getEnvelope(OGREnvelope3D *psEnvelope) const override;
 
-    OGRBoolean IsEmpty() const override
+    bool IsEmpty() const override
     {
         return !(flags & OGR_G_NOT_EMPTY_POINT);
     }
@@ -1232,9 +1231,9 @@ class CPL_DLL OGRPoint : public OGRGeometry
     }
 
     // ISpatialRelation
-    OGRBoolean Equals(const OGRGeometry *) const override;
-    OGRBoolean Intersects(const OGRGeometry *) const override;
-    OGRBoolean Within(const OGRGeometry *) const override;
+    bool Equals(const OGRGeometry *) const override;
+    bool Intersects(const OGRGeometry *) const override;
+    bool Within(const OGRGeometry *) const override;
 
     // Non standard from OGRGeometry
     const char *getGeometryName() const override;
@@ -1273,7 +1272,7 @@ class CPL_DLL OGRPointIterator
 {
   public:
     virtual ~OGRPointIterator();
-    virtual OGRBoolean getNextPoint(OGRPoint *p) = 0;
+    virtual bool getNextPoint(OGRPoint *p) = 0;
 
     static void destroy(OGRPointIterator *);
 };
@@ -1361,7 +1360,7 @@ class CPL_DLL OGRCurve : public OGRGeometry
     // non standard
     virtual int getNumPoints() const = 0;
     virtual OGRPointIterator *getPointIterator() const = 0;
-    virtual OGRBoolean IsConvex() const;
+    virtual bool IsConvex() const;
     virtual double get_Area() const = 0;
     virtual double get_GeodesicArea(
         const OGRSpatialReference *poSRSOverride = nullptr) const = 0;
@@ -1612,7 +1611,7 @@ class CPL_DLL OGRSimpleCurve : public OGRCurve
     void empty() override;
     void getEnvelope(OGREnvelope *psEnvelope) const override;
     void getEnvelope(OGREnvelope3D *psEnvelope) const override;
-    OGRBoolean IsEmpty() const override;
+    bool IsEmpty() const override;
     OGRSimpleCurve *clone() const override = 0;
 
     // ICurve methods.
@@ -1645,12 +1644,12 @@ class CPL_DLL OGRSimpleCurve : public OGRCurve
     double getM(int i) const;
 
     // ISpatialRelation
-    OGRBoolean Equals(const OGRGeometry *) const override;
+    bool Equals(const OGRGeometry *) const override;
 
     // non standard.
     bool setCoordinateDimension(int nDimension) override;
-    bool set3D(OGRBoolean bIs3D) override;
-    bool setMeasured(OGRBoolean bIsMeasured) override;
+    bool set3D(bool bIs3D) override;
+    bool setMeasured(bool bIsMeasured) override;
     bool setNumPoints(int nNewPointCount, int bZeroizeNewContent = TRUE);
     bool setPoint(int, OGRPoint *);
     bool setPoint(int, double, double);
@@ -1883,10 +1882,9 @@ class CPL_DLL OGRLinearRing : public OGRLineString
     //! @endcond
 
     void closeRings() override;
-    OGRBoolean isPointInRing(const OGRPoint *pt,
-                             int bTestEnvelope = TRUE) const;
-    OGRBoolean isPointOnRingBoundary(const OGRPoint *pt,
-                                     int bTestEnvelope = TRUE) const;
+    bool isPointInRing(const OGRPoint *pt, int bTestEnvelope = TRUE) const;
+    bool isPointOnRingBoundary(const OGRPoint *pt,
+                               int bTestEnvelope = TRUE) const;
     OGRErr transform(OGRCoordinateTransformation *poCT) override;
 
     /** Return pointer of this in upper class */
@@ -1934,7 +1932,7 @@ class CPL_DLL OGRCircularString : public OGRSimpleCurve
 {
   private:
     void ExtendEnvelopeWithCircular(OGREnvelope *psEnvelope) const;
-    OGRBoolean IsValidFast(std::string *posReason = nullptr) const;
+    bool IsValidFast(std::string *posReason = nullptr) const;
     int IsFullCircle(double &cx, double &cy, double &square_R) const;
 
   protected:
@@ -1982,7 +1980,7 @@ class CPL_DLL OGRCircularString : public OGRSimpleCurve
                                     OGRErr *err = nullptr) const override;
 
     // IGeometry interface.
-    OGRBoolean IsValid(std::string *posReason = nullptr) const override;
+    bool IsValid(std::string *posReason = nullptr) const override;
     void getEnvelope(OGREnvelope *psEnvelope) const override;
     void getEnvelope(OGREnvelope3D *psEnvelope) const override;
     OGRCircularString *clone() const override;
@@ -2003,8 +2001,7 @@ class CPL_DLL OGRCircularString : public OGRSimpleCurve
     OGRwkbGeometryType getGeometryType() const override;
     const char *getGeometryName() const override;
     bool segmentize(double dfMaxLength) override;
-    virtual OGRBoolean
-    hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
+    bool hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
     virtual OGRGeometry *
     getLinearGeometry(double dfMaxAngleStepSizeDegrees = 0,
                       const char *const *papszOptions = nullptr) const override;
@@ -2099,7 +2096,7 @@ class CPL_DLL OGRCurveCollection
     }
 
     void empty(OGRGeometry *poGeom);
-    OGRBoolean IsEmpty() const;
+    bool IsEmpty() const;
     void getEnvelope(OGREnvelope *psEnvelope) const;
     void getEnvelope(OGREnvelope3D *psEnvelope) const;
 
@@ -2122,10 +2119,10 @@ class CPL_DLL OGRCurveCollection
                             OGRErr *err) const;
     OGRErr exportToWkb(const OGRGeometry *poGeom, unsigned char *,
                        const OGRwkbExportOptions * = nullptr) const;
-    OGRBoolean Equals(const OGRCurveCollection *poOCC) const;
+    bool Equals(const OGRCurveCollection *poOCC) const;
     bool setCoordinateDimension(OGRGeometry *poGeom, int nNewDimension);
-    bool set3D(OGRGeometry *poGeom, OGRBoolean bIs3D);
-    bool setMeasured(OGRGeometry *poGeom, OGRBoolean bIsMeasured);
+    bool set3D(OGRGeometry *poGeom, bool bIs3D);
+    bool setMeasured(OGRGeometry *poGeom, bool bIsMeasured);
     void assignSpatialReference(OGRGeometry *poGeom,
                                 const OGRSpatialReference *poSR);
     int getNumCurves() const;
@@ -2144,7 +2141,7 @@ class CPL_DLL OGRCurveCollection
     void flattenTo2D(OGRGeometry *poGeom);
     bool segmentize(double dfMaxLength);
     void swapXY();
-    OGRBoolean hasCurveGeometry(int bLookForNonLinear) const;
+    bool hasCurveGeometry(int bLookForNonLinear) const;
 };
 
 //! @endcond
@@ -2260,7 +2257,7 @@ class CPL_DLL OGRCompoundCurve : public OGRCurve
     void empty() override;
     void getEnvelope(OGREnvelope *psEnvelope) const override;
     void getEnvelope(OGREnvelope3D *psEnvelope) const override;
-    OGRBoolean IsEmpty() const override;
+    bool IsEmpty() const override;
 
     // ICurve methods.
     double get_Length() const override;
@@ -2280,7 +2277,7 @@ class CPL_DLL OGRCompoundCurve : public OGRCurve
         const OGRSpatialReference *poSRSOverride = nullptr) const override;
 
     // ISpatialRelation.
-    OGRBoolean Equals(const OGRGeometry *) const override;
+    bool Equals(const OGRGeometry *) const override;
 
     // ICompoundCurve method.
     int getNumCurves() const;
@@ -2289,8 +2286,8 @@ class CPL_DLL OGRCompoundCurve : public OGRCurve
 
     // Non-standard.
     bool setCoordinateDimension(int nDimension) override;
-    bool set3D(OGRBoolean bIs3D) override;
-    bool setMeasured(OGRBoolean bIsMeasured) override;
+    bool set3D(bool bIs3D) override;
+    bool setMeasured(bool bIsMeasured) override;
 
     virtual void
     assignSpatialReference(const OGRSpatialReference *poSR) override;
@@ -2316,8 +2313,7 @@ class CPL_DLL OGRCompoundCurve : public OGRCurve
     OGRErr transform(OGRCoordinateTransformation *poCT) override;
     void flattenTo2D() override;
     bool segmentize(double dfMaxLength) override;
-    virtual OGRBoolean
-    hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
+    bool hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
     virtual OGRGeometry *
     getLinearGeometry(double dfMaxAngleStepSizeDegrees = 0,
                       const char *const *papszOptions = nullptr) const override;
@@ -2431,8 +2427,8 @@ class CPL_DLL OGRCurvePolygon : public OGRSurface
     static OGRPolygon *CasterToPolygon(OGRSurface *poSurface);
 
   private:
-    OGRBoolean IntersectsPoint(const OGRPoint *p) const;
-    OGRBoolean ContainsPoint(const OGRPoint *p) const;
+    bool IntersectsPoint(const OGRPoint *p) const;
+    bool ContainsPoint(const OGRPoint *p) const;
 
     virtual bool isRingCorrectType(const OGRCurve *poRing) const;
 
@@ -2505,10 +2501,9 @@ class CPL_DLL OGRCurvePolygon : public OGRSurface
     void empty() override;
     OGRErr transform(OGRCoordinateTransformation *poCT) override;
     void flattenTo2D() override;
-    OGRBoolean IsEmpty() const override;
+    bool IsEmpty() const override;
     bool segmentize(double dfMaxLength) override;
-    virtual OGRBoolean
-    hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
+    bool hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
     virtual OGRGeometry *
     getLinearGeometry(double dfMaxAngleStepSizeDegrees = 0,
                       const char *const *papszOptions = nullptr) const override;
@@ -2557,14 +2552,14 @@ class CPL_DLL OGRCurvePolygon : public OGRSurface
                     const char *const *papszOptions = nullptr) const;
 
     // ISpatialRelation
-    OGRBoolean Equals(const OGRGeometry *) const override;
-    OGRBoolean Intersects(const OGRGeometry *) const override;
-    OGRBoolean Contains(const OGRGeometry *) const override;
+    bool Equals(const OGRGeometry *) const override;
+    bool Intersects(const OGRGeometry *) const override;
+    bool Contains(const OGRGeometry *) const override;
 
     // Non standard
     bool setCoordinateDimension(int nDimension) override;
-    bool set3D(OGRBoolean bIs3D) override;
-    bool setMeasured(OGRBoolean bIsMeasured) override;
+    bool set3D(bool bIs3D) override;
+    bool setMeasured(bool bIsMeasured) override;
 
     virtual void
     assignSpatialReference(const OGRSpatialReference *poSR) override;
@@ -2717,8 +2712,7 @@ class CPL_DLL OGRPolygon : public OGRCurvePolygon
     const char *getGeometryName() const override;
     OGRwkbGeometryType getGeometryType() const override;
     OGRPolygon *clone() const override;
-    virtual OGRBoolean
-    hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
+    bool hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
     virtual OGRGeometry *
     getCurveGeometry(const char *const *papszOptions = nullptr) const override;
     virtual OGRGeometry *
@@ -2762,7 +2756,7 @@ class CPL_DLL OGRPolygon : public OGRCurvePolygon
     OGRLinearRing *stealExteriorRing();
     virtual OGRLinearRing *stealInteriorRing(int);
 
-    OGRBoolean IsPointOnSurface(const OGRPoint *) const;
+    bool IsPointOnSurface(const OGRPoint *) const;
 
     /** Return pointer of this in upper class */
     inline OGRCurvePolygon *toUpperClass()
@@ -2928,7 +2922,7 @@ class CPL_DLL OGRGeometryCollection : public OGRGeometry
                                  int nRecLevel, OGRwkbVariant,
                                  size_t &nBytesConsumedOut);
     //! @endcond
-    virtual OGRBoolean isCompatibleSubType(OGRwkbGeometryType) const;
+    virtual bool isCompatibleSubType(OGRwkbGeometryType) const;
 
   public:
     /** Create an empty geometry collection. */
@@ -2977,10 +2971,9 @@ class CPL_DLL OGRGeometryCollection : public OGRGeometry
     void empty() override;
     OGRErr transform(OGRCoordinateTransformation *poCT) override;
     void flattenTo2D() override;
-    OGRBoolean IsEmpty() const override;
+    bool IsEmpty() const override;
     bool segmentize(double dfMaxLength) override;
-    virtual OGRBoolean
-    hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
+    bool hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
     virtual OGRGeometry *
     getCurveGeometry(const char *const *papszOptions = nullptr) const override;
     virtual OGRGeometry *
@@ -3029,12 +3022,12 @@ class CPL_DLL OGRGeometryCollection : public OGRGeometry
     const OGRGeometry *getGeometryRef(int) const;
 
     // ISpatialRelation
-    OGRBoolean Equals(const OGRGeometry *) const override;
+    bool Equals(const OGRGeometry *) const override;
 
     // Non standard
     bool setCoordinateDimension(int nDimension) override;
-    bool set3D(OGRBoolean bIs3D) override;
-    bool setMeasured(OGRBoolean bIsMeasured) override;
+    bool set3D(bool bIs3D) override;
+    bool setMeasured(bool bIsMeasured) override;
     virtual OGRErr addGeometry(const OGRGeometry *);
     virtual OGRErr addGeometryDirectly(OGRGeometry *);
     OGRErr addGeometry(std::unique_ptr<OGRGeometry> geom);
@@ -3112,7 +3105,7 @@ inline OGRGeometryCollection::ChildType **end(OGRGeometryCollection *poGeom)
 class CPL_DLL OGRMultiSurface : public OGRGeometryCollection
 {
   protected:
-    OGRBoolean isCompatibleSubType(OGRwkbGeometryType) const override;
+    bool isCompatibleSubType(OGRwkbGeometryType) const override;
 
   public:
     /** Create an empty multi surface collection. */
@@ -3198,8 +3191,7 @@ class CPL_DLL OGRMultiSurface : public OGRGeometryCollection
     }
 
     // Non standard
-    virtual OGRBoolean
-    hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
+    bool hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
 
     /** Return pointer of this in upper class */
     inline OGRGeometryCollection *toUpperClass()
@@ -3272,7 +3264,7 @@ inline OGRMultiSurface::ChildType **end(OGRMultiSurface *poGeom)
 class CPL_DLL OGRMultiPolygon : public OGRMultiSurface
 {
   protected:
-    OGRBoolean isCompatibleSubType(OGRwkbGeometryType) const override;
+    bool isCompatibleSubType(OGRwkbGeometryType) const override;
     friend class OGRPolyhedralSurface;
     friend class OGRTriangulatedSurface;
 
@@ -3359,8 +3351,7 @@ class CPL_DLL OGRMultiPolygon : public OGRMultiSurface
                                     OGRErr *err = nullptr) const override;
 
     // Non standard
-    virtual OGRBoolean
-    hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
+    bool hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
 
     /** Return pointer of this in upper class */
     inline OGRGeometryCollection *toUpperClass()
@@ -3437,7 +3428,7 @@ class CPL_DLL OGRPolyhedralSurface : public OGRSurface
     OGRSurfaceCasterToPolygon GetCasterToPolygon() const override;
     virtual OGRSurfaceCasterToCurvePolygon
     GetCasterToCurvePolygon() const override;
-    virtual OGRBoolean isCompatibleSubType(OGRwkbGeometryType) const;
+    virtual bool isCompatibleSubType(OGRwkbGeometryType) const;
     virtual const char *getSubGeometryName() const;
     virtual OGRwkbGeometryType getSubGeometryType() const;
     std::string exportToWktInternal(const OGRWktOptions &opts,
@@ -3526,7 +3517,7 @@ class CPL_DLL OGRPolyhedralSurface : public OGRSurface
 
     void flattenTo2D() override;
     OGRErr transform(OGRCoordinateTransformation *) override;
-    OGRBoolean Equals(const OGRGeometry *) const override;
+    bool Equals(const OGRGeometry *) const override;
     double get_Area() const override;
     virtual double get_GeodesicArea(
         const OGRSpatialReference *poSRSOverride = nullptr) const override;
@@ -3537,8 +3528,7 @@ class CPL_DLL OGRPolyhedralSurface : public OGRSurface
     OGRErr PointOnSurface(OGRPoint *) const override;
 
     static OGRMultiPolygon *CastToMultiPolygon(OGRPolyhedralSurface *poPS);
-    virtual OGRBoolean
-    hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
+    bool hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
     virtual OGRErr addGeometry(const OGRGeometry *);
     OGRErr addGeometryDirectly(OGRGeometry *poNewGeom);
     OGRErr addGeometry(std::unique_ptr<OGRGeometry> poNewGeom);
@@ -3547,10 +3537,10 @@ class CPL_DLL OGRPolyhedralSurface : public OGRSurface
     OGRPolygon *getGeometryRef(int i);
     const OGRPolygon *getGeometryRef(int i) const;
 
-    OGRBoolean IsEmpty() const override;
+    bool IsEmpty() const override;
     bool setCoordinateDimension(int nDimension) override;
-    bool set3D(OGRBoolean bIs3D) override;
-    bool setMeasured(OGRBoolean bIsMeasured) override;
+    bool set3D(bool bIs3D) override;
+    bool setMeasured(bool bIsMeasured) override;
     void swapXY() override;
     OGRErr removeGeometry(int iIndex, int bDelete = TRUE);
 
@@ -3616,7 +3606,7 @@ class CPL_DLL OGRTriangulatedSurface : public OGRPolyhedralSurface
 {
   protected:
     //! @cond Doxygen_Suppress
-    OGRBoolean isCompatibleSubType(OGRwkbGeometryType) const override;
+    bool isCompatibleSubType(OGRwkbGeometryType) const override;
     const char *getSubGeometryName() const override;
     OGRwkbGeometryType getSubGeometryType() const override;
 
@@ -3761,7 +3751,7 @@ class CPL_DLL OGRMultiPoint : public OGRGeometryCollection
     OGRErr importFromWkt_Bracketed(const char **, int bHasM, int bHasZ);
 
   protected:
-    OGRBoolean isCompatibleSubType(OGRwkbGeometryType) const override;
+    bool isCompatibleSubType(OGRwkbGeometryType) const override;
 
   public:
     /** Create an empty multi point collection. */
@@ -3866,8 +3856,7 @@ class CPL_DLL OGRMultiPoint : public OGRGeometryCollection
     }
 
     // Non-standard.
-    virtual OGRBoolean
-    hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
+    bool hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
 
     OGR_ALLOW_CAST_TO_THIS(MultiPoint)
     OGR_ALLOW_UPCAST_TO(GeometryCollection)
@@ -3920,7 +3909,7 @@ class CPL_DLL OGRMultiCurve : public OGRGeometryCollection
     static OGRErr addCurveDirectlyFromWkt(OGRGeometry *poSelf,
                                           OGRCurve *poCurve);
     //! @endcond
-    OGRBoolean isCompatibleSubType(OGRwkbGeometryType) const override;
+    bool isCompatibleSubType(OGRwkbGeometryType) const override;
 
   public:
     /** Create an empty multi curve collection. */
@@ -4003,8 +3992,7 @@ class CPL_DLL OGRMultiCurve : public OGRGeometryCollection
     int getDimension() const override;
 
     // Non-standard.
-    virtual OGRBoolean
-    hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
+    bool hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
 
     /** Return pointer of this in upper class */
     inline OGRGeometryCollection *toUpperClass()
@@ -4075,7 +4063,7 @@ inline OGRMultiCurve::ChildType **end(OGRMultiCurve *poGeom)
 class CPL_DLL OGRMultiLineString : public OGRMultiCurve
 {
   protected:
-    OGRBoolean isCompatibleSubType(OGRwkbGeometryType) const override;
+    bool isCompatibleSubType(OGRwkbGeometryType) const override;
 
   public:
     /** Create an empty multi line string collection. */
@@ -4152,8 +4140,7 @@ class CPL_DLL OGRMultiLineString : public OGRMultiCurve
                                     OGRErr *err = nullptr) const override;
 
     // Non standard
-    virtual OGRBoolean
-    hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
+    bool hasCurveGeometry(int bLookForNonLinear = FALSE) const override;
 
     /** Return pointer of this in upper class */
     inline OGRGeometryCollection *toUpperClass()

--- a/ogr/ogr_p.h
+++ b/ogr/ogr_p.h
@@ -73,11 +73,10 @@ OGRWktReadPointsM(const char *pszInput, OGRRawPoint **ppaoPoints,
 void CPL_DLL OGRMakeWktCoordinate(char *, double, double, double, int);
 std::string CPL_DLL OGRMakeWktCoordinate(double, double, double, int,
                                          const OGRWktOptions &opts);
-void CPL_DLL OGRMakeWktCoordinateM(char *, double, double, double, double,
-                                   OGRBoolean, OGRBoolean);
-std::string CPL_DLL OGRMakeWktCoordinateM(double, double, double, double,
-                                          OGRBoolean, OGRBoolean,
-                                          const OGRWktOptions &opts);
+void CPL_DLL OGRMakeWktCoordinateM(char *, double, double, double, double, bool,
+                                   bool);
+std::string CPL_DLL OGRMakeWktCoordinateM(double, double, double, double, bool,
+                                          bool, const OGRWktOptions &opts);
 
 #endif
 

--- a/ogr/ogr_wkb.cpp
+++ b/ogr/ogr_wkb.cpp
@@ -35,7 +35,10 @@
 
 static inline bool OGRWKBNeedSwap(GByte b)
 {
-    return b != CPL_IS_LSB;
+    if constexpr (CPL_IS_LSB)
+        return b != 1;
+    else
+        return b != 0;
 }
 
 /************************************************************************/

--- a/ogr/ogrcircularstring.cpp
+++ b/ogr/ogrcircularstring.cpp
@@ -686,7 +686,7 @@ OGRCircularString::CurveToLine(double dfMaxAngleStepSizeDegrees,
 /*                            IsValidFast()                             */
 /************************************************************************/
 
-OGRBoolean OGRCircularString::IsValidFast(std::string *posReason) const
+bool OGRCircularString::IsValidFast(std::string *posReason) const
 
 {
     if (nPointCount == 1 || nPointCount == 2 ||
@@ -713,7 +713,7 @@ OGRBoolean OGRCircularString::IsValidFast(std::string *posReason) const
 /*                              IsValid()                               */
 /************************************************************************/
 
-OGRBoolean OGRCircularString::IsValid(std::string *posReason) const
+bool OGRCircularString::IsValid(std::string *posReason) const
 
 {
     return IsValidFast(posReason) && OGRGeometry::IsValid(posReason);
@@ -723,8 +723,7 @@ OGRBoolean OGRCircularString::IsValid(std::string *posReason) const
 /*                          hasCurveGeometry()                          */
 /************************************************************************/
 
-OGRBoolean
-OGRCircularString::hasCurveGeometry(int /* bLookForNonLinear */) const
+bool OGRCircularString::hasCurveGeometry(int /* bLookForNonLinear */) const
 {
     return TRUE;
 }

--- a/ogr/ogrcompoundcurve.cpp
+++ b/ogr/ogrcompoundcurve.cpp
@@ -222,7 +222,7 @@ void OGRCompoundCurve::getEnvelope(OGREnvelope3D *psEnvelope) const
 /*                              IsEmpty()                               */
 /************************************************************************/
 
-OGRBoolean OGRCompoundCurve::IsEmpty() const
+bool OGRCompoundCurve::IsEmpty() const
 {
     return oCC.IsEmpty();
 }
@@ -332,7 +332,7 @@ OGRCompoundCurve::CurveToLine(double dfMaxAngleStepSizeDegrees,
 /*                               Equals()                               */
 /************************************************************************/
 
-OGRBoolean OGRCompoundCurve::Equals(const OGRGeometry *poOther) const
+bool OGRCompoundCurve::Equals(const OGRGeometry *poOther) const
 {
     if (poOther == this)
         return TRUE;
@@ -352,12 +352,12 @@ bool OGRCompoundCurve::setCoordinateDimension(int nNewDimension)
     return oCC.setCoordinateDimension(this, nNewDimension);
 }
 
-bool OGRCompoundCurve::set3D(OGRBoolean bIs3D)
+bool OGRCompoundCurve::set3D(bool bIs3D)
 {
     return oCC.set3D(this, bIs3D);
 }
 
-bool OGRCompoundCurve::setMeasured(OGRBoolean bIsMeasured)
+bool OGRCompoundCurve::setMeasured(bool bIsMeasured)
 {
     return oCC.setMeasured(this, bIsMeasured);
 }
@@ -652,7 +652,7 @@ void OGRCompoundCurve::swapXY()
 /*                          hasCurveGeometry()                          */
 /************************************************************************/
 
-OGRBoolean OGRCompoundCurve::hasCurveGeometry(int bLookForNonLinear) const
+bool OGRCompoundCurve::hasCurveGeometry(int bLookForNonLinear) const
 {
     if (bLookForNonLinear)
     {
@@ -712,14 +712,14 @@ class OGRCompoundCurvePointIterator final : public OGRPointIterator
         delete poCurveIter;
     }
 
-    OGRBoolean getNextPoint(OGRPoint *p) override;
+    bool getNextPoint(OGRPoint *p) override;
 };
 
 /************************************************************************/
 /*                            getNextPoint()                            */
 /************************************************************************/
 
-OGRBoolean OGRCompoundCurvePointIterator::getNextPoint(OGRPoint *p)
+bool OGRCompoundCurvePointIterator::getNextPoint(OGRPoint *p)
 {
     if (iCurCurve == poCC->getNumCurves())
         return FALSE;

--- a/ogr/ogrcurve.cpp
+++ b/ogr/ogrcurve.cpp
@@ -57,7 +57,7 @@ int OGRCurve::getDimension() const
  * @return TRUE if closed, else FALSE.
  */
 
-int OGRCurve::get_IsClosed() const
+bool OGRCurve::get_IsClosed() const
 
 {
     OGRPoint oStartPoint;
@@ -69,30 +69,22 @@ int OGRCurve::get_IsClosed() const
     if (oStartPoint.Is3D() && oEndPoint.Is3D())
     {
         // XYZ type
-        if (oStartPoint.getX() == oEndPoint.getX() &&
-            oStartPoint.getY() == oEndPoint.getY() &&
-            oStartPoint.getZ() == oEndPoint.getZ())
-        {
-            return TRUE;
-        }
-        else
-            return FALSE;
+        return (oStartPoint.getX() == oEndPoint.getX() &&
+                oStartPoint.getY() == oEndPoint.getY() &&
+                oStartPoint.getZ() == oEndPoint.getZ());
     }
 
     // one of the points is 3D
     else if (oStartPoint.Is3D() != oEndPoint.Is3D())
     {
-        return FALSE;
+        return false;
     }
 
     else
     {
         // XY type
-        if (oStartPoint.getX() == oEndPoint.getX() &&
-            oStartPoint.getY() == oEndPoint.getY())
-            return TRUE;
-        else
-            return FALSE;
+        return (oStartPoint.getX() == oEndPoint.getX() &&
+                oStartPoint.getY() == oEndPoint.getY());
     }
 }
 

--- a/ogr/ogrcurve.cpp
+++ b/ogr/ogrcurve.cpp
@@ -711,7 +711,7 @@ OGRCurve::ConstIterator OGRCurve::end() const
  * @return TRUE if clockwise otherwise FALSE.
  */
 
-int OGRCurve::isClockwise() const
+bool OGRCurve::isClockwise() const
 
 {
     // WARNING: keep in sync OGRLineString::isClockwise(),
@@ -719,7 +719,7 @@ int OGRCurve::isClockwise() const
 
     const int nPointCount = getNumPoints();
     if (nPointCount < 3)
-        return TRUE;
+        return true;
 
     bool bUseFallback = false;
 
@@ -811,9 +811,9 @@ int OGRCurve::isClockwise() const
     if (!bUseFallback)
     {
         if (crossproduct > 0)  // CCW
-            return FALSE;
+            return false;
         else if (crossproduct < 0)  // CW
-            return TRUE;
+            return true;
     }
 
     // This is a degenerate case: the extent of the polygon is less than EPSILON

--- a/ogr/ogrcurve.cpp
+++ b/ogr/ogrcurve.cpp
@@ -80,8 +80,7 @@ int OGRCurve::get_IsClosed() const
     }
 
     // one of the points is 3D
-    else if (((oStartPoint.Is3D() & oEndPoint.Is3D()) == 0) &&
-             ((oStartPoint.Is3D() | oEndPoint.Is3D()) == 1))
+    else if (oStartPoint.Is3D() != oEndPoint.Is3D())
     {
         return FALSE;
     }
@@ -302,7 +301,7 @@ int OGRCurve::get_IsClosed() const
  *
  */
 
-OGRBoolean OGRCurve::IsConvex() const
+bool OGRCurve::IsConvex() const
 {
     bool bRet = true;
     OGRPointIterator *poPointIter = getPointIterator();
@@ -448,7 +447,7 @@ int OGRCurve::IntersectsPoint(CPL_UNUSED const OGRPoint *p) const
 OGRPointIterator::~OGRPointIterator() = default;
 
 /**
- * \fn OGRBoolean OGRPointIterator::getNextPoint(OGRPoint* p);
+ * \fn bool OGRPointIterator::getNextPoint(OGRPoint* p);
  *
  * \brief Returns the next point followed by the iterator.
  *

--- a/ogr/ogrcurvecollection.cpp
+++ b/ogr/ogrcurvecollection.cpp
@@ -514,7 +514,7 @@ void OGRCurveCollection::getEnvelope(OGREnvelope3D *psEnvelope) const
 /*                              IsEmpty()                               */
 /************************************************************************/
 
-OGRBoolean OGRCurveCollection::IsEmpty() const
+bool OGRCurveCollection::IsEmpty() const
 {
     for (auto &&poSubGeom : *this)
     {
@@ -528,7 +528,7 @@ OGRBoolean OGRCurveCollection::IsEmpty() const
 /*                               Equals()                               */
 /************************************************************************/
 
-OGRBoolean OGRCurveCollection::Equals(const OGRCurveCollection *poOCC) const
+bool OGRCurveCollection::Equals(const OGRCurveCollection *poOCC) const
 {
     if (getNumCurves() != poOCC->getNumCurves())
         return FALSE;
@@ -560,7 +560,7 @@ bool OGRCurveCollection::setCoordinateDimension(OGRGeometry *poGeom,
     return poGeom->OGRGeometry::setCoordinateDimension(nNewDimension);
 }
 
-bool OGRCurveCollection::set3D(OGRGeometry *poGeom, OGRBoolean bIs3D)
+bool OGRCurveCollection::set3D(OGRGeometry *poGeom, bool bIs3D)
 {
     for (auto &&poSubGeom : *this)
     {
@@ -571,8 +571,7 @@ bool OGRCurveCollection::set3D(OGRGeometry *poGeom, OGRBoolean bIs3D)
     return poGeom->OGRGeometry::set3D(bIs3D);
 }
 
-bool OGRCurveCollection::setMeasured(OGRGeometry *poGeom,
-                                     OGRBoolean bIsMeasured)
+bool OGRCurveCollection::setMeasured(OGRGeometry *poGeom, bool bIsMeasured)
 {
     for (auto &&poSubGeom : *this)
     {
@@ -720,7 +719,7 @@ void OGRCurveCollection::swapXY()
 /*                          hasCurveGeometry()                          */
 /************************************************************************/
 
-OGRBoolean OGRCurveCollection::hasCurveGeometry(int bLookForNonLinear) const
+bool OGRCurveCollection::hasCurveGeometry(int bLookForNonLinear) const
 {
     for (auto &&poSubGeom : *this)
     {

--- a/ogr/ogrcurvepolygon.cpp
+++ b/ogr/ogrcurvepolygon.cpp
@@ -588,7 +588,7 @@ OGRCurvePolygon::CurvePolyToPoly(double dfMaxAngleStepSizeDegrees,
 /*                          hasCurveGeometry()                          */
 /************************************************************************/
 
-OGRBoolean OGRCurvePolygon::hasCurveGeometry(int bLookForNonLinear) const
+bool OGRCurvePolygon::hasCurveGeometry(int bLookForNonLinear) const
 {
     if (bLookForNonLinear)
     {
@@ -633,7 +633,7 @@ void OGRCurvePolygon::getEnvelope(OGREnvelope3D *psEnvelope) const
 /*                               Equals()                               */
 /************************************************************************/
 
-OGRBoolean OGRCurvePolygon::Equals(const OGRGeometry *poOther) const
+bool OGRCurvePolygon::Equals(const OGRGeometry *poOther) const
 
 {
     if (poOther == this)
@@ -754,12 +754,12 @@ bool OGRCurvePolygon::setCoordinateDimension(int nNewDimension)
     return oCC.setCoordinateDimension(this, nNewDimension);
 }
 
-bool OGRCurvePolygon::set3D(OGRBoolean bIs3D)
+bool OGRCurvePolygon::set3D(bool bIs3D)
 {
     return oCC.set3D(this, bIs3D);
 }
 
-bool OGRCurvePolygon::setMeasured(OGRBoolean bIsMeasured)
+bool OGRCurvePolygon::setMeasured(bool bIsMeasured)
 {
     return oCC.setMeasured(this, bIsMeasured);
 }
@@ -777,7 +777,7 @@ void OGRCurvePolygon::assignSpatialReference(const OGRSpatialReference *poSR)
 /*                              IsEmpty()                               */
 /************************************************************************/
 
-OGRBoolean OGRCurvePolygon::IsEmpty() const
+bool OGRCurvePolygon::IsEmpty() const
 {
     return oCC.IsEmpty();
 }
@@ -810,13 +810,13 @@ void OGRCurvePolygon::swapXY()
 /*                           ContainsPoint()                            */
 /************************************************************************/
 
-OGRBoolean OGRCurvePolygon::ContainsPoint(const OGRPoint *p) const
+bool OGRCurvePolygon::ContainsPoint(const OGRPoint *p) const
 {
     if (getExteriorRingCurve() != nullptr && getNumInteriorRings() == 0)
     {
         const int nRet = getExteriorRingCurve()->ContainsPoint(p);
         if (nRet >= 0)
-            return nRet;
+            return CPL_TO_BOOL(nRet);
     }
 
     return OGRGeometry::Contains(p);
@@ -826,13 +826,13 @@ OGRBoolean OGRCurvePolygon::ContainsPoint(const OGRPoint *p) const
 /*                          IntersectsPoint()                           */
 /************************************************************************/
 
-OGRBoolean OGRCurvePolygon::IntersectsPoint(const OGRPoint *p) const
+bool OGRCurvePolygon::IntersectsPoint(const OGRPoint *p) const
 {
     if (getExteriorRingCurve() != nullptr && getNumInteriorRings() == 0)
     {
         const int nRet = getExteriorRingCurve()->IntersectsPoint(p);
         if (nRet >= 0)
-            return nRet;
+            return CPL_TO_BOOL(nRet);
     }
 
     return OGRGeometry::Intersects(p);
@@ -842,7 +842,7 @@ OGRBoolean OGRCurvePolygon::IntersectsPoint(const OGRPoint *p) const
 /*                              Contains()                              */
 /************************************************************************/
 
-OGRBoolean OGRCurvePolygon::Contains(const OGRGeometry *poOtherGeom) const
+bool OGRCurvePolygon::Contains(const OGRGeometry *poOtherGeom) const
 
 {
     if (!IsEmpty() && poOtherGeom != nullptr &&
@@ -858,7 +858,7 @@ OGRBoolean OGRCurvePolygon::Contains(const OGRGeometry *poOtherGeom) const
 /*                             Intersects()                             */
 /************************************************************************/
 
-OGRBoolean OGRCurvePolygon::Intersects(const OGRGeometry *poOtherGeom) const
+bool OGRCurvePolygon::Intersects(const OGRGeometry *poOtherGeom) const
 
 {
     if (!IsEmpty() && poOtherGeom != nullptr &&

--- a/ogr/ogrfeature.cpp
+++ b/ogr/ogrfeature.cpp
@@ -5985,7 +5985,7 @@ OGRErr OGR_F_SetFID(OGRFeatureH hFeat, GIntBig nFID)
  * @return TRUE if they are equal, otherwise FALSE.
  */
 
-OGRBoolean OGRFeature::Equal(const OGRFeature *poFeature) const
+bool OGRFeature::Equal(const OGRFeature *poFeature) const
 
 {
     if (poFeature == this)

--- a/ogr/ogrgeometry.cpp
+++ b/ogr/ogrgeometry.cpp
@@ -568,7 +568,7 @@ void OGR_G_AssignSpatialReference(OGRGeometryH hGeom, OGRSpatialReferenceH hSRS)
  * @return TRUE if the geometries intersect, otherwise FALSE.
  */
 
-OGRBoolean OGRGeometry::Intersects(const OGRGeometry *poOtherGeom) const
+bool OGRGeometry::Intersects(const OGRGeometry *poOtherGeom) const
 
 {
     if (poOtherGeom == nullptr)
@@ -594,7 +594,7 @@ OGRBoolean OGRGeometry::Intersects(const OGRGeometry *poOtherGeom) const
     GEOSGeom hThisGeosGeom = exportToGEOS(hGEOSCtxt);
     GEOSGeom hOtherGeosGeom = poOtherGeom->exportToGEOS(hGEOSCtxt);
 
-    OGRBoolean bResult = FALSE;
+    bool bResult = false;
     if (hThisGeosGeom != nullptr && hOtherGeosGeom != nullptr)
     {
         bResult =
@@ -612,7 +612,7 @@ OGRBoolean OGRGeometry::Intersects(const OGRGeometry *poOtherGeom) const
 // Old API compatibility function.
 
 //! @cond Doxygen_Suppress
-OGRBoolean OGRGeometry::Intersect(OGRGeometry *poOtherGeom) const
+bool OGRGeometry::Intersect(OGRGeometry *poOtherGeom) const
 
 {
     return Intersects(poOtherGeom);
@@ -1118,7 +1118,7 @@ bool OGRGeometry::setCoordinateDimension(int nNewDimension)
  * @return (since 3.10) true in case of success, false in case of memory allocation error
  */
 
-bool OGRGeometry::set3D(OGRBoolean bIs3D)
+bool OGRGeometry::set3D(bool bIs3D)
 
 {
     if (bIs3D)
@@ -1142,7 +1142,7 @@ bool OGRGeometry::set3D(OGRBoolean bIs3D)
  * @return (since 3.10) true in case of success, false in case of memory allocation error
  */
 
-bool OGRGeometry::setMeasured(OGRBoolean bIsMeasured)
+bool OGRGeometry::setMeasured(bool bIsMeasured)
 
 {
     if (bIsMeasured)
@@ -1202,7 +1202,7 @@ void OGR_G_Set3D(OGRGeometryH hGeom, int bIs3D)
 {
     VALIDATE_POINTER0(hGeom, "OGR_G_Set3D");
 
-    OGRGeometry::FromHandle(hGeom)->set3D(bIs3D);
+    OGRGeometry::FromHandle(hGeom)->set3D(CPL_TO_BOOL(bIs3D));
 }
 
 /************************************************************************/
@@ -1228,11 +1228,11 @@ void OGR_G_SetMeasured(OGRGeometryH hGeom, int bIsMeasured)
 {
     VALIDATE_POINTER0(hGeom, "OGR_G_SetMeasured");
 
-    OGRGeometry::FromHandle(hGeom)->setMeasured(bIsMeasured);
+    OGRGeometry::FromHandle(hGeom)->setMeasured(CPL_TO_BOOL(bIsMeasured));
 }
 
 /**
- * \fn int OGRGeometry::Equals( OGRGeometry *poOtherGeom ) const;
+ * \fn bool OGRGeometry::Equals( OGRGeometry *poOtherGeom ) const;
  *
  * \brief Returns TRUE if two geometries are equivalent.
  *
@@ -1254,7 +1254,7 @@ void OGR_G_SetMeasured(OGRGeometryH hGeom, int bIsMeasured)
 // Backward compatibility method.
 
 //! @cond Doxygen_Suppress
-int OGRGeometry::Equal(OGRGeometry *poOtherGeom) const
+bool OGRGeometry::Equal(OGRGeometry *poOtherGeom) const
 {
     return Equals(poOtherGeom);
 }
@@ -2221,7 +2221,7 @@ void OGR_G_Empty(OGRGeometryH hGeom)
 }
 
 /**
- * \fn OGRBoolean OGRGeometry::IsEmpty() const;
+ * \fn bool OGRGeometry::IsEmpty() const;
  *
  * \brief Returns TRUE (non-zero) if the object has no points.
  *
@@ -2277,7 +2277,7 @@ int OGR_G_IsEmpty(OGRGeometryH hGeom)
  * @return TRUE if the geometry has no points, otherwise FALSE.
  */
 
-OGRBoolean OGRGeometry::IsValid(std::string *posReason) const
+bool OGRGeometry::IsValid(std::string *posReason) const
 
 {
     if (posReason)
@@ -2333,7 +2333,7 @@ OGRBoolean OGRGeometry::IsValid(std::string *posReason) const
         return FALSE;
 
 #else
-        OGRBoolean bResult = FALSE;
+        bool bResult = false;
 
         // Some invalid geometries, such as lines with one point, or
         // rings that do not close, cannot be converted to GEOS.
@@ -2506,7 +2506,7 @@ char *OGR_G_GetInvalidityReason(OGRGeometryH hGeom)
  * @return TRUE if the geometry has no points, otherwise FALSE.
  */
 
-OGRBoolean OGRGeometry::IsSimple() const
+bool OGRGeometry::IsSimple() const
 
 {
 #ifndef HAVE_GEOS
@@ -2515,7 +2515,7 @@ OGRBoolean OGRGeometry::IsSimple() const
 
 #else
 
-    OGRBoolean bResult = FALSE;
+    bool bResult = false;
 
     GEOSContextHandle_t hGEOSCtxt = createGEOSContext();
     GEOSGeom hThisGeosGeom = exportToGEOS(hGEOSCtxt);
@@ -2577,7 +2577,7 @@ int OGR_G_IsSimple(OGRGeometryH hGeom)
  * length and closure (self-intersection is not checked), otherwise FALSE.
  */
 
-OGRBoolean OGRGeometry::IsRing() const
+bool OGRGeometry::IsRing() const
 
 {
 #ifndef HAVE_GEOS
@@ -2586,7 +2586,7 @@ OGRBoolean OGRGeometry::IsRing() const
 
 #else
 
-    OGRBoolean bResult = FALSE;
+    bool bResult = false;
 
     GEOSContextHandle_t hGEOSCtxt = createGEOSContext();
     GEOSGeom hThisGeosGeom = exportToGEOS(hGEOSCtxt);
@@ -3587,8 +3587,8 @@ GEOSGeom OGRGeometry::exportToGEOS(GEOSContextHandle_t hGEOSCtxt,
     std::unique_ptr<OGRGeometry> poModifiedInput = nullptr;
     const OGRGeometry *poGeosInput = this;
 
-    const bool bHasZ = CPL_TO_BOOL(poGeosInput->Is3D());
-    bool bHasM = CPL_TO_BOOL(poGeosInput->IsMeasured());
+    const bool bHasZ = poGeosInput->Is3D();
+    bool bHasM = poGeosInput->IsMeasured();
 
     if (poGeosInput->hasCurveGeometry())
     {
@@ -3715,7 +3715,7 @@ GEOSGeom OGRGeometry::exportToGEOS(GEOSContextHandle_t hGEOSCtxt,
  *
  */
 
-OGRBoolean OGRGeometry::hasCurveGeometry(CPL_UNUSED int bLookForNonLinear) const
+bool OGRGeometry::hasCurveGeometry(CPL_UNUSED int bLookForNonLinear) const
 {
     return FALSE;
 }
@@ -4101,12 +4101,12 @@ static OGRGeometry *BuildGeometryFromTwoGeoms(
 /*                      OGRGEOSBooleanPredicate()                       */
 /************************************************************************/
 
-static OGRBoolean OGRGEOSBooleanPredicate(
+static bool OGRGEOSBooleanPredicate(
     const OGRGeometry *poSelf, const OGRGeometry *poOtherGeom,
     char (*pfnGEOSFunction_r)(GEOSContextHandle_t, const GEOSGeometry *,
                               const GEOSGeometry *))
 {
-    OGRBoolean bResult = FALSE;
+    bool bResult = false;
 
     GEOSContextHandle_t hGEOSCtxt = poSelf->createGEOSContext();
     GEOSGeom hThisGeosGeom = poSelf->exportToGEOS(hGEOSCtxt);
@@ -4191,7 +4191,7 @@ OGRGeometry *OGRGeometry::MakeValid(CSLConstList papszOptions) const
     else if (wkbFlatten(getGeometryType()) == wkbCurvePolygon)
     {
         GEOSContextHandle_t hGEOSCtxt = initGEOS_r(nullptr, nullptr);
-        OGRBoolean bIsValid = FALSE;
+        bool bIsValid = false;
         GEOSGeom hGeosGeom = exportToGEOS(hGEOSCtxt);
         if (hGeosGeom)
         {
@@ -5999,7 +5999,7 @@ OGRGeometryH OGR_G_SymmetricDifference(OGRGeometryH hThis, OGRGeometryH hOther)
  * @return TRUE if they are disjoint, otherwise FALSE.
  */
 
-OGRBoolean OGRGeometry::Disjoint(const OGRGeometry *poOtherGeom) const
+bool OGRGeometry::Disjoint(const OGRGeometry *poOtherGeom) const
 
 {
     (void)poOtherGeom;
@@ -6072,7 +6072,7 @@ int OGR_G_Disjoint(OGRGeometryH hThis, OGRGeometryH hOther)
  * @return TRUE if they are touching, otherwise FALSE.
  */
 
-OGRBoolean OGRGeometry::Touches(const OGRGeometry *poOtherGeom) const
+bool OGRGeometry::Touches(const OGRGeometry *poOtherGeom) const
 
 {
     (void)poOtherGeom;
@@ -6145,8 +6145,7 @@ int OGR_G_Touches(OGRGeometryH hThis, OGRGeometryH hOther)
  * @return TRUE if they are crossing, otherwise FALSE.
  */
 
-OGRBoolean
-OGRGeometry::Crosses(UNUSED_PARAMETER const OGRGeometry *poOtherGeom) const
+bool OGRGeometry::Crosses(UNUSED_PARAMETER const OGRGeometry *poOtherGeom) const
 
 {
     if (IsSFCGALCompatible() || poOtherGeom->IsSFCGALCompatible())
@@ -6253,7 +6252,7 @@ int OGR_G_Crosses(OGRGeometryH hThis, OGRGeometryH hOther)
  * @return TRUE if poOtherGeom is within this geometry, otherwise FALSE.
  */
 
-OGRBoolean OGRGeometry::Within(const OGRGeometry *poOtherGeom) const
+bool OGRGeometry::Within(const OGRGeometry *poOtherGeom) const
 
 {
     (void)poOtherGeom;
@@ -6326,7 +6325,7 @@ int OGR_G_Within(OGRGeometryH hThis, OGRGeometryH hOther)
  * @return TRUE if poOtherGeom contains this geometry, otherwise FALSE.
  */
 
-OGRBoolean OGRGeometry::Contains(const OGRGeometry *poOtherGeom) const
+bool OGRGeometry::Contains(const OGRGeometry *poOtherGeom) const
 
 {
     (void)poOtherGeom;
@@ -6400,7 +6399,7 @@ int OGR_G_Contains(OGRGeometryH hThis, OGRGeometryH hOther)
  * @return TRUE if they are overlapping, otherwise FALSE.
  */
 
-OGRBoolean OGRGeometry::Overlaps(const OGRGeometry *poOtherGeom) const
+bool OGRGeometry::Overlaps(const OGRGeometry *poOtherGeom) const
 
 {
     (void)poOtherGeom;
@@ -8833,7 +8832,7 @@ OGRGeometry *OGRGeometry::SFCGALexportToOGR(
 //! @endcond
 
 //! @cond Doxygen_Suppress
-OGRBoolean OGRGeometry::IsSFCGALCompatible() const
+bool OGRGeometry::IsSFCGALCompatible() const
 {
     const OGRwkbGeometryType eGType = wkbFlatten(getGeometryType());
     if (eGType == wkbTriangle || eGType == wkbPolyhedralSurface ||

--- a/ogr/ogrgeometrycollection.cpp
+++ b/ogr/ogrgeometrycollection.cpp
@@ -1138,7 +1138,7 @@ void OGRGeometryCollection::getEnvelope(OGREnvelope3D *psEnvelope) const
 /*                               Equals()                               */
 /************************************************************************/
 
-OGRBoolean OGRGeometryCollection::Equals(const OGRGeometry *poOther) const
+bool OGRGeometryCollection::Equals(const OGRGeometry *poOther) const
 
 {
     if (poOther == this)
@@ -1232,7 +1232,7 @@ bool OGRGeometryCollection::setCoordinateDimension(int nNewDimension)
     return OGRGeometry::setCoordinateDimension(nNewDimension);
 }
 
-bool OGRGeometryCollection::set3D(OGRBoolean bIs3D)
+bool OGRGeometryCollection::set3D(bool bIs3D)
 {
     for (auto &poSubGeom : *this)
     {
@@ -1243,7 +1243,7 @@ bool OGRGeometryCollection::set3D(OGRBoolean bIs3D)
     return OGRGeometry::set3D(bIs3D);
 }
 
-bool OGRGeometryCollection::setMeasured(OGRBoolean bIsMeasured)
+bool OGRGeometryCollection::setMeasured(bool bIsMeasured)
 {
     for (auto &poSubGeom : *this)
     {
@@ -1491,7 +1491,7 @@ double OGRGeometryCollection::get_GeodesicLength(
 /*                              IsEmpty()                               */
 /************************************************************************/
 
-OGRBoolean OGRGeometryCollection::IsEmpty() const
+bool OGRGeometryCollection::IsEmpty() const
 {
     for (const auto &poSubGeom : *this)
     {
@@ -1552,7 +1552,7 @@ void OGRGeometryCollection::swapXY()
  * @return TRUE or FALSE
  */
 
-OGRBoolean OGRGeometryCollection::isCompatibleSubType(
+bool OGRGeometryCollection::isCompatibleSubType(
     CPL_UNUSED OGRwkbGeometryType eSubType) const
 {
     // Accept all geometries as sub-geometries.
@@ -1563,7 +1563,7 @@ OGRBoolean OGRGeometryCollection::isCompatibleSubType(
 /*                          hasCurveGeometry()                          */
 /************************************************************************/
 
-OGRBoolean OGRGeometryCollection::hasCurveGeometry(int bLookForNonLinear) const
+bool OGRGeometryCollection::hasCurveGeometry(int bLookForNonLinear) const
 {
     for (const auto &poSubGeom : *this)
     {

--- a/ogr/ogrgeometryfactory.cpp
+++ b/ogr/ogrgeometryfactory.cpp
@@ -1448,7 +1448,7 @@ OGRGeometryFactory::removeLowerDimensionSubGeoms(const OGRGeometry *poGeom)
     }
     const OGRGeometryCollection *poGC = poGeom->toGeometryCollection();
     int nMaxDim = 0;
-    OGRBoolean bHasCurve = FALSE;
+    bool bHasCurve = false;
     for (const auto poSubGeom : *poGC)
     {
         nMaxDim = std::max(nMaxDim, poSubGeom->getDimension());
@@ -3793,10 +3793,10 @@ static bool ContainsPole(const OGRGeometry *poGeom, const OGRPoint *poPole)
                 const auto poRing = poPoly->getExteriorRingCurve();
                 OGRPolygon oPolygon;
                 oPolygon.addRing(poRing);
-                return CPL_TO_BOOL(oPolygon.Contains(poPole));
+                return oPolygon.Contains(poPole);
             }
 
-            return CPL_TO_BOOL(poGeom->Contains(poPole));
+            return poGeom->Contains(poPole);
         }
 
         case wkbMultiPolygon:
@@ -3814,7 +3814,7 @@ static bool ContainsPole(const OGRGeometry *poGeom, const OGRPoint *poPole)
         default:
             break;
     }
-    return CPL_TO_BOOL(poGeom->Contains(poPole));
+    return poGeom->Contains(poPole);
 }
 
 /************************************************************************/
@@ -3847,7 +3847,7 @@ static std::unique_ptr<OGRGeometry> TransformBeforePolarToGeographic(
     OGRPoint oNearPoleAntimeridian(dfNearPoleAntiMeridianX,
                                    dfNearPoleAntiMeridianY);
     const bool bContainsNearPoleAntimeridian =
-        CPL_TO_BOOL(poDstGeom->Contains(&oNearPoleAntimeridian));
+        poDstGeom->Contains(&oNearPoleAntimeridian);
 
     // Does the geometry intersects the antimeridian ?
     OGRLineString oAntiMeridianLine;
@@ -3856,12 +3856,12 @@ static std::unique_ptr<OGRGeometry> TransformBeforePolarToGeographic(
     oAntiMeridianLine.transform(poRevCT);
     const bool bIntersectsAntimeridian =
         bContainsNearPoleAntimeridian ||
-        CPL_TO_BOOL(poDstGeom->Intersects(&oAntiMeridianLine));
+        poDstGeom->Intersects(&oAntiMeridianLine);
 
     // Does the geometry touches the pole (but not intersect the antimeridian) ?
     const bool bRegularTouchesPole =
         !bContainsPole && !bContainsNearPoleAntimeridian &&
-        !bIntersectsAntimeridian && CPL_TO_BOOL(poDstGeom->Touches(&oPole));
+        !bIntersectsAntimeridian && poDstGeom->Touches(&oPole);
 
     // Create a polygon of nearly a full hemisphere, but excluding the anti
     // meridian and the pole.
@@ -5176,8 +5176,8 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
         if (poRet)
         {
             poRet->assignSpatialReference(poGeom->getSpatialReference());
-            poRet->set3D(OGR_GT_HasZ(eTargetType));
-            poRet->setMeasured(OGR_GT_HasM(eTargetType));
+            poRet->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+            poRet->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         }
         return poRet;
     }
@@ -5191,16 +5191,16 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
             forceTo(std::move(poGeom), eTargetTypeFlat, papszOptions);
         if (poGeomNew)
         {
-            poGeomNew->set3D(OGR_GT_HasZ(eTargetType));
-            poGeomNew->setMeasured(OGR_GT_HasM(eTargetType));
+            poGeomNew->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+            poGeomNew->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         }
         return poGeomNew;
     }
 
     if (eTypeFlat == eTargetTypeFlat)
     {
-        poGeom->set3D(OGR_GT_HasZ(eTargetType));
-        poGeom->setMeasured(OGR_GT_HasM(eTargetType));
+        poGeom->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+        poGeom->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         return poGeom;
     }
 
@@ -5225,8 +5225,8 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
         OGRGeometryCollection *poGC = poGeom.release()->toGeometryCollection();
         auto poRet = std::unique_ptr<OGRGeometry>(
             OGRGeometryCollection::CastToGeometryCollection(poGC));
-        poRet->set3D(OGR_GT_HasZ(eTargetType));
-        poRet->setMeasured(OGR_GT_HasM(eTargetType));
+        poRet->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+        poRet->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         return poRet;
     }
 
@@ -5235,8 +5235,8 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
         auto poPS = std::make_unique<OGRPolyhedralSurface>();
         poPS->assignSpatialReference(poGeom->getSpatialReference());
         poPS->addGeometryDirectly(OGRTriangle::CastToPolygon(poGeom.release()));
-        poPS->set3D(OGR_GT_HasZ(eTargetType));
-        poPS->setMeasured(OGR_GT_HasM(eTargetType));
+        poPS->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+        poPS->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         return poPS;
     }
     else if (eType == wkbPolygon && eTargetTypeFlat == wkbPolyhedralSurface)
@@ -5244,8 +5244,8 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
         auto poPS = std::make_unique<OGRPolyhedralSurface>();
         poPS->assignSpatialReference(poGeom->getSpatialReference());
         poPS->addGeometry(std::move(poGeom));
-        poPS->set3D(OGR_GT_HasZ(eTargetType));
-        poPS->setMeasured(OGR_GT_HasM(eTargetType));
+        poPS->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+        poPS->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         return poPS;
     }
     else if (eType == wkbMultiPolygon &&
@@ -5257,8 +5257,8 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
         {
             poPS->addGeometry(poPoly);
         }
-        poPS->set3D(OGR_GT_HasZ(eTargetType));
-        poPS->setMeasured(OGR_GT_HasM(eTargetType));
+        poPS->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+        poPS->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         return poPS;
     }
     else if (eType == wkbTIN && eTargetTypeFlat == wkbPolyhedralSurface)
@@ -5294,8 +5294,8 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
         auto poTS = std::make_unique<OGRTriangulatedSurface>();
         poTS->assignSpatialReference(poGeom->getSpatialReference());
         poTS->addGeometry(std::move(poGeom));
-        poTS->set3D(OGR_GT_HasZ(eTargetType));
-        poTS->setMeasured(OGR_GT_HasM(eTargetType));
+        poTS->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+        poTS->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         return poTS;
     }
     else if (eType == wkbPolygon && eTargetTypeFlat == wkbTIN)
@@ -5312,8 +5312,8 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
         auto poTS = std::make_unique<OGRTriangulatedSurface>();
         poTS->assignSpatialReference(poGeom->getSpatialReference());
         poTS->addGeometry(std::move(poTriangle));
-        poTS->set3D(OGR_GT_HasZ(eTargetType));
-        poTS->setMeasured(OGR_GT_HasM(eTargetType));
+        poTS->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+        poTS->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         return poTS;
     }
     else if (eType == wkbMultiPolygon && eTargetTypeFlat == wkbTIN)
@@ -5335,8 +5335,8 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
             OGRErr eErr = OGRERR_NONE;
             poTS->addGeometry(std::make_unique<OGRTriangle>(*poPoly, eErr));
         }
-        poTS->set3D(OGR_GT_HasZ(eTargetType));
-        poTS->setMeasured(OGR_GT_HasM(eTargetType));
+        poTS->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+        poTS->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         return poTS;
     }
     else if (eType == wkbPolyhedralSurface && eTargetTypeFlat == wkbTIN)
@@ -5348,8 +5348,8 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
             if (!(poLR != nullptr && poLR->getNumPoints() == 4 &&
                   poPoly->getNumInteriorRings() == 0))
             {
-                poGeom->set3D(OGR_GT_HasZ(eTargetType));
-                poGeom->setMeasured(OGR_GT_HasM(eTargetType));
+                poGeom->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+                poGeom->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
                 return poGeom;
             }
         }
@@ -5360,8 +5360,8 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
             OGRErr eErr = OGRERR_NONE;
             poTS->addGeometry(std::make_unique<OGRTriangle>(*poPoly, eErr));
         }
-        poTS->set3D(OGR_GT_HasZ(eTargetType));
-        poTS->setMeasured(OGR_GT_HasM(eTargetType));
+        poTS->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+        poTS->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         return poTS;
     }
 
@@ -5372,14 +5372,14 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
         if (!(poLR != nullptr && poLR->getNumPoints() == 4 &&
               poPoly->getNumInteriorRings() == 0))
         {
-            poGeom->set3D(OGR_GT_HasZ(eTargetType));
-            poGeom->setMeasured(OGR_GT_HasM(eTargetType));
+            poGeom->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+            poGeom->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
             return poGeom;
         }
         OGRErr eErr = OGRERR_NONE;
         auto poTriangle = std::make_unique<OGRTriangle>(*poPoly, eErr);
-        poTriangle->set3D(OGR_GT_HasZ(eTargetType));
-        poTriangle->setMeasured(OGR_GT_HasM(eTargetType));
+        poTriangle->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+        poTriangle->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         return poTriangle;
     }
 
@@ -5403,8 +5403,8 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
         auto poGC = std::make_unique<OGRGeometryCollection>();
         poGC->assignSpatialReference(poGeom->getSpatialReference());
         poGC->addGeometry(std::move(poGeom));
-        poGC->set3D(OGR_GT_HasZ(eTargetType));
-        poGC->setMeasured(OGR_GT_HasM(eTargetType));
+        poGC->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+        poGC->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         return poGC;
     }
 
@@ -5422,8 +5422,8 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
             poGeom.reset(
                 OGRCurve::CastToLineString(poGeom.release()->toCurve()));
         poRet->toGeometryCollection()->addGeometry(std::move(poGeom));
-        poRet->set3D(OGR_GT_HasZ(eTargetType));
-        poRet->setMeasured(OGR_GT_HasM(eTargetType));
+        poRet->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+        poRet->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         return poRet;
     }
 
@@ -5434,8 +5434,8 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
             OGRCurve::CastToCompoundCurve(poGeom.release()->toCurve()));
         if (poRet)
         {
-            poRet->set3D(OGR_GT_HasZ(eTargetType));
-            poRet->setMeasured(OGR_GT_HasM(eTargetType));
+            poRet->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+            poRet->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         }
         return poRet;
     }
@@ -5448,8 +5448,8 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
             if (poCP->addRing(std::move(poCurve)) == OGRERR_NONE)
             {
                 poCP->assignSpatialReference(poGeom->getSpatialReference());
-                poCP->set3D(OGR_GT_HasZ(eTargetType));
-                poCP->setMeasured(OGR_GT_HasM(eTargetType));
+                poCP->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+                poCP->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
                 return poCP;
             }
         }
@@ -5481,16 +5481,16 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
         auto poRet =
             std::unique_ptr<OGRGeometry>(OGRSurface::CastToCurvePolygon(
                 OGRTriangle::CastToPolygon(poGeom.release())->toSurface()));
-        poRet->set3D(OGR_GT_HasZ(eTargetType));
-        poRet->setMeasured(OGR_GT_HasM(eTargetType));
+        poRet->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+        poRet->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         return poRet;
     }
     else if (eType == wkbPolygon && eTargetTypeFlat == wkbCurvePolygon)
     {
         auto poRet = std::unique_ptr<OGRGeometry>(
             OGRSurface::CastToCurvePolygon(poGeom.release()->toPolygon()));
-        poRet->set3D(OGR_GT_HasZ(eTargetType));
-        poRet->setMeasured(OGR_GT_HasM(eTargetType));
+        poRet->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+        poRet->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         return poRet;
     }
     else if (OGR_GT_IsSubClassOf(eType, wkbCurvePolygon) &&
@@ -5511,8 +5511,8 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
         auto poRet =
             std::unique_ptr<OGRGeometry>(OGRMultiPolygon::CastToMultiSurface(
                 poGeom.release()->toMultiPolygon()));
-        poRet->set3D(OGR_GT_HasZ(eTargetType));
-        poRet->setMeasured(OGR_GT_HasM(eTargetType));
+        poRet->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+        poRet->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         return poRet;
     }
     else if (eType == wkbMultiLineString && eTargetTypeFlat == wkbMultiCurve)
@@ -5520,8 +5520,8 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
         auto poRet =
             std::unique_ptr<OGRGeometry>(OGRMultiLineString::CastToMultiCurve(
                 poGeom.release()->toMultiLineString()));
-        poRet->set3D(OGR_GT_HasZ(eTargetType));
-        poRet->setMeasured(OGR_GT_HasM(eTargetType));
+        poRet->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+        poRet->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         return poRet;
     }
     else if (OGR_GT_IsSubClassOf(eType, wkbGeometryCollection))
@@ -5573,8 +5573,8 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
     {
         auto poNewGeom =
             std::unique_ptr<OGRGeometry>(forceToLineString(poGeom.release()));
-        poNewGeom->set3D(OGR_GT_HasZ(eTargetType));
-        poNewGeom->setMeasured(OGR_GT_HasM(eTargetType));
+        poNewGeom->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+        poNewGeom->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         poGeom = std::move(poNewGeom);
     }
     else if (eTargetTypeFlat == wkbPolygon)
@@ -5583,8 +5583,8 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
             std::unique_ptr<OGRGeometry>(forceToPolygon(poGeom.release()));
         if (poNewGeom)
         {
-            poNewGeom->set3D(OGR_GT_HasZ(eTargetType));
-            poNewGeom->setMeasured(OGR_GT_HasM(eTargetType));
+            poNewGeom->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+            poNewGeom->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         }
         poGeom = std::move(poNewGeom);
     }
@@ -5594,8 +5594,8 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
             std::unique_ptr<OGRGeometry>(forceToMultiPolygon(poGeom.release()));
         if (poNewGeom)
         {
-            poNewGeom->set3D(OGR_GT_HasZ(eTargetType));
-            poNewGeom->setMeasured(OGR_GT_HasM(eTargetType));
+            poNewGeom->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+            poNewGeom->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         }
         poGeom = std::move(poNewGeom);
     }
@@ -5603,16 +5603,16 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
     {
         auto poNewGeom = std::unique_ptr<OGRGeometry>(
             forceToMultiLineString(poGeom.release()));
-        poNewGeom->set3D(OGR_GT_HasZ(eTargetType));
-        poNewGeom->setMeasured(OGR_GT_HasM(eTargetType));
+        poNewGeom->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+        poNewGeom->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         poGeom = std::move(poNewGeom);
     }
     else if (eTargetTypeFlat == wkbMultiPoint)
     {
         auto poNewGeom =
             std::unique_ptr<OGRGeometry>(forceToMultiPoint(poGeom.release()));
-        poNewGeom->set3D(OGR_GT_HasZ(eTargetType));
-        poNewGeom->setMeasured(OGR_GT_HasM(eTargetType));
+        poNewGeom->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
+        poNewGeom->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));
         poGeom = std::move(poNewGeom);
     }
 

--- a/ogr/ogrgeometryfactory.cpp
+++ b/ogr/ogrgeometryfactory.cpp
@@ -2066,7 +2066,7 @@ std::unique_ptr<OGRGeometry> OGRGeometryFactory::organizePolygons(
                 sPolyEx.dfArea = sPolyEx.poCurvePolygon->get_Area();
             const auto *poExteriorRing =
                 sPolyEx.poCurvePolygon->getExteriorRingCurve();
-            sPolyEx.bIsCW = CPL_TO_BOOL(poExteriorRing->isClockwise());
+            sPolyEx.bIsCW = poExteriorRing->isClockwise();
             poExteriorRing->StartPoint(&sPolyEx.sPoint);
             if (sPolyEx.bIsCW)
             {

--- a/ogr/ogrlinearring.cpp
+++ b/ogr/ogrlinearring.cpp
@@ -612,7 +612,7 @@ bool OGRLinearRing::isPointOnRingBoundary(const OGRPoint *poPoint,
 OGRErr OGRLinearRing::transform(OGRCoordinateTransformation *poCT)
 
 {
-    const bool bIsClosed = getNumPoints() > 2 && CPL_TO_BOOL(get_IsClosed());
+    const bool bIsClosed = getNumPoints() > 2 && get_IsClosed();
     OGRErr eErr = OGRLineString::transform(poCT);
     if (bIsClosed && eErr == OGRERR_NONE && !get_IsClosed())
     {

--- a/ogr/ogrlinearring.cpp
+++ b/ogr/ogrlinearring.cpp
@@ -449,8 +449,8 @@ void OGRLinearRing::closeRings()
  *                      ring envelope must be checked first.
  * @return TRUE or FALSE.
  */
-OGRBoolean OGRLinearRing::isPointInRing(const OGRPoint *poPoint,
-                                        int bTestEnvelope) const
+bool OGRLinearRing::isPointInRing(const OGRPoint *poPoint,
+                                  int bTestEnvelope) const
 {
     if (nullptr == poPoint)
     {
@@ -517,7 +517,7 @@ OGRBoolean OGRLinearRing::isPointInRing(const OGRPoint *poPoint,
 
     // If iNumCrossings number is even, given point is outside the ring,
     // when the crossings number is odd, the point is inside the ring.
-    return iNumCrossings % 2;  // OGRBoolean
+    return (iNumCrossings % 2) != 0;
 }
 
 /************************************************************************/
@@ -530,8 +530,8 @@ OGRBoolean OGRLinearRing::isPointInRing(const OGRPoint *poPoint,
  *                      ring envelope must be checked first.
  * @return TRUE or FALSE.
  */
-OGRBoolean OGRLinearRing::isPointOnRingBoundary(const OGRPoint *poPoint,
-                                                int bTestEnvelope) const
+bool OGRLinearRing::isPointOnRingBoundary(const OGRPoint *poPoint,
+                                          int bTestEnvelope) const
 {
     if (nullptr == poPoint)
     {

--- a/ogr/ogrlinestring.cpp
+++ b/ogr/ogrlinestring.cpp
@@ -3282,14 +3282,14 @@ double OGRLineString::get_AreaOfCurveSegments() const
  * @return TRUE if clockwise otherwise FALSE.
  */
 
-int OGRLineString::isClockwise() const
+bool OGRLineString::isClockwise() const
 
 {
     // WARNING: keep in sync OGRLineString::isClockwise(),
     // OGRCurve::isClockwise() and OGRWKBIsClockwiseRing()
 
     if (nPointCount < 2)
-        return TRUE;
+        return true;
 
     bool bUseFallback = false;
 
@@ -3359,9 +3359,9 @@ int OGRLineString::isClockwise() const
     if (!bUseFallback)
     {
         if (crossproduct > 0)  // CCW
-            return FALSE;
+            return false;
         else if (crossproduct < 0)  // CW
-            return TRUE;
+            return true;
     }
 
     // This is a degenerate case: the extent of the polygon is less than EPSILON

--- a/ogr/ogrlinestring.cpp
+++ b/ogr/ogrlinestring.cpp
@@ -186,7 +186,7 @@ bool OGRSimpleCurve::setCoordinateDimension(int nNewDimension)
     return true;
 }
 
-bool OGRSimpleCurve::set3D(OGRBoolean bIs3D)
+bool OGRSimpleCurve::set3D(bool bIs3D)
 
 {
     if (bIs3D)
@@ -196,7 +196,7 @@ bool OGRSimpleCurve::set3D(OGRBoolean bIs3D)
     return true;
 }
 
-bool OGRSimpleCurve::setMeasured(OGRBoolean bIsMeasured)
+bool OGRSimpleCurve::setMeasured(bool bIsMeasured)
 
 {
     if (bIsMeasured)
@@ -2031,9 +2031,9 @@ std::string OGRSimpleCurve::exportToWkt(const OGRWktOptions &opts,
     {
         wkt += '(';
 
-        OGRBoolean hasZ = Is3D();
-        OGRBoolean hasM =
-            (opts.variant != wkbVariantIso ? FALSE : IsMeasured());
+        const bool hasZ = Is3D();
+        const bool hasM =
+            (opts.variant != wkbVariantIso ? false : IsMeasured());
 
         try
         {
@@ -2491,7 +2491,7 @@ void OGRSimpleCurve::getEnvelope(OGREnvelope3D *psEnvelope) const
 /*                               Equals()                               */
 /************************************************************************/
 
-OGRBoolean OGRSimpleCurve::Equals(const OGRGeometry *poOther) const
+bool OGRSimpleCurve::Equals(const OGRGeometry *poOther) const
 
 {
     if (poOther == this)
@@ -2636,7 +2636,7 @@ OGRErr OGRSimpleCurve::transform(OGRCoordinateTransformation *poCT)
 /*                              IsEmpty()                               */
 /************************************************************************/
 
-OGRBoolean OGRSimpleCurve::IsEmpty() const
+bool OGRSimpleCurve::IsEmpty() const
 {
     return (nPointCount == 0);
 }
@@ -2850,14 +2850,14 @@ class OGRSimpleCurvePointIterator final : public OGRPointIterator
     {
     }
 
-    OGRBoolean getNextPoint(OGRPoint *p) override;
+    bool getNextPoint(OGRPoint *p) override;
 };
 
 /************************************************************************/
 /*                            getNextPoint()                            */
 /************************************************************************/
 
-OGRBoolean OGRSimpleCurvePointIterator::getNextPoint(OGRPoint *p)
+bool OGRSimpleCurvePointIterator::getNextPoint(OGRPoint *p)
 {
     if (iCurPoint >= poSC->getNumPoints())
         return FALSE;

--- a/ogr/ogrmulticurve.cpp
+++ b/ogr/ogrmulticurve.cpp
@@ -107,10 +107,9 @@ const char *OGRMultiCurve::getGeometryName() const
 /*                        isCompatibleSubType()                         */
 /************************************************************************/
 
-OGRBoolean
-OGRMultiCurve::isCompatibleSubType(OGRwkbGeometryType eGeomType) const
+bool OGRMultiCurve::isCompatibleSubType(OGRwkbGeometryType eGeomType) const
 {
-    return OGR_GT_IsCurve(eGeomType);
+    return CPL_TO_BOOL(OGR_GT_IsCurve(eGeomType));
 }
 
 /*! @cond Doxygen_Suppress */
@@ -160,7 +159,7 @@ std::string OGRMultiCurve::exportToWkt(const OGRWktOptions &opts,
 /*                          hasCurveGeometry()                          */
 /************************************************************************/
 
-OGRBoolean OGRMultiCurve::hasCurveGeometry(int bLookForNonLinear) const
+bool OGRMultiCurve::hasCurveGeometry(int bLookForNonLinear) const
 {
     if (bLookForNonLinear)
         return OGRGeometryCollection::hasCurveGeometry(TRUE);

--- a/ogr/ogrmultilinestring.cpp
+++ b/ogr/ogrmultilinestring.cpp
@@ -98,8 +98,7 @@ const char *OGRMultiLineString::getGeometryName() const
 /*                        isCompatibleSubType()                         */
 /************************************************************************/
 
-OGRBoolean
-OGRMultiLineString::isCompatibleSubType(OGRwkbGeometryType eGeomType) const
+bool OGRMultiLineString::isCompatibleSubType(OGRwkbGeometryType eGeomType) const
 {
     return wkbFlatten(eGeomType) == wkbLineString;
 }
@@ -159,8 +158,7 @@ std::string OGRMultiLineString::exportToWkt(const OGRWktOptions &opts,
 /*                          hasCurveGeometry()                          */
 /************************************************************************/
 
-OGRBoolean
-OGRMultiLineString::hasCurveGeometry(int /* bLookForNonLinear */) const
+bool OGRMultiLineString::hasCurveGeometry(int /* bLookForNonLinear */) const
 {
     return false;
 }

--- a/ogr/ogrmultipoint.cpp
+++ b/ogr/ogrmultipoint.cpp
@@ -103,8 +103,7 @@ const char *OGRMultiPoint::getGeometryName() const
 /*                        isCompatibleSubType()                         */
 /************************************************************************/
 
-OGRBoolean
-OGRMultiPoint::isCompatibleSubType(OGRwkbGeometryType eGeomType) const
+bool OGRMultiPoint::isCompatibleSubType(OGRwkbGeometryType eGeomType) const
 {
     return wkbFlatten(eGeomType) == wkbPoint;
 }
@@ -398,7 +397,7 @@ OGRErr OGRMultiPoint::importFromWkt_Bracketed(const char **ppszInput, int bHasM,
 /*                          hasCurveGeometry()                          */
 /************************************************************************/
 
-OGRBoolean OGRMultiPoint::hasCurveGeometry(int /* bLookForNonLinear */) const
+bool OGRMultiPoint::hasCurveGeometry(int /* bLookForNonLinear */) const
 {
     return FALSE;
 }

--- a/ogr/ogrmultipolygon.cpp
+++ b/ogr/ogrmultipolygon.cpp
@@ -95,8 +95,7 @@ const char *OGRMultiPolygon::getGeometryName() const
 /*                        isCompatibleSubType()                         */
 /************************************************************************/
 
-OGRBoolean
-OGRMultiPolygon::isCompatibleSubType(OGRwkbGeometryType eGeomType) const
+bool OGRMultiPolygon::isCompatibleSubType(OGRwkbGeometryType eGeomType) const
 {
     return wkbFlatten(eGeomType) == wkbPolygon;
 }
@@ -154,7 +153,7 @@ std::string OGRMultiPolygon::exportToWkt(const OGRWktOptions &opts,
 /*                          hasCurveGeometry()                          */
 /************************************************************************/
 
-OGRBoolean OGRMultiPolygon::hasCurveGeometry(int /* bLookForNonLinear */) const
+bool OGRMultiPolygon::hasCurveGeometry(int /* bLookForNonLinear */) const
 {
     return FALSE;
 }

--- a/ogr/ogrmultisurface.cpp
+++ b/ogr/ogrmultisurface.cpp
@@ -108,8 +108,7 @@ const char *OGRMultiSurface::getGeometryName() const
 /*                        isCompatibleSubType()                         */
 /************************************************************************/
 
-OGRBoolean
-OGRMultiSurface::isCompatibleSubType(OGRwkbGeometryType eGeomType) const
+bool OGRMultiSurface::isCompatibleSubType(OGRwkbGeometryType eGeomType) const
 {
     OGRwkbGeometryType eFlattenGeomType = wkbFlatten(eGeomType);
     return eFlattenGeomType == wkbPolygon ||
@@ -257,7 +256,7 @@ std::string OGRMultiSurface::exportToWkt(const OGRWktOptions &opts,
 /*                          hasCurveGeometry()                          */
 /************************************************************************/
 
-OGRBoolean OGRMultiSurface::hasCurveGeometry(int bLookForNonLinear) const
+bool OGRMultiSurface::hasCurveGeometry(int bLookForNonLinear) const
 {
     if (bLookForNonLinear)
         return OGRGeometryCollection::hasCurveGeometry(TRUE);

--- a/ogr/ogrpoint.cpp
+++ b/ogr/ogrpoint.cpp
@@ -668,7 +668,7 @@ void OGRPoint::getEnvelope(OGREnvelope3D *psEnvelope) const
 /*                               Equal()                                */
 /************************************************************************/
 
-OGRBoolean OGRPoint::Equals(const OGRGeometry *poOther) const
+bool OGRPoint::Equals(const OGRGeometry *poOther) const
 
 {
     if (poOther == this)
@@ -721,7 +721,7 @@ void OGRPoint::swapXY()
 /*                               Within()                               */
 /************************************************************************/
 
-OGRBoolean OGRPoint::Within(const OGRGeometry *poOtherGeom) const
+bool OGRPoint::Within(const OGRGeometry *poOtherGeom) const
 
 {
     if (!IsEmpty() && poOtherGeom != nullptr &&
@@ -738,7 +738,7 @@ OGRBoolean OGRPoint::Within(const OGRGeometry *poOtherGeom) const
 /*                             Intersects()                             */
 /************************************************************************/
 
-OGRBoolean OGRPoint::Intersects(const OGRGeometry *poOtherGeom) const
+bool OGRPoint::Intersects(const OGRGeometry *poOtherGeom) const
 
 {
     if (!IsEmpty() && poOtherGeom != nullptr &&

--- a/ogr/ogrpolygon.cpp
+++ b/ogr/ogrpolygon.cpp
@@ -767,7 +767,7 @@ std::string OGRPolygon::exportToWkt(const OGRWktOptions &opts,
 /** Return whether the point is on the surface.
  * @return TRUE or FALSE
  */
-OGRBoolean OGRPolygon::IsPointOnSurface(const OGRPoint *pt) const
+bool OGRPolygon::IsPointOnSurface(const OGRPoint *pt) const
 {
     if (nullptr == pt)
         return FALSE;
@@ -827,7 +827,7 @@ OGRPolygon::CurvePolyToPoly(CPL_UNUSED double dfMaxAngleStepSizeDegrees,
 /*                          hasCurveGeometry()                          */
 /************************************************************************/
 
-OGRBoolean OGRPolygon::hasCurveGeometry(CPL_UNUSED int bLookForNonLinear) const
+bool OGRPolygon::hasCurveGeometry(CPL_UNUSED int bLookForNonLinear) const
 {
     return FALSE;
 }

--- a/ogr/ogrpolyhedralsurface.cpp
+++ b/ogr/ogrpolyhedralsurface.cpp
@@ -530,8 +530,8 @@ OGRPolyhedralSurface::GetCasterToCurvePolygon() const
 /************************************************************************/
 
 //! @cond Doxygen_Suppress
-OGRBoolean
-OGRPolyhedralSurface::isCompatibleSubType(OGRwkbGeometryType eSubType) const
+bool OGRPolyhedralSurface::isCompatibleSubType(
+    OGRwkbGeometryType eSubType) const
 {
     return wkbFlatten(eSubType) == wkbPolygon;
 }
@@ -566,7 +566,7 @@ OGRwkbGeometryType OGRPolyhedralSurface::getSubGeometryType() const
 /*                               Equals()                               */
 /************************************************************************/
 
-OGRBoolean OGRPolyhedralSurface::Equals(const OGRGeometry *poOther) const
+bool OGRPolyhedralSurface::Equals(const OGRGeometry *poOther) const
 {
 
     if (poOther == this)
@@ -896,7 +896,7 @@ const OGRPolygon *OGRPolyhedralSurface::getGeometryRef(int i) const
  * @return TRUE if the PolyhedralSurface is empty, FALSE otherwise
  */
 
-OGRBoolean OGRPolyhedralSurface::IsEmpty() const
+bool OGRPolyhedralSurface::IsEmpty() const
 {
     return oMP.IsEmpty();
 }
@@ -909,7 +909,7 @@ OGRBoolean OGRPolyhedralSurface::IsEmpty() const
  * \brief Set the type as 3D geometry
  */
 
-bool OGRPolyhedralSurface::set3D(OGRBoolean bIs3D)
+bool OGRPolyhedralSurface::set3D(bool bIs3D)
 {
     return oMP.set3D(bIs3D) && OGRGeometry::set3D(bIs3D);
 }
@@ -922,7 +922,7 @@ bool OGRPolyhedralSurface::set3D(OGRBoolean bIs3D)
  * \brief Set the type as Measured
  */
 
-bool OGRPolyhedralSurface::setMeasured(OGRBoolean bIsMeasured)
+bool OGRPolyhedralSurface::setMeasured(bool bIsMeasured)
 {
     return oMP.setMeasured(bIsMeasured) &&
            OGRGeometry::setMeasured(bIsMeasured);
@@ -966,7 +966,7 @@ void OGRPolyhedralSurface::swapXY()
 /*                          hasCurveGeometry()                          */
 /************************************************************************/
 
-OGRBoolean OGRPolyhedralSurface::hasCurveGeometry(int) const
+bool OGRPolyhedralSurface::hasCurveGeometry(int) const
 {
     return FALSE;
 }

--- a/ogr/ogrsf_frmts/csv/ogrcsvdatasource.cpp
+++ b/ogr/ogrsf_frmts/csv/ogrcsvdatasource.cpp
@@ -504,7 +504,7 @@ bool OGRCSVDataSource::Open(const char *pszFilename, bool bUpdateIn,
 
 {
     pszName = CPLStrdup(pszFilename);
-    bUpdate = CPL_TO_BOOL(bUpdateIn);
+    bUpdate = bUpdateIn;
 
     if (bUpdate && bForceOpen && EQUAL(pszFilename, "/vsistdout/"))
         return TRUE;

--- a/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobufdataset.cpp
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobufdataset.cpp
@@ -229,11 +229,11 @@ GDALDataset *OGRFlatGeobufDataset::Open(GDALOpenInfo *poOpenInfo)
     if (OGRFlatGeobufDriverIdentify(poOpenInfo) == FALSE)
         return nullptr;
 
-    const auto bVerifyBuffers =
+    const bool bVerifyBuffers =
         CPLFetchBool(poOpenInfo->papszOpenOptions, "VERIFY_BUFFERS", true);
 
-    auto isDir = CPL_TO_BOOL(poOpenInfo->bIsDirectory);
-    auto bUpdate = poOpenInfo->eAccess == GA_Update;
+    const bool isDir = poOpenInfo->bIsDirectory;
+    const bool bUpdate = poOpenInfo->eAccess == GA_Update;
 
     if (isDir && bUpdate)
     {

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlaswriter.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlaswriter.cpp
@@ -1650,7 +1650,7 @@ static bool AreGeomsEqualAxisOrderInsensitive(const OGRGeometry *poGeomRef,
     if (poGeomRef->Equals(poGeomModifiable))
         return true;
     poGeomModifiable->swapXY();
-    return CPL_TO_BOOL(poGeomRef->Equals(poGeomModifiable));
+    return poGeomRef->Equals(poGeomModifiable);
 }
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/gmt/ogr_gmt.h
+++ b/ogr/ogrsf_frmts/gmt/ogr_gmt.h
@@ -57,7 +57,7 @@ class OGRGmtLayer final : public OGRLayer,
     bool bValidFile;
 
     OGRGmtLayer(GDALDataset *poDS, const char *pszFilename, VSILFILE *fp,
-                const OGRSpatialReference *poSRS, int bUpdate);
+                const OGRSpatialReference *poSRS, bool bUpdate);
     ~OGRGmtLayer() override;
 
     void ResetReading() override;
@@ -102,7 +102,7 @@ class OGRGmtDataSource final : public GDALDataset
     ~OGRGmtDataSource() override;
 
     int Open(const char *pszFilename, VSILFILE *fp,
-             const OGRSpatialReference *poSRS, int bUpdate);
+             const OGRSpatialReference *poSRS, bool bUpdate);
 
     int GetLayerCount() const override
     {

--- a/ogr/ogrsf_frmts/gmt/ogrgmtdatasource.cpp
+++ b/ogr/ogrsf_frmts/gmt/ogrgmtdatasource.cpp
@@ -40,10 +40,10 @@ OGRGmtDataSource::~OGRGmtDataSource()
 /************************************************************************/
 
 int OGRGmtDataSource::Open(const char *pszFilename, VSILFILE *fp,
-                           const OGRSpatialReference *poSRS, int bUpdateIn)
+                           const OGRSpatialReference *poSRS, bool bUpdateIn)
 
 {
-    bUpdate = CPL_TO_BOOL(bUpdateIn);
+    bUpdate = bUpdateIn;
 
     OGRGmtLayer *poLayer =
         new OGRGmtLayer(this, pszFilename, fp, poSRS, bUpdate);
@@ -179,7 +179,7 @@ OGRGmtDataSource::ICreateLayer(const char *pszLayerName,
     /* -------------------------------------------------------------------- */
     /*      Return open layer handle.                                       */
     /* -------------------------------------------------------------------- */
-    if (Open(osFilename, fp, poSRS, TRUE))
+    if (Open(osFilename, fp, poSRS, true))
     {
         OGRLayer *poLayer = papoLayers[nLayers - 1];
         if (strcmp(pszGeom, "") != 0)

--- a/ogr/ogrsf_frmts/gmt/ogrgmtlayer.cpp
+++ b/ogr/ogrsf_frmts/gmt/ogrgmtlayer.cpp
@@ -22,12 +22,10 @@
 
 OGRGmtLayer::OGRGmtLayer(GDALDataset *poDS, const char *pszFilename,
                          VSILFILE *fp, const OGRSpatialReference *poSRS,
-                         int bUpdateIn)
-    : m_poDS(poDS), poFeatureDefn(nullptr), iNextFID(0),
-      bUpdate(CPL_TO_BOOL(bUpdateIn)),
+                         bool bUpdateIn)
+    : m_poDS(poDS), poFeatureDefn(nullptr), iNextFID(0), bUpdate(bUpdateIn),
       // Assume header complete in readonly mode.
-      bHeaderComplete(CPL_TO_BOOL(!bUpdate)), bRegionComplete(false),
-      nRegionOffset(0),
+      bHeaderComplete(!bUpdate), bRegionComplete(false), nRegionOffset(0),
       m_fp(fp ? fp : VSIFOpenL(pszFilename, (bUpdateIn ? "r+" : "r"))),
       papszKeyedValues(nullptr), bValidFile(false)
 {

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackageutility.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackageutility.cpp
@@ -238,8 +238,8 @@ GByte *GPkgGeometryFromOGR(const OGRGeometry *poGeometry, int iSrsId,
         wkbExportOptions.sPrecision = *psPrecision;
     wkbExportOptions.eByteOrder = static_cast<OGRwkbByteOrder>(CPL_IS_LSB);
     OGRErr err;
-    OGRBoolean bPoint = (wkbFlatten(poGeometry->getGeometryType()) == wkbPoint);
-    OGRBoolean bEmpty = poGeometry->IsEmpty();
+    bool bPoint = (wkbFlatten(poGeometry->getGeometryType()) == wkbPoint);
+    bool bEmpty = poGeometry->IsEmpty();
     /* We voluntarily use getCoordinateDimension() so as to get only 2 for
      * XY/XYM */
     /* and 3 for XYZ/XYZM as we currently don't write envelopes with M extent.
@@ -373,7 +373,7 @@ OGRErr GPkgHeaderFromWKB(const GByte *pabyGpkg, size_t nGpkgLen,
 #ifdef notdef
     poHeader->bExtentHasM = false;
 #endif
-    OGRBoolean bSwap = OGR_SWAP(poHeader->eByteOrder);
+    bool bSwap = OGR_SWAP(poHeader->eByteOrder);
 
     /* Envelope */
     int iEnvelope = (byFlags & (0x07 << 1)) >> 1;
@@ -521,7 +521,7 @@ bool GPkgUpdateHeader(GByte *pabyGpkg, size_t nGpkgLen, int nSrsId, double MinX,
     /* Flags */
     const GByte byFlags = pabyGpkg[3];
     const auto eByteOrder = static_cast<OGRwkbByteOrder>(byFlags & 0x01);
-    const OGRBoolean bSwap = OGR_SWAP(eByteOrder);
+    const bool bSwap = OGR_SWAP(eByteOrder);
 
     /* SrsId */
     if (bSwap)

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackageutility.h
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackageutility.h
@@ -18,8 +18,8 @@
 
 typedef struct
 {
-    OGRBoolean bEmpty;
-    OGRBoolean bExtended;
+    bool bEmpty;
+    bool bExtended;
     OGRwkbByteOrder eByteOrder;
     int iSrsId;
     bool bExtentHasXY;

--- a/ogr/ogrsf_frmts/jsonfg/ogrjsonfgwritelayer.cpp
+++ b/ogr/ogrsf_frmts/jsonfg/ogrjsonfgwritelayer.cpp
@@ -342,10 +342,10 @@ OGRErr OGRJSONFGWriteLayer::ICreateFeature(OGRFeature *poFeature)
     json_object *poPlace = nullptr;
     if (const OGRGeometry *poGeom = poFeature->GetGeometryRef())
     {
-        const bool bHasCurve = CPL_TO_BOOL(poGeom->hasCurveGeometry(true));
+        const bool bHasCurve = poGeom->hasCurveGeometry(true);
         if (bHasCurve)
             m_bCurveWritten = true;
-        const bool bHasMeasure = CPL_TO_BOOL(poGeom->IsMeasured());
+        const bool bHasMeasure = poGeom->IsMeasured();
         if (bHasMeasure)
             m_bMeasureWritten = true;
         bool bWritePlace = false;

--- a/ogr/ogrsf_frmts/libkml/ogrlibkmldatasource.cpp
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmldatasource.cpp
@@ -1516,7 +1516,7 @@ static bool CheckIsKMZ(const char *pszFilename)
 
 int OGRLIBKMLDataSource::Open(const char *pszFilename, bool bUpdateIn)
 {
-    bUpdate = CPL_TO_BOOL(bUpdateIn);
+    bUpdate = bUpdateIn;
 
     /***** dir *****/
     VSIStatBufL sStatBuf;

--- a/ogr/ogrsf_frmts/mapml/ogrmapmldataset.cpp
+++ b/ogr/ogrsf_frmts/mapml/ogrmapmldataset.cpp
@@ -1134,9 +1134,7 @@ void OGRMapMLWriterLayer::writePolygon(CPLXMLNode *psContainer,
     bool bFirstRing = true;
     for (const auto poRing : *poPoly)
     {
-        const bool bReversePointOrder =
-            (bFirstRing && CPL_TO_BOOL(poRing->isClockwise())) ||
-            (!bFirstRing && !CPL_TO_BOOL(poRing->isClockwise()));
+        const bool bReversePointOrder = bFirstRing == poRing->isClockwise();
         bFirstRing = false;
         CPLXMLNode *psCoordinates =
             CPLCreateXMLNode(psPolygon, CXT_Element, "map-coordinates");

--- a/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
@@ -2745,7 +2745,7 @@ void OGRMSSQLSpatialTableLayer::AppendFieldValue(CPLODBCStatement *poStatement,
 
     // Flag indicating NULL or not-a-date date value
     // e.g. 0000-00-00 - there is no year 0
-    OGRBoolean bIsDateNull = FALSE;
+    bool bIsDateNull = FALSE;
 
     const char *pszStrValue = poFeature->GetFieldAsString(i);
 

--- a/ogr/ogrsf_frmts/mvt/ogrmvtdataset.cpp
+++ b/ogr/ogrsf_frmts/mvt/ogrmvtdataset.cpp
@@ -1036,7 +1036,7 @@ OGRMVTLayer::ParseGeometry(unsigned int nGeomType,
         {
             std::unique_ptr<OGRMultiPolygon> poMultiPoly;
             std::unique_ptr<OGRPolygon> poPoly;
-            int externalIsClockwise = 0;
+            bool externalIsClockwise = false;
             int nX = 0;
             int nY = 0;
             OGREnvelope sExteriorRingEnvelope;

--- a/ogr/ogrsf_frmts/ngw/ogrngwlayer.cpp
+++ b/ogr/ogrsf_frmts/ngw/ogrngwlayer.cpp
@@ -1070,7 +1070,7 @@ GIntBig OGRNGWLayer::GetFeatureCount(int bForce)
 OGRErr OGRNGWLayer::IGetExtent(int /* iGeomField */, OGREnvelope *psExtent,
                                bool bForce)
 {
-    if (!stExtent.IsInit() || CPL_TO_BOOL(bForce))
+    if (!stExtent.IsInit() || bForce)
     {
         auto aosHTTPOptions = poDS->GetHeaders(false);
         bool bResult = NGWAPI::GetExtent(poDS->GetUrl(), osResourceId,

--- a/ogr/ogrsf_frmts/ods/ogrodsdatasource.cpp
+++ b/ogr/ogrsf_frmts/ods/ogrodsdatasource.cpp
@@ -53,8 +53,7 @@ class ODSCellEvaluator : public IODSCellEvaluator
 OGRODSLayer::OGRODSLayer(OGRODSDataSource *poDSIn, const char *pszName,
                          bool bUpdatedIn)
     : OGRMemLayer(pszName, nullptr, wkbNone), poDS(poDSIn),
-      bUpdated(CPL_TO_BOOL(bUpdatedIn)), bHasHeaderLine(false),
-      m_poAttrQueryODS(nullptr)
+      bUpdated(bUpdatedIn), bHasHeaderLine(false), m_poAttrQueryODS(nullptr)
 {
     SetAdvertizeUTF8(true);
 }

--- a/ogr/ogrsf_frmts/openfilegdb/filegdbtable_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbtable_write.cpp
@@ -946,11 +946,8 @@ bool FileGDBTable::EncodeGeometry(const FileGDBGeomField *poGeomField,
                     {
                         const int nNumPoints = poLS->getNumPoints();
                         m_anNumberPointsPerPart.push_back(nNumPoints);
-                        const bool bIsClockwise =
-                            CPL_TO_BOOL(poLS->isClockwise());
-                        const bool bReverseOrder =
-                            (bFirstRing && !bIsClockwise) ||
-                            (!bFirstRing && bIsClockwise);
+                        const bool bIsClockwise = poLS->isClockwise();
+                        const bool bReverseOrder = bFirstRing != bIsClockwise;
                         bFirstRing = false;
                         for (int i = 0; i < nNumPoints; ++i)
                         {
@@ -971,11 +968,8 @@ bool FileGDBTable::EncodeGeometry(const FileGDBGeomField *poGeomField,
                     bool bFirstRing = true;
                     for (const auto *poRing : *poCurvePoly)
                     {
-                        const bool bIsClockwise =
-                            CPL_TO_BOOL(poRing->isClockwise());
-                        const bool bReverseOrder =
-                            (bFirstRing && !bIsClockwise) ||
-                            (!bFirstRing && bIsClockwise);
+                        const bool bIsClockwise = poRing->isClockwise();
+                        const bool bReverseOrder = bFirstRing != bIsClockwise;
                         bFirstRing = false;
                         if (auto poCC =
                                 dynamic_cast<const OGRCompoundCurve *>(poRing))

--- a/ogr/ogrsf_frmts/s57/ogrs57datasource.cpp
+++ b/ogr/ogrsf_frmts/s57/ogrs57datasource.cpp
@@ -290,8 +290,8 @@ int OGRS57DataSource::Open(const char *pszFilename)
 
         for (int iModule = 0; iModule < nModules; iModule++)
         {
-            bSuccess &= CPL_TO_BOOL(
-                papoModules[iModule]->CollectClassList(anClassCount));
+            bSuccess = bSuccess &&
+                       papoModules[iModule]->CollectClassList(anClassCount);
         }
 
         bool bGeneric = false;

--- a/ogr/ogrsf_frmts/shape/ogrshapedatasource.cpp
+++ b/ogr/ogrsf_frmts/shape/ogrshapedatasource.cpp
@@ -228,7 +228,7 @@ bool OGRShapeDataSource::Open(GDALOpenInfo *poOpenInfo, bool bTestOpen,
 
     eAccess = poOpenInfo->eAccess;
 
-    m_bSingleFileDataSource = CPL_TO_BOOL(bForceSingleFileDataSource);
+    m_bSingleFileDataSource = bForceSingleFileDataSource;
 
     /* -------------------------------------------------------------------- */
     /*      If m_bSingleFileDataSource is TRUE we don't try to do anything  */

--- a/ogr/ogrsf_frmts/shape/shape2ogr.cpp
+++ b/ogr/ogrsf_frmts/shape/shape2ogr.cpp
@@ -994,8 +994,8 @@ static OGRErr SHPWriteOGRObject(SHPHandle hSHP, int iShape,
             const int nNumPoints = poRing->getNumPoints();
             // Exterior ring must be clockwise oriented in shapefiles
             const bool bInvertOrder =
-                !bRewind && CPL_TO_BOOL(bIsOuterRing ? !poRing->isClockwise()
-                                                     : poRing->isClockwise());
+                !bRewind &&
+                (bIsOuterRing ? !poRing->isClockwise() : poRing->isClockwise());
             for (int i = 0; i < nNumPoints; i++)
             {
                 const int iPoint = bInvertOrder ? nNumPoints - 1 - i : i;

--- a/ogr/ogrsf_frmts/shape/shape2ogr.cpp
+++ b/ogr/ogrsf_frmts/shape/shape2ogr.cpp
@@ -595,7 +595,7 @@ static OGRErr SHPWriteOGRObject(SHPHandle hSHP, int iShape,
         const bool bHasZ = (hSHP->nShapeType == SHPT_MULTIPOINTM ||
                             hSHP->nShapeType == SHPT_MULTIPOINTZ);
         const bool bHasM = wkbHasM(eLayerGeomType) && bHasZ;
-        const bool bIsGeomMeasured = CPL_TO_BOOL(poGeom->IsMeasured());
+        const bool bIsGeomMeasured = poGeom->IsMeasured();
 
         std::vector<double> adfX;
         std::vector<double> adfY;
@@ -719,7 +719,7 @@ static OGRErr SHPWriteOGRObject(SHPHandle hSHP, int iShape,
         const bool bHasZ =
             (hSHP->nShapeType == SHPT_ARCM || hSHP->nShapeType == SHPT_ARCZ);
         const bool bHasM = wkbHasM(eLayerGeomType) && bHasZ;
-        const bool bIsGeomMeasured = CPL_TO_BOOL(poGeom->IsMeasured());
+        const bool bIsGeomMeasured = poGeom->IsMeasured();
 
         try
         {
@@ -961,7 +961,7 @@ static OGRErr SHPWriteOGRObject(SHPHandle hSHP, int iShape,
         const bool bHasZ = (hSHP->nShapeType == SHPT_POLYGONM ||
                             hSHP->nShapeType == SHPT_POLYGONZ);
         const bool bHasM = wkbHasM(eLayerGeomType) && bHasZ;
-        const bool bIsGeomMeasured = CPL_TO_BOOL(poGeom->IsMeasured());
+        const bool bIsGeomMeasured = poGeom->IsMeasured();
 
         std::vector<int> anRingStart;
         std::vector<double> adfX;

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitelayer.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitelayer.cpp
@@ -3016,7 +3016,7 @@ int OGRSQLiteLayer::ComputeSpatiaLiteGeometrySize(const OGRGeometry *poGeometry,
             int nDimension = 2;
             int nPointsDouble = nPoints;
             int nPointsFloat = 0;
-            bool bHasM = CPL_TO_BOOL(poGeometry->IsMeasured());
+            bool bHasM = poGeometry->IsMeasured();
             if (bSpatialite2D == true)
             {
                 // nDimension = 2;

--- a/ogr/ogrsf_frmts/wasp/ogrwasplayer.cpp
+++ b/ogr/ogrsf_frmts/wasp/ogrwasplayer.cpp
@@ -262,7 +262,7 @@ OGRLineString *OGRWAsPLayer::Simplify(const OGRLineString &line) const
     OGRPoint startPt, endPt;
     poLine->StartPoint(&startPt);
     poLine->EndPoint(&endPt);
-    const bool isRing = CPL_TO_BOOL(startPt.Equals(&endPt));
+    const bool isRing = startPt.Equals(&endPt);
 
     if (pdfAdjacentPointTolerance.get() && *pdfAdjacentPointTolerance > 0)
     {

--- a/ogr/ogrsf_frmts/xlsx/ogrxlsxdatasource.cpp
+++ b/ogr/ogrsf_frmts/xlsx/ogrxlsxdatasource.cpp
@@ -970,7 +970,7 @@ void OGRXLSXDataSource::endElementTable(CPL_UNUSED const char *pszNameIn)
 
         if (poCurLayer)
         {
-            poCurLayer->SetUpdatable(CPL_TO_BOOL(bUpdatable));
+            poCurLayer->SetUpdatable(bUpdatable);
             poCurLayer->SetUpdated(false);
         }
 

--- a/ogr/ogrtriangulatedsurface.cpp
+++ b/ogr/ogrtriangulatedsurface.cpp
@@ -109,8 +109,8 @@ OGRwkbGeometryType OGRTriangulatedSurface::getGeometryType() const
 /************************************************************************/
 
 //! @cond Doxygen_Suppress
-OGRBoolean
-OGRTriangulatedSurface::isCompatibleSubType(OGRwkbGeometryType eSubType) const
+bool OGRTriangulatedSurface::isCompatibleSubType(
+    OGRwkbGeometryType eSubType) const
 {
     return wkbFlatten(eSubType) == wkbTriangle;
 }

--- a/ogr/ogrutils.cpp
+++ b/ogr/ogrutils.cpp
@@ -336,7 +336,7 @@ std::string OGRMakeWktCoordinate(double x, double y, double z, int nDimension,
 /************************************************************************/
 
 void OGRMakeWktCoordinateM(char *pszTarget, double x, double y, double z,
-                           double m, OGRBoolean hasZ, OGRBoolean hasM)
+                           double m, bool hasZ, bool hasM)
 
 {
     std::string wkt =
@@ -345,7 +345,7 @@ void OGRMakeWktCoordinateM(char *pszTarget, double x, double y, double z,
 }
 
 std::string OGRMakeWktCoordinateM(double x, double y, double z, double m,
-                                  OGRBoolean hasZ, OGRBoolean hasM,
+                                  bool hasZ, bool hasM,
                                   const OGRWktOptions &opts)
 {
     std::string wkt;

--- a/port/cpl_port.h
+++ b/port/cpl_port.h
@@ -609,9 +609,9 @@ static inline char *CPL_afl_friendly_strstr(const char *haystack,
 #endif
 
 #if defined(CPL_LSB)
-#define CPL_IS_LSB 1
+#define CPL_IS_LSB (1 == 1)
 #else
-#define CPL_IS_LSB 0
+#define CPL_IS_LSB (0 == 1)
 #endif
 /*! @endcond */
 

--- a/port/cpl_port.h
+++ b/port/cpl_port.h
@@ -1155,6 +1155,8 @@ extern "C++"
     {
     }
 
+    inline static bool CPL_TO_BOOL(bool x) = delete;
+
     inline static bool CPL_TO_BOOL(int x)
     {
         return x != 0;

--- a/port/cpl_virtualmem.cpp
+++ b/port/cpl_virtualmem.cpp
@@ -2254,7 +2254,7 @@ CPLVirtualMem *CPLVirtualMemDerivedNew(
     ctxt->pDataToFree = nullptr;
     ctxt->nSize = static_cast<size_t>(nSize);
     ctxt->nPageSize = pVMemBase->nPageSize;
-    ctxt->bSingleThreadUsage = CPL_TO_BOOL(pVMemBase->bSingleThreadUsage);
+    ctxt->bSingleThreadUsage = pVMemBase->bSingleThreadUsage;
     ctxt->pfnFreeUserData = pfnFreeUserData;
     ctxt->pCbkUserData = pCbkUserData;
 

--- a/port/cpl_vsi.h
+++ b/port/cpl_vsi.h
@@ -109,20 +109,20 @@ int CPL_DLL VSIStat(const char *, VSIStatBuf *) CPL_WARN_UNUSED_RESULT;
 
 #ifdef _WIN32
 #define VSI_ISLNK(x) (0) /* N/A on Windows */
-#define VSI_ISREG(x) ((x) & S_IFREG)
-#define VSI_ISDIR(x) ((x) & S_IFDIR)
-#define VSI_ISCHR(x) ((x) & S_IFCHR)
+#define VSI_ISREG(x) (((x) & S_IFREG) != 0)
+#define VSI_ISDIR(x) (((x) & S_IFDIR) != 0)
+#define VSI_ISCHR(x) (((x) & S_IFCHR) != 0)
 #define VSI_ISBLK(x) (0) /* N/A on Windows */
 #else
 /** Test if the file is a symbolic link */
-#define VSI_ISLNK(x) S_ISLNK(x)
+#define VSI_ISLNK(x) (S_ISLNK(x) != 0)
 /** Test if the file is a regular file */
-#define VSI_ISREG(x) S_ISREG(x)
+#define VSI_ISREG(x) (S_ISREG(x) != 0)
 /** Test if the file is a directory */
-#define VSI_ISDIR(x) S_ISDIR(x)
+#define VSI_ISDIR(x) (S_ISDIR(x) != 0)
 /*! @cond Doxygen_Suppress */
-#define VSI_ISCHR(x) S_ISCHR(x)
-#define VSI_ISBLK(x) S_ISBLK(x)
+#define VSI_ISCHR(x) (S_ISCHR(x) != 0)
+#define VSI_ISBLK(x) (S_ISBLK(x) != 0)
 /*! @endcond */
 #endif
 

--- a/port/cpl_vsil.cpp
+++ b/port/cpl_vsil.cpp
@@ -2304,7 +2304,7 @@ bool VSIFilesystemHandler::Sync(const char *pszSource, const char *pszTarget,
             osTarget = CPLFormFilenameSafe(osTarget.c_str(),
                                            CPLGetFilename(pszSource), nullptr);
             bTargetIsFile = VSIStatL(osTarget.c_str(), &sTarget) == 0 &&
-                            !CPL_TO_BOOL(VSI_ISDIR(sTarget.st_mode));
+                            !VSI_ISDIR(sTarget.st_mode);
         }
         if (bTargetIsFile)
         {

--- a/port/cpl_vsil_adls.cpp
+++ b/port/cpl_vsil_adls.cpp
@@ -449,7 +449,7 @@ bool VSIDIRADLS::AnalysePathList(const std::string &osBaseURL,
             prop.eExists = EXIST_YES;
             prop.bHasComputedFileSize = true;
             prop.fileSize = entry->nSize;
-            prop.bIsDirectory = CPL_TO_BOOL(VSI_ISDIR(entry->nMode));
+            prop.bIsDirectory = VSI_ISDIR(entry->nMode);
             prop.nMode = entry->nMode;
             prop.mTime = static_cast<time_t>(entry->nMTime);
             prop.ETag = std::move(ETag);

--- a/port/cpl_vsil_s3.cpp
+++ b/port/cpl_vsil_s3.cpp
@@ -4818,7 +4818,7 @@ bool IVSIS3LikeFSHandler::Sync(const char *pszSource, const char *pszTarget,
                 osTarget = CPLFormFilenameSafe(
                     osTarget.c_str(), CPLGetFilename(pszSource), nullptr);
                 bTargetIsFile = VSIStatL(osTarget.c_str(), &sTarget) == 0 &&
-                                !CPL_TO_BOOL(VSI_ISDIR(sTarget.st_mode));
+                                !VSI_ISDIR(sTarget.st_mode);
             }
         }
 


### PR DESCRIPTION
and remove unnecessary uses of CPL_TO_BOOL()

More reasonable as 3.14 material at this point
