### PR TITLE
Update libkml.rst with field removal example

### DIFF
--- a/doc/source/drivers/vector/libkml.rst
+++ b/doc/source/drivers/vector/libkml.rst
@@ -586,6 +586,8 @@ For example, if you want a field called 'Cities' to map to the
 `<name> <https://developers.google.com/kml/documentation/kmlreference#name>`__;
 tag in KML, you can set a configuration option. Note these are independent of layer
 creation and dataset creation options' `<name>`.
+Use an empty value to remove a field, e.g.,
+`LIBKML_EXTRUDE_FIELD=`
 
 -  .. config:: LIBKML_ID_FIELD
       :default: id


### PR DESCRIPTION
Add example for removing a field in LIBKML configuration.

Else, frankly, the user will never imagine it is possible.

They would think "if I tried that then the program would just replace it with some default."

So here we finally document the happy truth.

The only one that didn't work too well was the first one in the list.

--config LIBKML_ID_FIELD=

But that is probably expected.

So there is no way to eliminate the ID in 

``` 
  <Placemark id="graticule_k_00.2">
```
thus making the file smaller... well OK,  I guess we'll just get used to it. (Especially with KMZ, when it's tough to just run sed(1) on the output.)

