### PR TITLE
[Backport release/3.13] JP2Grok: scale overview coords up to full resolution before calling Grok

### DIFF
--- a/autotest/gdrivers/jp2grok.py
+++ b/autotest/gdrivers/jp2grok.py
@@ -1351,6 +1351,72 @@ def test_jp2grok_transcode_ignored_options(tmp_path):
 
 
 ###############################################################################
+# Test overview decode returns correct data (not a top-left crop)
+
+
+def test_jp2grok_overview_decode():
+    np = pytest.importorskip("numpy")
+
+    # Create a 256x256 image with a diagonal gradient so each quadrant
+    # has a distinct mean value, making it easy to detect a crop bug.
+    src_ds = gdal.GetDriverByName("MEM").Create("", 256, 256, 1, gdal.GDT_Byte)
+    arr = np.zeros((256, 256), dtype=np.uint8)
+    for y in range(256):
+        for x in range(256):
+            arr[y, x] = (x + y) * 255 // 510  # 0 at (0,0) .. 255 at (255,255)
+    src_ds.GetRasterBand(1).WriteArray(arr)
+    sr = osr.SpatialReference()
+    sr.ImportFromEPSG(32631)
+    src_ds.SetProjection(sr.ExportToWkt())
+    src_ds.SetGeoTransform([450000, 1, 0, 5000000, 0, -1])
+
+    # Encode lossless with 5-3 wavelet so overviews are exact
+    fname = "/vsimem/test_jp2grok_overview_decode.jp2"
+    out_ds = gdaltest.jp2grok_drv.CreateCopy(
+        fname, src_ds, options=["REVERSIBLE=YES", "QUALITY=100"]
+    )
+    del out_ds, src_ds
+
+    ds = gdal.Open(fname)
+    assert ds is not None
+    band = ds.GetRasterBand(1)
+    ov_count = band.GetOverviewCount()
+    assert ov_count > 0, "Expected at least one overview level"
+
+    # The full-resolution checksum
+    full_cs = band.Checksum()
+    assert full_cs == 53143
+
+    # Read overview level 0 (factor-of-2 reduction => 128×128)
+    ov0 = band.GetOverview(0)
+    assert ov0.XSize == 128 and ov0.YSize == 128
+
+    ov_data = ov0.ReadAsArray()
+
+    # The mean of the diagonal gradient at full res is ~127.
+    # At the overview the mean should be similar.
+    ov_mean = float(np.mean(ov_data))
+    assert (
+        100 < ov_mean < 155
+    ), f"Overview mean {ov_mean} out of range — likely a crop bug"
+
+    # Check that bottom-right quadrant is brighter than top-left quadrant
+    tl_mean = float(np.mean(ov_data[:64, :64]))
+    br_mean = float(np.mean(ov_data[64:, 64:]))
+    assert br_mean > tl_mean + 30, (
+        f"Bottom-right mean ({br_mean}) should be much larger "
+        f"than top-left mean ({tl_mean}) — overview may be a crop"
+    )
+
+    # Also test ReadRaster at overview resolution via the main band
+    data = band.ReadRaster(0, 0, 256, 256, buf_xsize=128, buf_ysize=128)
+    assert data == ov_data
+
+    ds = None
+    gdal.Unlink(fname)
+
+
+###############################################################################
 # Test driver metadata
 
 

--- a/frmts/grok/grkdatasetbase.h
+++ b/frmts/grok/grkdatasetbase.h
@@ -2736,18 +2736,50 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
                     area_y1_ == 0)
                 {
                     // No AdviseRead region: use swath coordinates.
-                    // to trigger full image asynch decompress
-                    decompressParams.dw_x0 = swath_x0;
-                    decompressParams.dw_y0 = swath_y0;
-                    decompressParams.dw_x1 = swath_x0 + swath_width;
-                    decompressParams.dw_y1 = swath_y0 + swath_height;
+                    // The decode area must be expressed in full-resolution
+                    // canvas coordinates (grid reference).  For overview
+                    // datasets (iLevel > 0), swath coordinates are in the
+                    // reduced overview space and must be scaled up to
+                    // full resolution.
+                    if (iLevel > 0 && nParentXSize > 0 && nParentYSize > 0)
+                    {
+                        const int scale = 1 << iLevel;
+                        decompressParams.dw_x0 = swath_x0 * scale;
+                        decompressParams.dw_y0 = swath_y0 * scale;
+                        decompressParams.dw_x1 = std::min(
+                            (swath_x0 + swath_width) * scale, nParentXSize);
+                        decompressParams.dw_y1 = std::min(
+                            (swath_y0 + swath_height) * scale, nParentYSize);
+                    }
+                    else
+                    {
+                        decompressParams.dw_x0 = swath_x0;
+                        decompressParams.dw_y0 = swath_y0;
+                        decompressParams.dw_x1 = swath_x0 + swath_width;
+                        decompressParams.dw_y1 = swath_y0 + swath_height;
+                    }
                 }
                 else
                 {
-                    decompressParams.dw_x0 = area_x0_;
-                    decompressParams.dw_y0 = area_y0_;
-                    decompressParams.dw_x1 = area_x1_;
-                    decompressParams.dw_y1 = area_y1_;
+                    // AdviseRead region — also in dataset pixel space,
+                    // needs scaling for overview datasets.
+                    if (iLevel > 0 && nParentXSize > 0 && nParentYSize > 0)
+                    {
+                        const int scale = 1 << iLevel;
+                        decompressParams.dw_x0 = area_x0_ * scale;
+                        decompressParams.dw_y0 = area_y0_ * scale;
+                        decompressParams.dw_x1 = std::min(
+                            static_cast<int>(area_x1_) * scale, nParentXSize);
+                        decompressParams.dw_y1 = std::min(
+                            static_cast<int>(area_y1_) * scale, nParentYSize);
+                    }
+                    else
+                    {
+                        decompressParams.dw_x0 = area_x0_;
+                        decompressParams.dw_y0 = area_y0_;
+                        decompressParams.dw_x1 = area_x1_;
+                        decompressParams.dw_y1 = area_y1_;
+                    }
                 }
             }
 


### PR DESCRIPTION
Backport #14521
 **Authored by:** @boxerab