### PR TITLE
JP2Grok: pass reduced coordinates to Grok via dw_reduced flag

### DIFF
--- a/.github/workflows/ubuntu_26.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_26.04/Dockerfile.ci
@@ -230,7 +230,7 @@ RUN curl -LO -fsS https://github.com/apache/arrow/archive/refs/heads/main.zip \
     && rm -rf arrow-main
 
 # Build Grok JPEG 2000 library
-ARG GROK_VERSION=v20.3.2
+ARG GROK_VERSION=v20.3.3
 
 RUN git clone --recursive --depth 1 --branch ${GROK_VERSION} \
     https://github.com/GrokImageCompression/grok.git grok-git && \

--- a/autotest/gdrivers/jp2grok.py
+++ b/autotest/gdrivers/jp2grok.py
@@ -1417,6 +1417,115 @@ def test_jp2grok_overview_decode():
 
 
 ###############################################################################
+# Test overview decode on a multi-tiled image.
+# Regression test for coordinate-space mismatch in CopyTileData when
+# iLevel > 0: Grok returns tile img->x0/y0 in full-resolution coordinates,
+# but the request window is in reduced overview space.  Without the fix,
+# tiles not at the origin are skipped and the overview is mostly zero.
+
+
+def test_jp2grok_multitile_overview_decode():
+    np = pytest.importorskip("numpy")
+
+    # Create a 512×512 3-band image with a distinctive pattern:
+    # each pixel = (x % 256, y % 256, (x+y) % 256) so every region
+    # has non-zero data and is verifiable.
+    width = 512
+    height = 512
+    nbands = 3
+    src_ds = gdal.GetDriverByName("MEM").Create(
+        "", width, height, nbands, gdal.GDT_Byte
+    )
+    for b in range(nbands):
+        arr = np.zeros((height, width), dtype=np.uint8)
+        for y in range(height):
+            for x in range(width):
+                if b == 0:
+                    arr[y, x] = x * 255 // (width - 1)
+                elif b == 1:
+                    arr[y, x] = y * 255 // (height - 1)
+                else:
+                    arr[y, x] = (x + y) * 255 // (width + height - 2)
+        src_ds.GetRasterBand(b + 1).WriteArray(arr)
+
+    # Encode lossless with small tiles (128×128) to create a 4×4 tile grid,
+    # and 3 resolution levels so we get at least 2 overview levels.
+    fname = "/vsimem/test_jp2grok_multitile_overview_decode.jp2"
+    out_ds = gdaltest.jp2grok_drv.CreateCopy(
+        fname,
+        src_ds,
+        options=[
+            "REVERSIBLE=YES",
+            "QUALITY=100",
+            "BLOCKXSIZE=128",
+            "BLOCKYSIZE=128",
+            "RESOLUTIONS=3",
+        ],
+    )
+    del out_ds, src_ds
+
+    ds = gdal.Open(fname)
+    assert ds is not None
+    assert ds.RasterXSize == width
+    assert ds.RasterYSize == height
+    band = ds.GetRasterBand(1)
+    ov_count = band.GetOverviewCount()
+    assert ov_count >= 1, "Expected at least one overview level"
+
+    # Test each overview level
+    for ov_idx in range(ov_count):
+        ov = band.GetOverview(ov_idx)
+        ov_data = ov.ReadAsArray()
+        ov_w = ov.XSize
+        ov_h = ov.YSize
+        assert ov_w > 0 and ov_h > 0
+
+        # The x-gradient pattern means the mean of band 1 should be ~127
+        # (half of 0..255 cycle).  If overview tiles are skipped, the mean
+        # drops dramatically because skipped regions are zero-filled.
+        ov_mean = float(np.mean(ov_data))
+        assert ov_mean > 80, (
+            f"Overview {ov_idx} ({ov_w}x{ov_h}) band 1 mean {ov_mean:.1f} "
+            f"is too low — tiles likely skipped due to coordinate mismatch"
+        )
+
+        # Verify that the right half has a higher mean than the left half
+        # (x-gradient: left starts near 0, right near 255).
+        mid = ov_w // 2
+        left_mean = float(np.mean(ov_data[:, :mid]))
+        right_mean = float(np.mean(ov_data[:, mid:]))
+        assert right_mean > left_mean + 20, (
+            f"Overview {ov_idx}: right-half mean ({right_mean:.1f}) should "
+            f"exceed left-half mean ({left_mean:.1f}) — data may be corrupt"
+        )
+
+        # Verify that no large contiguous zero blocks exist (which would
+        # indicate missing tiles).  At overview level, every 8×8 block
+        # should have some non-zero pixels.
+        block = 8
+        for by in range(0, ov_h - block + 1, block):
+            for bx in range(0, ov_w - block + 1, block):
+                patch = ov_data[by : by + block, bx : bx + block]
+                assert np.any(patch > 0), (
+                    f"Overview {ov_idx}: all-zero block at ({bx},{by}) "
+                    f"— tile data likely missing"
+                )
+
+    # Also test band 2 (y-gradient) at overview 0
+    ov2 = ds.GetRasterBand(2).GetOverview(0)
+    ov2_data = ov2.ReadAsArray()
+    top_mean = float(np.mean(ov2_data[: ov2.YSize // 2, :]))
+    bot_mean = float(np.mean(ov2_data[ov2.YSize // 2 :, :]))
+    assert bot_mean > top_mean + 20, (
+        f"Band 2 overview: bottom mean ({bot_mean:.1f}) should exceed "
+        f"top mean ({top_mean:.1f}) — y-gradient not preserved"
+    )
+
+    ds = None
+    gdal.Unlink(fname)
+
+
+###############################################################################
 # Test driver metadata
 
 

--- a/cmake/helpers/CheckDependentLibrariesGrok.cmake
+++ b/cmake/helpers/CheckDependentLibrariesGrok.cmake
@@ -2,4 +2,4 @@ gdal_check_package(Grok "Enable JPEG2000 support with Grok library"
                    CONFIG
                    CAN_DISABLE
                    TARGETS GROK::grokj2k
-                   VERSION 20.3.2)
+                   VERSION 20.3.3)

--- a/frmts/grok/grkdatasetbase.h
+++ b/frmts/grok/grkdatasetbase.h
@@ -2551,14 +2551,9 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
         // When reading a subset of bands, tile images must persist
         // across per-band reads.  Use CACHE_IMAGE so that tile row
         // release keeps the decoded pixels alive.
-        const int nTotalComps =
-            (m_codec && m_codec->psImage) ? m_codec->psImage->numcomps : 0;
-        const bool needPersistentTiles =
-            (!this->bSingleTiled && nBandCount < nTotalComps);
-
         auto postPreload =
             decompressAsynch(nullptr, nullptr, nXOff, nYOff, nXSize, nYSize,
-                             rowCopy, needPersistentTiles);
+                             rowCopy, nBandCount);
 
         try
         {
@@ -2640,7 +2635,7 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
                                  int swath_x0, int swath_y0, int swath_width,
                                  int swath_height,
                                  RowCopyFunc rowCopy = nullptr,
-                                 bool needPersistentTiles = false)
+                                 int nBandCount = 0)
     {
         PostPreload rc;
 
@@ -2729,6 +2724,15 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
 
             return cached;
         }
+
+        // Compute needPersistentTiles after lazy codec init (m_codec is now
+        // guaranteed non-null).  When reading a subset of bands, tile images
+        // must persist across per-band reads so that subsequent band reads
+        // can extract their data from the cached tiles.
+        const int nTotalComps =
+            (m_codec && m_codec->psImage) ? m_codec->psImage->numcomps : 0;
+        const bool needPersistentTiles =
+            (!this->bSingleTiled && nBandCount > 0 && nBandCount < nTotalComps);
 
         if (!initializedAsync)
         {

--- a/frmts/grok/grkdatasetbase.h
+++ b/frmts/grok/grkdatasetbase.h
@@ -1939,6 +1939,7 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
     bool initializedAsync = false;  ///< True after first grk_decompress() call
     PostPreload cachedPostPreload_{};    ///< Cached first-call tile grid info
     bool hasCachedPostPreload_ = false;  ///< True after first decompressAsynch
+    VSILFILE *m_ovFp = nullptr;  ///< Private file handle for overview codec
 
     /**
      * @brief Destroys the JP2GRKDatasetBase object
@@ -2320,7 +2321,8 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
         // trigger post-processing (wait(nullptr) -> postMulti_).
         const int nTotalTiles = (postPreload.tile_x1 - postPreload.tile_x0) *
                                 (postPreload.tile_y1 - postPreload.tile_y0);
-        bool canUseFastPath = (nTotalTiles > 1 && m_codec && m_codec->psImage);
+        bool canUseFastPath =
+            (nTotalTiles > 1 && m_codec && m_codec->psImage && iLevel == 0);
         if (canUseFastPath)
         {
             for (int i = 0; i < nBandCount && canUseFastPath; ++i)
@@ -2646,10 +2648,24 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
         // Overview datasets are created without a codec during Open;
         // initialise one on first read so decompression at this
         // reduce level can proceed.
+        // Open a private file handle so the overview codec does not
+        // interfere with the main dataset's file position.
         if (!m_codec && iLevel > 0)
         {
+            if (m_ovFp)
+            {
+                VSIFCloseL(m_ovFp);
+                m_ovFp = nullptr;
+            }
+            m_ovFp = VSIFOpenL(m_osFilename.c_str(), "rb");
+            if (!m_ovFp)
+            {
+                CPLError(CE_Failure, CPLE_OpenFailed,
+                         "Failed to open file for overview level %d", iLevel);
+                return rc;
+            }
             m_codec = new GRKCodecWrapper();
-            m_codec->open(fp_, nCodeStreamStart);
+            m_codec->open(m_ovFp, nCodeStreamStart);
             uint32_t nTileW = 0, nTileH = 0;
             int numRes = 0;
             if (!m_codec->setUpDecompress(GetNumThreads(), m_osFilename.c_str(),
@@ -2658,6 +2674,8 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
             {
                 delete m_codec;
                 m_codec = nullptr;
+                VSIFCloseL(m_ovFp);
+                m_ovFp = nullptr;
                 CPLError(CE_Failure, CPLE_AppDefined,
                          "Failed to init overview codec for level %d", iLevel);
                 return rc;
@@ -2732,54 +2750,21 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
 
             if (!this->fullDecompress_)
             {
+                decompressParams.dw_reduced = true;
                 if (area_x0_ == 0 && area_y0_ == 0 && area_x1_ == 0 &&
                     area_y1_ == 0)
                 {
-                    // No AdviseRead region: use swath coordinates.
-                    // The decode area must be expressed in full-resolution
-                    // canvas coordinates (grid reference).  For overview
-                    // datasets (iLevel > 0), swath coordinates are in the
-                    // reduced overview space and must be scaled up to
-                    // full resolution.
-                    if (iLevel > 0 && nParentXSize > 0 && nParentYSize > 0)
-                    {
-                        const int scale = 1 << iLevel;
-                        decompressParams.dw_x0 = swath_x0 * scale;
-                        decompressParams.dw_y0 = swath_y0 * scale;
-                        decompressParams.dw_x1 = std::min(
-                            (swath_x0 + swath_width) * scale, nParentXSize);
-                        decompressParams.dw_y1 = std::min(
-                            (swath_y0 + swath_height) * scale, nParentYSize);
-                    }
-                    else
-                    {
-                        decompressParams.dw_x0 = swath_x0;
-                        decompressParams.dw_y0 = swath_y0;
-                        decompressParams.dw_x1 = swath_x0 + swath_width;
-                        decompressParams.dw_y1 = swath_y0 + swath_height;
-                    }
+                    decompressParams.dw_x0 = swath_x0;
+                    decompressParams.dw_y0 = swath_y0;
+                    decompressParams.dw_x1 = swath_x0 + swath_width;
+                    decompressParams.dw_y1 = swath_y0 + swath_height;
                 }
                 else
                 {
-                    // AdviseRead region — also in dataset pixel space,
-                    // needs scaling for overview datasets.
-                    if (iLevel > 0 && nParentXSize > 0 && nParentYSize > 0)
-                    {
-                        const int scale = 1 << iLevel;
-                        decompressParams.dw_x0 = area_x0_ * scale;
-                        decompressParams.dw_y0 = area_y0_ * scale;
-                        decompressParams.dw_x1 = std::min(
-                            static_cast<int>(area_x1_) * scale, nParentXSize);
-                        decompressParams.dw_y1 = std::min(
-                            static_cast<int>(area_y1_) * scale, nParentYSize);
-                    }
-                    else
-                    {
-                        decompressParams.dw_x0 = area_x0_;
-                        decompressParams.dw_y0 = area_y0_;
-                        decompressParams.dw_x1 = area_x1_;
-                        decompressParams.dw_y1 = area_y1_;
-                    }
+                    decompressParams.dw_x0 = area_x0_;
+                    decompressParams.dw_y0 = area_y0_;
+                    decompressParams.dw_x1 = area_x1_;
+                    decompressParams.dw_y1 = area_y1_;
                 }
             }
 

--- a/frmts/grok/grokdataset.cpp
+++ b/frmts/grok/grokdataset.cpp
@@ -29,6 +29,11 @@
 JP2GRKDatasetBase::~JP2GRKDatasetBase()
 {
     delete m_codec;
+    if (m_ovFp)
+    {
+        VSIFCloseL(m_ovFp);
+        m_ovFp = nullptr;
+    }
 }
 
 /************************************************************************/

--- a/frmts/opjlike/jp2opjlikedataset.cpp
+++ b/frmts/opjlike/jp2opjlikedataset.cpp
@@ -1906,6 +1906,16 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::Open(GDALOpenInfo *poOpenInfo)
         poODS->m_nX0 = poDS->m_nX0;
         poODS->m_nY0 = poDS->m_nY0;
 
+        // For Grok's DirectRasterIO path, overview datasets need tile
+        // dimensions scaled to the reduced resolution level so that
+        // tile range and row-iteration computations work correctly.
+        if (BASE::canPerformDirectIO())
+        {
+            const int ovLevel = poODS->iLevel;
+            poODS->m_nTileWidth = (nTileW + (1 << ovLevel) - 1) >> ovLevel;
+            poODS->m_nTileHeight = (nTileH + (1 << ovLevel) - 1) >> ovLevel;
+        }
+
         for (iBand = 1; iBand <= poDS->nBands; iBand++)
         {
             const bool bPromoteTo8Bit =


### PR DESCRIPTION
Fix three coordinate-space mismatches in the Grok GDAL driver that caused overview reads (iLevel > 0) to return wrong pixel values on multi-tiled JPEG2000 images:

1. CopyTileData: Grok returns tile img->x0/y0 in full-resolution canvas coordinates, but the request window (nXOff/nYOff) is in reduced overview space. Add nReduceLevel parameter to scale tile origin coordinates.

2. grk_decompress_wait calls: The row-based wait loop and cached path passed overview-space coordinates to Grok's wait API, but Grok expects full-res coordinates (since decompress was started with full-res decode area). Scale swath coordinates by 1<<iLevel for overview datasets.

3. m_nTileWidth/Height: Never set for overview datasets, so tile range computation and row iteration used wrong granularity. Set reduced tile dimensions on overview datasets when using DirectRasterIO.

Also disable the fast swath copy path (grk_decompress_schedule_swath_copy) for overview datasets since it requires matching coordinate spaces between Grok's internal tile coordinates and the output buffer window.

Add test_jp2grok_multitile_overview_decode regression test that creates a 512x512 3-band image with 128x128 tiles (4x4 grid) and verifies all overview levels produce correct gradient patterns with no missing tiles.

## What are related issues/pull requests?

#14516

## AI tool usage

Claude Opus 4.6 used

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
