### PR TITLE
FindSQLite3: Add missing cmake includes (CheckCXXSourceCompiles)

### DIFF
--- a/cmake/modules/packages/FindSQLite3.cmake
+++ b/cmake/modules/packages/FindSQLite3.cmake
@@ -73,6 +73,8 @@ if(SQLite3_INCLUDE_DIR)
 endif()
 
 if(SQLite3_INCLUDE_DIR AND SQLite3_LIBRARY)
+    include(CheckCSourceCompiles)
+    include(CheckCXXSourceCompiles)
     include(CheckSymbolExists)
     cmake_push_check_state(RESET)
     # check column metadata


### PR DESCRIPTION
## What does this PR do?

Fix missing includes for CheckCXXSourceCompiles in FindSQLite3.cmake

## What are related issues/pull requests?

None

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS: Any
* Compiler: Any
* CMake: 3.31
