### PR TITLE
Doc: fix typo in the usage example for OGR_L_GetArrowStream()

### DIFF
--- a/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
@@ -2876,7 +2876,7 @@ bool OGRLayer::GetArrowStream(struct ArrowArrayStream *out_stream,
     if( stream.get_schema(&stream, &schema) == 0 )
     {
         // Do something useful
-        schema.release(schema);
+        schema.release(&schema);
     }
     while( true )
     {


### PR DESCRIPTION
Fixes small typo for schema release.

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.
