### PR TITLE
MiraMonRaster: fix issue 14550 

### DIFF
--- a/frmts/miramon/miramon_palettes.cpp
+++ b/frmts/miramon/miramon_palettes.cpp
@@ -482,6 +482,10 @@ MMRPalettes::GetPaletteColors_PAL_P25_P65(const CPLString &os_Color_Paleta_DBF)
     const char *pszLine;
     while ((pszLine = CPLReadLineL(fpColorTable)) != nullptr)
     {
+        // Ignore empty lines
+        if (pszLine[0] == '\0')
+            continue;
+
         if (nNReadPaletteColors >= m_nNPaletteColors)
         {
             VSIFCloseL(fpColorTable);
@@ -489,10 +493,6 @@ MMRPalettes::GetPaletteColors_PAL_P25_P65(const CPLString &os_Color_Paleta_DBF)
                      osColorTableFileName.c_str());
             return CE_Failure;
         }
-
-        // Ignore empty lines
-        if (pszLine[0] == '\0')
-            continue;
 
         const CPLStringList aosTokens(CSLTokenizeString2(pszLine, " \t", 0));
         if (aosTokens.size() != 4)

--- a/frmts/miramon/miramon_palettes.cpp
+++ b/frmts/miramon/miramon_palettes.cpp
@@ -482,6 +482,14 @@ MMRPalettes::GetPaletteColors_PAL_P25_P65(const CPLString &os_Color_Paleta_DBF)
     const char *pszLine;
     while ((pszLine = CPLReadLineL(fpColorTable)) != nullptr)
     {
+        if (nNReadPaletteColors >= m_nNPaletteColors)
+        {
+            VSIFCloseL(fpColorTable);
+            CPLError(CE_Failure, CPLE_AppDefined, "Invalid color table: \"%s\"",
+                     osColorTableFileName.c_str());
+            return CE_Failure;
+        }
+
         // Ignore empty lines
         if (pszLine[0] == '\0')
             continue;


### PR DESCRIPTION
## What does this PR do?
Fixes the issue 14550 discovered by Claude, Anthropic's AI assistant, and triaged manually with manual report writing by Ada Logics in collaboration with Anthropic Research. The limits of legacy palettes were not taken into account, resulting in a heap buffer overflow. The number of entries is now restricted according to the limits of each palette type. If a palette contains more values than expected, the message "Invalid color table" is displayed.


## What are related issues/pull requests?
https://github.com/OSGeo/gdal/issues/14550

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Review
 - [x] Adjust for comments
 - [ ] All CI builds and checks have passed

