### PR TITLE
MRF: Fix input JPEG missmatch

### DIFF
--- a/frmts/mrf/JPEG_band.cpp
+++ b/frmts/mrf/JPEG_band.cpp
@@ -708,12 +708,25 @@ CPLErr JPEG_Codec::DecompressJPEG(buf_mgr &dst, const buf_mgr &isrc)
     // Tolerate different input if we can do the conversion
     // Gray and RGB for example
     // This also means that a RGB MRF can be read as grayscale and vice versa
-    // If libJPEG can't convert it will throw an error
+    // If libJPEG can't convert it will throw an error later
     //
-    if (nbands == 3 && cinfo.num_components != nbands)
-        cinfo.out_color_space = JCS_RGB;
-    if (nbands == 1 && cinfo.num_components != nbands)
-        cinfo.out_color_space = JCS_GRAYSCALE;
+    if (nbands != cinfo.num_components)
+    {
+        switch (cinfo.num_components)
+        {
+            case 1:
+                cinfo.out_color_space = JCS_GRAYSCALE;
+                break;
+            case 3:
+                cinfo.out_color_space = JCS_RGB;
+                break;
+            default:
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "MRF: Input JPEG type missmatch");
+                jpeg_destroy_decompress(&cinfo);
+                return CE_Failure;
+        }
+    }
 
     const int datasize = ((cinfo.data_precision == 8) ? 1 : 2);
     if (cinfo.image_width >

--- a/frmts/mrf/JPEG_band.cpp
+++ b/frmts/mrf/JPEG_band.cpp
@@ -712,7 +712,7 @@ CPLErr JPEG_Codec::DecompressJPEG(buf_mgr &dst, const buf_mgr &isrc)
     //
     if (nbands != cinfo.num_components)
     {
-        switch (cinfo.num_components)
+        switch (nbands)
         {
             case 1:
                 cinfo.out_color_space = JCS_GRAYSCALE;


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
Add a test for input JPEGs having invalid number of channels

## What are related issues/pull requests?
Fixes #14549

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
