### PR TITLE
Doc: Add sql and filter examples

### DIFF
--- a/doc/source/programs/gdal_vector_filter.rst
+++ b/doc/source/programs/gdal_vector_filter.rst
@@ -103,3 +103,23 @@ Examples
    .. code-block:: bash
 
         $ gdal vector filter --bbox=2,49,3,50 in.gpkg out.gpkg --overwrite
+
+.. example::
+   :title: Filter Shapefile features with an attribute query
+   :id: gdal-vector-filter-where
+
+   .. tabs::
+
+      .. code-tab:: bash
+
+        gdal vector pipeline \
+            ! read in.shp \
+            ! filter --where "CODE IS NULL AND NAME NOT LIKE 'TEMP%'" \
+            ! write out.gpkg
+
+      .. code-tab:: ps1
+
+        gdal vector pipeline `
+            ! read in.shp `
+            ! filter --where "CODE IS NULL AND NAME NOT LIKE 'TEMP%'" `
+            ! write out.gpkg

--- a/doc/source/programs/gdal_vector_sql.rst
+++ b/doc/source/programs/gdal_vector_sql.rst
@@ -137,3 +137,23 @@ Examples
        $ gdal vector pipeline read europe.gpkg ! \
                               sql --sql "SELECT * FROM country WHERE pop > 1e6" ! \
                               write --append --output-layer-name=world world.gpkg
+
+.. example::
+   :title: List unique values in a Shapefile field
+   :id: gdal-vector-sql-distinct
+
+   .. tabs::
+
+      .. code-tab:: bash
+
+        gdal vector pipeline \
+            ! read in.shp \
+            ! sql --sql "SELECT DISTINCT CODE FROM in ORDER BY CODE" \
+            ! info --features
+
+      .. code-tab:: ps1
+
+        gdal vector pipeline `
+            ! read in.shp `
+            ! sql --sql "SELECT DISTINCT CODE FROM in ORDER BY CODE" `
+            ! info --features

--- a/doc/source/user/cookbook.rst
+++ b/doc/source/user/cookbook.rst
@@ -51,6 +51,12 @@ Vector How do I...
     - :example:`gdal-vector-info-list-layers`
     - :example:`gdal-vector-info-geom-name`
 
+... filter features using an attribute query?
+   :example:`gdal-vector-filter-where`
+
+... list unique values in a field?
+   :example:`gdal-vector-sql-distinct`
+
 Raster and Vector How do I...
 -----------------------------
 


### PR DESCRIPTION
Adds two new pipeline examples for `gdal vector filter` and `gdal vector sql`, and links to them from the cookbook.
Tested on GDAL master on both Linux and Windows. 