### PR TITLE
gdal raster tile: add automatic source overview selection

### DIFF
--- a/alg/gdalwarpkernel.cpp
+++ b/alg/gdalwarpkernel.cpp
@@ -4630,7 +4630,6 @@ static bool GWKResampleOptimizedLanczos(const GDALWarpKernel *poWK, int iBand,
     GPtrDiff_t iRowOffset =
         iSrcOffset + static_cast<GPtrDiff_t>(jMin - 1) * nSrcXSize + iMin;
 
-    int nCountValid = 0;
     const bool bIsNonComplex = !GDALDataTypeIsComplex(poWK->eWorkingDataType);
 
     for (int j = jMin; j <= jMax; ++j)
@@ -4656,8 +4655,6 @@ static bool GWKResampleOptimizedLanczos(const GDALWarpKernel *poWK, int iBand,
                 // Skip sampling if pixel has zero density.
                 if (padfRowDensity[i - iMin] < SRC_DENSITY_THRESHOLD_DOUBLE)
                     continue;
-
-                nCountValid++;
 
                 //  Use a cached set of weights for this row.
                 const double dfWeight2 = dfWeight1 * padfWeightsXShifted[i];
@@ -4700,13 +4697,36 @@ static bool GWKResampleOptimizedLanczos(const GDALWarpKernel *poWK, int iBand,
         }
     }
 
-    if (dfAccumulatorWeight < 0.000001 ||
-        (padfRowDensity != nullptr &&
-         (dfAccumulatorDensity < 0.000001 ||
-          nCountValid < (jMax - jMin + 1) * (iMax - iMin + 1) / 2)))
+    if (dfAccumulatorWeight < 0.000001)
     {
         *pdfDensity = 0.0;
         return false;
+    }
+    else if (padfRowDensity)
+    {
+        if (dfAccumulatorDensity < 0.000001)
+        {
+            *pdfDensity = 0.0;
+            return false;
+        }
+
+        // TODO: previously we returned *pdfDensity when
+        // nCountValid < (jMax - jMin + 1) * (iMax - iMin + 1) / 2)
+        // that was initially introduced in
+        // https://github.com/OSGeo/gdal/commit/b68d31418f4826402dc44b52152c0493b682fea8
+        // but in scenarios like https://github.com/OSGeo/gdal/issues/14560
+        // this lead to almst full removal of text printed on transparent
+        // background. It is not clear what we should do.
+        //
+        // Wisdom from https://mastodon.social/@martinfleis@fosstodon.org/116568957538009577
+        // LJW: "It is a fundamental change of support problem with no closed
+        // solution. We looked into bootstrapping to solve it, but never
+        // published. Basic idea was to bootstrap a constant sample size, set
+        // the weight of candidates as a kernel function on the distance from
+        // the target, and set the bandwidth needed at each pixel as that
+        // which maximizes the entropy of a histogram of sample weights.
+        // Best you can do is define some loss and optimize the resampling
+        // against it."
     }
 
     // Calculate the output taking into account weighting.

--- a/apps/gdalalg_raster_tile.cpp
+++ b/apps/gdalalg_raster_tile.cpp
@@ -416,6 +416,18 @@ GDALRasterTileAlgorithm::GDALRasterTileAlgorithm(bool standaloneStep)
 }
 
 /************************************************************************/
+/*                      ~GDALRasterTileAlgorithm()                      */
+/************************************************************************/
+
+GDALRasterTileAlgorithm::~GDALRasterTileAlgorithm()
+{
+    if (m_poSrcOvrDS)
+    {
+        m_poSrcOvrDS->ReleaseRef();
+    }
+}
+
+/************************************************************************/
 /*                           GetTileIndices()                           */
 /************************************************************************/
 
@@ -5070,11 +5082,44 @@ bool GDALRasterTileAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
         return false;
     }
 
+    /* -------------------------------------------------------------------- */
+    /*      Select source overview                                          */
+    /* -------------------------------------------------------------------- */
+
+    const int nDstXSize = (nMaxTileX - nMinTileX + 1) * tileMatrix.mTileWidth;
+    const int nDstYSize = (nMaxTileY - nMinTileY + 1) * tileMatrix.mTileHeight;
+
+    const int nSrcOvrCount = m_poSrcDS->GetRasterBand(1)->GetOverviewCount();
+    if (nSrcOvrCount > 0 &&
+        m_poSrcDS->GetRasterXSize() > tileMatrix.mTileWidth &&
+        m_poSrcDS->GetRasterYSize() > tileMatrix.mTileHeight)
+    {
+        const double dfTargetRatioX =
+            static_cast<double>(m_poSrcDS->GetRasterXSize()) / nDstXSize;
+        const double dfTargetRatioY =
+            static_cast<double>(m_poSrcDS->GetRasterYSize()) / nDstYSize;
+        // take the minimum of these ratios #7019
+        const double dfTargetRatio = std::min(dfTargetRatioX, dfTargetRatioY);
+        if (dfTargetRatio > 1.0)
+        {
+            const int iBestOvr = GDALBandGetBestOverviewLevel(
+                m_poSrcDS->GetRasterBand(1), dfTargetRatio,
+                /* dfOversamplingThreshold = */ 1.0);
+            if (iBestOvr >= 0)
+            {
+                CPLDebug("WARP", "Selecting overview level %d", iBestOvr);
+                m_poSrcOvrDS =
+                    GDALCreateOverviewDataset(m_poSrcDS, iBestOvr,
+                                              /* bThisLevelOnly = */ false);
+                m_poSrcDS = m_poSrcOvrDS;
+            }
+        }
+    }
+
     FakeMaxZoomDataset oFakeMaxZoomDS(
-        (nMaxTileX - nMinTileX + 1) * tileMatrix.mTileWidth,
-        (nMaxTileY - nMinTileY + 1) * tileMatrix.mTileHeight, nDstBands,
-        tileMatrix.mTileWidth, tileMatrix.mTileHeight, psWO->eWorkingDataType,
-        dstGT, oSRS_TMS, dstBuffer);
+        nDstXSize, nDstYSize, nDstBands, tileMatrix.mTileWidth,
+        tileMatrix.mTileHeight, psWO->eWorkingDataType, dstGT, oSRS_TMS,
+        dstBuffer);
     CPL_IGNORE_RET_VAL(oFakeMaxZoomDS.GetSpatialRef());
 
     psWO->hSrcDS = GDALDataset::ToHandle(m_poSrcDS);
@@ -5652,6 +5697,11 @@ bool GDALRasterTileAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
     for (int i = 1; i <= m_poSrcDS->GetRasterCount(); ++i)
         aeColorInterp.push_back(
             m_poSrcDS->GetRasterBand(i)->GetColorInterpretation());
+    if (m_poSrcOvrDS)
+    {
+        m_poSrcOvrDS->ReleaseRef();
+        m_poSrcOvrDS = nullptr;
+    }
     if (m_inputDataset[0].HasDatasetBeenOpenedByAlgorithm())
     {
         m_inputDataset[0].Close();

--- a/apps/gdalalg_raster_tile.h
+++ b/apps/gdalalg_raster_tile.h
@@ -40,6 +40,7 @@ class GDALRasterTileAlgorithm /* non final */
     static constexpr const char *HELP_URL = "/programs/gdal_raster_tile.html";
 
     explicit GDALRasterTileAlgorithm(bool standaloneStep = false);
+    ~GDALRasterTileAlgorithm() override;
 
     bool CanBeLastStep() const override
     {
@@ -106,6 +107,7 @@ class GDALRasterTileAlgorithm /* non final */
     std::string m_numThreadsStr{"ALL_CPUS"};
     std::map<std::string, std::string> m_mapTileMatrixIdentifierToScheme{};
     GDALDataset *m_poSrcDS = nullptr;
+    GDALDataset *m_poSrcOvrDS = nullptr;
     bool m_bIsNamedNonMemSrcDS = false;
     GDALDriver *m_poDstDriver = nullptr;
     std::string m_osGDALPath{};

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -2711,44 +2711,15 @@ GDALWarpDirect(const char *pszDest, GDALDatasetH hDstDS, int nSrcCount,
 
             if (dfTargetRatio > 1.0)
             {
-                // Note: keep this logic for overview selection in sync between
-                // gdalwarp_lib.cpp and rasterio.cpp
                 const char *pszOversampligThreshold = CPLGetConfigOption(
                     "GDALWARP_OVERSAMPLING_THRESHOLD", nullptr);
                 const double dfOversamplingThreshold =
                     pszOversampligThreshold ? CPLAtof(pszOversampligThreshold)
                                             : 1.0;
 
-                int iBestOvr = -1;
-                double dfBestRatio = 0;
-                for (int iOvr = -1; iOvr < nOvCount; iOvr++)
-                {
-                    const double dfOvrRatio =
-                        iOvr < 0
-                            ? 1.0
-                            : static_cast<double>(poSrcDS->GetRasterXSize()) /
-                                  poSrcDS->GetRasterBand(1)
-                                      ->GetOverview(iOvr)
-                                      ->GetXSize();
-
-                    // Is it nearly the requested factor and better (lower) than
-                    // the current best factor?
-                    // Use an epsilon because of numerical instability.
-                    constexpr double EPSILON = 1e-1;
-                    if (dfOvrRatio >=
-                            dfTargetRatio * dfOversamplingThreshold + EPSILON ||
-                        dfOvrRatio <= dfBestRatio)
-                    {
-                        continue;
-                    }
-
-                    iBestOvr = iOvr;
-                    dfBestRatio = dfOvrRatio;
-                    if (std::abs(dfTargetRatio - dfOvrRatio) < EPSILON)
-                    {
-                        break;
-                    }
-                }
+                const int iBestOvr = GDALBandGetBestOverviewLevel(
+                    poSrcDS->GetRasterBand(1), dfTargetRatio,
+                    dfOversamplingThreshold);
                 const int iOvr =
                     iBestOvr + (psOptions->nOvLevel - OVR_LEVEL_AUTO);
                 if (iOvr >= 0)

--- a/autotest/utilities/test_gdalalg_raster_tile.py
+++ b/autotest/utilities/test_gdalalg_raster_tile.py
@@ -2281,3 +2281,22 @@ def test_gdalalg_raster_tile_pipeline_error(tmp_path):
                 input=src_ds,
                 pipeline=f"mosaic ! tile {out_dirname} --min-zoom=0 --max-zoom=3",
             )
+
+
+def test_gdalalg_raster_tile_overview_selection(tmp_vsimem):
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 512, 512, 1)
+    src_ds.GetRasterBand(1).Fill(255)
+    src_ds.BuildOverviews("NONE", [2])
+    src_ds.GetRasterBand(1).GetOverview(0).Fill(127)
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(3857)
+    src_ds.SetSpatialRef(srs)
+    MAX_GM = 20037508.342789244
+    RES = 2 * MAX_GM / 512
+    src_ds.SetGeoTransform([-MAX_GM, RES, 0, MAX_GM, 0, -RES])
+
+    gdal.alg.raster.tile(input=src_ds, output=tmp_vsimem, max_zoom=0)
+
+    ds = gdal.Open(tmp_vsimem / "0/0/0.png")
+    assert ds.GetRasterBand(1).ComputeRasterMinMax() == (127, 127)

--- a/gcore/gdal_cpp_functions.h
+++ b/gcore/gdal_cpp_functions.h
@@ -226,6 +226,10 @@ GDALGetThreadSafeDataset(std::unique_ptr<GDALDataset> poDS, int nScopeFlags);
 GDALDataset CPL_DLL *GDALGetThreadSafeDataset(GDALDataset *poDS,
                                               int nScopeFlags);
 
+int GDALBandGetBestOverviewLevel(GDALRasterBand *poBand,
+                                 double dfTargetDownsamplingRatio,
+                                 double dfOversamplingThreshold);
+
 void GDALNullifyOpenDatasetsList();
 CPLMutex **GDALGetphDMMutex();
 CPLMutex **GDALGetphDLMutex();

--- a/gcore/rasterio.cpp
+++ b/gcore/rasterio.cpp
@@ -4442,6 +4442,69 @@ void GDALCopyBits(const GByte *pabySrcData, int nSrcOffset, int nSrcStep,
 }
 
 /************************************************************************/
+/*                    GDALBandGetBestOverviewLevel()                    */
+/************************************************************************/
+
+int GDALBandGetBestOverviewLevel(GDALRasterBand *poBand,
+                                 double dfTargetDownsamplingRatio,
+                                 double dfOversamplingThreshold)
+{
+    int iBestOvr = -1;
+    double dfBestRatio = 0;
+    const int nOvCount = poBand->GetOverviewCount();
+    constexpr double EPSILON = 1e-1;
+    for (int iOvr = -1; iOvr < nOvCount; iOvr++)
+    {
+        double dfOvrRatio = 1.0;
+        GDALRasterBand *poOvrBand = nullptr;
+        if (iOvr >= 0)
+        {
+            poOvrBand = poBand->GetOverview(iOvr);
+            if (poOvrBand == nullptr ||
+                poOvrBand->GetXSize() > poBand->GetXSize() ||
+                poOvrBand->GetYSize() > poBand->GetYSize())
+            {
+                continue;
+            }
+            dfOvrRatio = std::min(static_cast<double>(poBand->GetXSize()) /
+                                      poOvrBand->GetXSize(),
+                                  static_cast<double>(poBand->GetYSize()) /
+                                      poOvrBand->GetYSize());
+        }
+
+        // Is it nearly the requested factor and better (lower) than
+        // the current best factor?
+        // Use an epsilon because of numerical instability.
+        if (dfOvrRatio >=
+                dfTargetDownsamplingRatio * dfOversamplingThreshold + EPSILON ||
+            dfOvrRatio <= dfBestRatio)
+        {
+            continue;
+        }
+
+        if (poOvrBand)
+        {
+            // Ignore AVERAGE_BIT2GRAYSCALE overviews.
+            const char *pszResampling =
+                poOvrBand->GetMetadataItem("RESAMPLING");
+            if (pszResampling != nullptr &&
+                STARTS_WITH_CI(pszResampling, "AVERAGE_BIT2"))
+            {
+                continue;
+            }
+        }
+
+        iBestOvr = iOvr;
+        dfBestRatio = dfOvrRatio;
+        if (std::abs(dfTargetDownsamplingRatio - dfOvrRatio) < EPSILON)
+        {
+            break;
+        }
+    }
+    return iBestOvr;
+}
+
+/************************************************************************/
 /*                    GDALGetBestOverviewLevel()                        */
 /*                                                                      */
 /* Returns the best overview level to satisfy the query or -1 if none   */
@@ -4482,74 +4545,26 @@ int GDALBandGetBestOverviewLevel2(GDALRasterBand *poBand, int &nXOff,
     /*      downsampled) that is still less than (or only a little more)    */
     /*      downsampled than the request.                                   */
     /* -------------------------------------------------------------------- */
-    const int nOverviewCount = poBand->GetOverviewCount();
-    GDALRasterBand *poBestOverview = nullptr;
-    double dfBestDownsamplingFactor = 0;
-    int nBestOverviewLevel = -1;
 
     const char *pszOversampligThreshold =
         CPLGetConfigOption("GDAL_OVERVIEW_OVERSAMPLING_THRESHOLD", nullptr);
 
-    // Note: keep this logic for overview selection in sync between
-    // gdalwarp_lib.cpp and rasterio.cpp
     // Cf https://github.com/OSGeo/gdal/pull/9040#issuecomment-1898524693
     const double dfOversamplingThreshold =
         pszOversampligThreshold ? CPLAtof(pszOversampligThreshold)
         : psExtraArg && psExtraArg->eResampleAlg != GRIORA_NearestNeighbour
             ? 1.0
             : 1.2;
-    for (int iOverview = 0; iOverview < nOverviewCount; iOverview++)
-    {
-        GDALRasterBand *poOverview = poBand->GetOverview(iOverview);
-        if (poOverview == nullptr ||
-            poOverview->GetXSize() > poBand->GetXSize() ||
-            poOverview->GetYSize() > poBand->GetYSize())
-        {
-            continue;
-        }
-
-        // Compute downsampling factor of this overview
-        const double dfDownsamplingFactor = std::min(
-            poBand->GetXSize() / static_cast<double>(poOverview->GetXSize()),
-            poBand->GetYSize() / static_cast<double>(poOverview->GetYSize()));
-
-        // Is it nearly the requested factor and better (lower) than
-        // the current best factor?
-        // Use an epsilon because of numerical instability.
-        constexpr double EPSILON = 1e-1;
-        if (dfDownsamplingFactor >=
-                dfDesiredDownsamplingFactor * dfOversamplingThreshold +
-                    EPSILON ||
-            dfDownsamplingFactor <= dfBestDownsamplingFactor)
-        {
-            continue;
-        }
-
-        // Ignore AVERAGE_BIT2GRAYSCALE overviews for RasterIO purposes.
-        const char *pszResampling = poOverview->GetMetadataItem("RESAMPLING");
-
-        if (pszResampling != nullptr &&
-            STARTS_WITH_CI(pszResampling, "AVERAGE_BIT2"))
-            continue;
-
-        // OK, this is our new best overview.
-        poBestOverview = poOverview;
-        nBestOverviewLevel = iOverview;
-        dfBestDownsamplingFactor = dfDownsamplingFactor;
-
-        if (std::abs(dfDesiredDownsamplingFactor - dfDownsamplingFactor) <
-            EPSILON)
-        {
-            break;
-        }
-    }
+    const int iBestOvrLevel = GDALBandGetBestOverviewLevel(
+        poBand, dfDesiredDownsamplingFactor, dfOversamplingThreshold);
 
     /* -------------------------------------------------------------------- */
     /*      If we didn't find an overview that helps us, just return        */
     /*      indicating failure and the full resolution image will be used.  */
     /* -------------------------------------------------------------------- */
-    if (nBestOverviewLevel < 0)
+    if (iBestOvrLevel < 0)
         return -1;
+    const GDALRasterBand *poBestOverview = poBand->GetOverview(iBestOvrLevel);
 
     /* -------------------------------------------------------------------- */
     /*      Recompute the source window in terms of the selected            */
@@ -4597,7 +4612,7 @@ int GDALBandGetBestOverviewLevel2(GDALRasterBand *poBand, int &nXOff,
     nXSize = nOXSize;
     nYSize = nOYSize;
 
-    return nBestOverviewLevel;
+    return iBestOvrLevel;
 }
 
 /************************************************************************/


### PR DESCRIPTION
and Warper Lanczos: remove special case when the ratio of valid source pixels/total is below 1/2

Refs #14560

Not the ultimate fix as the behaviour of Lanczos in presence of nodata is yet to be found