### PR TITLE
geotiff: optimize 10 bit packing in write path

### DIFF
--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -12681,6 +12681,8 @@ def test_tiff_no_get_sibling_files(tmp_vsimem):
 @pytest.mark.parametrize("width", [1, 2, 3, 4, 5, 7, 8, 100, 101, 103, 256])
 def test_tiff_write_10bit_roundtrip(tmp_vsimem, width):
     """Verify optimized 10-bit packing produces correct output for various widths."""
+    
+    gdaltest.importorskip_gdal_array()
     np = pytest.importorskip("numpy")
 
     fname = tmp_vsimem / f"test_10bit_{width}.tif"

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -12676,3 +12676,21 @@ def test_tiff_no_get_sibling_files(tmp_vsimem):
             with gdal.Open(tmp_vsimem / "foo.tif") as ds:
                 ds.GetRasterBand(1).GetDefaultRAT()
     assert res[0]
+
+
+@pytest.mark.parametrize("width", [1, 2, 3, 4, 5, 7, 8, 100, 101, 103, 256])
+def test_tiff_write_10bit_roundtrip(tmp_vsimem, width):
+    """Verify optimized 10-bit packing produces correct output for various widths."""
+    np = pytest.importorskip("numpy")
+
+    fname = tmp_vsimem / f"test_10bit_{width}.tif"
+    ds = gdaltest.tiff_drv.Create(
+        fname, width, 1, 1, gdal.GDT_UInt16, options=["NBITS=10"]
+    )
+    data = np.arange(width, dtype=np.uint16) % 1024
+    ds.GetRasterBand(1).WriteArray(data.reshape(1, width))
+    ds = None  # flush to disk before re-opening
+
+    with gdal.Open(fname) as ds:
+        read = ds.GetRasterBand(1).ReadAsArray().flatten()
+    assert np.array_equal(data, read)

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -12681,7 +12681,7 @@ def test_tiff_no_get_sibling_files(tmp_vsimem):
 @pytest.mark.parametrize("width", [1, 2, 3, 4, 5, 7, 8, 100, 101, 103, 256])
 def test_tiff_write_10bit_roundtrip(tmp_vsimem, width):
     """Verify optimized 10-bit packing produces correct output for various widths."""
-    
+
     gdaltest.importorskip_gdal_array()
     np = pytest.importorskip("numpy")
 

--- a/frmts/gtiff/gtiffoddbitsband.cpp
+++ b/frmts/gtiff/gtiffoddbitsband.cpp
@@ -13,6 +13,7 @@
 
 #include "gtiffoddbitsband.h"
 
+#include <algorithm>
 #include "gdal_priv.h"
 #include "cpl_float.h"  // CPLFloatToHalf()
 #include "gtiffdataset.h"
@@ -214,6 +215,64 @@ CPLErr GTiffOddBitsBand::IWriteBlock(int nBlockXOff, int nBlockYOff,
                     }
 
                     iBitOffset += m_poGDS->m_nBitsPerSample;
+                }
+                continue;
+            }
+
+            if (m_poGDS->m_nBitsPerSample == 10 && eDataType == GDT_UInt16)
+            {
+                // Optimized 10-bit packing: 4 pixels -> 5 bytes.
+                // Avoids the generic per-bit loop which is ~10x slower.
+                const GUInt16 *pSrc =
+                    static_cast<const GUInt16 *>(pImage) + iPixel;
+                GByte *pDst = m_poGDS->m_pabyBlockBuf + (iBitOffset >> 3);
+                int iX = 0;
+                const int nFastLimit = nBlockXSize - 3;  // may be <= 0
+                for (; iX < nFastLimit; iX += 4)
+                {
+                    GUInt32 v0 = pSrc[0];
+                    GUInt32 v1 = pSrc[1];
+                    GUInt32 v2 = pSrc[2];
+                    GUInt32 v3 = pSrc[3];
+                    if ((v0 | v1 | v2 | v3) > nMaxVal)
+                    {
+                        v0 = std::min(v0, nMaxVal);
+                        v1 = std::min(v1, nMaxVal);
+                        v2 = std::min(v2, nMaxVal);
+                        v3 = std::min(v3, nMaxVal);
+                        if (!m_poGDS->m_bClipWarn)
+                        {
+                            m_poGDS->m_bClipWarn = true;
+                            ReportError(
+                                CE_Warning, CPLE_AppDefined,
+                                "One or more pixels clipped to fit %d bit "
+                                "domain.",
+                                m_poGDS->m_nBitsPerSample);
+                        }
+                    }
+                    pDst[0] = static_cast<GByte>(v0 >> 2);
+                    pDst[1] = static_cast<GByte>((v0 << 6) | (v1 >> 4));
+                    pDst[2] = static_cast<GByte>((v1 << 4) | (v2 >> 6));
+                    pDst[3] = static_cast<GByte>((v2 << 2) | (v3 >> 8));
+                    pDst[4] = static_cast<GByte>(v3);
+                    pSrc += 4;
+                    pDst += 5;
+                }
+                // Handle remaining 1-3 pixels with the generic per-bit path
+                iPixel += iX;
+                iBitOffset += static_cast<GInt64>(iX) * 10;
+                for (; iX < nBlockXSize; ++iX)
+                {
+                    GUInt32 nInWord = static_cast<GUInt16 *>(pImage)[iPixel++];
+                    if (nInWord > nMaxVal)
+                        nInWord = nMaxVal;
+                    for (int iBit = 0; iBit < 10; ++iBit)
+                    {
+                        if (nInWord & (1 << (9 - iBit)))
+                            m_poGDS->m_pabyBlockBuf[iBitOffset >> 3] |=
+                                (0x80 >> (iBitOffset & 7));
+                        ++iBitOffset;
+                    }
                 }
                 continue;
             }


### PR DESCRIPTION
## What does this PR do?

This PR adds fast path to optimize 10 bit TIFF packing. This is around 10 times faster than the generic routine - noticed this issue when decompressing a HiRISE image that was extremely slow.


## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
