### PR TITLE
gdal vector reproject/clean-coverage/simplify-coverage: make it passthrough for non-spatial layers

### DIFF
--- a/apps/gdalalg_vector_clean_coverage.cpp
+++ b/apps/gdalalg_vector_clean_coverage.cpp
@@ -203,7 +203,7 @@ bool GDALVectorCleanCoverageAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
 
     for (auto &&poSrcLayer : poSrcDS->GetLayers())
     {
-        if (m_activeLayer.empty() ||
+        if ((m_activeLayer.empty() && poSrcLayer->GetGeomType() != wkbNone) ||
             m_activeLayer == poSrcLayer->GetDescription())
         {
             progressHelper.AddProcessedLayer(*poSrcLayer);
@@ -214,7 +214,7 @@ bool GDALVectorCleanCoverageAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
         }
     }
 
-    if (!progressHelper.HasProcessedLayers())
+    if (!m_activeLayer.empty() && !progressHelper.HasProcessedLayers())
     {
         ReportError(CE_Failure, CPLE_AppDefined,
                     "Specified layer '%s' was not found",

--- a/apps/gdalalg_vector_reproject.cpp
+++ b/apps/gdalalg_vector_reproject.cpp
@@ -78,7 +78,8 @@ bool GDALVectorReprojectAlgorithm::RunStep(GDALPipelineStepRunContext &)
         ret = (poSrcLayer != nullptr);
         if (ret)
         {
-            if (m_activeLayer.empty() ||
+            if ((m_activeLayer.empty() &&
+                 poSrcLayer->GetGeomType() != wkbNone) ||
                 m_activeLayer == poSrcLayer->GetDescription())
             {
                 const OGRSpatialReference *poSrcLayerCRS;

--- a/apps/gdalalg_vector_simplify_coverage.cpp
+++ b/apps/gdalalg_vector_simplify_coverage.cpp
@@ -137,7 +137,7 @@ bool GDALVectorSimplifyCoverageAlgorithm::RunStep(
 
     for (auto &&poSrcLayer : poSrcDS->GetLayers())
     {
-        if (m_activeLayer.empty() ||
+        if ((m_activeLayer.empty() && poSrcLayer->GetGeomType() != wkbNone) ||
             m_activeLayer == poSrcLayer->GetDescription())
         {
             progressHelper.AddProcessedLayer(*poSrcLayer);
@@ -148,7 +148,7 @@ bool GDALVectorSimplifyCoverageAlgorithm::RunStep(
         }
     }
 
-    if (!progressHelper.HasProcessedLayers())
+    if (!m_activeLayer.empty() && !progressHelper.HasProcessedLayers())
     {
         ReportError(CE_Failure, CPLE_AppDefined,
                     "Specified layer '%s' was not found",

--- a/autotest/utilities/test_gdalalg_vector_clean_coverage.py
+++ b/autotest/utilities/test_gdalalg_vector_clean_coverage.py
@@ -231,3 +231,17 @@ def test_gdalalg_vector_clean_coverage_test_ogrsf(tmp_path):
     assert "INFO" in ret
     assert "ERROR" not in ret
     assert "FAILURE" not in ret
+
+
+def test_gdalalg_vector_clean_coverage_on_aspatial_layer():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 0, 0, 0, gdal.GDT_Unknown)
+    src_lyr = src_ds.CreateLayer("the_layer", geom_type=ogr.wkbNone)
+    src_lyr.CreateFeature(ogr.Feature(src_lyr.GetLayerDefn()))
+
+    with gdal.alg.vector.clean_coverage(
+        input=src_ds, output="", output_format="MEM"
+    ) as alg:
+        ds = alg.Output()
+        lyr = ds.GetLayer(0)
+        assert lyr.GetFeatureCount() == 1

--- a/autotest/utilities/test_gdalalg_vector_reproject.py
+++ b/autotest/utilities/test_gdalalg_vector_reproject.py
@@ -195,3 +195,17 @@ def test_gdalalg_vector_reproject_test_ogrsf(tmp_path):
     assert "INFO" in ret
     assert "ERROR" not in ret
     assert "FAILURE" not in ret
+
+
+def test_gdalalg_vector_reproject_on_aspatial_layer():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 0, 0, 0, gdal.GDT_Unknown)
+    src_lyr = src_ds.CreateLayer("the_layer", geom_type=ogr.wkbNone)
+    src_lyr.CreateFeature(ogr.Feature(src_lyr.GetLayerDefn()))
+
+    with gdal.alg.vector.reproject(
+        input=src_ds, output="", output_format="MEM", output_crs="EPSG:4326"
+    ) as alg:
+        ds = alg.Output()
+        lyr = ds.GetLayer(0)
+        assert lyr.GetFeatureCount() == 1

--- a/autotest/utilities/test_gdalalg_vector_simplify_coverage.py
+++ b/autotest/utilities/test_gdalalg_vector_simplify_coverage.py
@@ -171,3 +171,17 @@ def test_gdalalg_vector_simplify_coverage_test_ogrsf(tmp_path):
     assert "INFO" in ret
     assert "ERROR" not in ret
     assert "FAILURE" not in ret
+
+
+def test_gdalalg_vector_simplify_coverage_on_aspatial_layer():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 0, 0, 0, gdal.GDT_Unknown)
+    src_lyr = src_ds.CreateLayer("the_layer", geom_type=ogr.wkbNone)
+    src_lyr.CreateFeature(ogr.Feature(src_lyr.GetLayerDefn()))
+
+    with gdal.alg.vector.simplify_coverage(
+        input=src_ds, output="", output_format="MEM", tolerance=1
+    ) as alg:
+        ds = alg.Output()
+        lyr = ds.GetLayer(0)
+        assert lyr.GetFeatureCount() == 1


### PR DESCRIPTION
Fixes #14446
