### PR TITLE
GTiff: Add TIFFOpenOptionsSetMaxSingleMemAlloc to prevent OOM DoS

### DIFF
--- a/frmts/gtiff/tifvsi.cpp
+++ b/frmts/gtiff/tifvsi.cpp
@@ -453,6 +453,8 @@ static void VSI_TIFFSetOpenOptions(TIFFOpenOptions *opts)
         TIFFOpenOptionsSetMaxCumulatedMemAlloc(
             opts, static_cast<tmsize_t>(nMemLimit));
     }
+    TIFFOpenOptionsSetMaxSingleMemAlloc(
+        opts, static_cast<tmsize_t>(256 * 1024 * 1024));  // 256MB single alloc limit
 #endif
 }
 #endif


### PR DESCRIPTION
## What does this PR do?

Adds `TIFFOpenOptionsSetMaxSingleMemAlloc()` with a 256MB limit in
`VSI_TIFFSetOpenOptions()` to prevent denial-of-service via malformed
TIFF files with invalid SamplesPerPixel values.

A 3KB malicious TIFF file with `SamplesPerPixel=0xFFF9` (65,529) causes
GDAL to attempt allocating ~16.4GB in a single allocation:

ERROR 2: ./frmts/gtiff/gtiffdataset_read.cpp, 3264:
cannot allocate 1x16382250000 bytes
real    0m0.150s
Exit: 1

GDAL already has `TIFFOpenOptionsSetMaxCumulatedMemAlloc()` for cumulative
limits, but was missing the single-allocation guard. This patch adds the
missing protection.

## What are related issues/pull requests?

Related to libtiff GitLab Issue #781:
https://gitlab.com/libtiff/libtiff/-/issues/781

libtiff maintainers confirmed that protection against this type of
attack is the responsibility of the consuming application (GDAL).

## AI tool usage

- [ ] AI tools were not used in the development of this PR.

## Tasklist

- [x] Code change is minimal and focused
- [ ] Add test case(s)
- [ ] Review
- [ ] All CI builds and checks have passed

## Environment

- OS: Ubuntu 24.04 WSL2
- Compiler: GCC 13.2.0 / Clang 18.1.3
- GDAL: master branch (commit 12ac58ce07)