### PR TITLE
Add 'gdal driver zarr add-georeferencing-convention'

### DIFF
--- a/autotest/cpp/CMakeLists.txt
+++ b/autotest/cpp/CMakeLists.txt
@@ -89,6 +89,7 @@ add_executable(
   test_gdal_algorithm.cpp
   test_gdal_dted.cpp
   test_gdal_gtiff.cpp
+  test_gdal_mdim.cpp
   test_gdal_minmax_element.cpp
   test_gdal_pixelfn.cpp
   test_gdal_typetraits.cpp

--- a/autotest/cpp/test_gdal_mdim.cpp
+++ b/autotest/cpp/test_gdal_mdim.cpp
@@ -1,0 +1,62 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Project:  C++ Test Suite for GDAL/OGR
+// Purpose:  Test GDAL multidim API
+// Author:   Even Rouault <even.rouault at spatialys.com>
+//
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2026, Even Rouault <even.rouault at spatialys.com>
+/*
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#include "gdal_unit_test.h"
+
+#include "gdal_multidim_cpp.h"
+#include "memdataset.h"
+
+#include <vector>
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
+
+namespace test_gdal_mdim
+{
+
+struct test_gdal_mdim : public ::testing::Test
+{
+};
+
+TEST_F(test_gdal_mdim, RecursivelyVisitArrays)
+{
+    auto poDS = std::unique_ptr<GDALDataset>(
+        MEMDataset::CreateMultiDimensional("", nullptr, nullptr));
+
+    auto poRG = poDS->GetRootGroup();
+    auto poArray1 = poRG->CreateMDArray("array1", {},
+                                        GDALExtendedDataType::Create(GDT_Byte));
+    auto poSubGroup = poRG->CreateGroup("subgroup");
+    auto poArray2 = poSubGroup->CreateMDArray(
+        "array2", {}, GDALExtendedDataType::Create(GDT_Byte));
+    auto poSubGroup2 = poRG->CreateGroup("subgroup2");
+    auto poArray3 = poSubGroup2->CreateMDArray(
+        "array3", {}, GDALExtendedDataType::Create(GDT_Byte));
+
+    std::vector<std::shared_ptr<GDALMDArray>> visitedArrays;
+    poRG->RecursivelyVisitArrays(
+        [&visitedArrays](const std::shared_ptr<GDALMDArray> &array)
+        { visitedArrays.push_back(array); });
+
+    ASSERT_EQ(visitedArrays.size(), 3U);
+    EXPECT_EQ(visitedArrays[0].get(), poArray1.get());
+    EXPECT_EQ(visitedArrays[1].get(), poArray2.get());
+    EXPECT_EQ(visitedArrays[2].get(), poArray3.get());
+}
+
+}  // namespace test_gdal_mdim
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -9223,3 +9223,40 @@ def test_zarr_v3_read_sharded_too_small_input_buffer(tmp_vsimem):
         Exception, match="input buffer is too small to hold the shard index"
     ):
         ds.GetRasterBand(1).Checksum()
+
+
+###############################################################################
+#
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_add_georeferencing_convention_spatial_proj(tmp_vsimem):
+
+    gdal.alg.raster.convert(
+        input="data/byte.tif",
+        output=tmp_vsimem / "out.zarr",
+        creation_option={"FORMAT": "ZARR_V3", "GEOREFERENCING_CONVENTION": "GDAL"},
+    )
+
+    with gdal.VSIFile(tmp_vsimem / "out.zarr" / "out" / "zarr.json", "rb") as f:
+        data = f.read()
+    j = json.loads(data)
+    assert "_CRS" in j["attributes"]
+    assert "zarr_conventions" not in j["attributes"]
+
+    gdal.alg.driver.zarr.add_georeferencing_convention(
+        input=tmp_vsimem / "out.zarr", convention="spatial_proj"
+    )
+
+    with gdal.VSIFile(tmp_vsimem / "out.zarr" / "out" / "zarr.json", "rb") as f:
+        data = f.read()
+    j = json.loads(data)
+    assert "_CRS" in j["attributes"]
+    assert "zarr_conventions" in j["attributes"]
+    assert j["attributes"]["proj:code"] == "EPSG:26711"
+
+    with pytest.raises(Exception, match="is not a ZARR dataset"):
+        gdal.alg.driver.zarr.add_georeferencing_convention(
+            input=gdal.GetDriverByName("MEM").Create("", 1, 1),
+            convention="spatial_proj",
+        )

--- a/doc/source/drivers/raster/zarr.rst
+++ b/doc/source/drivers/raster/zarr.rst
@@ -220,6 +220,8 @@ Georeferencing encoding (CRS and geotransformation matrix)
 The Zarr specification has no provision for spatial reference system encoding.
 Several conventions
 
+.. _raster_zarr.gdal.convention:
+
 GDAL convention
 +++++++++++++++
 
@@ -750,6 +752,12 @@ The following options are creation options of the classic raster API only:
       default value is the value of the INTERLEAVE metadata item of the
       IMAGE_STRUCTURE metadata domain of the source dataset, if set.
       See :ref:`raster_data_model_interleave_mode` for more details.
+
+
+Add a georeferencing convention to an existing ZARR dataset
+-----------------------------------------------------------
+
+See :ref:`gdal_driver_zarr_add_georeferencing_convention`.
 
 
 Examples

--- a/doc/source/programs/gdal_driver_zarr_add_georeferencing_convention.rst
+++ b/doc/source/programs/gdal_driver_zarr_add_georeferencing_convention.rst
@@ -40,7 +40,7 @@ Add (but not replace) a georeferencing convention to an existing ZARR dataset.
 
 This has only effect on arrays for which georeferencing is recognized.
 
-This can for example been used to add the Zarr `spatial <https://github.com/zarr-conventions/spatial>`__
+This can been used for example to add the Zarr `spatial <https://github.com/zarr-conventions/spatial>`__
 and `geo-proj <https://github.com/zarr-conventions/geo-proj>`__ conventions
 by specifying :option:`--convention` to ``spatial_proj``.
 

--- a/doc/source/programs/gdal_driver_zarr_add_georeferencing_convention.rst
+++ b/doc/source/programs/gdal_driver_zarr_add_georeferencing_convention.rst
@@ -1,0 +1,73 @@
+.. _gdal_driver_zarr_add_georeferencing_convention:
+
+================================================================================
+``gdal driver zarr add-georeferencing-convention``
+================================================================================
+
+.. versionadded:: 3.14
+
+.. only:: html
+
+    Add a georeferencing convention to an existing ZARR dataset
+
+.. Index:: gdal driver zarr add-georeferencing-convention
+
+Synopsis
+--------
+
+.. We are not using 'program-output:: gdal driver zarr add-georeferencing-convention --help-doc' on purpose,
+   because the Zar driver may not be built.
+
+.. code-block::
+
+    Usage: gdal driver zarr add-georeferencing-convention [OPTIONS] <INPUT> <CONVENTION>
+
+    Add a georeferencing convention to an existing ZARR dataset
+
+    Positional arguments:
+      -i, --input <INPUT>        Input multidimensional raster dataset [required]
+      --convention <CONVENTION>  Georeferencing convention. CONVENTION=GDAL|spatial_proj [required]
+
+    Common Options:
+      -h, --help                 Display help message and exit
+      --json-usage               Display usage as JSON document and exit
+      --config <KEY>=<VALUE>     Configuration option [may be repeated]
+
+Description
+-----------
+
+Add (but not replace) a georeferencing convention to an existing ZARR dataset.
+
+This has only effect on arrays for which georeferencing is recognized.
+
+This can for example been used to add the Zarr `spatial <https://github.com/zarr-conventions/spatial>`__
+and `geo-proj <https://github.com/zarr-conventions/geo-proj>`__ conventions
+by specifying :option:`--convention` to ``spatial_proj``.
+
+Program-Specific Options
+------------------------
+
+.. option:: --convention GDAL|spatial_proj
+
+    Name of the georeferencing convention to add.
+
+    ``GDAL`` uses a ``_CRS`` attribute (cf :ref:`raster_zarr.gdal.convention`).
+
+    ``spatial_proj`` uses the Zarr `spatial <https://github.com/zarr-conventions/spatial>`__
+    and `geo-proj <https://github.com/zarr-conventions/geo-proj>`__ conventions.
+
+
+.. Return status code
+.. ------------------
+
+.. include:: return_code.rst
+
+Examples
+--------
+
+.. example::
+    :title: Add the ``spatial_proj`` convention.
+
+   .. code-block:: bash
+
+       gdal driver zarr add-georeferencing-conventions my.zarr spatial_proj

--- a/doc/source/programs/index.rst
+++ b/doc/source/programs/index.rst
@@ -369,6 +369,7 @@ Driver specific commands
    gdal_driver_openfilegdb_repack
    gdal_driver_parquet_create_metadata_file
    gdal_driver_pdf_list_layers
+   gdal_driver_zarr_add_georeferencing_convention
 
 .. only:: html
 
@@ -379,6 +380,7 @@ Driver specific commands
     - :ref:`gdal_driver_openfilegdb_repack`: Repack in-place a FileGeodatabase dataset
     - :ref:`gdal_driver_parquet_create_metadata_file`:  Create the _metadata file for a partitioned Parquet dataset
     - :ref:`gdal_driver_pdf_list_layers`: Return the list of layers of a PDF file.
+    - :ref:`gdal_driver_zarr_add_georeferencing_convention`: Add a georeferencing convention to an existing ZARR dataset.
 
 
 .. _programs_traditional:

--- a/frmts/zarr/zarr.h
+++ b/frmts/zarr/zarr.h
@@ -977,6 +977,9 @@ class ZarrArray CPL_NON_FINAL : public GDALPamMDArray
     mutable std::mutex m_oMutex{};
     CPLStringList m_aosCreationOptions{};
 
+    // Value of CRS_ATTRIBUTE_NAME attribute before removing it from m_oAttrGroup
+    CPLJSONObject m_oCRSAttribute{};
+
     struct CachedBlock
     {
         ZarrByteVectorQuickResize abyDecoded{};
@@ -1254,6 +1257,11 @@ class ZarrArray CPL_NON_FINAL : public GDALPamMDArray
     void SetCreationOptions(CSLConstList papszOptions)
     {
         m_aosCreationOptions = papszOptions;
+    }
+
+    void InvalidateGeoreferencing()
+    {
+        m_bSRSModified = true;
     }
 
     static void DecodeSourceElt(const std::vector<DtypeElt> &elts,

--- a/frmts/zarr/zarr_array.cpp
+++ b/frmts/zarr/zarr_array.cpp
@@ -227,6 +227,7 @@ ZarrArray::ZarrArray(
       m_bUseOptimizedCodePaths(CPLTestBool(
           CPLGetConfigOption("GDAL_ZARR_USE_OPTIMIZED_CODE_PATHS", "YES")))
 {
+    m_oCRSAttribute.Deinit();
 }
 
 /************************************************************************/
@@ -259,6 +260,9 @@ CPLJSONObject ZarrArray::SerializeSpecialAttributes()
         EQUAL(m_aosCreationOptions.FetchNameValueDef(
                   "GEOREFERENCING_CONVENTION", "GDAL"),
               "SPATIAL_PROJ");
+
+    if (m_oCRSAttribute.IsValid() && bUseSpatialProjConventions)
+        oAttrs.Add(CRS_ATTRIBUTE_NAME, m_oCRSAttribute);
 
     const auto ExportToWkt2AndPROJJSON = [this](CPLJSONObject &oContainer,
                                                 const char *pszWKT2AttrName,
@@ -2530,6 +2534,7 @@ bool ZarrArray::SetSpatialRef(const OGRSpatialReference *poSRS)
     {
         return GDALPamMDArray::SetSpatialRef(poSRS);
     }
+    m_oCRSAttribute.Deinit();
     m_poSRS.reset();
     if (poSRS)
         m_poSRS.reset(poSRS->Clone());
@@ -3404,6 +3409,7 @@ void ZarrArray::SetAttributes(const std::shared_ptr<ZarrGroupBase> &poGroup,
                             SET_FROM_USER_INPUT_LIMITATIONS_get()) ==
                     OGRERR_NONE)
                 {
+                    m_oCRSAttribute = crs;
                     oAttributes.Delete(CRS_ATTRIBUTE_NAME);
                     break;
                 }

--- a/frmts/zarr/zarrdriver.cpp
+++ b/frmts/zarr/zarrdriver.cpp
@@ -16,6 +16,7 @@
 
 #include "cpl_minixml.h"
 
+#include "gdalalgorithm.h"
 #include "gdal_frmts.h"
 
 #include <algorithm>
@@ -2209,6 +2210,92 @@ GDALDataset *ZarrDataset::CreateCopy(const char *pszFilename,
 }
 
 /************************************************************************/
+/*               ZARRAddGeoreferencingConventionAlgorithm               */
+/************************************************************************/
+
+#ifndef _
+#define _(x) (x)
+#endif
+
+namespace
+{
+class ZARRAddGeoreferencingConventionAlgorithm final : public GDALAlgorithm
+{
+  public:
+    ZARRAddGeoreferencingConventionAlgorithm()
+        : GDALAlgorithm(
+              "add-georeferencing-convention",
+              std::string("Add a georeferencing convention to an existing ZARR "
+                          "dataset"),
+              "/programs/gdal_driver_zarr_add_georeferencing_convention.html")
+    {
+        AddInputDatasetArg(&m_dataset,
+                           GDAL_OF_MULTIDIM_RASTER | GDAL_OF_UPDATE);
+        AddArg("convention", 0, _("Georeferencing convention"),
+               &m_georeferencingConvention)
+            .SetRequired()
+            .SetPositional()
+            .SetChoices("GDAL", "spatial_proj");
+    }
+
+  protected:
+    bool RunImpl(GDALProgressFunc, void *) override;
+
+  private:
+    GDALArgDatasetValue m_dataset{};
+    std::string m_georeferencingConvention{};
+};
+
+bool ZARRAddGeoreferencingConventionAlgorithm::RunImpl(GDALProgressFunc, void *)
+{
+    auto poDS = dynamic_cast<ZarrDataset *>(m_dataset.GetDatasetRef());
+    if (!poDS)
+    {
+        ReportError(CE_Failure, CPLE_AppDefined, "%s is not a ZARR dataset",
+                    m_dataset.GetName().c_str());
+        return false;
+    }
+
+    auto poRG = poDS->GetRootGroup();
+    CPLAssert(poRG);
+
+    poRG->RecursivelyVisitArrays(
+        [this](const std::shared_ptr<GDALMDArray> &poArray)
+        {
+            ZarrArray *poZarrArray = dynamic_cast<ZarrArray *>(poArray.get());
+            if (poZarrArray && poZarrArray->GetSpatialRef())
+            {
+                CPLStringList aosOptions;
+                aosOptions.SetNameValue("GEOREFERENCING_CONVENTION",
+                                        m_georeferencingConvention.c_str());
+                poZarrArray->SetCreationOptions(aosOptions.List());
+                poZarrArray->InvalidateGeoreferencing();
+            }
+        });
+
+    return true;
+}
+}  // namespace
+
+/************************************************************************/
+/*                   ZarrDriverInstantiateAlgorithm()                   */
+/************************************************************************/
+
+static GDALAlgorithm *
+ZarrDriverInstantiateAlgorithm(const std::vector<std::string> &aosPath)
+{
+    if (aosPath.size() == 1 && aosPath[0] == "add-georeferencing-convention")
+    {
+        return std::make_unique<ZARRAddGeoreferencingConventionAlgorithm>()
+            .release();
+    }
+    else
+    {
+        return nullptr;
+    }
+}
+
+/************************************************************************/
 /*                         GDALRegister_Zarr()                          */
 /************************************************************************/
 
@@ -2231,6 +2318,7 @@ void GDALRegister_Zarr()
     poDriver->pfnRename = ZarrDatasetRename;
     poDriver->pfnCopyFiles = ZarrDatasetCopyFiles;
     poDriver->pfnClearCaches = ZarrDriverClearCaches;
+    poDriver->pfnInstantiateAlgorithm = ZarrDriverInstantiateAlgorithm;
 
     GetGDALDriverManager()->RegisterDriver(poDriver);
 }

--- a/frmts/zarr/zarrdrivercore.cpp
+++ b/frmts/zarr/zarrdrivercore.cpp
@@ -170,6 +170,8 @@ void ZARRDriverSetCommonMetadata(GDALDriver *poDriver)
     poDriver->SetMetadataItem(GDAL_DCAP_CREATECOPY, "YES");
     poDriver->SetMetadataItem(GDAL_DCAP_CREATE_MULTIDIMENSIONAL, "YES");
 
+    poDriver->DeclareAlgorithm({"add-georeferencing-convention"});
+
     poDriver->SetMetadataItem(GDAL_DCAP_UPDATE, "YES");
     poDriver->SetMetadataItem(GDAL_DMD_UPDATE_ITEMS,
                               "GeoTransform SRS NoData "

--- a/gcore/multidim/gdal_multidim.h
+++ b/gcore/multidim/gdal_multidim.h
@@ -21,6 +21,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <vector>
@@ -465,6 +466,9 @@ class CPL_DLL GDALGroup : public GDALIHasAttribute
 
     std::shared_ptr<GDALGroup>
     SubsetDimensionFromSelection(const std::string &osSelection) const;
+
+    void RecursivelyVisitArrays(
+        std::function<void(const std::shared_ptr<GDALMDArray> &)> visitor);
 
     //! @cond Doxygen_Suppress
     virtual void ParentRenamed(const std::string &osNewParentFullName);

--- a/gcore/multidim/gdalmultidim_group.cpp
+++ b/gcore/multidim/gdalmultidim_group.cpp
@@ -1318,3 +1318,41 @@ bool GDALGroup::CheckValidAndErrorOutIfNot() const
 }
 
 //! @endcond
+
+/************************************************************************/
+/*                       RecursivelyVisitArrays()                       */
+/************************************************************************/
+
+/** Recursively visit arrays of this group and its subgroups.
+ *
+ * @param visitor Callback function called on visited arrays.
+ *
+ * @since GDAL 3.14
+ */
+void GDALGroup::RecursivelyVisitArrays(
+    std::function<void(const std::shared_ptr<GDALMDArray> &)> visitor)
+{
+    std::queue<std::shared_ptr<GDALGroup>> oQueue;
+    auto poSelf = m_pSelf.lock();
+    if (poSelf)
+        oQueue.push(poSelf);
+    while (!oQueue.empty())
+    {
+        auto poGroup = oQueue.front();
+        oQueue.pop();
+
+        for (const std::string &osName : poGroup->GetMDArrayNames())
+        {
+            auto poArray = poGroup->OpenMDArray(osName);
+            if (poArray)
+                visitor(poArray);
+        }
+
+        for (const std::string &osName : poGroup->GetGroupNames())
+        {
+            auto poSubGroup = poGroup->OpenGroup(osName);
+            if (poSubGroup)
+                oQueue.push(poSubGroup);
+        }
+    }
+}


### PR DESCRIPTION
Add (but not replace) a georeferencing convention to an existing ZARR dataset.

This has only effect on arrays for which georeferencing is recognized.

This can for example been used to add the Zarr `spatial <https://github.com/zarr-conventions/spatial>`__ and `geo-proj <https://github.com/zarr-conventions/geo-proj>`__ conventions by specifying :option:`--convention` to ``spatial_proj``.
