### PR TITLE
[Backport release/3.13] MITAB: fix EscapeString heap-buffer-overflow write when all characters are double-quotes

### DIFF
--- a/autotest/ogr/ogr_mitab.py
+++ b/autotest/ogr/ogr_mitab.py
@@ -2571,6 +2571,19 @@ def test_ogr_mitab_description(tmp_vsimem):
 
 
 ###############################################################################
+# Check write/read description
+
+
+def test_ogr_mitab_all_double_quotes(tmp_vsimem):
+    filename = tmp_vsimem / "test_description.tab"
+
+    ds = ogr.GetDriverByName("MapInfo File").CreateDataSource(filename)
+    lyr = ds.CreateLayer("test_description", options=["DESCRIPTION=" + ('"' * 100)])
+    lyr.CreateField(ogr.FieldDefn("test", ogr.OFTInteger))
+    assert lyr.GetMetadataItem("DESCRIPTION") == ('"' * 100)
+
+
+###############################################################################
 # Test writing and reading back unset/null date, time, datetime
 
 

--- a/ogr/ogrsf_frmts/mitab/mitab_tabfile.cpp
+++ b/ogr/ogrsf_frmts/mitab/mitab_tabfile.cpp
@@ -60,7 +60,7 @@ static char *EscapeString(const char *pszInput,
     char *pszOutput = static_cast<char *>(CPLMalloc(nLength * 2 + 1));
     int iOut = 0;
     int nDoubleQuotesCount = 0;
-    for (int iIn = 0; iIn < static_cast<int>(nLength + 1); ++iIn)
+    for (int iIn = 0; iIn < static_cast<int>(nLength); ++iIn)
     {
         if (pszInput[iIn] == '"')
         {


### PR DESCRIPTION
Backport #14533
 **Authored by:** @rouault