### PR TITLE
Parquet: declare empty GDAL_DMD_CREATIONOPTIONLIST

### DIFF
--- a/alg/gdaltransformer.cpp
+++ b/alg/gdaltransformer.cpp
@@ -2237,8 +2237,8 @@ void *GDALCreateGenImgProjTransformer2(GDALDatasetH hSrcDS, GDALDatasetH hDstDS,
                                        CSLConstList papszOptions)
 
 {
-    GDALValidateOptions(GDALGetGenImgProjTranformerOptionList(), papszOptions,
-                        "option", "transformer options");
+    GDALValidateOptions(nullptr, GDALGetGenImgProjTranformerOptionList(),
+                        papszOptions, "option", "transformer options");
 
     double dfWestLongitudeDeg = 0.0;
     double dfSouthLatitudeDeg = 0.0;

--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -378,8 +378,8 @@ int GDALWarpOperation::ValidateOptions()
         aosWO.SetNameValue("ERROR_OUT_IF_EMPTY_SOURCE_WINDOW", nullptr);
         aosWO.SetNameValue("MULT_FACTOR_VERTICAL_SHIFT_PIPELINE", nullptr);
         aosWO.SetNameValue("SRC_FILL_RATIO_HEURISTICS", nullptr);
-        GDALValidateOptions(GDALWarpGetOptionList(), aosWO.List(), "option",
-                            "warp options");
+        GDALValidateOptions(nullptr, GDALWarpGetOptionList(), aosWO.List(),
+                            "option", "warp options");
     }
 
     const char *pszSampleSteps =

--- a/autotest/ogr/ogr_csv.py
+++ b/autotest/ogr/ogr_csv.py
@@ -3631,6 +3631,20 @@ def test_ogr_csv_creation_illegal_layer_name(tmp_vsimem):
 ###############################################################################
 
 
+@gdaltest.enable_exceptions()
+def test_ogr_csv_used_creation_option_instead_of_layer_creation_option(tmp_vsimem):
+
+    with gdaltest.error_raised(
+        gdal.CE_Warning, match="but a layer creation option of that name exists"
+    ):
+        gdal.GetDriverByName("CSV").CreateVector(
+            tmp_vsimem / "out", options=["SEPARATOR=COMMA"]
+        )
+
+
+###############################################################################
+
+
 if __name__ == "__main__":
     gdal.UseExceptions()
     if len(sys.argv) != 2:

--- a/autotest/ogr/ogr_mitab.py
+++ b/autotest/ogr/ogr_mitab.py
@@ -3118,3 +3118,19 @@ def test_ogr_mitab_mif_multilinestring_one_point(tmp_vsimem):
         lyr = ds.GetLayer(0)
         f = lyr.GetNextFeature()
         assert f.GetGeometryRef().ExportToWkt() == "MULTILINESTRING ((1 2))"
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_ogr_mitab_used_layer_creation_option_instead_of_creation_option(tmp_vsimem):
+
+    with gdal.GetDriverByName("MapInfo File").CreateVector(
+        tmp_vsimem / "out.mif"
+    ) as ds:
+        with gdaltest.error_raised(
+            gdal.CE_Warning, match="but a creation option of that name exists"
+        ):
+            lyr = ds.CreateLayer("out", options=["FORMAT=TAB"])
+            lyr.CreateField(ogr.FieldDefn("x"))

--- a/gcore/gdal_cpp_functions.h
+++ b/gcore/gdal_cpp_functions.h
@@ -245,7 +245,7 @@ CPLErr CPL_DLL EXIFExtractMetadata(char **&papszMetadata, void *fpL,
 
 int GDALValidateOpenOptions(GDALDriverH hDriver,
                             const char *const *papszOptionOptions);
-int GDALValidateOptions(const char *pszOptionList,
+int GDALValidateOptions(GDALDriverH hDriver, const char *pszOptionList,
                         const char *const *papszOptionsToValidate,
                         const char *pszErrorMessageOptionType,
                         const char *pszErrorMessageContainerName);

--- a/gcore/gdaldataset.cpp
+++ b/gcore/gdaldataset.cpp
@@ -2516,8 +2516,9 @@ CPLErr GDALDataset::BuildOverviews(const char *pszResampling, int nOverviews,
 
             CPLString osDriver;
             osDriver.Printf("driver %s", poDriver->GetDescription());
-            GDALValidateOptions(pszOptionList, aosOptions.List(),
-                                "overview creation option", osDriver);
+            GDALValidateOptions(GDALDriver::ToHandle(poDriver), pszOptionList,
+                                aosOptions.List(), "overview creation option",
+                                osDriver);
         }
     }
 
@@ -6141,8 +6142,8 @@ int GDALDataset::ValidateLayerCreationOptions(const char *const *papszLCO)
     }
     CPLString osDataset;
     osDataset.Printf("dataset %s", GetDescription());
-    return GDALValidateOptions(pszOptionList, papszLCO, "layer creation option",
-                               osDataset);
+    return GDALValidateOptions(GDALDriver::ToHandle(poDriver), pszOptionList,
+                               papszLCO, "layer creation option", osDataset);
 }
 
 //! @endcond

--- a/gcore/gdaldriver.cpp
+++ b/gcore/gdaldriver.cpp
@@ -2495,6 +2495,24 @@ int GDALValidateOptions(GDALDriverH hDriver, const char *pszOptionList,
                                            "that name exists.";
                     }
                 }
+                else if (hDriver && EQUAL(pszErrorMessageOptionType,
+                                          "layer creation option"))
+                {
+                    const char *pszLCOList =
+                        GDALDriver::FromHandle(hDriver)->GetMetadataItem(
+                            GDAL_DMD_CREATIONOPTIONLIST);
+                    if (pszLCOList &&
+                        (CPLString(pszLCOList)
+                                 .ifind(CPLSPrintf("\"%s\"", pszKey)) !=
+                             std::string::npos ||
+                         CPLString(pszLCOList)
+                                 .ifind(CPLSPrintf("'%s'", pszKey)) !=
+                             std::string::npos))
+                    {
+                        pszAdditionalMsg = ", but a creation option of "
+                                           "that name exists.";
+                    }
+                }
 
                 CPLError(CE_Warning, CPLE_NotSupported,
                          "%s does not support %s %s%s",

--- a/gcore/gdaldriver.cpp
+++ b/gcore/gdaldriver.cpp
@@ -393,8 +393,8 @@ GDALDriver::CreateMultiDimensional(const char *pszFilename,
             GetMetadataItem(GDAL_DMD_MULTIDIM_DATASET_CREATIONOPTIONLIST);
         CPLString osDriver;
         osDriver.Printf("driver %s", GetDescription());
-        GDALValidateOptions(pszOptionList, papszOptions, "creation option",
-                            osDriver);
+        GDALValidateOptions(GDALDriver::ToHandle(this), pszOptionList,
+                            papszOptions, "creation option", osDriver);
     }
 
     auto poDstDS = pfnCreateMultiDimensional(pszFilename, papszRootGroupOptions,
@@ -2318,8 +2318,9 @@ int CPL_STDCALL GDALValidateCreationOptions(GDALDriverH hDriver,
         papszOptionsToValidate = papszOptionsToFree;
     }
 
-    const bool bRet = CPL_TO_BOOL(GDALValidateOptions(
-        pszOptionList, papszOptionsToValidate, "creation option", osDriver));
+    const bool bRet = CPL_TO_BOOL(
+        GDALValidateOptions(hDriver, pszOptionList, papszOptionsToValidate,
+                            "creation option", osDriver));
     CSLDestroy(papszOptionsToFree);
     return bRet;
 }
@@ -2338,15 +2339,15 @@ int GDALValidateOpenOptions(GDALDriverH hDriver,
     CPLString osDriver;
     osDriver.Printf("driver %s",
                     GDALDriver::FromHandle(hDriver)->GetDescription());
-    return GDALValidateOptions(pszOptionList, papszOpenOptions, "open option",
-                               osDriver);
+    return GDALValidateOptions(hDriver, pszOptionList, papszOpenOptions,
+                               "open option", osDriver);
 }
 
 /************************************************************************/
 /*                        GDALValidateOptions()                         */
 /************************************************************************/
 
-int GDALValidateOptions(const char *pszOptionList,
+int GDALValidateOptions(GDALDriverH hDriver, const char *pszOptionList,
                         const char *const *papszOptionsToValidate,
                         const char *pszErrorMessageOptionType,
                         const char *pszErrorMessageContainerName)
@@ -2475,10 +2476,30 @@ int GDALValidateOptions(const char *pszOptionList,
                  CPLFetchBool(papszOptionsToValidate, "VALIDATE_OPEN_OPTIONS",
                               true)))
             {
+                const char *pszAdditionalMsg = "";
+                if (hDriver &&
+                    EQUAL(pszErrorMessageOptionType, "creation option"))
+                {
+                    const char *pszLCOList =
+                        GDALDriver::FromHandle(hDriver)->GetMetadataItem(
+                            GDAL_DS_LAYER_CREATIONOPTIONLIST);
+                    if (pszLCOList &&
+                        (CPLString(pszLCOList)
+                                 .ifind(CPLSPrintf("\"%s\"", pszKey)) !=
+                             std::string::npos ||
+                         CPLString(pszLCOList)
+                                 .ifind(CPLSPrintf("'%s'", pszKey)) !=
+                             std::string::npos))
+                    {
+                        pszAdditionalMsg = ", but a layer creation option of "
+                                           "that name exists.";
+                    }
+                }
+
                 CPLError(CE_Warning, CPLE_NotSupported,
-                         "%s does not support %s %s",
+                         "%s does not support %s %s%s",
                          pszErrorMessageContainerName,
-                         pszErrorMessageOptionType, pszKey);
+                         pszErrorMessageOptionType, pszKey, pszAdditionalMsg);
                 bRet = false;
             }
 

--- a/ogr/ogrsf_frmts/parquet/ogrparquetdrivercore.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetdrivercore.cpp
@@ -102,6 +102,10 @@ void OGRParquetDriverSetCommonMetadata(GDALDriver *poDriver)
                               "AlternativeName Domain");
     poDriver->SetMetadataItem(GDAL_DMD_SUPPORTED_SQL_DIALECTS, "OGRSQL SQLITE");
 
+    poDriver->SetMetadataItem(GDAL_DMD_CREATIONOPTIONLIST,
+                              "<CreationOptionList>"
+                              "</CreationOptionList>");
+
     poDriver->SetMetadataItem(
         GDAL_DMD_OPENOPTIONLIST,
         "<OpenOptionList>"


### PR DESCRIPTION
and:
- Dataset creation: emit an explicit warning when a dsco doesn't exist but a lco of same name does
- Layer creation: emit an explicit warning when a lco doesn't exist but a dsco of same name does

Fixes #14485 