### PR TITLE
C# bindings: Decode exception messages as UTF-8 strings

### DIFF
--- a/swig/csharp/CMakeLists.txt
+++ b/swig/csharp/CMakeLists.txt
@@ -175,9 +175,9 @@ function (gdal_csharp_wrap)
     # SWIG command
     COMMAND
       ${SWIG_EXECUTABLE} -namespace ${_CSHARP_NAMESPACE} -outdir ${_CSHARP_WORKING_DIRECTORY} -DSWIG2_CSHARP
-      -DSWIG_CSHARP_NO_STRING_HELPER -dllimport ${_CSHARP_WRAPPER} -Wall -I${PROJECT_SOURCE_DIR}/swig/include 
-      -I${PROJECT_SOURCE_DIR}/swig/include/csharp -I${PROJECT_SOURCE_DIR}/gdal -c++ -csharp -o ${_CSHARP_WRAPPER}.cpp
-      ${_CSHARP_SWIG_INTERFACE}      
+      -DSWIG_CSHARP_NO_STRING_HELPER -DSWIG_CSHARP_NO_STRING_WITH_LENGTH_HELPER -dllimport ${_CSHARP_WRAPPER}
+      -Wall -I${PROJECT_SOURCE_DIR}/swig/include -I${PROJECT_SOURCE_DIR}/swig/include/csharp
+      -I${PROJECT_SOURCE_DIR}/gdal -c++ -csharp -o ${_CSHARP_WRAPPER}.cpp ${_CSHARP_SWIG_INTERFACE}      
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS ${GDAL_SWIG_COMMON_INTERFACE_FILES} ${PROJECT_SOURCE_DIR}/swig/include/csharp/typemaps_csharp.i
             ${_CSHARP_SWIG_INTERFACE})

--- a/swig/csharp/apps/GDALTestUtf8.cs
+++ b/swig/csharp/apps/GDALTestUtf8.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 using OSGeo.GDAL;
@@ -236,16 +237,93 @@ namespace testapp
         private static void TestCSharpExceptions()
         {
             Console.WriteLine("Testing C# exceptions with Unicode messages.");
-            try
+            const int SWIG_CSharpApplicationException = 0;
+            const int SWIG_CSharpArithmeticException = 1;
+            const int SWIG_CSharpDivideByZeroException = 2;
+            const int SWIG_CSharpIndexOutOfRangeException = 3;
+            const int SWIG_CSharpInvalidCastException = 4;
+            const int SWIG_CSharpInvalidOperationException = 5;
+            const int SWIG_CSharpIOException = 6;
+            const int SWIG_CSharpNullReferenceException = 7;
+            const int SWIG_CSharpOutOfMemoryException = 8;
+            const int SWIG_CSharpOverflowException = 9;
+            const int SWIG_CSharpSystemException = 10;
+            Dictionary<int, Type> exs = new()
             {
-                Gdal.Error(CPLErr.CE_Failure, 0, UnicodeString);
-                throw new Exception($"{nameof(Gdal)}.{nameof(Gdal.Error)} did not throw an exception as expected.");
+                { SWIG_CSharpApplicationException, typeof(System.ApplicationException)  },
+                { SWIG_CSharpArithmeticException, typeof(System.ArithmeticException)  },
+                { SWIG_CSharpDivideByZeroException, typeof(System.DivideByZeroException)  },
+                { SWIG_CSharpIndexOutOfRangeException, typeof(System.IndexOutOfRangeException)  },
+                { SWIG_CSharpInvalidCastException, typeof(System.InvalidCastException)  },
+                { SWIG_CSharpInvalidOperationException, typeof(System.InvalidOperationException)  },
+                { SWIG_CSharpIOException, typeof(System.IO.IOException)  },
+                { SWIG_CSharpNullReferenceException, typeof(System.NullReferenceException)  },
+                { SWIG_CSharpOutOfMemoryException, typeof(System.OutOfMemoryException)  },
+                { SWIG_CSharpOverflowException, typeof(System.OverflowException)  },
+                { SWIG_CSharpSystemException, typeof(System.SystemException)  },
+                { int.MinValue, typeof(System.ApplicationException)  },
+                { int.MaxValue, typeof(System.ApplicationException)  }
+            };
+
+            var testException = GetPrivateGdalMethod<Action<int, string>>("TestSwigSetException");
+            foreach (var code in exs.Keys)
+            {
+                try
+                {
+                    testException(code, UnicodeString);
+                }
+                catch (Exception ex)
+                {
+                    var exType = exs[code];
+                    if (ex.GetType() != exs[code])
+                    {
+                        throw new Exception($"SWIG error code {code} did not throw {exType.Name}.", ex);
+                    }
+                    AssertEqual(UnicodeString, ex.Message, exs[code].Name);
+                }
             }
-            catch (ApplicationException ex)
+
+            Console.WriteLine("Testing C# exceptions with Unicode messages.");
+            const int SWIG_CSharpArgumentException = 0;
+            const int SWIG_CSharpArgumentNullException = 1;
+            const int SWIG_CSharpArgumentOutOfRangeException = 2;
+            Dictionary<int, Type> argumentExceptions = new()
             {
-                AssertEqual(UnicodeString, ex.Message, $"{nameof(Gdal)}.{nameof(Gdal.Error)}");
+                { SWIG_CSharpArgumentException, typeof(System.ArgumentException)  },
+                { SWIG_CSharpArgumentNullException, typeof(System.ArgumentNullException)  },
+                { SWIG_CSharpArgumentOutOfRangeException, typeof(System.ArgumentOutOfRangeException)  },
+                { int.MinValue, typeof(System.ArgumentException)  },
+                { int.MaxValue, typeof(System.ArgumentException)  }
+            };
+
+            var testArgException = GetPrivateGdalMethod<Action<int, string, string>>("TestSwigSetArgumentException");
+            foreach (var code in argumentExceptions.Keys)
+            {
+                try
+                {
+                    testArgException(code, UnicodeString, UnicodeString);
+                }
+                catch (ArgumentException ex)
+                {
+                    var exType = argumentExceptions[code];
+                    if (ex.GetType() != exType)
+                    {
+                        throw new Exception($"SWIG error code {code} did not throw {exType.Name}.", ex);
+                    }
+                    AssertEqual(UnicodeString, ex.ParamName, exType.Name);
+
+                    //ArgumentException Messages are in form of "<message> (Parameter '<parameter_name>')"
+                    if (ex.Message.Length < UnicodeString.Length)
+                        throw new Exception("Exception message is too short to contain " + nameof(UnicodeString), ex);
+                    AssertEqual(UnicodeString, ex.Message.Substring(0, UnicodeString.Length), exType.Name);
+                }
             }
         }
+
+        private static TDelegate GetPrivateGdalMethod<TDelegate>(string methodName) where TDelegate : Delegate
+            => typeof(Gdal).GetMethod(methodName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+            ?.CreateDelegate<TDelegate>()
+            ?? throw new MissingMethodException($"Could not get non-public, static method {methodName} from {nameof(Gdal)}");
     }
 }
 

--- a/swig/csharp/apps/GDALTestUtf8.cs
+++ b/swig/csharp/apps/GDALTestUtf8.cs
@@ -23,6 +23,7 @@ namespace testapp
             TestUnicodeDatasetLayerName();
             TestUnicodeFieldDefs();
             TestUnicodeVrtFiles();
+            TestCSharpExceptions();
         }
 
         private static void AssertEqual(string expected, string actual, string funcName)
@@ -230,6 +231,19 @@ namespace testapp
                 AssertEqual(vrtFile, list[0], $"{nameof(Dataset)}.{nameof(vrt.GetFileList)}()[0]");
                 AssertEqual(fileName1, list[1], $"{nameof(Dataset)}.{nameof(vrt.GetFileList)}()[1]");
                 AssertEqual(fileName2, list[2], $"{nameof(Dataset)}.{nameof(vrt.GetFileList)}()[2]");
+            }
+        }
+        private static void TestCSharpExceptions()
+        {
+            Console.WriteLine("Testing C# exceptions with Unicode messages.");
+            try
+            {
+                Gdal.Error(CPLErr.CE_Failure, 0, UnicodeString);
+                throw new Exception($"{nameof(Gdal)}.{nameof(Gdal.Error)} did not throw an exception as expected.");
+            }
+            catch (ApplicationException ex)
+            {
+                AssertEqual(UnicodeString, ex.Message, $"{nameof(Gdal)}.{nameof(Gdal.Error)}");
             }
         }
     }

--- a/swig/include/csharp/csharp_strings.i
+++ b/swig/include/csharp/csharp_strings.i
@@ -441,12 +441,12 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
       => SWIGPendingException.Set(new ArgumentException(Utf8UnmanagedToString(pMessage), Utf8UnmanagedToString(pParamName), SWIGPendingException.Retrieve()));
     static void SetPendingArgumentNullException(IntPtr pMessage, IntPtr pParamName) {
       Exception e = SWIGPendingException.Retrieve();
-	  string message = e == null ? " Inner Exception: " + e.Message : Utf8UnmanagedToString(pMessage);
+	  string message = e != null ? " Inner Exception: " + e.Message : Utf8UnmanagedToString(pMessage);
       SWIGPendingException.Set(new ArgumentNullException(Utf8UnmanagedToString(pParamName), message));
     }
     static void SetPendingArgumentOutOfRangeException(IntPtr pMessage, IntPtr pParamName) {
       Exception e = SWIGPendingException.Retrieve();
-	  string message = e == null ? " Inner Exception: " + e.Message : Utf8UnmanagedToString(pMessage);
+	  string message = e != null ? " Inner Exception: " + e.Message : Utf8UnmanagedToString(pMessage);
       SWIGPendingException.Set(new ArgumentOutOfRangeException(Utf8UnmanagedToString(pParamName), message));
     }
     unsafe static string Utf8UnmanagedToString(IntPtr pUtf8Bts) {

--- a/swig/include/csharp/csharp_strings.i
+++ b/swig/include/csharp/csharp_strings.i
@@ -358,3 +358,108 @@ SWIGEXPORT void SWIGSTDCALL RegisterUtf8StringCallback_$module(CSharpUtf8StringH
     CSLDestroy((char**)string_list_ptr);
   }
 %}
+
+/******************************************************************************
+ * SWIG helper for C# exceptions with UTF-8 string parameters
+ *
+ * This helper class supercedes SWIG's built-in SWIGExceptionHelper.
+ * SWIGExceptionHelper is still present and registers its own callbacks. Then
+ * ExceptionHelperUtf8 registers its own callbacks, overwriting the callbacks
+ * previously registered by SWIGExceptionHelper. Do this instead of defining
+ * SWIG_CSHARP_NO_EXCEPTION_HELPER so that we can still make use of the C#
+ * exception infrastructure built into SWIG.
+ *****************************************************************************/
+
+%pragma(csharp) imclasscode=%{
+  public class ExceptionHelperUtf8 {
+    public delegate void ExceptionDelegateUtf8(IntPtr pMessage);
+    public delegate void ExceptionArgumentDelegateUtf8(IntPtr pMessage, IntPtr pParamName);
+	
+    [DllImport("$dllimport", EntryPoint = "SWIGRegisterExceptionCallbacks_$module")]
+    public static extern void RegisterExceptionCallbacksUtf8(
+        ExceptionDelegateUtf8 applicationDelegate,
+        ExceptionDelegateUtf8 arithmeticDelegate,
+        ExceptionDelegateUtf8 divideByZeroDelegate,
+        ExceptionDelegateUtf8 indexOutOfRangeDelegate,
+        ExceptionDelegateUtf8 invalidCastDelegate,
+        ExceptionDelegateUtf8 invalidOperationDelegate,
+        ExceptionDelegateUtf8 ioDelegate,
+        ExceptionDelegateUtf8 nullReferenceDelegate,
+        ExceptionDelegateUtf8 outOfMemoryDelegate,
+        ExceptionDelegateUtf8 overflowDelegate,
+        ExceptionDelegateUtf8 systemExceptionDelegate);
+
+    [DllImport("$dllimport", EntryPoint = "SWIGRegisterExceptionArgumentCallbacks_$module")]
+    public static extern void RegisterExceptionCallbacksArgumentUtf8(
+        ExceptionArgumentDelegateUtf8 argumentDelegate,
+        ExceptionArgumentDelegateUtf8 argumentNullDelegate,
+        ExceptionArgumentDelegateUtf8 argumentOutOfRangeDelegate);
+
+    static ExceptionHelperUtf8() {
+      RegisterExceptionCallbacksUtf8(
+        new ExceptionDelegateUtf8(SetPendingApplicationException),
+        new ExceptionDelegateUtf8(SetPendingArithmeticException),
+        new ExceptionDelegateUtf8(SetPendingDivideByZeroException),
+        new ExceptionDelegateUtf8(SetPendingIndexOutOfRangeException),
+        new ExceptionDelegateUtf8(SetPendingInvalidCastException),
+        new ExceptionDelegateUtf8(SetPendingInvalidOperationException),
+        new ExceptionDelegateUtf8(SetPendingIOException),
+        new ExceptionDelegateUtf8(SetPendingNullReferenceException),
+        new ExceptionDelegateUtf8(SetPendingOutOfMemoryException),
+        new ExceptionDelegateUtf8(SetPendingOverflowException),
+        new ExceptionDelegateUtf8(SetPendingSystemException));
+		
+      RegisterExceptionCallbacksArgumentUtf8(
+        new ExceptionArgumentDelegateUtf8(SetPendingArgumentException),
+        new ExceptionArgumentDelegateUtf8(SetPendingArgumentNullException),
+        new ExceptionArgumentDelegateUtf8(SetPendingArgumentOutOfRangeException));
+    }
+
+    static void SetPendingApplicationException(IntPtr pMessage)
+      => SWIGPendingException.Set(new ApplicationException(Utf8UnmanagedToString(pMessage), SWIGPendingException.Retrieve()));
+    static void SetPendingArithmeticException(IntPtr pMessage)
+      => SWIGPendingException.Set(new ArithmeticException(Utf8UnmanagedToString(pMessage), SWIGPendingException.Retrieve()));
+    static void SetPendingDivideByZeroException(IntPtr pMessage)
+      => SWIGPendingException.Set(new DivideByZeroException(Utf8UnmanagedToString(pMessage), SWIGPendingException.Retrieve()));
+    static void SetPendingIndexOutOfRangeException(IntPtr pMessage)
+      => SWIGPendingException.Set(new IndexOutOfRangeException(Utf8UnmanagedToString(pMessage), SWIGPendingException.Retrieve()));
+    static void SetPendingInvalidCastException(IntPtr pMessage)
+      => SWIGPendingException.Set(new InvalidCastException(Utf8UnmanagedToString(pMessage), SWIGPendingException.Retrieve()));
+    static void SetPendingInvalidOperationException(IntPtr pMessage)
+      => SWIGPendingException.Set(new InvalidOperationException(Utf8UnmanagedToString(pMessage), SWIGPendingException.Retrieve()));
+    static void SetPendingIOException(IntPtr pMessage)
+      => SWIGPendingException.Set(new System.IO.IOException(Utf8UnmanagedToString(pMessage), SWIGPendingException.Retrieve()));
+    static void SetPendingNullReferenceException(IntPtr pMessage)
+      => SWIGPendingException.Set(new NullReferenceException(Utf8UnmanagedToString(pMessage), SWIGPendingException.Retrieve()));
+    static void SetPendingOutOfMemoryException(IntPtr pMessage)
+      => SWIGPendingException.Set(new OutOfMemoryException(Utf8UnmanagedToString(pMessage), SWIGPendingException.Retrieve()));
+    static void SetPendingOverflowException(IntPtr pMessage)
+      => SWIGPendingException.Set(new OverflowException(Utf8UnmanagedToString(pMessage), SWIGPendingException.Retrieve()));
+    static void SetPendingSystemException(IntPtr pMessage)
+      => SWIGPendingException.Set(new SystemException(Utf8UnmanagedToString(pMessage), SWIGPendingException.Retrieve()));
+    static void SetPendingArgumentException(IntPtr pMessage, IntPtr pParamName)
+      => SWIGPendingException.Set(new ArgumentException(Utf8UnmanagedToString(pMessage), Utf8UnmanagedToString(pParamName), SWIGPendingException.Retrieve()));
+    static void SetPendingArgumentNullException(IntPtr pMessage, IntPtr pParamName) {
+      Exception e = SWIGPendingException.Retrieve();
+	  string message = e == null ? " Inner Exception: " + e.Message : Utf8UnmanagedToString(pMessage);
+      SWIGPendingException.Set(new ArgumentNullException(Utf8UnmanagedToString(pParamName), message));
+    }
+    static void SetPendingArgumentOutOfRangeException(IntPtr pMessage, IntPtr pParamName) {
+      Exception e = SWIGPendingException.Retrieve();
+	  string message = e == null ? " Inner Exception: " + e.Message : Utf8UnmanagedToString(pMessage);
+      SWIGPendingException.Set(new ArgumentOutOfRangeException(Utf8UnmanagedToString(pParamName), message));
+    }
+    unsafe static string Utf8UnmanagedToString(IntPtr pUtf8Bts) {
+      if (pUtf8Bts == IntPtr.Zero)
+        return null;
+
+      byte* pStringUtf8 = (byte*)pUtf8Bts;
+      int len = 0;
+      while (pStringUtf8[len] != 0) len = checked(len + 1);
+
+      return System.Text.Encoding.UTF8.GetString(pStringUtf8, len);
+    }
+  }
+  //Instantiate the helper class so that the static constructor executes
+  static readonly ExceptionHelperUtf8 exceptionHelperUtf8 = new ExceptionHelperUtf8();
+%}

--- a/swig/include/csharp/gdal_csharp.i
+++ b/swig/include/csharp/gdal_csharp.i
@@ -397,3 +397,15 @@ GByte* wrapper_VSIGetMemFileBuffer(const char *utf8_string, vsi_l_offset *pnData
 }
 
 %clear (vsi_l_offset *pnDataLength);
+
+/* expose exception message setters for testing */
+%csmethodmodifiers TestSwigSetException "private";
+%csmethodmodifiers TestSwigSetArgumentException "private";
+%inline %{
+  void TestSwigSetException(int code, const char *message) {
+    SWIG_CSharpSetPendingException(static_cast<SWIG_CSharpExceptionCodes>(code), message);
+  }
+  void TestSwigSetArgumentException(int code, const char *message, const char *param_name) {
+    SWIG_CSharpSetPendingExceptionArgument(static_cast<SWIG_CSharpExceptionArgumentCodes>(code), message, param_name);
+  }
+%}


### PR DESCRIPTION
## What does this PR do?

Enable UTF-8 encoded exception messages. Replaces SWIG's built-in `SWIGExceptionHelper` with `ExceptionHelperUtf8`, which decodes exception message strings with UTF-8 instead of converting them to ANSI.

It also disables the unused SWIG "string with length helper".

This will conflict with changes in #14366, and this PR should be merged first.

@runette

## What are related issues/pull requests?

Building on the changes made in #14283.

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [X] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [X] Add test case(s)
 - [x] Review
 - [x] Adjust for comments

## Environment

Provide environment details, if relevant:
Mono and dotnet.
