### PR TITLE
MiraMonRaster: fixing issue 14461

### DIFF
--- a/frmts/miramon/miramon_palettes.cpp
+++ b/frmts/miramon/miramon_palettes.cpp
@@ -308,6 +308,18 @@ CPLErr MMRPalettes::GetPaletteColors_DBF(const CPLString &os_Color_Paleta_DBF)
         return CE_Failure;
     }
 
+    if (oColorTable.BytesPerRecord == UINT32_MAX)
+    {
+        CPLError(CE_Failure, CPLE_AssertionFailed,
+                 "Invalid color table:"
+                 "\"%s\".",
+                 osColorTableFileName.c_str());
+
+        VSIFCloseL(oColorTable.pfDataBase);
+        MM_ReleaseMainFields(&oColorTable);
+        return CE_Failure;
+    }
+
     // Guessing or reading the number of colors of the palette.
     MM_ACCUMULATED_BYTES_TYPE_DBF nBufferSize = oColorTable.BytesPerRecord + 1;
     char *pzsRecord = static_cast<char *>(VSI_CALLOC_VERBOSE(1, nBufferSize));


### PR DESCRIPTION
## What does this PR do?
Fixes issue 14461 where a limit of number of bytes per a record in a DBF talbe is reached.

## What are related issues/pull requests?
https://github.com/OSGeo/gdal/issues/14461#issuecomment-4335427267

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Review
 - [x] Adjust for comments
