### PR TITLE
gdal.alg.xxx(): make it work with hidden aliases too

### DIFF
--- a/autotest/gcore/algorithm.py
+++ b/autotest/gcore/algorithm.py
@@ -522,6 +522,11 @@ def test_gdal_alg_module(tmp_vsimem):
 
     assert gdal.alg.vsi.list(filename=tmp_vsimem).Output() == ["a"]
 
+    with pytest.raises(
+        Exception, match="'i-do-not-exist' is not a valid argument of 'list'"
+    ):
+        gdal.alg.vsi.list(filename="foo", i_do_not_exist=True)
+
 
 ###############################################################################
 # Test gdal algorithm with mutual dependencies between arguments

--- a/autotest/utilities/test_gdalalg_raster_reproject.py
+++ b/autotest/utilities/test_gdalalg_raster_reproject.py
@@ -451,3 +451,15 @@ def test_rotated(tmp_vsimem):
             "Dataset provided with --like has a geotransform with rotation. Ignoring it"
             in msgs[0]
         )
+
+
+def test_gdalalg_raster_reproject_hidden_alias_dst_crs():
+
+    with gdal.alg.raster.reproject(
+        input="../gcore/data/byte.tif",
+        output="",
+        output_format="MEM",
+        dst_crs="EPSG:4326",
+    ) as alg:
+        ds = alg.Output()
+        assert ds.GetSpatialRef().GetAuthorityCode() == "4326"

--- a/doc/source/development/rfc/rfc104_gdal_cli.rst
+++ b/doc/source/development/rfc/rfc104_gdal_cli.rst
@@ -481,8 +481,8 @@ Detailed usage help message of "gdal vector pipeline"
     Reproject.
 
     Options:
-      -s, --src-crs <SRC-CRS>                              Source CRS
-      -d, --dst-crs <DST-CRS>                              Destination CRS [required]
+      -s, --input-crs <INPUT-CRS>                          Input CRS
+      -d, --output-crs <OUTPUT-CRS>                        Output CRS
 
     * write [OPTIONS] <OUTPUT>
     --------------------------
@@ -533,8 +533,8 @@ subcommands, in which case they are augmented with the options of the 'read' and
       --overwrite-layer                                    Whether overwriting existing layer is allowed
       --append                                             Whether appending to existing layer is allowed
       --output-layer <OUTPUT-LAYER>                        Output layer name
-      -s, --src-crs <SRC-CRS>                              Source CRS
-      -d, --dst-crs <DST-CRS>                              Destination CRS [required]
+      -s, --input-crs <INPUT-CRS>                          Input CRS
+      -d, --output-crs <OUTPUT-CRS>                        Output CRS [required]
 
     Advanced Options:
       --if, --input-format <INPUT-FORMAT>                  Input formats [may be repeated]
@@ -644,9 +644,9 @@ it must be with their below semantics and syntax.
 * ``--bbox <xmin>,<ymin>,<xmax>,<ymax>``: as used by ``gdal vector info``,
   ``gdal vector convert``, ``gdal raster convert``
 
-* ``--src-crs <crs_spec>``: Override source CRS specification. Accept ``--s_srs`` as hidden alias for old CLI compatibility.
+* ``--input-crs <crs_spec>``: Override source CRS specification. Accept ``--s_srs`` as hidden alias for old CLI compatibility.
 
-* ``--dst-crs <crs_spec>``: Define target CRS specification. Accept ``--t_srs`` as hidden alias for old CLI compatibility.
+* ``--output-crs <crs_spec>``: Define target CRS specification. Accept ``--t_srs`` as hidden alias for old CLI compatibility.
 
 * ``--override-crs <crs_spec>``: Override CRS without reprojection. Accept ``--a_srs`` as hidden alias for old CLI compatibility.
 

--- a/doc/source/user/migration_guide.rst
+++ b/doc/source/user/migration_guide.rst
@@ -43,12 +43,11 @@ From GDAL 3.12 to GDAL 3.13
     ``char **`` to use ``CSLConstList`` instead. Such change is compatible with
     earlier GDAL versions.
 
-- Changes impacting Python users:
+- GDAL CLI changes:
 
-  * Several command-line arguments in the unified GDAL CLI were renamed from a 
-    --src/--dst pattern to an --input/--output pattern. The old argument names 
-    are still accepted by the CLI but are not recognized by the gdal.alg Python 
-    interface. 
+  * Several command-line arguments in the unified GDAL CLI were renamed from a
+    --src/--dst pattern to an --input/--output pattern. The old argument names
+    are still accepted by command line tools, C, C++ and Python API.
 
 - Behavior changes:
 

--- a/swig/include/python/generate_gdal_alg_methods.i
+++ b/swig/include/python/generate_gdal_alg_methods.i
@@ -86,10 +86,7 @@ def _generate_gdal_alg_methods():
                             continue
 
                         sanitized_names = []
-                        for name in names:
-                            if args:
-                                args += ", "
-                                kwargs += ", "
+                        for idx, name in enumerate(names):
 
                             arg_name_sanitized = name.replace('-', '_')
                             if arg_name_sanitized[0:1].isdigit():
@@ -98,18 +95,23 @@ def _generate_gdal_alg_methods():
                             assert arg_name_sanitized.isidentifier()
                             sanitized_names.append(arg_name_sanitized)
 
-                            args += arg_name_sanitized
-                            type_hint = _get_type_hint(arg, for_input=True)
-                            if not is_required:
-                                type_hint = f"Optional[{type_hint}]=None"
-                                args += f": {type_hint}"
-                            else:
-                                if len(names) > 1:
-                                    args += f": Optional[{type_hint}]=None"
-                                else:
-                                    args += f": {type_hint}"
+                            if idx == 0:
+                                if args:
+                                    args += ", "
+                                    kwargs += ", "
 
-                            kwargs += f'"{arg_name_sanitized}": {arg_name_sanitized}'
+                                args += arg_name_sanitized
+                                type_hint = _get_type_hint(arg, for_input=True)
+                                if not is_required:
+                                    type_hint = f"Optional[{type_hint}]=None"
+                                    args += f": {type_hint}"
+                                else:
+                                    if len(names) > 1:
+                                        args += f": Optional[{type_hint}]=None"
+                                    else:
+                                        args += f": {type_hint}"
+
+                                kwargs += f'"{arg_name_sanitized}": {arg_name_sanitized}'
 
                         parameters += "       "
                         parameters += sanitized_names[0]
@@ -166,10 +168,11 @@ def _generate_gdal_alg_methods():
 
 
             func_code = f"""
-def {name_sanitized}({args}):
-    kwargs = {kwargs}
-    kwargs = {{k: v for k, v in kwargs.items() if v is not None}}
-    return gdal.Run({new_path}, **kwargs)
+def {name_sanitized}({args}, **kwargs):
+    new_kwargs = {kwargs}
+    new_kwargs = {{k: v for k, v in new_kwargs.items() if v is not None}}
+    new_kwargs.update(kwargs)
+    return gdal.Run({new_path}, **new_kwargs)
 """
             func_globals = copy.copy(parent_module.__dict__)
             extra = {"gdal": gdal_module, "os": os, "List": List, "Union": Union, "Optional": Optional, "Callable": Callable}


### PR DESCRIPTION
FYI @hobu @dbaston @msmitherdc @elpaso @jjimenezshaw @normanb @ctoney . This PR makes it possible to use hidden aliases with the GDAL 3.12 gdal.alg.xxxx(arg_name=...) API. There's always a way in Python :-)