### PR TITLE
JP2Grok: support latest Grok 20.3.2 release

### DIFF
--- a/.github/workflows/ubuntu_26.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_26.04/Dockerfile.ci
@@ -230,7 +230,7 @@ RUN curl -LO -fsS https://github.com/apache/arrow/archive/refs/heads/main.zip \
     && rm -rf arrow-main
 
 # Build Grok JPEG 2000 library
-ARG GROK_VERSION=v20.2.8
+ARG GROK_VERSION=v20.3.2
 
 RUN git clone --recursive --depth 1 --branch ${GROK_VERSION} \
     https://github.com/GrokImageCompression/grok.git grok-git && \

--- a/autotest/gdrivers/jp2grok.py
+++ b/autotest/gdrivers/jp2grok.py
@@ -277,7 +277,7 @@ def test_jp2grok_10():
     gdal.Unlink("/vsimem/jp2grok_10.jp2")
 
     # Quite a bit of difference...
-    assert maxdiff <= 35, "Image too different from reference"
+    assert maxdiff <= 38, "Image too different from reference"
 
 
 ###############################################################################
@@ -592,7 +592,7 @@ def test_jp2grok_22():
     assert fourth_band.GetMetadataItem("NBITS", "IMAGE_STRUCTURE") == "1"
     ds = None
     ds = gdal.Open("/vsimem/jp2grok_22.jp2")
-    assert ds.GetRasterBand(4).Checksum() == 22499
+    assert ds.GetRasterBand(4).Checksum() == 26477
     ds = None
     gdal.Unlink("/vsimem/jp2grok_22.jp2")
 
@@ -721,7 +721,7 @@ def test_jp2grok_24():
     ds = None
     ds = gdal.Open("/vsimem/jp2grok_24.jp2")
     assert ds.GetRasterBand(2).GetMetadataItem("NBITS", "IMAGE_STRUCTURE") is None
-    assert ds.GetRasterBand(2).Checksum() == 22499
+    assert ds.GetRasterBand(2).Checksum() == 27389
     ds = None
     gdal.Unlink("/vsimem/jp2grok_24.jp2")
 

--- a/cmake/helpers/CheckDependentLibrariesGrok.cmake
+++ b/cmake/helpers/CheckDependentLibrariesGrok.cmake
@@ -2,4 +2,4 @@ gdal_check_package(Grok "Enable JPEG2000 support with Grok library"
                    CONFIG
                    CAN_DISABLE
                    TARGETS GROK::grokj2k
-                   VERSION 20.2.8)
+                   VERSION 20.3.2)

--- a/frmts/grok/grkdatasetbase.h
+++ b/frmts/grok/grkdatasetbase.h
@@ -476,8 +476,9 @@ struct GRKCodecWrapper
      */
     void allocComponentParams(int nBands)
     {
+        // need to zero-init the component structs
         pasBandParams = static_cast<grk_image_comp *>(
-            CPLMalloc(nBands * sizeof(grk_image_comp)));
+            CPLCalloc(nBands, sizeof(grk_image_comp)));
     }
 
     /**
@@ -2131,6 +2132,91 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
         if (xStart >= xEnd || yStart >= yEnd)
             return CE_None;
 
+        // can use fast path when there is no sub-sampling, no alpha promotion
+        // and output pixels are contiguous
+        const int elemSize = GDALGetDataTypeSizeBytes(eBufType);
+        bool canFastCopy = (nPromoteAlphaBandIdx < 0 &&
+                            nPixelSpace == elemSize && elemSize > 0);
+        for (int i = 0; i < nBandCount && canFastCopy; ++i)
+        {
+            const int b = panBandMap[i] - 1;
+            if (b < 0 || b >= img->numcomps)
+                canFastCopy = false;
+            else
+            {
+                const auto &comp = img->comps[b];
+                if (comp.dx != 1 || comp.dy != 1 || !comp.data)
+                    canFastCopy = false;
+            }
+        }
+
+        if (canFastCopy)
+        {
+            const int copyWidth = xEnd - xStart;
+            for (int i = 0; i < nBandCount; ++i)
+            {
+                const int srcBandIdx = panBandMap[i] - 1;
+                const auto &comp = img->comps[srcBandIdx];
+                const int srcXStart = xStart - tileXOff;
+
+                for (int iY = yStart; iY < yEnd; ++iY)
+                {
+                    const int srcRow = iY - tileYOff;
+                    const int dstRow = iY - nYOff;
+                    const int dstX = xStart - nXOff;
+                    auto dst = static_cast<uint8_t *>(pData) +
+                               dstRow * nLineSpace + dstX * nPixelSpace +
+                               i * nBandSpace;
+
+                    if (comp.data_type == GRK_INT_16)
+                    {
+                        const auto src =
+                            static_cast<int16_t *>(comp.data) +
+                            srcRow * static_cast<int>(comp.stride) + srcXStart;
+                        if (eBufType == GDT_UInt16 || eBufType == GDT_Int16)
+                        {
+                            memcpy(dst, src, copyWidth * sizeof(int16_t));
+                        }
+                        else if (eBufType == GDT_Byte)
+                        {
+                            for (int x = 0; x < copyWidth; ++x)
+                                dst[x] = static_cast<GByte>(src[x]);
+                        }
+                        else if (eBufType == GDT_Int32 ||
+                                 eBufType == GDT_UInt32)
+                        {
+                            auto dst32 = reinterpret_cast<int32_t *>(dst);
+                            for (int x = 0; x < copyWidth; ++x)
+                                dst32[x] = src[x];
+                        }
+                    }
+                    else
+                    {
+                        const auto src =
+                            static_cast<int32_t *>(comp.data) +
+                            srcRow * static_cast<int>(comp.stride) + srcXStart;
+                        if (eBufType == GDT_Int32 || eBufType == GDT_UInt32)
+                        {
+                            memcpy(dst, src, copyWidth * sizeof(int32_t));
+                        }
+                        else if (eBufType == GDT_UInt16 ||
+                                 eBufType == GDT_Int16)
+                        {
+                            auto dst16 = reinterpret_cast<int16_t *>(dst);
+                            for (int x = 0; x < copyWidth; ++x)
+                                dst16[x] = static_cast<int16_t>(src[x]);
+                        }
+                        else if (eBufType == GDT_Byte)
+                        {
+                            for (int x = 0; x < copyWidth; ++x)
+                                dst[x] = static_cast<GByte>(src[x]);
+                        }
+                    }
+                }
+            }
+            return CE_None;
+        }
+
         // Scalar per-pixel loop that handles dx/dy subsampling, alpha promotion,
         // and all five output types.
         CPLErr eErr = CE_None;
@@ -2165,7 +2251,13 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
                     const GPtrDiff_t dstOffset =
                         bufX * nPixelSpace + bufY * nLineSpace + i * nBandSpace;
 
-                    int32_t value = static_cast<int32_t *>(comp.data)[tileIdx];
+                    // Grok v20.3.x can use 16 bit storage for images with
+                    // precision ≤ 12 bits - we need to  cast to correct type
+                    int32_t value;
+                    if (comp.data_type == GRK_INT_16)
+                        value = static_cast<int16_t *>(comp.data)[tileIdx];
+                    else
+                        value = static_cast<int32_t *>(comp.data)[tileIdx];
                     if (srcBandIdx == nPromoteAlphaBandIdx)
                         value *= 255;
                     if (eBufType == GDT_Byte)


### PR DESCRIPTION
## What does this PR do?

Bump Grok version to 20.3.2
This version has a fast 16 bit decompression path, so we need to be aware of data type. Also, 16 bit is a tad more lossy, so unit tests have been tweaked accordingly.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
