### PR TITLE
autotest: allow tests to run with pytest < 8.2

### DIFF
--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -2179,11 +2179,15 @@ def gdal_has_vrt_expression_dialect(dialect):
 ###############################################################################
 
 
-def importorskip_gdal_array():
+def importorskip(lib):
     pytest_version = [int(x) for x in pytest.__version__.split(".")]
     if pytest_version >= [8, 2, 0]:
-        return pytest.importorskip("osgeo.gdal_array", exc_type=ImportError)
-    return pytest.importorskip("osgeo.gdal_array")
+        return pytest.importorskip(lib, exc_type=ImportError)
+    return pytest.importorskip(lib)
+
+
+def importorskip_gdal_array():
+    return importorskip("osgeo.gdal_array")
 
 
 ###############################################################################

--- a/autotest/pyscripts/test_gdal_calc.py
+++ b/autotest/pyscripts/test_gdal_calc.py
@@ -27,7 +27,7 @@ from osgeo import gdal
 
 # test that numpy is available, if not skip all tests
 np = pytest.importorskip("numpy")
-gdal_calc = pytest.importorskip("osgeo_utils.gdal_calc", exc_type=ImportError)
+gdal_calc = gdaltest.importorskip("osgeo_utils.gdal_calc")
 gdal_array = gdaltest.importorskip_gdal_array()
 try:
     GDALTypeCodeToNumericTypeCode = gdal_array.GDALTypeCodeToNumericTypeCode

--- a/autotest/pyscripts/test_gdallocationinfo_py.py
+++ b/autotest/pyscripts/test_gdallocationinfo_py.py
@@ -12,11 +12,13 @@
 #
 # SPDX-License-Identifier: MIT
 ###############################################################################
+
+import gdaltest
 import pytest
 
 # test that numpy is available, if not skip all tests
 np = pytest.importorskip("numpy")
-pytest.importorskip("osgeo_utils.samples.gdallocationinfo", exc_type=ImportError)
+gdaltest.importorskip("osgeo_utils.samples.gdallocationinfo")
 
 from itertools import product
 


### PR DESCRIPTION
Follow-on to #12086

Noticed this when running tests for 3.13.0rc2 on Ubuntu 24.04. It's nice to be able to run the tests without setting up a virtual environment to get a newer pytest.