### PR TITLE
Doc: gti.rst fix typo with GTI OpenOptions for extent

### DIFF
--- a/doc/source/drivers/raster/gti.rst
+++ b/doc/source/drivers/raster/gti.rst
@@ -415,10 +415,10 @@ mentioned in the previous section.
             <Dataset>other.gti.gpkg</Dataset>
             <Layer>other_layer</Layer>                 <!-- optional -->
             <OpenOptions>                              <!-- optional -->
-                <OOI key="XMIN">2</OOI>
-                <OOI key="YMIN">49</OOI>
-                <OOI key="XMAX">3</OOI>
-                <OOI key="YMAX">50</OOI>
+                <OOI key="MINX">2</OOI>
+                <OOI key="MINY">49</OOI>
+                <OOI key="MAXX">3</OOI>
+                <OOI key="MAXY">50</OOI>
             </OpenOptions>
         </Overview>
 
@@ -683,10 +683,10 @@ needed, one ``<Overview>`` element per level must be specified.
             <Dataset>other.gti.gpkg</Dataset>
             <Layer>other_layer</Layer>
             <OpenOptions>
-                <OOI key="XMIN">2</OOI>
-                <OOI key="YMIN">49</OOI>
-                <OOI key="XMAX">3</OOI>
-                <OOI key="YMAX">50</OOI>
+                <OOI key="MINX">2</OOI>
+                <OOI key="MINY">49</OOI>
+                <OOI key="MAXX">3</OOI>
+                <OOI key="MAXY">50</OOI>
             </OpenOptions>
         </Overview>
 
@@ -763,7 +763,7 @@ an integer index (starting at 0 since GDAL 3.9.2, starting at 1 in previous vers
         # of the main GTI dataset (assuming such extent is 2,49,3,50).
         OVERVIEW_4_DATASET=other.gti.gpkg
         OVERVIEW_4_LAYER=layer
-        OVERVIEW_4_OPEN_OPTIONS=XMIN=2,YMIN=49,XMAX=3,YMAX=50
+        OVERVIEW_4_OPEN_OPTIONS=MINX=2,MINY=49,MAXX=3,MAXY=50
 
 
 Multi-threading optimizations


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

While testing GTI I noticed the OpenOptions in examples are documented as `XMAX` when [the GTI OpenOptions documented](https://gdal.org/en/stable/drivers/raster/gti.html#open-options) are of the format `MAXX`.

There are a few remaining references to `XMAX` related to spatial SQL.  I am unsure if those should be `XMAX` or `MAXX`.

## What are related issues/pull requests?
None

## AI tool usage

None

## Tasklist

 - [X] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [X] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed