### PR TITLE
OCI: set OCI_ATTR_PREFETCH_ROWS for SELECT prefetch (default 1k)

### DIFF
--- a/doc/source/drivers/vector/oci.rst
+++ b/doc/source/drivers/vector/oci.rst
@@ -132,6 +132,12 @@ The following configuration options are available:
 
       Sets the name of the field to be used as the FID.
 
+-  .. config:: OCI_PREFETCH_ROWS
+      :default: 1000
+      :since: 3.14
+
+      Sets the number of rows to prefetch per round-trip.
+
 Layer Creation Options
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/spelling_wordlist.txt
+++ b/doc/source/spelling_wordlist.txt
@@ -1196,8 +1196,8 @@ gpsbabel
 gpx
 gradians
 Grantor
-graylevel
 graticule
+graylevel
 grayscale
 Grayscale
 grc
@@ -2531,10 +2531,10 @@ positionName
 posix
 Posix
 posList
+poSR
 poSrcDS
 poSrcFDefn
 poSrcFeature
-poSR
 poSRS
 Postel
 postfix
@@ -2585,6 +2585,7 @@ precompiled
 precompute
 predefine
 predelete
+prefetch
 preinstalled
 preload
 premultiplication

--- a/ogr/ogrsf_frmts/oci/ogrocistatement.cpp
+++ b/ogr/ogrsf_frmts/oci/ogrocistatement.cpp
@@ -248,6 +248,21 @@ CPLErr OGROCIStatement::Execute(const char *pszSQLStatement, int nMode)
     }
 
     /* -------------------------------------------------------------------- */
+    /*      Configure row prefetching.                                      */
+    /* -------------------------------------------------------------------- */
+    if (bSelect)
+    {
+        ub4 nPrefetchRows = static_cast<ub4>(
+            atoi(CPLGetConfigOption("OCI_PREFETCH_ROWS", "1000")));
+        if (poSession->Failed(OCIAttrSet(hStatement, OCI_HTYPE_STMT,
+                                         &nPrefetchRows, sizeof(ub4),
+                                         OCI_ATTR_PREFETCH_ROWS,
+                                         poSession->hError),
+                              "OCIAttrSet(OCI_ATTR_PREFETCH_ROWS)"))
+            return CE_Failure;
+    }
+
+    /* -------------------------------------------------------------------- */
     /*      Execute the statement.                                          */
     /* -------------------------------------------------------------------- */
     if (poSession->Failed(

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -696,6 +696,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "NITF_USEGEOLOB", // from nitfimage.c
    "OCI_DEFAULT_DIM", // from ogrociwritablelayer.cpp
    "OCI_FID", // from ogrocidatasource.cpp, ogrociloaderlayer.cpp, ogrociselectlayer.cpp, ogrocitablelayer.cpp
+   "OCI_PREFETCH_ROWS", // from ogrocistatement.cpp
    "ODBC_OGR_FID", // from ogrodbclayer.cpp
    "ODS_RESOLVE_FORMULAS", // from ogrodsdatasource.cpp
    "OGR2OGR_MIN_FEATURES_FOR_THREADED_REPROJ", // from ogr2ogr_lib.cpp


### PR DESCRIPTION
## What does this PR do?

Closes #14546 by making `OCI_ATTR_PREFETCH_ROWS` available via a new config option on the OCI driver, `OCI_PREFETCH_ROWS`. This allows tuning the default 1-row-at-a-time behavior, solving the issue of slow transfers on connections with decent throughput but high latency. 

## What are related issues/pull requests?

#14546, opened by me some days ago. 

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s): *no; would provide little to no value without a real endpoint*
 - [x] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [x] Manually tested in various configurations against real Oracle DB

## Environment

Provide environment details, if relevant:

* OS: Arch Linux (7.0.3-zen)
* Compiler: GCC 15.2.1
