### PR TITLE
MiraMonVector: fix issue 508096396

### DIFF
--- a/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
@@ -2229,7 +2229,7 @@ static int MMClosePolygonLayer(struct MiraMonVectLayerInfo *hMiraMonLayer)
 
 end_label:
     fclose_and_nullify(&pMMPolygonLayer->pF);
-
+    fclose_and_nullify(&pMMPolygonLayer->pFPS);
     fclose_and_nullify(&pMMPolygonLayer->pFPAL);
 
     return ret_code;


### PR DESCRIPTION
## What does this PR do?
Fixes the issue 508096396 where a memory leak appears. It was a forgotten fclose of one file in case of failure on closing Plygon layer.

## What are related issues/pull requests?
https://oss-fuzz.com/testcase-detail/6585096965783552

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Review
 - [ ] Adjust for comments
