### PR TITLE
Python: make gdal.alg.xxxx(...) accept aliases of argument names

### DIFF
--- a/autotest/gcore/algorithm.py
+++ b/autotest/gcore/algorithm.py
@@ -491,8 +491,10 @@ def test_gdal_alg_module(tmp_vsimem):
        filename: str
            File or directory name
        output_format: Optional[str]=None
+           Aliases: format
            Output format
        long_listing: Optional[bool]=None
+           Aliases: long
            Use a long listing format
        recursive: Optional[bool]=None
            List subdirectories recursively

--- a/autotest/utilities/test_gdalalg_raster_create.py
+++ b/autotest/utilities/test_gdalalg_raster_create.py
@@ -414,12 +414,10 @@ def test_gdalalg_raster_create_copy_override_crs():
 
 def test_gdalalg_raster_create_copy_override_bbox():
 
-    alg = get_alg()
-    alg["output"] = ""
-    alg["output-format"] = "MEM"
-    alg["input"] = get_ref_ds()
-    alg["bbox"] = [1, 47, 2, 48]
-    assert alg.Run()
+    # Also test using 'like' alias of 'input' argument
+    alg = gdal.alg.raster.create(
+        output="", output_format="MEM", like=get_ref_ds(), bbox=[1, 47, 2, 48]
+    )
     ds = alg["output"].GetDataset()
     assert ds.GetGeoTransform() == (1.0, 0.5, 0.0, 48.0, 0.0, -0.25)
 

--- a/swig/include/python/generate_gdal_alg_methods.i
+++ b/swig/include/python/generate_gdal_alg_methods.i
@@ -70,34 +70,57 @@ def _generate_gdal_alg_methods():
                 for arg_name in alg.GetArgNames():
                     arg = alg.GetArg(arg_name)
                     if arg.IsInput() and not arg.IsHiddenForAPI():
+
+                        names = [ arg_name ]
+                        aliases = arg.GetAliases()
+                        if aliases:
+                            for alias in aliases:
+                                if len(alias) >= 4:  # no 'if', 'of', 'abs', etc.
+                                    names.append(alias)
+
                         is_required = (arg.IsRequired() or arg_name == "pipeline")
-                        if pass_idx == 1 and not is_required:
+                        is_required_without_alias = is_required and len(names) == 1
+                        if pass_idx == 1 and not is_required_without_alias:
                             continue
-                        elif pass_idx == 2 and is_required:
+                        elif pass_idx == 2 and is_required_without_alias:
                             continue
-                        if args:
-                            args += ", "
-                            kwargs += ", "
 
-                        arg_name_sanitized = arg_name.replace('-', '_')
-                        if arg_name_sanitized[0:1].isdigit():
-                            arg_name_sanitized = '_' + arg_name_sanitized
+                        sanitized_names = []
+                        for name in names:
+                            if args:
+                                args += ", "
+                                kwargs += ", "
 
-                        assert arg_name_sanitized.isidentifier()
+                            arg_name_sanitized = name.replace('-', '_')
+                            if arg_name_sanitized[0:1].isdigit():
+                                arg_name_sanitized = '_' + arg_name_sanitized
 
-                        args += arg_name_sanitized
-                        type_hint = _get_type_hint(arg, for_input=True)
-                        if not is_required:
-                            type_hint = f"Optional[{type_hint}]=None"
-                        args += f": {type_hint}"
+                            assert arg_name_sanitized.isidentifier()
+                            sanitized_names.append(arg_name_sanitized)
 
-                        kwargs += f'"{arg_name_sanitized}": {arg_name_sanitized}'
+                            args += arg_name_sanitized
+                            type_hint = _get_type_hint(arg, for_input=True)
+                            if not is_required:
+                                type_hint = f"Optional[{type_hint}]=None"
+                                args += f": {type_hint}"
+                            else:
+                                if len(names) > 1:
+                                    args += f": Optional[{type_hint}]=None"
+                                else:
+                                    args += f": {type_hint}"
+
+                            kwargs += f'"{arg_name_sanitized}": {arg_name_sanitized}'
 
                         parameters += "       "
-                        parameters += arg_name_sanitized
+                        parameters += sanitized_names[0]
                         parameters += ": "
                         parameters += type_hint
                         parameters += "\n"
+                        if len(sanitized_names) > 1:
+                            parameters += "       "
+                            parameters += "    Aliases: "
+                            parameters += ", ".join(sanitized_names[1:])
+                            parameters += "\n"
                         parameters += "       "
                         parameters += "    "
                         parameters += arg.GetDescription()


### PR DESCRIPTION
CC @dbaston  this should help for the backward compatibility story of https://github.com/OSGeo/gdal/pull/14383