### PR TITLE
GRIB: Avoid invalid read in g2clib comunpack()

### DIFF
--- a/autotest/gdrivers/grib.py
+++ b/autotest/gdrivers/grib.py
@@ -13,6 +13,7 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import base64
 import os
 import shutil
 import struct
@@ -2438,3 +2439,17 @@ def test_grib_grib2_tmerc_negative_false_easting_false_northing(tmp_vsimem):
             "+proj=tmerc +lat_0=-1 +lon_0=-2 +k=1 +x_0=-300000 +y_0=-400000"
             in ds.GetSpatialRef().ExportToProj4()
         )
+
+
+@gdaltest.enable_exceptions()
+def test_grib_complex_unpacking_invalid_bits_per_packed_value(tmp_vsimem):
+
+    with gdal.VSIFile(tmp_vsimem / "src.grib2", "wb") as infile:
+        infile.write(
+            base64.b64decode(
+                "R1JJQgAAAAIAAAAAAAAA4gAAABUBAAcAAAIBAQfoAQEAAAAAAQAAAEgDAAAAABAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACIEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxBQAAABAAAwAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAQjyAAAAAAEAAAAQAAJbAAAABgb/AAAAGAcBookAAVwDBAUlBwgJCgUMDQ4PNzc3Nw=="
+            )
+        )
+
+    with pytest.raises(Exception, match="Error reading GRIB data"):
+        gdal.Translate("", tmp_vsimem / "src.grib2", format="MEM")

--- a/frmts/grib/degrib/g2clib/comunpack.c
+++ b/frmts/grib/degrib/g2clib/comunpack.c
@@ -147,7 +147,7 @@ int comunpack(unsigned char *cpack,g2int cpack_length,g2int lensec,g2int idrsnum
       if (idrsnum == 3) {
          if (nbitsd != 0) {
 // one mistake here should be unsigned int
-              gbit(cpack,&ival1,iofst,nbitsd);
+              int ok = gbit2(cpack, cpack_length, &ival1, iofst,nbitsd) != -1;
               iofst=iofst+nbitsd;
 //              gbit(cpack,&isign,iofst,1);
 //              iofst=iofst+1
@@ -156,7 +156,7 @@ int comunpack(unsigned char *cpack,g2int cpack_length,g2int lensec,g2int idrsnum
 //              if (isign == 1) ival1=-ival1;
               if (idrstmpl[16] == 2) {
 // one mistake here should be unsigned int
-                 gbit(cpack,&ival2,iofst,nbitsd);
+                 ok = ok && gbit2(cpack, cpack_length, &ival2,iofst,nbitsd) != -1;
                  iofst=iofst+nbitsd;
 //                 gbit(cpack,&isign,iofst,1);
 //                 iofst=iofst+1;
@@ -164,10 +164,19 @@ int comunpack(unsigned char *cpack,g2int cpack_length,g2int lensec,g2int idrsnum
 //                 iofst=iofst+nbitsd-1;
 //                 if (isign == 1) ival2=-ival2;
               }
-              gbit(cpack,&isign,iofst,1);
+              ok = ok && gbit2(cpack, cpack_length, &isign,iofst,1) != -1;
               iofst=iofst+1;
-              gbit(cpack,&minsd,iofst,nbitsd-1);
+              ok = ok && gbit2(cpack, cpack_length, &minsd,iofst,nbitsd-1) != - 1;
               iofst=iofst+nbitsd-1;
+
+              if (!ok)
+              {
+                  free(ifld);
+                  free(gref);
+                  free(gwidth);
+                  return -1;
+              }
+
               if (isign == 1 && minsd != INT_MIN) minsd=-minsd;
          }
          else {

--- a/frmts/grib/gribdataset.cpp
+++ b/frmts/grib/gribdataset.cpp
@@ -847,7 +847,7 @@ CPLErr GRIBRasterBand::LoadData()
         ReadGribData(poGDS->fp, start, subgNum, &m_Grib_Data, &m_Grib_MetaData);
         if (!m_Grib_Data)
         {
-            CPLError(CE_Failure, CPLE_AppDefined, "Out of memory.");
+            CPLError(CE_Failure, CPLE_AppDefined, "Error reading GRIB data.");
             if (m_Grib_MetaData != nullptr)
             {
                 MetaFree(m_Grib_MetaData);


### PR DESCRIPTION
Resolves https://github.com/OSGeo/gdal/issues/14548

It appears that the same issue remains upstream:

https://github.com/NOAA-EMC/NCEPLIBS-g2c/blob/ead6f9542136048fa6a2187c9da08bbffea6541a/src/comunpack.c#L107