### PR TITLE
MiraMonVector: Repeated field names/description improvements

### DIFF
--- a/autotest/ogr/ogr_miramon_vector.py
+++ b/autotest/ogr/ogr_miramon_vector.py
@@ -1596,7 +1596,7 @@ def test_ogr_miramon_vector_sql_select_preserve_reserved_fields():
     out_ds = None
     ds = None
 
-    rel_filename = out_filename[:-4] + ".rel"
+    rel_filename = out_filename[:-4] + "P.rel"
 
     with open(rel_filename, "rt", encoding="latin1") as f:
         rel_content = f.read()

--- a/autotest/ogr/ogr_miramon_vector.py
+++ b/autotest/ogr/ogr_miramon_vector.py
@@ -1566,3 +1566,46 @@ def test_ogr_miramon_write_launder_layer_name(tmp_path):
         match="Layer name 'not/allowed' laundered as 'not_allowed' for filename compatibility",
     ):
         ds.CreateLayer("not/allowed", srs=srs, geom_type=ogr.wkbUnknown)
+
+
+###############################################################################
+
+
+def test_ogr_miramon_vector_sql_select_preserve_reserved_fields():
+
+    src_filename = "data/miramon/Polygons/SimplePolygons/SimplePolFile.pol"
+
+    import os
+    import tempfile
+
+    tmp_dir = tempfile.mkdtemp()
+    out_filename = os.path.join(tmp_dir, "selected.pol")
+
+    ds = ogr.Open(src_filename)
+    assert ds is not None
+
+    out_ds = gdal.VectorTranslate(
+        out_filename,
+        ds,
+        format="MiraMonVector",
+        SQLStatement="SELECT * FROM SimplePolFile WHERE ATT1 = 'C'",
+    )
+
+    assert out_ds is not None
+
+    out_ds = None
+    ds = None
+
+    rel_filename = out_filename[:-4] + ".rel"
+
+    with open(rel_filename, "rt", encoding="latin1") as f:
+        rel_content = f.read()
+
+    assert rel_content.count("[TAULA_PRINCIPAL:ID_GRAFIC]") == 1
+    assert rel_content.count("[TAULA_PRINCIPAL:ID_GRAFIC2]") == 1
+
+    assert rel_content.count("[TAULA_PRINCIPAL:N_VERTEXS]") == 1
+    assert rel_content.count("[TAULA_PRINCIPAL:PERIMETRE]") == 1
+    assert rel_content.count("[TAULA_PRINCIPAL:AREA]") == 1
+    assert rel_content.count("[TAULA_PRINCIPAL:N_ARCS]") == 1
+    assert rel_content.count("[TAULA_PRINCIPAL:N_POLIG]") == 1

--- a/frmts/miramon_common/mm_gdal_driver_structs.h
+++ b/frmts/miramon_common/mm_gdal_driver_structs.h
@@ -355,7 +355,15 @@ struct MiraMonRecord
 struct MiraMonDataBaseField
 {
     char pszFieldName[MM_MAX_LON_FIELD_NAME_DBF + 1];
+    // A layer, when translated to MiraMon cannot have some
+    // specific field names (ID_GRAFIC, for instance).
+    // If pszFieldName is modified because of it
+    // we need to keep it somewhere in order to write metadata.
+    char pszFieldModifName[MM_MAX_LON_FIELD_NAME_DBF + 1];
     char pszFieldDescription[MM_MAX_BYTES_FIELD_DESC + 1];
+    // In the case of a modified field name, we also need
+    // to keep the description somewhere in order to write metadata.
+    char pszFieldModifDescription[MM_MAX_BYTES_FIELD_DESC + 1];
     enum FieldType eFieldType;   // See enum FieldType
     GUInt32 nFieldSize;          // MM_MAX_BYTES_IN_A_FIELD_EXT as maximum
     GUInt32 nNumberOfDecimals;   // MM_MAX_BYTES_IN_A_FIELD_EXT as maximum

--- a/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
@@ -6108,30 +6108,34 @@ int MMCreateMMDB(struct MiraMonVectLayerInfo *hMiraMonLayer,
                            .pszFieldModifName,
                        pBD_XP->pField[nIField].FieldName);
 
+                strcpy(
+                    hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]
+                        .pszFieldModifDescription,
+                    pBD_XP->pField[nIField].FieldDescription[MM_DEF_LANGUAGE]);
+
                 // In this case we are going to use also the modified description in metadata
-                char szTemp[MM_MAX_BYTES_FIELD_DESC + 1];
                 switch (hMiraMonLayer->nMMLanguage)
                 {
                     case MM_CAT_LANGUAGE:
-                        snprintf(szTemp, sizeof(szTemp), "%s (previ)",
-                                 pBD_XP->pField[nIField]
-                                     .FieldDescription[MM_DEF_LANGUAGE]);
+                        CPLStrlcat(
+                            hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]
+                                .pszFieldModifDescription,
+                            " (previ)", MM_MAX_BYTES_FIELD_DESC + 1);
                         break;
                     case MM_SPA_LANGUAGE:
-                        snprintf(szTemp, sizeof(szTemp), "%s (previo)",
-                                 pBD_XP->pField[nIField]
-                                     .FieldDescription[MM_DEF_LANGUAGE]);
+                        CPLStrlcat(
+                            hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]
+                                .pszFieldModifDescription,
+                            " (previo)", MM_MAX_BYTES_FIELD_DESC + 1);
                         break;
                     default:
                     case MM_ENG_LANGUAGE:
-                        snprintf(szTemp, sizeof(szTemp), "%s (previous)",
-                                 pBD_XP->pField[nIField]
-                                     .FieldDescription[MM_DEF_LANGUAGE]);
+                        CPLStrlcat(
+                            hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]
+                                .pszFieldModifDescription,
+                            " (previous)", MM_MAX_BYTES_FIELD_DESC + 1);
                         break;
                 }
-                strcpy(hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]
-                           .pszFieldModifDescription,
-                       szTemp);
             }
             else
                 *hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]

--- a/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
@@ -6109,32 +6109,29 @@ int MMCreateMMDB(struct MiraMonVectLayerInfo *hMiraMonLayer,
                        pBD_XP->pField[nIField].FieldName);
 
                 // In this case we are going to use also the modified description in metadata
-                strcpy(
-                    hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]
-                        .pszFieldModifDescription,
-                    pBD_XP->pField[nIField].FieldDescription[MM_DEF_LANGUAGE]);
-
+                char szTemp[MM_MAX_BYTES_FIELD_DESC + 1];
                 switch (hMiraMonLayer->nMMLanguage)
                 {
                     case MM_CAT_LANGUAGE:
-                        strncat(hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]
-                                    .pszFieldModifDescription,
-                                " (previ)", MM_MAX_BYTES_FIELD_DESC);
+                        snprintf(szTemp, sizeof(szTemp), "%s (previ)",
+                                 pBD_XP->pField[nIField]
+                                     .FieldDescription[MM_DEF_LANGUAGE]);
                         break;
                     case MM_SPA_LANGUAGE:
-                        strncat(hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]
-                                    .pszFieldModifDescription,
-                                " (previo)", MM_MAX_BYTES_FIELD_DESC);
+                        snprintf(szTemp, sizeof(szTemp), "%s (previo)",
+                                 pBD_XP->pField[nIField]
+                                     .FieldDescription[MM_DEF_LANGUAGE]);
                         break;
                     default:
                     case MM_ENG_LANGUAGE:
-                        strncat(hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]
-                                    .pszFieldModifDescription,
-                                " (previous)", MM_MAX_BYTES_FIELD_DESC);
+                        snprintf(szTemp, sizeof(szTemp), "%s (previous)",
+                                 pBD_XP->pField[nIField]
+                                     .FieldDescription[MM_DEF_LANGUAGE]);
                         break;
                 }
-                hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]
-                    .pszFieldModifDescription[MM_MAX_BYTES_FIELD_DESC] = '\0';
+                strcpy(hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]
+                           .pszFieldModifDescription,
+                       szTemp);
             }
             else
                 *hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]

--- a/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
@@ -5615,21 +5615,50 @@ static int MMWriteMetadataFile(struct MiraMonVectorMetaData *hMMMD)
         // For each field of the databes
         for (nIField = 0; nIField < hMMMD->pLayerDB->nNFields; nIField++)
         {
-            VSIFPrintfL(pF, LineReturn "[%s:%s]" LineReturn,
-                        SECTION_TAULA_PRINCIPAL,
-                        hMMMD->pLayerDB->pFields[nIField].pszFieldName);
+            bool bModifiedFieldName = false;
+            if (*hMMMD->pLayerDB->pFields[nIField].pszFieldModifName != '\0')
+                bModifiedFieldName = true;
+
+            // If exists a modified name we need to document that one.
+            VSIFPrintfL(
+                pF, LineReturn "[%s:%s]" LineReturn, SECTION_TAULA_PRINCIPAL,
+                bModifiedFieldName
+                    ? hMMMD->pLayerDB->pFields[nIField].pszFieldModifName
+                    : hMMMD->pLayerDB->pFields[nIField].pszFieldName);
 
             if (!MMIsEmptyString(
                     hMMMD->pLayerDB->pFields[nIField].pszFieldDescription) &&
                 !MMIsEmptyString(
                     hMMMD->pLayerDB->pFields[nIField].pszFieldName))
             {
-                MMWrite_ANSI_MetadataKeyDescriptor(
-                    hMMMD, pF,
-                    hMMMD->pLayerDB->pFields[nIField].pszFieldDescription,
-                    hMMMD->pLayerDB->pFields[nIField].pszFieldDescription,
-                    hMMMD->pLayerDB->pFields[nIField].pszFieldDescription,
-                    CPL_ENC_UTF8);
+                if (bModifiedFieldName)
+                {
+                    MMWrite_ANSI_MetadataKeyDescriptor(
+                        hMMMD, pF,
+                        hMMMD->pLayerDB->pFields[nIField]
+                            .pszFieldModifDescription,
+                        hMMMD->pLayerDB->pFields[nIField]
+                            .pszFieldModifDescription,
+                        hMMMD->pLayerDB->pFields[nIField]
+                            .pszFieldModifDescription,
+                        CPL_ENC_UTF8);
+                }
+                else
+                {
+                    MMWrite_ANSI_MetadataKeyDescriptor(
+                        hMMMD, pF,
+                        hMMMD->pLayerDB->pFields[nIField].pszFieldDescription,
+                        hMMMD->pLayerDB->pFields[nIField].pszFieldDescription,
+                        hMMMD->pLayerDB->pFields[nIField].pszFieldDescription,
+                        CPL_ENC_UTF8);
+                }
+            }
+
+            if (bModifiedFieldName &&
+                EQUAL(szMMNomCampIdGraficDefecte,
+                      hMMMD->pLayerDB->pFields[nIField].pszFieldName))
+            {
+                VSIFPrintfL(pF, "TractamentVariable=Ordinal" LineReturn);
             }
 
             // Exception in a particular case: "altura" is a catalan word that means
@@ -6068,6 +6097,49 @@ int MMCreateMMDB(struct MiraMonVectLayerInfo *hMiraMonLayer,
             MM_DuplicateFieldDBXP(pBD_XP->pField + nIField, &MMField);
             MM_ModifyFieldNameAndDescriptorIfPresentBD_XP(
                 pBD_XP->pField + nIField, pBD_XP, FALSE, 0);
+
+            if (!EQUAL(pBD_XP->pField[nIField].FieldName,
+                       hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]
+                           .pszFieldName))
+            {
+                // We need to preserve the final given name to write
+                // metadata with the modified new name.
+                strcpy(hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]
+                           .pszFieldModifName,
+                       pBD_XP->pField[nIField].FieldName);
+
+                // In this case we are going to use also the modified description in metadata
+                strcpy(
+                    hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]
+                        .pszFieldModifDescription,
+                    pBD_XP->pField[nIField].FieldDescription[MM_DEF_LANGUAGE]);
+
+                switch (hMiraMonLayer->nMMLanguage)
+                {
+                    case MM_CAT_LANGUAGE:
+                        strncat(hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]
+                                    .pszFieldModifDescription,
+                                " (previ)", MM_MAX_BYTES_FIELD_DESC);
+                        break;
+                    case MM_SPA_LANGUAGE:
+                        strncat(hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]
+                                    .pszFieldModifDescription,
+                                " (previo)", MM_MAX_BYTES_FIELD_DESC);
+                        break;
+                    default:
+                    case MM_ENG_LANGUAGE:
+                        strncat(hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]
+                                    .pszFieldModifDescription,
+                                " (previous)", MM_MAX_BYTES_FIELD_DESC);
+                        break;
+                }
+                hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]
+                    .pszFieldModifDescription[MM_MAX_BYTES_FIELD_DESC] = '\0';
+            }
+            else
+                *hMiraMonLayer->pLayerDB->pFields[nIFieldLayer]
+                     .pszFieldModifName = '\0';
+
             if (pBD_XP->pField[nIField].FieldType == 'F')
                 pBD_XP->pField[nIField].FieldType = 'N';
         }


### PR DESCRIPTION
## What does this PR do?
In a MiraMon vector layer, some fields are mandatory. For example, ID_GRAFIC is required for all layer types (points, arcs, and polygons), while other mandatory fields may exist depending on the specific layer type.

A problem appeared when translating a MiraMon layer into another MiraMon layer, for example using ogr2ogr with an SQL query to select a subset of features. In these cases, if a field from the source layer had the same name as one of the mandatory fields, the source field was correctly renamed (for example, ID_GRAFIC became ID_GRAFIC2). However, when writing the metadata file (.rel) for the output layer, the renamed field information was lost and ID_GRAFIC was written twice.

This issue has now been fixed with a simple rule:

When a field name conflicts with one of the mandatory MiraMon fields, both the original field name and the renamed field name are preserved internally.
The renamed field name is then correctly used when writing the metadata.
Additionally, the field description is updated by appending " (previous)" to indicate its origin.

This problem was discovered during MiraMon-to-MiraMon translations. From now on, these translations will correctly preserve field names and metadata consistency.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)  Checking....
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

