### PR TITLE
[cli] API: allow to specify arg dependencies (mutual and unidirectional)

### DIFF
--- a/apps/data/gdal_algorithm.schema.json
+++ b/apps/data/gdal_algorithm.schema.json
@@ -154,6 +154,14 @@
           "type": "boolean",
           "$comment": "Whether this argument is required"
         },
+        "depends_on":
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "$comment": "List of other arguments that this argument depends on (if this argument is specified all other arguments in the list must be specified as well)."
+            },
         "packed_values_allowed": {
           "type": "boolean",
           "$comment": "For command-line specification, for multi-valued arguments (type: integer_list, real_list, string_list), whether comma-separated values are accepted. e.g. '--my-arg=first,second'"
@@ -177,6 +185,10 @@
         "mutual_exclusion_group": {
           "type": "string",
           "$comment": "Identifier shared by several arguments to mean they are mutually exclusive."
+        },
+        "mutual_dependency_group": {
+          "type": "string",
+          "$comment": "Identifier shared by several arguments to mean they are mutually dependant (if one is specified all other arguments in the same group must be specified as well)."
         },
         "metadata": {
           "type": "object",

--- a/apps/gdalalg_raster_clip.cpp
+++ b/apps/gdalalg_raster_clip.cpp
@@ -87,6 +87,8 @@ GDALRasterClipAlgorithm::GDALRasterClipAlgorithm(bool standaloneStep)
     AddArg("allow-bbox-outside-source", 0,
            _("Allow clipping box to include pixels outside input dataset"),
            &m_allowExtentOutsideSource);
+    // Note: this would be a use case for multiple exclusion groups because it is not
+    //       compatible with "window"
     AddArg("add-alpha", 0,
            _("Adds an alpha mask band to the destination when the source "
              "raster have none."),

--- a/apps/gdalalg_raster_create.cpp
+++ b/apps/gdalalg_raster_create.cpp
@@ -80,10 +80,10 @@ GDALRasterCreateAlgorithm::GDALRasterCreateAlgorithm(
 
     AddArg("copy-metadata", 0, _("Copy metadata from input dataset"),
            &m_copyMetadata)
-        .AddDependency(*inputArg);
+        .AddDirectDependency(*inputArg);
     AddArg("copy-overviews", 0,
            _("Create same overview levels as input dataset"), &m_copyOverviews)
-        .AddDependency(*inputArg);
+        .AddDirectDependency(*inputArg);
 }
 
 /************************************************************************/

--- a/apps/gdalalg_raster_create.cpp
+++ b/apps/gdalalg_raster_create.cpp
@@ -74,10 +74,16 @@ GDALRasterCreateAlgorithm::GDALRasterCreateAlgorithm(
                                 { return ParseAndValidateKeyValue(arg); });
         arg.AddHiddenAlias("mo");
     }
+
+    const auto inputArg = GetArg(GDAL_ARG_NAME_INPUT);
+    CPLAssertNotNull(inputArg);
+
     AddArg("copy-metadata", 0, _("Copy metadata from input dataset"),
-           &m_copyMetadata);
+           &m_copyMetadata)
+        .AddDependency(*inputArg);
     AddArg("copy-overviews", 0,
-           _("Create same overview levels as input dataset"), &m_copyOverviews);
+           _("Create same overview levels as input dataset"), &m_copyOverviews)
+        .AddDependency(*inputArg);
 }
 
 /************************************************************************/
@@ -353,13 +359,10 @@ bool GDALRasterCreateAlgorithm::RunStep(GDALPipelineStepRunContext &)
 
     if (m_copyMetadata)
     {
-        if (!poSrcDS)
-        {
-            ReportError(CE_Failure, CPLE_AppDefined,
-                        "Argument 'copy-metadata' can only be set when an "
-                        "input dataset is set");
-            return false;
-        }
+
+        // This should never happen because of the dependency set
+        CPLAssertNotNull(poSrcDS);
+
         {
             const CPLStringList aosDomains(poSrcDS->GetMetadataDomainList());
             for (const char *domain : aosDomains)
@@ -412,13 +415,9 @@ bool GDALRasterCreateAlgorithm::RunStep(GDALPipelineStepRunContext &)
 
     if (m_copyOverviews && m_bandCount > 0)
     {
-        if (!poSrcDS)
-        {
-            ReportError(CE_Failure, CPLE_AppDefined,
-                        "Argument 'copy-overviews' can only be set when an "
-                        "input dataset is set");
-            return false;
-        }
+        // This should never happen because of the dependency set
+        CPLAssertNotNull(poSrcDS);
+
         if (poSrcDS->GetRasterXSize() != poRetDS->GetRasterXSize() ||
             poSrcDS->GetRasterYSize() != poRetDS->GetRasterYSize())
         {

--- a/apps/gdalalg_raster_scale.cpp
+++ b/apps/gdalalg_raster_scale.cpp
@@ -34,12 +34,14 @@ GDALRasterScaleAlgorithm::GDALRasterScaleAlgorithm(bool standaloneStep)
     AddOutputDataTypeArg(&m_type);
     AddBandArg(&m_band,
                _("Select band to restrict the scaling (1-based index)"));
-    AddArg("src-min", 0, _("Minimum value of the source range"), &m_srcMin);
-    AddArg("src-max", 0, _("Maximum value of the source range"), &m_srcMax);
-    AddArg("dst-min", 0, _("Minimum value of the destination range"),
-           &m_dstMin);
-    AddArg("dst-max", 0, _("Maximum value of the destination range"),
-           &m_dstMax);
+    AddArg("src-min", 0, _("Minimum value of the source range"), &m_srcMin)
+        .SetMutualDependencyGroup("src-max-min");
+    AddArg("src-max", 0, _("Maximum value of the source range"), &m_srcMax)
+        .SetMutualDependencyGroup("src-max-min");
+    AddArg("dst-min", 0, _("Minimum value of the destination range"), &m_dstMin)
+        .SetMutualDependencyGroup("dst-max-min");
+    AddArg("dst-max", 0, _("Maximum value of the destination range"), &m_dstMax)
+        .SetMutualDependencyGroup("dst-max-min");
     AddArg("exponent", 0,
            _("Exponent to apply non-linear scaling with a power function"),
            &m_exponent);
@@ -68,32 +70,21 @@ bool GDALRasterScaleAlgorithm::RunStep(GDALPipelineStepRunContext &)
     }
     aosOptions.AddString(m_band > 0 ? CPLSPrintf("-scale_%d", m_band)
                                     : "-scale");
+
+    CPLAssert((std::isnan(m_srcMax) && std::isnan(m_srcMin)) ||
+              (!std::isnan(m_srcMax) && !std::isnan(m_srcMin)));
+
     if (!std::isnan(m_srcMin))
     {
-        if (std::isnan(m_srcMax))
-        {
-            ReportError(CE_Failure, CPLE_AppDefined,
-                        "src-max must be specified when src-min is specified");
-            return false;
-        }
+        CPLAssert(!std::isnan(m_srcMax));
         aosOptions.AddString(CPLSPrintf("%.17g", m_srcMin));
         aosOptions.AddString(CPLSPrintf("%.17g", m_srcMax));
     }
-    else if (!std::isnan(m_srcMax))
-    {
-        ReportError(CE_Failure, CPLE_AppDefined,
-                    "src-min must be specified when src-max is specified");
-        return false;
-    }
 
+    CPLAssert((std::isnan(m_dstMax) && std::isnan(m_dstMin)) ||
+              (!std::isnan(m_dstMax) && !std::isnan(m_dstMin)));
     if (!std::isnan(m_dstMin))
     {
-        if (std::isnan(m_dstMax))
-        {
-            ReportError(CE_Failure, CPLE_AppDefined,
-                        "dst-max must be specified when dst-min is specified");
-            return false;
-        }
         if (std::isnan(m_srcMin))
         {
             aosOptions.AddString("NaN");
@@ -101,12 +92,6 @@ bool GDALRasterScaleAlgorithm::RunStep(GDALPipelineStepRunContext &)
         }
         aosOptions.AddString(CPLSPrintf("%.17g", m_dstMin));
         aosOptions.AddString(CPLSPrintf("%.17g", m_dstMax));
-    }
-    else if (!std::isnan(m_dstMax))
-    {
-        ReportError(CE_Failure, CPLE_AppDefined,
-                    "dst-min must be specified when dst-max is specified");
-        return false;
     }
 
     if (!std::isnan(m_exponent))

--- a/autotest/cpp/test_gdal_algorithm.cpp
+++ b/autotest/cpp/test_gdal_algorithm.cpp
@@ -3620,9 +3620,16 @@ TEST_F(test_gdal_algorithm, direct_dependencies)
         MyAlgorithm()
         {
             AddArg("flag1", 0, "", &m_flag1)
-                .AddDependency(AddArg("flag2", 0, "", &m_flag2));
+                .AddDirectDependency(AddArg("flag2", 0, "", &m_flag2));
         }
     };
+
+    {
+        MyAlgorithm alg;
+        EXPECT_EQ(alg.GetArgDependencies("flag1"),
+                  std::vector<std::string>{"flag2"});
+        EXPECT_EQ(alg.GetArgDependencies("flag2"), std::vector<std::string>{});
+    }
 
     {
         MyAlgorithm alg;

--- a/autotest/cpp/test_gdal_algorithm.cpp
+++ b/autotest/cpp/test_gdal_algorithm.cpp
@@ -3619,8 +3619,8 @@ TEST_F(test_gdal_algorithm, direct_dependencies)
 
         MyAlgorithm()
         {
-            AddArg("flag1", 0, "", &m_flag1).AddDependency("flag2");
-            AddArg("flag2", 0, "", &m_flag2);
+            AddArg("flag1", 0, "", &m_flag1)
+                .AddDependency(AddArg("flag2", 0, "", &m_flag2));
         }
     };
 

--- a/autotest/cpp/test_gdal_algorithm.cpp
+++ b/autotest/cpp/test_gdal_algorithm.cpp
@@ -3518,6 +3518,140 @@ TEST_F(test_gdal_algorithm, mutually_exclusive)
     }
 }
 
+TEST_F(test_gdal_algorithm, mutually_dependent)
+{
+    class MyAlgorithm : public MyAlgorithmWithDummyRun
+    {
+      public:
+        bool m_flag1 = false;
+        bool m_flag2 = false;
+        bool m_flag3 = false;
+
+        MyAlgorithm()
+        {
+            AddArg("flag1", 0, "", &m_flag1)
+                .SetMutualDependencyGroup("my_group");
+            AddArg("flag2", 0, "", &m_flag2)
+                .SetMutualDependencyGroup("my_group");
+            AddArg("flag3", 0, "", &m_flag3)
+                .SetMutualDependencyGroup("my_group");
+        }
+    };
+
+    {
+        MyAlgorithm alg;
+        alg.GetUsageForCLI(false);
+        EXPECT_TRUE(alg.ParseCommandLineArguments({}));
+    }
+
+    {
+        MyAlgorithm alg;
+        EXPECT_TRUE(
+            alg.ParseCommandLineArguments({"--flag1", "--flag2", "--flag3"}));
+    }
+
+    {
+        MyAlgorithm alg;
+        CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
+        CPLErrorReset();
+        EXPECT_FALSE(alg.ParseCommandLineArguments({"--flag1"}));
+        EXPECT_EQ(CPLGetLastErrorType(), CE_Failure);
+        EXPECT_STREQ(CPLGetLastErrorMsg(),
+                     "test: Argument(s) 'flag1' require(s) that the following "
+                     "argument(s) are also specified: flag2, flag3.");
+    }
+
+    {
+        MyAlgorithm alg;
+        CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
+        CPLErrorReset();
+        EXPECT_FALSE(alg.ParseCommandLineArguments({"--flag2"}));
+        EXPECT_EQ(CPLGetLastErrorType(), CE_Failure);
+        EXPECT_STREQ(CPLGetLastErrorMsg(),
+                     "test: Argument(s) 'flag2' require(s) that the following "
+                     "argument(s) are also specified: flag1, flag3.");
+    }
+
+    {
+        MyAlgorithm alg;
+        CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
+        CPLErrorReset();
+        EXPECT_FALSE(alg.ParseCommandLineArguments({"--flag3"}));
+        EXPECT_EQ(CPLGetLastErrorType(), CE_Failure);
+        EXPECT_STREQ(CPLGetLastErrorMsg(),
+                     "test: Argument(s) 'flag3' require(s) that the following "
+                     "argument(s) are also specified: flag1, flag2.");
+    }
+
+    {
+        MyAlgorithm alg;
+        CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
+        CPLErrorReset();
+        EXPECT_FALSE(alg.ParseCommandLineArguments({"--flag1", "--flag2"}));
+        EXPECT_EQ(CPLGetLastErrorType(), CE_Failure);
+    }
+
+    {
+        MyAlgorithm alg;
+        CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
+        CPLErrorReset();
+        EXPECT_FALSE(alg.ParseCommandLineArguments({"--flag2", "--flag3"}));
+        EXPECT_EQ(CPLGetLastErrorType(), CE_Failure);
+    }
+
+    {
+        MyAlgorithm alg;
+        CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
+        CPLErrorReset();
+        EXPECT_FALSE(alg.ParseCommandLineArguments({"--flag1", "--flag3"}));
+        EXPECT_EQ(CPLGetLastErrorType(), CE_Failure);
+    }
+}
+
+// Test dependencies
+TEST_F(test_gdal_algorithm, direct_dependencies)
+{
+    class MyAlgorithm : public MyAlgorithmWithDummyRun
+    {
+      public:
+        bool m_flag1 = false;
+        bool m_flag2 = false;
+
+        MyAlgorithm()
+        {
+            AddArg("flag1", 0, "", &m_flag1).AddDependency("flag2");
+            AddArg("flag2", 0, "", &m_flag2);
+        }
+    };
+
+    {
+        MyAlgorithm alg;
+        alg.GetUsageForCLI(false);
+        EXPECT_TRUE(alg.ParseCommandLineArguments({}));
+    }
+
+    {
+        MyAlgorithm alg;
+        EXPECT_TRUE(alg.ParseCommandLineArguments({"--flag2"}));
+    }
+
+    {
+        MyAlgorithm alg;
+        CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
+        CPLErrorReset();
+        EXPECT_FALSE(alg.ParseCommandLineArguments({"--flag1"}));
+        EXPECT_EQ(CPLGetLastErrorType(), CE_Failure);
+        EXPECT_STREQ(CPLGetLastErrorMsg(),
+                     "test: Argument 'flag1' depends on argument 'flag2' that "
+                     "has not been specified.");
+    }
+
+    {
+        MyAlgorithm alg;
+        EXPECT_TRUE(alg.ParseCommandLineArguments({"--flag1", "--flag2"}));
+    }
+}
+
 TEST_F(test_gdal_algorithm, invalid_input_format)
 {
     class MyAlgorithm : public MyAlgorithmWithDummyRun

--- a/autotest/gcore/algorithm.py
+++ b/autotest/gcore/algorithm.py
@@ -519,3 +519,112 @@ def test_gdal_alg_module(tmp_vsimem):
     gdal.reregister_gdal_alg()
 
     assert gdal.alg.vsi.list(filename=tmp_vsimem).Output() == ["a"]
+
+
+###############################################################################
+# Test gdal algorithm with mutual dependencies between arguments
+
+
+def test_algorithm_mutual_dependencies(tmp_path):
+
+    reg = gdal.GetGlobalAlgorithmRegistry()
+
+    # Check no deps
+    alg = reg["raster"]["info"]
+    # We should really return an empty list here but SWIG CSLToList typemap returns PyNone
+    assert alg.GetArgDependencies("input") is None
+    assert alg.GetArg("input").GetMutualDependencyGroup() == ""
+    assert alg.GetArg("input").GetDirectDependencies() is None
+
+    alg = reg["raster"]["create"]
+
+    assert alg.GetArg("copy-metadata").GetDirectDependencies() == ["input"]
+    assert alg.GetArg("copy-overviews").GetDirectDependencies() == ["input"]
+    assert alg.GetArgDependencies("copy-metadata") == ["input"]
+    assert alg.GetArgDependencies("copy-overviews") == ["input"]
+
+    usage = json.loads(alg.GetUsageAsJSON())
+    copy_md = [a for a in usage["input_arguments"] if a["name"] == "copy-metadata"][0]
+    assert copy_md["depends_on"] == ["input"]
+
+    copy_ov = [a for a in usage["input_arguments"] if a["name"] == "copy-overviews"][0]
+    assert copy_ov["depends_on"] == ["input"]
+
+    alg["output"] = str(tmp_path / "out.tif")
+    alg["copy-metadata"] = True
+
+    with pytest.raises(
+        RuntimeError,
+        match=" Argument 'copy-metadata' depends on argument 'input' that has not been specified.",
+    ):
+        alg.Run()
+
+    alg = reg["raster"]["create"]
+    alg["output"] = str(tmp_path / "out.tif")
+    alg["copy-overviews"] = True
+
+    with pytest.raises(
+        RuntimeError,
+        match=" Argument 'copy-overviews' depends on argument 'input' that has not been specified.",
+    ):
+        alg.Run()
+
+    # Check mutual dependency group
+    alg = reg["raster"]["scale"]
+
+    usage = json.loads(alg.GetUsageAsJSON())
+    src_min = [a for a in usage["input_arguments"] if a["name"] == "src-min"][0]
+    src_max = [a for a in usage["input_arguments"] if a["name"] == "src-max"][0]
+    dst_min = [a for a in usage["input_arguments"] if a["name"] == "dst-min"][0]
+    dst_max = [a for a in usage["input_arguments"] if a["name"] == "dst-max"][0]
+
+    assert src_min["mutual_dependency_group"] == "src-max-min"
+    assert src_max["mutual_dependency_group"] == "src-max-min"
+    assert dst_min["mutual_dependency_group"] == "dst-max-min"
+    assert dst_max["mutual_dependency_group"] == "dst-max-min"
+
+    src_min_arg = alg.GetArg("src-min")
+    src_max_arg = alg.GetArg("src-max")
+    dst_min_arg = alg.GetArg("dst-min")
+    dst_max_arg = alg.GetArg("dst-max")
+
+    assert src_min_arg.GetMutualDependencyGroup() == "src-max-min"
+    assert src_max_arg.GetMutualDependencyGroup() == "src-max-min"
+    assert dst_min_arg.GetMutualDependencyGroup() == "dst-max-min"
+    assert dst_max_arg.GetMutualDependencyGroup() == "dst-max-min"
+
+    assert src_min["depends_on"] == ["src-max"]
+    assert src_max["depends_on"] == ["src-min"]
+    assert dst_min["depends_on"] == ["dst-max"]
+    assert dst_max["depends_on"] == ["dst-min"]
+
+    # This does not include mutual dependencies
+    assert src_min_arg.GetDirectDependencies() is None
+    assert src_max_arg.GetDirectDependencies() is None
+    assert dst_min_arg.GetDirectDependencies() is None
+    assert dst_max_arg.GetDirectDependencies() is None
+
+    # This includes both direct and mutual dependencies
+    assert alg.GetArgDependencies("src-max") == ["src-min"]
+    assert alg.GetArgDependencies("src-min") == ["src-max"]
+    assert alg.GetArgDependencies("dst-min") == ["dst-max"]
+    assert alg.GetArgDependencies("dst-max") == ["dst-min"]
+
+    alg["src-min"] = 1
+    alg["output"] = str(tmp_path / "out.tif")
+    alg["input"] = "data/byte.tif"
+    with pytest.raises(
+        RuntimeError,
+        match=r"Argument\(s\) 'src-min' require\(s\) that the following argument\(s\) are also specified: src-max.",
+    ):
+        alg.Run()
+
+    alg = reg["raster"]["scale"]
+    alg["src-max"] = 10
+    alg["input"] = "data/byte.tif"
+    alg["output"] = str(tmp_path / "out.tif")
+    with pytest.raises(
+        RuntimeError,
+        match=r"Argument\(s\) 'src-max' require\(s\) that the following argument\(s\) are also specified: src-min.",
+    ):
+        alg.Run()

--- a/autotest/utilities/test_gdalalg_raster_create.py
+++ b/autotest/utilities/test_gdalalg_raster_create.py
@@ -250,7 +250,7 @@ def test_gdalalg_raster_create_copy_metadata_missing_input():
     alg["size"] = [1, 1]
     with pytest.raises(
         Exception,
-        match="Argument 'copy-metadata' can only be set when an input dataset is set",
+        match="Argument 'copy-metadata' depends on argument 'input' that has not been specified.",
     ):
         alg.Run()
 
@@ -277,7 +277,7 @@ def test_gdalalg_raster_create_copy_overviews_missing_input():
     alg["size"] = [1, 1]
     with pytest.raises(
         Exception,
-        match="Argument 'copy-overviews' can only be set when an input dataset is set",
+        match="Argument 'copy-overviews' depends on argument 'input' that has not been specified.",
     ):
         alg.Run()
 

--- a/autotest/utilities/test_gdalalg_raster_scale.py
+++ b/autotest/utilities/test_gdalalg_raster_scale.py
@@ -95,7 +95,10 @@ def test_gdalalg_raster_scale_missing_srcmin():
     alg["output"] = ""
     alg["output-format"] = "MEM"
     alg["src-max"] = 0
-    with pytest.raises(Exception, match="scale: src-min must be specified"):
+    with pytest.raises(
+        Exception,
+        match=r"Argument\(s\) 'src-max' require\(s\) that the following argument\(s\) are also specified: src-min.",
+    ):
         alg.Run()
 
 
@@ -109,7 +112,10 @@ def test_gdalalg_raster_scale_missing_srcmax():
     alg["output"] = ""
     alg["output-format"] = "MEM"
     alg["src-min"] = 0
-    with pytest.raises(Exception, match="scale: src-max must be specified"):
+    with pytest.raises(
+        Exception,
+        match=r"Argument\(s\) 'src-min' require\(s\) that the following argument\(s\) are also specified: src-max.",
+    ):
         alg.Run()
 
 
@@ -123,7 +129,10 @@ def test_gdalalg_raster_scale_missing_dstmin():
     alg["output"] = ""
     alg["output-format"] = "MEM"
     alg["dst-max"] = 0
-    with pytest.raises(Exception, match="scale: dst-min must be specified"):
+    with pytest.raises(
+        Exception,
+        match=r"Argument\(s\) 'dst-max' require\(s\) that the following argument\(s\) are also specified: dst-min.",
+    ):
         alg.Run()
 
 
@@ -137,7 +146,10 @@ def test_gdalalg_raster_scale_missing_dstmax():
     alg["output"] = ""
     alg["output-format"] = "MEM"
     alg["dst-min"] = 0
-    with pytest.raises(Exception, match="scale: dst-max must be specified"):
+    with pytest.raises(
+        Exception,
+        match=r"Argument\(s\) 'dst-min' require\(s\) that the following argument\(s\) are also specified: dst-max.",
+    ):
         alg.Run()
 
 

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -7763,6 +7763,7 @@ GDALAlgorithmArgH GDALAlgorithmGetArgNonConst(GDALAlgorithmH hAlg,
  *  This includes both regular dependencies and mutual dependencies.
  *
  * @param hAlg Handle to an algorithm. Must NOT be null.
+ * @param pszArgName Argument name. Must NOT be null.
  * @return a NULL terminated list of names, which must be destroyed with
  * CSLDestroy()
  * @since 3.11

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -3192,7 +3192,7 @@ bool GDALAlgorithm::ValidateArguments()
             }
 
             // Check direct dependencies
-            for (const auto &dependency : arg->GetDependencies())
+            for (const auto &dependency : arg->GetDirectDependencies())
             {
                 auto depArg = GetArg(dependency);
                 if (!depArg)
@@ -6659,62 +6659,38 @@ GDALAlgorithm::GetUsageForCLI(bool shortUsage,
                 }
             }
 
-            // Check mutual dependency
+            // Check dependency
             std::string dependencyArgs;
-            const auto dependencies{arg->GetDependencies()};
 
-            if (!dependencies.empty())
+            for (const auto &dependencyArgumentName :
+                 GetArgDependencies(arg->GetName()))
             {
-                for (const auto &dependencyArgumentName : dependencies)
-                {
-                    const auto otherArg{GetArg(dependencyArgumentName)};
-                    if (otherArg != nullptr)
-                    {
-                        if (otherArg->IsHidden() ||
-                            otherArg->IsHiddenForCLI() || otherArg == arg)
-                        {
-                            continue;
-                        }
-
-                        if (!dependencyArgs.empty())
-                        {
-                            dependencyArgs += ", ";
-                        }
-
-                        dependencyArgs += "--";
-                        dependencyArgs += otherArg->GetName();
-                    }
-                    else
-                    {
-                        CPLError(
-                            CE_Warning, CPLE_AppDefined,
-                            "Argument '%s' depends on unknown argument '%s'",
-                            arg->GetName().c_str(),
-                            dependencyArgumentName.c_str());
-                    }
-                }
-            }
-
-            const auto &mutualDependencyGroup = arg->GetMutualDependencyGroup();
-            if (!mutualDependencyGroup.empty())
-            {
-
-                for (const auto &otherArg : m_args)
+                const auto otherArg{GetArg(dependencyArgumentName)};
+                if (otherArg != nullptr)
                 {
                     if (otherArg->IsHidden() || otherArg->IsHiddenForCLI() ||
-                        otherArg.get() == arg)
-                        continue;
-                    if (otherArg->GetMutualDependencyGroup() ==
-                        mutualDependencyGroup)
+                        otherArg == arg)
                     {
-                        if (!dependencyArgs.empty())
-                            dependencyArgs += ", ";
-
-                        dependencyArgs += "--";
-                        dependencyArgs += otherArg->GetName();
+                        continue;
                     }
+
+                    if (!dependencyArgs.empty())
+                    {
+                        dependencyArgs += ", ";
+                    }
+
+                    dependencyArgs += "--";
+                    dependencyArgs += otherArg->GetName();
+                }
+                else
+                {
+                    CPLError(CE_Warning, CPLE_AppDefined,
+                             "Argument '%s' depends on unknown argument '%s'",
+                             arg->GetName().c_str(),
+                             dependencyArgumentName.c_str());
                 }
             }
+
             if (!dependencyArgs.empty())
             {
                 osRet += "  ";
@@ -7041,26 +7017,17 @@ std::string GDALAlgorithm::GetUsageAsJSON() const
         }
 
         // Process dependencies
-        CPLJSONArray jDependencies;
-        const auto dependencies{arg->GetDependencies()};
-        for (const auto &dependencyArgumentName : dependencies)
-        {
-            jDependencies.Add(dependencyArgumentName);
-        }
-        // Add mutual dependencies as well, as they are effectively dependencies too
         const auto &mutualDependencyGroup = arg->GetMutualDependencyGroup();
         if (!mutualDependencyGroup.empty())
         {
             jArg.Add("mutual_dependency_group", mutualDependencyGroup);
-            for (const auto &otherArg : m_args)
-            {
-                if (otherArg.get() != arg &&
-                    otherArg->GetMutualDependencyGroup() ==
-                        mutualDependencyGroup)
-                {
-                    jDependencies.Add(otherArg->GetName());
-                }
-            }
+        }
+
+        CPLJSONArray jDependencies;
+        for (const auto &dependencyArgumentName :
+             GetArgDependencies(arg->GetName()))
+        {
+            jDependencies.Add(dependencyArgumentName);
         }
 
         if (jDependencies.Size() > 0)
@@ -7785,6 +7752,27 @@ GDALAlgorithmArgH GDALAlgorithmGetArgNonConst(GDALAlgorithmH hAlg,
     if (!arg)
         return nullptr;
     return std::make_unique<GDALAlgorithmArgHS>(arg).release();
+}
+
+/************************************************************************/
+/*                  GDALAlgorithmGetArgDependencies()                   */
+/************************************************************************/
+
+/** Return the list of argument names the specified argument depends on.
+ *
+ *  This includes both regular dependencies and mutual dependencies.
+ *
+ * @param hAlg Handle to an algorithm. Must NOT be null.
+ * @return a NULL terminated list of names, which must be destroyed with
+ * CSLDestroy()
+ * @since 3.11
+ */
+char **GDALAlgorithmGetArgDependencies(GDALAlgorithmH hAlg,
+                                       const char *pszArgName)
+{
+    VALIDATE_POINTER1(hAlg, __func__, nullptr);
+    VALIDATE_POINTER1(pszArgName, __func__, nullptr);
+    return CPLStringList(hAlg->ptr->GetArgDependencies(pszArgName)).StealList();
 }
 
 /************************************************************************/
@@ -8524,6 +8512,49 @@ const char *GDALAlgorithmArgGetMutualExclusionGroup(GDALAlgorithmArgH hArg)
 {
     VALIDATE_POINTER1(hArg, __func__, nullptr);
     return hArg->ptr->GetMutualExclusionGroup().c_str();
+}
+
+/************************************************************************/
+/*              GDALAlgorithmArgGetMutualDependencyGroup()              */
+/************************************************************************/
+
+/** Return the name of the mutual dependency group to which this argument
+ * belongs to.
+ *
+ * Or empty string if it does not belong to any dependency group.
+ *
+ * @param hArg Handle to an argument. Must NOT be null.
+ * @return string whose lifetime is bound to hArg and which must not
+ * be freed.
+ * @since 3.13
+ */
+const char *GDALAlgorithmArgGetMutualDependencyGroup(GDALAlgorithmArgH hArg)
+{
+    VALIDATE_POINTER1(hArg, __func__, nullptr);
+    return hArg->ptr->GetMutualDependencyGroup().c_str();
+}
+
+/************************************************************************/
+/*               GDALAlgorithmArgGetDirectDependencies()                */
+/************************************************************************/
+
+/** Return the list of names of arguments that this argument depends on.
+ *
+ *  This is not necessarily a symmetric relationship.
+ *  If argument A depends on argument B, it doesn't mean that B depends on A.
+ *  Mutual dependency groups are a special case of dependencies,
+ *  where all arguments of the group depend on each other and are not
+ *  returned by this method.
+ *
+ * @param hArg Handle to an argument. Must NOT be null.
+ * @return a NULL terminated list of names, which must be destroyed with
+ * CSLDestroy()
+ * @since 3.13
+ */
+char **GDALAlgorithmArgGetDirectDependencies(GDALAlgorithmArgH hArg)
+{
+    VALIDATE_POINTER1(hArg, __func__, nullptr);
+    return CPLStringList(hArg->ptr->GetDirectDependencies()).StealList();
 }
 
 /************************************************************************/

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -6628,6 +6628,51 @@ GDALAlgorithm::GetUsageForCLI(bool shortUsage,
                 osRet += " [not available in pipelines]";
             }
 
+            const auto dependencies{arg->GetDependencies()};
+            if (!dependencies.empty())
+            {
+                std::string otherArgs;
+                int depsCount = 0;
+                for (const auto &dependencyArgumentName : dependencies)
+                {
+                    const auto otherArg{GetArg(dependencyArgumentName)};
+                    if (otherArg != nullptr)
+                    {
+                        if (otherArg->IsHidden() ||
+                            otherArg->IsHiddenForCLI() || otherArg == arg)
+                        {
+                            continue;
+                        }
+
+                        if (!otherArgs.empty())
+                        {
+                            otherArgs += ", ";
+                        }
+
+                        otherArgs += "--";
+                        otherArgs += otherArg->GetName();
+                        depsCount++;
+                    }
+                    else
+                    {
+                        CPLError(
+                            CE_Warning, CPLE_AppDefined,
+                            "Argument '%s' depends on unknown argument '%s'",
+                            arg->GetName().c_str(),
+                            dependencyArgumentName.c_str());
+                    }
+                }
+
+                if (depsCount > 0)
+                {
+                    osRet += " [";
+                    osRet += "requires ";
+                    osRet += depsCount > 1 ? "arguments " : "argument ";
+                    osRet += otherArgs;
+                    osRet += ']';
+                }
+            }
+
             osRet += '\n';
 
             const auto &mutualExclusionGroup = arg->GetMutualExclusionGroup();
@@ -6862,7 +6907,7 @@ std::string GDALAlgorithm::GetUsageAsJSON() const
         oRoot.Add("user_provided_arguments_allowed", true);
     }
 
-    const auto ProcessArg = [](const GDALAlgorithmArg *arg)
+    const auto ProcessArg = [this](const GDALAlgorithmArg *arg)
     {
         CPLJSONObject jArg;
         jArg.Add("name", arg->GetName());
@@ -7003,6 +7048,35 @@ std::string GDALAlgorithm::GetUsageAsJSON() const
             jArg.Add("min_count", arg->GetMinCount());
             jArg.Add("max_count", arg->GetMaxCount());
         }
+
+        // Process dependencies
+        CPLJSONArray jDependencies;
+        const auto dependencies{arg->GetDependencies()};
+        for (const auto &dependencyArgumentName : dependencies)
+        {
+            jDependencies.Add(dependencyArgumentName);
+        }
+        // Add mutual dependencies as well, as they are effectively dependencies too
+        const auto &mutualDependencyGroup = arg->GetMutualDependencyGroup();
+        if (!mutualDependencyGroup.empty())
+        {
+            jArg.Add("mutual_dependency_group", mutualDependencyGroup);
+            for (const auto &otherArg : m_args)
+            {
+                if (otherArg.get() != arg &&
+                    otherArg->GetMutualDependencyGroup() ==
+                        mutualDependencyGroup)
+                {
+                    jDependencies.Add(otherArg->GetName());
+                }
+            }
+        }
+
+        if (jDependencies.Size() > 0)
+        {
+            jArg.Add("depends_on", jDependencies);
+        }
+
         jArg.Add("category", arg->GetCategory());
 
         if (arg->GetType() == GAAT_DATASET ||

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -3195,8 +3195,15 @@ bool GDALAlgorithm::ValidateArguments()
             for (const auto &dependency : arg->GetDependencies())
             {
                 auto depArg = GetArg(dependency);
-                CPLAssert(depArg);
-                if (!depArg->IsExplicitlySet())
+                if (!depArg)
+                {
+                    ret = false;
+                    ReportError(CE_Failure, CPLE_AppDefined,
+                                "Argument '%s' depends on argument '%s' that "
+                                "is not defined.",
+                                arg->GetName().c_str(), dependency.c_str());
+                }
+                else if (!depArg->IsExplicitlySet())
                 {
                     ret = false;
                     ReportError(CE_Failure, CPLE_AppDefined,

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -3148,11 +3148,13 @@ bool GDALAlgorithm::ValidateArguments()
     // The method may emit several errors if several constraints are not met.
     bool ret = true;
     std::map<std::string, std::string> mutualExclusionGroupUsed;
+    std::map<std::string, std::vector<std::string>> mutualDependencyGroupUsed;
     for (auto &arg : m_args)
     {
-        // Check mutually exclusive arguments
+        // Check mutually exclusive/dependent arguments
         if (arg->IsExplicitlySet())
         {
+
             const auto &mutualExclusionGroup = arg->GetMutualExclusionGroup();
             if (!mutualExclusionGroup.empty())
             {
@@ -3170,6 +3172,38 @@ bool GDALAlgorithm::ValidateArguments()
                 {
                     mutualExclusionGroupUsed[mutualExclusionGroup] =
                         arg->GetName();
+                }
+            }
+
+            const auto &mutualDependencyGroup = arg->GetMutualDependencyGroup();
+            if (!mutualDependencyGroup.empty())
+            {
+                if (mutualDependencyGroupUsed.find(mutualDependencyGroup) ==
+                    mutualDependencyGroupUsed.end())
+                {
+                    mutualDependencyGroupUsed[mutualDependencyGroup] = {
+                        arg->GetName()};
+                }
+                else
+                {
+                    mutualDependencyGroupUsed[mutualDependencyGroup].push_back(
+                        arg->GetName());
+                }
+            }
+
+            // Check direct dependencies
+            for (const auto &dependency : arg->GetDependencies())
+            {
+                auto depArg = GetArg(dependency);
+                CPLAssert(depArg);
+                if (!depArg->IsExplicitlySet())
+                {
+                    ret = false;
+                    ReportError(CE_Failure, CPLE_AppDefined,
+                                "Argument '%s' depends on argument '%s' that "
+                                "has not been specified.",
+                                arg->GetName().c_str(),
+                                depArg->GetName().c_str());
                 }
             }
         }
@@ -3285,6 +3319,50 @@ bool GDALAlgorithm::ValidateArguments()
         {
             ret = false;
         }
+    }
+
+    // Check mutual dependency groups
+    std::vector<std::string> processedGroups;
+    // Loop through group map and check there are not required args in the group that are not set
+    for (const auto &[groupName, argNames] : mutualDependencyGroupUsed)
+    {
+        if (std::find(processedGroups.begin(), processedGroups.end(),
+                      groupName) != processedGroups.end())
+            continue;
+        std::vector<std::string> missingArgs;
+        for (auto &arg : m_args)
+        {
+            const auto &mutualDependencyGroup = arg->GetMutualDependencyGroup();
+            if (mutualDependencyGroup == groupName &&
+                std::find(argNames.begin(), argNames.end(), arg->GetName()) ==
+                    argNames.end())
+            {
+                missingArgs.push_back(arg->GetName());
+            }
+        }
+        if (!missingArgs.empty())
+        {
+            ret = false;
+            std::string missingArgsStr;
+            for (const auto &missingArg : missingArgs)
+            {
+                if (!missingArgsStr.empty())
+                    missingArgsStr += ", ";
+                missingArgsStr += missingArg;
+            }
+            std::string givenArgsStr;
+            for (const auto &givenArg : argNames)
+            {
+                if (!givenArgsStr.empty())
+                    givenArgsStr += ", ";
+                givenArgsStr += givenArg;
+            }
+            ReportError(CE_Failure, CPLE_AppDefined,
+                        "Argument(s) '%s' require(s) that the following "
+                        "argument(s) are also specified: %s.",
+                        givenArgsStr.c_str(), missingArgsStr.c_str());
+        }
+        processedGroups.push_back(groupName);
     }
 
     for (const auto &f : m_validationActions)
@@ -6569,6 +6647,36 @@ GDALAlgorithm::GetUsageForCLI(bool shortUsage,
                     osRet += "  ";
                     osRet.append(maxOptLen, ' ');
                     osRet += "Mutually exclusive with ";
+                    osRet += otherArgs;
+                    osRet += '\n';
+                }
+            }
+
+            // Check mutual dependency
+            const auto &mutualDependencyGroup = arg->GetMutualDependencyGroup();
+            if (!mutualDependencyGroup.empty())
+            {
+                std::string otherArgs;
+                for (const auto &otherArg : m_args)
+                {
+                    if (otherArg->IsHidden() || otherArg->IsHiddenForCLI() ||
+                        otherArg.get() == arg)
+                        continue;
+                    if (otherArg->GetMutualDependencyGroup() ==
+                        mutualDependencyGroup)
+                    {
+                        if (!otherArgs.empty())
+                            otherArgs += ", ";
+                        otherArgs += "--";
+                        otherArgs += otherArg->GetName();
+                    }
+                }
+                if (!otherArgs.empty())
+                {
+                    osRet += "  ";
+                    osRet += "  ";
+                    osRet.append(maxOptLen, ' ');
+                    osRet += "Mutually dependent with ";
                     osRet += otherArgs;
                     osRet += '\n';
                 }

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -6628,51 +6628,6 @@ GDALAlgorithm::GetUsageForCLI(bool shortUsage,
                 osRet += " [not available in pipelines]";
             }
 
-            const auto dependencies{arg->GetDependencies()};
-            if (!dependencies.empty())
-            {
-                std::string otherArgs;
-                int depsCount = 0;
-                for (const auto &dependencyArgumentName : dependencies)
-                {
-                    const auto otherArg{GetArg(dependencyArgumentName)};
-                    if (otherArg != nullptr)
-                    {
-                        if (otherArg->IsHidden() ||
-                            otherArg->IsHiddenForCLI() || otherArg == arg)
-                        {
-                            continue;
-                        }
-
-                        if (!otherArgs.empty())
-                        {
-                            otherArgs += ", ";
-                        }
-
-                        otherArgs += "--";
-                        otherArgs += otherArg->GetName();
-                        depsCount++;
-                    }
-                    else
-                    {
-                        CPLError(
-                            CE_Warning, CPLE_AppDefined,
-                            "Argument '%s' depends on unknown argument '%s'",
-                            arg->GetName().c_str(),
-                            dependencyArgumentName.c_str());
-                    }
-                }
-
-                if (depsCount > 0)
-                {
-                    osRet += " [";
-                    osRet += "requires ";
-                    osRet += depsCount > 1 ? "arguments " : "argument ";
-                    osRet += otherArgs;
-                    osRet += ']';
-                }
-            }
-
             osRet += '\n';
 
             const auto &mutualExclusionGroup = arg->GetMutualExclusionGroup();
@@ -6705,10 +6660,45 @@ GDALAlgorithm::GetUsageForCLI(bool shortUsage,
             }
 
             // Check mutual dependency
+            std::string dependencyArgs;
+            const auto dependencies{arg->GetDependencies()};
+
+            if (!dependencies.empty())
+            {
+                for (const auto &dependencyArgumentName : dependencies)
+                {
+                    const auto otherArg{GetArg(dependencyArgumentName)};
+                    if (otherArg != nullptr)
+                    {
+                        if (otherArg->IsHidden() ||
+                            otherArg->IsHiddenForCLI() || otherArg == arg)
+                        {
+                            continue;
+                        }
+
+                        if (!dependencyArgs.empty())
+                        {
+                            dependencyArgs += ", ";
+                        }
+
+                        dependencyArgs += "--";
+                        dependencyArgs += otherArg->GetName();
+                    }
+                    else
+                    {
+                        CPLError(
+                            CE_Warning, CPLE_AppDefined,
+                            "Argument '%s' depends on unknown argument '%s'",
+                            arg->GetName().c_str(),
+                            dependencyArgumentName.c_str());
+                    }
+                }
+            }
+
             const auto &mutualDependencyGroup = arg->GetMutualDependencyGroup();
             if (!mutualDependencyGroup.empty())
             {
-                std::string otherArgs;
+
                 for (const auto &otherArg : m_args)
                 {
                     if (otherArg->IsHidden() || otherArg->IsHiddenForCLI() ||
@@ -6717,21 +6707,22 @@ GDALAlgorithm::GetUsageForCLI(bool shortUsage,
                     if (otherArg->GetMutualDependencyGroup() ==
                         mutualDependencyGroup)
                     {
-                        if (!otherArgs.empty())
-                            otherArgs += ", ";
-                        otherArgs += "--";
-                        otherArgs += otherArg->GetName();
+                        if (!dependencyArgs.empty())
+                            dependencyArgs += ", ";
+
+                        dependencyArgs += "--";
+                        dependencyArgs += otherArg->GetName();
                     }
                 }
-                if (!otherArgs.empty())
-                {
-                    osRet += "  ";
-                    osRet += "  ";
-                    osRet.append(maxOptLen, ' ');
-                    osRet += "Mutually dependent with ";
-                    osRet += otherArgs;
-                    osRet += '\n';
-                }
+            }
+            if (!dependencyArgs.empty())
+            {
+                osRet += "  ";
+                osRet += "  ";
+                osRet.append(maxOptLen, ' ');
+                osRet += "Depends on ";
+                osRet += dependencyArgs;
+                osRet += '\n';
             }
         };
 

--- a/gcore/gdalalgorithm_c.h
+++ b/gcore/gdalalgorithm_c.h
@@ -107,6 +107,9 @@ GDALAlgorithmInstantiateSubAlgorithm(GDALAlgorithmH, const char *pszSubAlgName);
 bool CPL_DLL GDALAlgorithmParseCommandLineArguments(GDALAlgorithmH,
                                                     CSLConstList papszArgs);
 
+char CPL_DLL **GDALAlgorithmGetArgDependencies(GDALAlgorithmH,
+                                               const char *pszArgumentName);
+
 GDALAlgorithmH CPL_DLL GDALAlgorithmGetActualAlgorithm(GDALAlgorithmH);
 
 bool CPL_DLL GDALAlgorithmRun(GDALAlgorithmH, GDALProgressFunc pfnProgress,
@@ -199,6 +202,8 @@ bool CPL_DLL GDALAlgorithmArgIsOutput(GDALAlgorithmArgH);
 
 const char CPL_DLL *GDALAlgorithmArgGetMutualExclusionGroup(GDALAlgorithmArgH);
 
+const char CPL_DLL *GDALAlgorithmArgGetMutualDependencyGroup(GDALAlgorithmArgH);
+
 bool CPL_DLL GDALAlgorithmArgGetAsBoolean(GDALAlgorithmArgH);
 
 const char CPL_DLL *GDALAlgorithmArgGetAsString(GDALAlgorithmArgH);
@@ -211,6 +216,8 @@ int CPL_DLL GDALAlgorithmArgGetAsInteger(GDALAlgorithmArgH);
 double CPL_DLL GDALAlgorithmArgGetAsDouble(GDALAlgorithmArgH);
 
 char CPL_DLL **GDALAlgorithmArgGetAsStringList(GDALAlgorithmArgH);
+
+char CPL_DLL **GDALAlgorithmArgGetDirectDependencies(GDALAlgorithmArgH);
 
 const int CPL_DLL *GDALAlgorithmArgGetAsIntegerList(GDALAlgorithmArgH,
                                                     size_t *pnCount);

--- a/gcore/gdalalgorithm_cpp.h
+++ b/gcore/gdalalgorithm_cpp.h
@@ -721,6 +721,35 @@ class CPL_DLL GDALAlgorithmArgDecl final
         return *this;
     }
 
+    /** Set the name of the mutual dependency group to which this argument
+     *  belongs to.
+     *  If at least one argument of the group is specified, all other arguments
+     *  will be required.
+     *  An argument can only belong to a single group.
+     */
+    GDALAlgorithmArgDecl &SetMutualDependencyGroup(const std::string &group)
+    {
+        m_mutualDependencyGroup = group;
+        return *this;
+    }
+
+    /** Returns the mutual dependency group name, or empty string if it doesn't belong to any group. */
+    inline const std::string &GetMutualDependencyGroup() const
+    {
+        return m_mutualDependencyGroup;
+    }
+
+    /**
+     * Adds a depdendency on another argument, meaning that if this argument is specified,
+     * the other argument must be specified too.
+     * Note that the dependency is not symmetric. If argument A depends on argument B, it doesn't mean that B depends on A.
+     */
+    GDALAlgorithmArgDecl &AddDependency(const std::string &otherArgName)
+    {
+        m_dependencies.push_back(otherArgName);
+        return *this;
+    }
+
     /** Set user-defined metadata item.
      */
     GDALAlgorithmArgDecl &
@@ -999,6 +1028,12 @@ class CPL_DLL GDALAlgorithmArgDecl final
         return m_mutualExclusionGroup;
     }
 
+    /** Return the list of arguments that this argument depends on. */
+    inline const std::vector<std::string> &GetDependencies() const
+    {
+        return m_dependencies;
+    }
+
     /** Return if this (string) argument accepts the \@filename syntax to
      * mean that the content of the specified file should be used as the
      * value of the argument.
@@ -1159,6 +1194,7 @@ class CPL_DLL GDALAlgorithmArgDecl final
     std::string m_category = GAAC_BASE;
     std::string m_metaVar{};
     std::string m_mutualExclusionGroup{};
+    std::string m_mutualDependencyGroup{};
     int m_minCount = 0;
     int m_maxCount = 0;
     bool m_required = false;
@@ -1180,6 +1216,7 @@ class CPL_DLL GDALAlgorithmArgDecl final
     std::map<std::string, std::vector<std::string>> m_metadata{};
     std::vector<std::string> m_aliases{};
     std::vector<std::string> m_hiddenAliases{};
+    std::vector<std::string> m_dependencies{};
     std::vector<char> m_shortNameAliases{};
     std::vector<std::string> m_choices{};
     std::vector<std::string> m_hiddenChoices{};
@@ -1461,6 +1498,18 @@ class CPL_DLL GDALAlgorithmArg /* non-final */
     inline const std::string &GetMutualExclusionGroup() const
     {
         return m_decl.GetMutualExclusionGroup();
+    }
+
+    /** Alias for GDALAlgorithmArgDecl::GetMutualDependencyGroup() */
+    inline const std::string &GetMutualDependencyGroup() const
+    {
+        return m_decl.GetMutualDependencyGroup();
+    }
+
+    /** Alias for GDALAlgorithmArgDecl::GetDependencies() */
+    inline const std::vector<std::string> &GetDependencies() const
+    {
+        return m_decl.GetDependencies();
     }
 
     /** Alias for GDALAlgorithmArgDecl::GetMetadata() */
@@ -2135,6 +2184,22 @@ class CPL_DLL GDALInConstructionAlgorithmArg final : public GDALAlgorithmArg
     SetMutualExclusionGroup(const std::string &group)
     {
         m_decl.SetMutualExclusionGroup(group);
+        return *this;
+    }
+
+    /** Alias for GDALAlgorithmArgDecl::SetMutualDependencyGroup() */
+    GDALInConstructionAlgorithmArg &
+    SetMutualDependencyGroup(const std::string &group)
+    {
+        m_decl.SetMutualDependencyGroup(group);
+        return *this;
+    }
+
+    /** Alias for GDALAlgorithmArgDecl::AddDependency() */
+    GDALInConstructionAlgorithmArg &
+    AddDependency(const std::string &otherArgName)
+    {
+        m_decl.AddDependency(otherArgName);
         return *this;
     }
 

--- a/gcore/gdalalgorithm_cpp.h
+++ b/gcore/gdalalgorithm_cpp.h
@@ -740,13 +740,13 @@ class CPL_DLL GDALAlgorithmArgDecl final
     }
 
     /**
-     * Adds a dependency on another argument, meaning that if this argument is specified,
+     * Adds a direct dependency on another argument, meaning that if this argument is specified,
      * the other argument must be specified too.
-     * Note that the dependency is not symmetric. If argument A depends on argument B, it doesn't mean that B depends on A.
+     * Note that the dependency is not mutual. If argument A depends on argument B, it doesn't mean that B depends on A.
      */
-    GDALAlgorithmArgDecl &AddDependency(const std::string &otherArgName)
+    GDALAlgorithmArgDecl &AddDirectDependency(const std::string &otherArgName)
     {
-        m_dependencies.push_back(otherArgName);
+        m_directDependencies.push_back(otherArgName);
         return *this;
     }
 
@@ -1028,10 +1028,19 @@ class CPL_DLL GDALAlgorithmArgDecl final
         return m_mutualExclusionGroup;
     }
 
-    /** Return the list of arguments that this argument depends on. */
-    inline const std::vector<std::string> &GetDependencies() const
+    /** Return the list of names of arguments that this argument directly depends on.
+     *
+     *  If argument A depends on argument B, it doesn't necessarily mean that B depends on A.
+     *
+     *  Mutual dependency groups are a special case of dependencies,
+     *  where all arguments of the group depend on each other and are not
+     *  returned by this method.
+     *
+     *  See also GetMutualDependencyGroup() and AddDirectDependency() methods.
+     */
+    inline const std::vector<std::string> &GetDirectDependencies() const
     {
-        return m_dependencies;
+        return m_directDependencies;
     }
 
     /** Return if this (string) argument accepts the \@filename syntax to
@@ -1216,7 +1225,7 @@ class CPL_DLL GDALAlgorithmArgDecl final
     std::map<std::string, std::vector<std::string>> m_metadata{};
     std::vector<std::string> m_aliases{};
     std::vector<std::string> m_hiddenAliases{};
-    std::vector<std::string> m_dependencies{};
+    std::vector<std::string> m_directDependencies{};
     std::vector<char> m_shortNameAliases{};
     std::vector<std::string> m_choices{};
     std::vector<std::string> m_hiddenChoices{};
@@ -1506,10 +1515,10 @@ class CPL_DLL GDALAlgorithmArg /* non-final */
         return m_decl.GetMutualDependencyGroup();
     }
 
-    /** Alias for GDALAlgorithmArgDecl::GetDependencies() */
-    inline const std::vector<std::string> &GetDependencies() const
+    /** Alias for GDALAlgorithmArgDecl::GetDirectDependencies() */
+    inline const std::vector<std::string> &GetDirectDependencies() const
     {
-        return m_decl.GetDependencies();
+        return m_decl.GetDirectDependencies();
     }
 
     /** Alias for GDALAlgorithmArgDecl::GetMetadata() */
@@ -2195,11 +2204,11 @@ class CPL_DLL GDALInConstructionAlgorithmArg final : public GDALAlgorithmArg
         return *this;
     }
 
-    /** Add a dependency from an argument */
+    /** Add a direct (not mutual) dependency from an argument */
     GDALInConstructionAlgorithmArg &
-    AddDependency(const GDALAlgorithmArg &otherArg)
+    AddDirectDependency(const GDALAlgorithmArg &otherArg)
     {
-        m_decl.AddDependency(otherArg.GetName());
+        m_decl.AddDirectDependency(otherArg.GetName());
         return *this;
     }
 
@@ -2540,6 +2549,33 @@ class CPL_DLL GDALAlgorithmRegistry
             return m_dummyArg;
         }
         return *alg;
+    }
+
+    /** Return a possibly empty list of names the specified argument
+     *  dependes on, this includes both direct and mutual dependencies */
+    std::vector<std::string> GetArgDependencies(const std::string &osName) const
+    {
+        const auto arg = GetArg(osName, false);
+        if (!arg)
+        {
+            ReportError(CE_Failure, CPLE_AppDefined,
+                        "Argument '%s' does not exist", osName.c_str());
+            return {};
+        }
+        std::vector<std::string> dependencies = arg->GetDirectDependencies();
+        if (const auto mutualDependencyGroup = arg->GetMutualDependencyGroup();
+            !mutualDependencyGroup.empty())
+        {
+            for (const auto &otherArg : m_args)
+            {
+                if (otherArg.get() == arg ||
+                    mutualDependencyGroup.compare(
+                        otherArg->GetMutualDependencyGroup()) != 0)
+                    continue;
+                dependencies.push_back(otherArg->GetName());
+            }
+        }
+        return dependencies;
     }
 
     /** Set the calling path to this algorithm.

--- a/gcore/gdalalgorithm_cpp.h
+++ b/gcore/gdalalgorithm_cpp.h
@@ -2552,7 +2552,7 @@ class CPL_DLL GDALAlgorithmRegistry
     }
 
     /** Return a possibly empty list of names the specified argument
-     *  dependes on, this includes both direct and mutual dependencies */
+     *  depends on, this includes both direct and mutual dependencies */
     std::vector<std::string> GetArgDependencies(const std::string &osName) const
     {
         const auto arg = GetArg(osName, false);

--- a/gcore/gdalalgorithm_cpp.h
+++ b/gcore/gdalalgorithm_cpp.h
@@ -740,7 +740,7 @@ class CPL_DLL GDALAlgorithmArgDecl final
     }
 
     /**
-     * Adds a depdendency on another argument, meaning that if this argument is specified,
+     * Adds a dependency on another argument, meaning that if this argument is specified,
      * the other argument must be specified too.
      * Note that the dependency is not symmetric. If argument A depends on argument B, it doesn't mean that B depends on A.
      */

--- a/gcore/gdalalgorithm_cpp.h
+++ b/gcore/gdalalgorithm_cpp.h
@@ -2195,11 +2195,11 @@ class CPL_DLL GDALInConstructionAlgorithmArg final : public GDALAlgorithmArg
         return *this;
     }
 
-    /** Alias for GDALAlgorithmArgDecl::AddDependency() */
+    /** Add a dependency from an argument */
     GDALInConstructionAlgorithmArg &
-    AddDependency(const std::string &otherArgName)
+    AddDependency(const GDALAlgorithmArg &otherArg)
     {
-        m_decl.AddDependency(otherArgName);
+        m_decl.AddDependency(otherArg.GetName());
         return *this;
     }
 

--- a/swig/include/Algorithm.i
+++ b/swig/include/Algorithm.i
@@ -211,6 +211,16 @@ public:
     return GDALAlgorithmArgGetMutualExclusionGroup(self);
   }
 
+  const char* GetMutualDependencyGroup() {
+      return GDALAlgorithmArgGetMutualDependencyGroup(self);
+  }
+
+%apply (char **CSL) {char **};
+  char **GetDirectDependencies() {
+      return GDALAlgorithmArgGetDirectDependencies( self );
+}
+%clear char **;
+
   bool GetAsBoolean() {
     return GDALAlgorithmArgGetAsBoolean(self);
   }
@@ -358,6 +368,14 @@ public:
     return GDALAlgorithmParseCommandLineArguments(self, args);
   }
 %clear char** args;
+
+
+%apply (char **CSL) {char **};
+char **GetArgDependencies(const char* argName) {
+    return GDALAlgorithmGetArgDependencies( self, argName );
+}
+%clear char **;
+
 
 %newobject GetActualAlgorithm;
   GDALAlgorithmHS* GetActualAlgorithm() {


### PR DESCRIPTION
This PR adds the possibility to define via API whether an input argument depends on another and, if the dependency is mutual to specify a mutual dependency group.

For instance: given arguments A, B, C 

- if A, B and C must all be set (or none of them), this can be enforced by specifying that they belong to the same mutual dependency group
- if A depends on B (but B can be set without also setting A) this can be enforced by specifying that A depends on (requires) B.

this constraints are exposed in the JSON usage for an argument as
```json
"mutual_dependency_group":"<group name>"
```

and 
```json
"depends_on": [ "<field 1>", "<field 2>" ...]
```
Note that the latter includes both dependencies (mutual and unidirectional).

This information appears in the help as:
```bash
gdal raster scale --help
Usage: gdal raster scale [OPTIONS] <INPUT> <OUTPUT>

[...]
Scale the values of the bands of a raster dataset.


Options:
  --src-min <SRC-MIN>                                      Minimum value of the source range
                                                           Depends on --src-max
  --src-max <SRC-MAX>                                      Maximum value of the source range
                                                           Depends on --src-min
  --dst-min <DST-MIN>                                      Minimum value of the destination range
                                                           Depends on --dst-max
  --dst-max <DST-MAX>                                      Maximum value of the destination range
                                                           Depends on --dst-min


[...]
```

```bash
gdal raster create --help
Usage: gdal raster create [OPTIONS] <OUTPUT>

[...]

Options:
  --copy-metadata                                          Copy metadata from input dataset
                                                           Depends on --input
  --copy-overviews                                         Create same overview levels as input dataset
                                                           Depends on --input
[...]
```

