### PR TITLE
Python bindings: Handle numpy types in Feature.SetField

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -224,6 +224,14 @@ def pytest_collection_modifyitems(config, items):
                     )
                 )
 
+        for mark in item.iter_markers("require_32bit"):
+            if sys.maxsize > (1 << 32) - 1:
+                item.add_marker(pytest.mark.skip("test requires a 32-bit system"))
+
+        for mark in item.iter_markers("require_64bit"):
+            if sys.maxsize < (1 << 63) - 1:
+                item.add_marker(pytest.mark.skip("test requires a 64-bit system"))
+
         for mark in item.iter_markers("require_curl"):
             if not gdaltest.built_against_curl():
                 item.add_marker(pytest.mark.skip("curl support not available"))

--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -846,10 +846,8 @@ def test_gdal_EscapeString():
     assert gdal.EscapeString("a\rb", gdal.CPLES_CSV) == '"a\rb"'
 
 
+@pytest.mark.require_32bit()
 def test_gdal_EscapeString_errors():
-
-    if sys.maxsize > 2**32:
-        pytest.skip("Test not available on 64 bit")
 
     try:
         # Allocation will be < 4 GB, but will fail being > 2 GB

--- a/autotest/gdrivers/gpkg.py
+++ b/autotest/gdrivers/gpkg.py
@@ -3866,10 +3866,8 @@ def test_gpkg_wkt2(version):
 
 
 @pytest.mark.slow()
+@pytest.mark.require_64bit()
 def test_gpkg_50000_25000_uint16():
-
-    if sys.maxsize < 2**32:
-        pytest.skip("Test not available on 32 bit")
 
     ds = gdal.Open(
         "/vsizip/data/gpkg/50000_25000_uint16.gpkg.zip/50000_25000_uint16.gpkg"
@@ -3896,10 +3894,8 @@ def test_gpkg_50000_25000_uint16():
 
 
 @pytest.mark.slow()
+@pytest.mark.require_64bit()
 def test_gpkg_50000_50000_uint16():
-
-    if sys.maxsize < 2**32:
-        pytest.skip("Test not available on 32 bit")
 
     ds = gdal.Open(
         "/vsizip/data/gpkg/50000_50000_uint16.gpkg.zip/50000_50000_uint16.gpkg"

--- a/autotest/gdrivers/memmultidim.py
+++ b/autotest/gdrivers/memmultidim.py
@@ -2538,7 +2538,7 @@ def test_mem_md_resize_dim_wrong_too_big_allocation_before_malloc():
         assert v.Resize([1 << 63]) == gdal.CE_Failure
 
 
-@pytest.mark.skipif(sys.maxsize < 2**32, reason="only on 64bit")
+@pytest.mark.require_64bit()
 def test_mem_md_resize_dim_wrong_too_big_allocation_at_malloc():
 
     drv = gdal.GetDriverByName("MEM")

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -3431,10 +3431,8 @@ def test_netcdf_open_empty_double_attr():
 
 
 @pytest.mark.slow()
+@pytest.mark.require_64bit()
 def test_netcdf_huge_block_size(tmp_path):
-
-    if sys.maxsize < 2**32:
-        pytest.skip("Test not available on 32 bit")
 
     import psutil
 

--- a/autotest/gdrivers/vrtwarp.py
+++ b/autotest/gdrivers/vrtwarp.py
@@ -438,10 +438,8 @@ def test_vrtwarp_read_vrt_of_warped_vrt():
 
 
 @pytest.mark.slow()
+@pytest.mark.require_64bit()
 def test_vrtwarp_read_blocks_larger_than_2_gigapixels():
-
-    if sys.maxsize < 2**32:
-        pytest.skip("Test not available on 32 bit")
 
     import psutil
 

--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -4533,10 +4533,8 @@ def test_zarr_read_nczar_repeated_array_names(tmp_vsimem):
         assert rg.GetGroupNames() == ["g"]
 
 
+@pytest.mark.require_64bit()
 def test_zarr_read_test_overflow_in_AllocateWorkingBuffers_due_to_fortran(tmp_vsimem):
-
-    if sys.maxsize < (1 << 32):
-        pytest.skip()
 
     gdal.Mkdir(tmp_vsimem / "test.zarr", 0)
 
@@ -4561,12 +4559,10 @@ def test_zarr_read_test_overflow_in_AllocateWorkingBuffers_due_to_fortran(tmp_vs
         assert ar.Read(count=[1, 1]) is None
 
 
+@pytest.mark.require_64bit()
 def test_zarr_read_test_overflow_in_AllocateWorkingBuffers_due_to_type_change(
     tmp_vsimem,
 ):
-
-    if sys.maxsize < (1 << 32):
-        pytest.skip()
 
     gdal.Mkdir(tmp_vsimem / "test.zarr", 0)
 

--- a/autotest/ogr/ogr_basic_test.py
+++ b/autotest/ogr/ogr_basic_test.py
@@ -1328,3 +1328,33 @@ def test_ogr_basic_dataset_get_spatial_ref():
     ds.CreateLayer("one", srs=None)
     ds.CreateLayer("two", srs=None)
     assert ds.GetSpatialRef() is None
+
+
+###############################################################################
+# Test SetField with numpy types
+
+
+@pytest.mark.require_64bit()
+def test_ogr_basic_numpy():
+
+    np = pytest.importorskip("numpy")
+
+    defn = ogr.FeatureDefn()
+    defn.AddFieldDefn(ogr.FieldDefn("int", ogr.OFTIntegerList))
+    defn.AddFieldDefn(ogr.FieldDefn("int64", ogr.OFTInteger64List))
+    defn.AddFieldDefn(ogr.FieldDefn("real", ogr.OFTRealList))
+    defn.AddFieldDefn(ogr.FieldDefn("string", ogr.OFTStringList))
+
+    f = ogr.Feature(defn)
+    f["int"] = np.array([1, 2, 3], dtype=np.int32)
+    f["int64"] = 2**32 + np.array([1, 2, 3], dtype=np.int64)
+    f["real"] = np.sqrt(np.array([1, 2, 3], dtype=np.float64))
+    f["string"] = np.array(["abc", "def", "ghi"])
+
+    assert f["int"] == [1, 2, 3]
+    assert f["int64"] == (2**32 + np.array([1, 2, 3])).tolist()
+    assert f["real"] == [1.0, math.sqrt(2), math.sqrt(3)]
+    assert f["string"] == ["abc", "def", "ghi"]
+
+    with pytest.raises(Exception, match="Unsupported type"):
+        f["int"] = np.array([[1, 2, 3], [4, 5, 6]])

--- a/autotest/utilities/test_gdalalg_raster_zonal_stats.py
+++ b/autotest/utilities/test_gdalalg_raster_zonal_stats.py
@@ -12,7 +12,6 @@
 ###############################################################################
 
 import math
-import sys
 
 import gdaltest
 import ogrtest
@@ -761,7 +760,7 @@ def test_gdalalg_raster_zonal_stats_polygon_zones_invalid_chunk_size(zonal):
         zonal["chunk-size"] = "512"
 
 
-@pytest.mark.skipif(sys.maxsize <= 1 << 32, reason="only works on 64 bit")
+@pytest.mark.require_64bit()
 def test_gdalalg_raster_zonal_stats_polygon_zones_large_chunk_size(zonal):
 
     zonal["input"] = "../gcore/data/byte.tif"

--- a/cmake/template/pytest.ini.in
+++ b/cmake/template/pytest.ini.in
@@ -20,6 +20,8 @@ gdal_version = @GDAL_VERSION_NO_DEV_SUFFIX@
 
 markers =
     random_order: Indicates whether tests can be run non-sequentially
+    require_32bit: Only run test(s) on 32-bit systems
+    require_64bit: Only run test(s) on 64-bit systems
     require_curl: Skip test(s) if curl support is absent
     require_creation_option: Skip test(s) if required creation option is not available
     require_driver: Skip test(s) if driver isn't present

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -728,6 +728,10 @@ def _WarnIfUserHasNotSpecifiedIfUsingExceptions():
             self._SetFieldBinary(fld_index, value)
             return
 
+        if hasattr(value, 'tolist'):
+            self._SetField2(fld_index, value.tolist())
+            return
+
         try:
             self.SetField(fld_index, value)
         except:


### PR DESCRIPTION
A better fix would probably involve messing with the typemaps to avoid copying the NumPy array into Python types, but this is definitely an improvement over the current behavior of silently doing nothing.