### PR TITLE
Optimize Lanczos resampling with Byte source density

### DIFF
--- a/alg/gdalwarpkernel.cpp
+++ b/alg/gdalwarpkernel.cpp
@@ -4627,6 +4627,65 @@ static bool GWKResampleOptimizedLanczos(const GDALWarpKernel *poWK, int iBand,
         return true;
     }
 
+    if (poWK->eWorkingDataType == GDT_UInt8 && !poWK->panUnifiedSrcValid &&
+        !poWK->papanBandSrcValid && poWK->pafUnifiedSrcDensity &&
+        padfRowDensity)
+    {
+        // Optimization for Byte data with a unified density mask, such as an
+        // alpha band, and no additional validity masks.
+        const GByte *pSrc =
+            reinterpret_cast<const GByte *>(poWK->papabySrcImage[iBand]);
+        pSrc += iSrcOffset + static_cast<GPtrDiff_t>(jMin) * nSrcXSize;
+
+        const float *pafDensity =
+            poWK->pafUnifiedSrcDensity + iSrcOffset +
+            static_cast<GPtrDiff_t>(jMin) * nSrcXSize;
+
+        for (int j = jMin; j <= jMax; ++j)
+        {
+            const double dfWeight1 = padfWeightsYShifted[j];
+            for (int i = iMin; i <= iMax; ++i)
+            {
+                const double dfDensity = double(pafDensity[i]);
+                if (dfDensity < SRC_DENSITY_THRESHOLD_DOUBLE)
+                    continue;
+
+                const double dfWeight2 = dfWeight1 * padfWeightsXShifted[i];
+                dfAccumulatorReal += pSrc[i] * dfWeight2;
+                dfAccumulatorDensity += dfDensity * dfWeight2;
+                dfAccumulatorWeight += dfWeight2;
+            }
+
+            pSrc += nSrcXSize;
+            pafDensity += nSrcXSize;
+        }
+
+        if (dfAccumulatorWeight < 0.000001)
+        {
+            *pdfDensity = 0.0;
+            return false;
+        }
+        if (dfAccumulatorDensity < 0.000001)
+        {
+            *pdfDensity = 0.0;
+            return false;
+        }
+
+        if (dfAccumulatorWeight < 0.99999 || dfAccumulatorWeight > 1.00001)
+        {
+            const double dfInvAcc = 1.0 / dfAccumulatorWeight;
+            *pdfReal = dfAccumulatorReal * dfInvAcc;
+            *pdfDensity = dfAccumulatorDensity * dfInvAcc;
+        }
+        else
+        {
+            *pdfReal = dfAccumulatorReal;
+            *pdfDensity = dfAccumulatorDensity;
+        }
+
+        return true;
+    }
+
     GPtrDiff_t iRowOffset =
         iSrcOffset + static_cast<GPtrDiff_t>(jMin - 1) * nSrcXSize + iMin;
 

--- a/autotest/utilities/test_gdalwarp.py
+++ b/autotest/utilities/test_gdalwarp.py
@@ -217,6 +217,79 @@ def test_gdalwarp_8(gdalwarp_path, testgdalwarp_gcp_tif, tmp_path):
     ds = None
 
 
+def test_gdalwarp_lanczos_src_alpha_byte(gdalwarp_path, tmp_path):
+
+    xsize = 17
+    ysize = 17
+    for i_band in range(4):
+        data = bytearray()
+        for y in range(ysize):
+            for x in range(xsize):
+                if i_band == 0:
+                    value = (x * 13 + y * 7) & 0xFF
+                elif i_band == 1:
+                    value = (x * 3 + y * 17 + 11) & 0xFF
+                elif i_band == 2:
+                    value = (x * 19 + y * 5 + 23) & 0xFF
+                else:
+                    value = 0 if x < 3 or y < 2 or (x + y) % 7 == 0 else 255
+                data.append(value)
+        (tmp_path / f"b{i_band + 1}.raw").write_bytes(data)
+
+    src_vrt = tmp_path / "src.vrt"
+    src_vrt.write_text(
+        f"""<VRTDataset rasterXSize="{xsize}" rasterYSize="{ysize}">
+  <SRS>EPSG:4326</SRS>
+  <GeoTransform> -1, 0.01, 0, 1, 0, -0.01 </GeoTransform>
+  <VRTRasterBand dataType="Byte" band="1" subClass="VRTRawRasterBand">
+    <ColorInterp>Red</ColorInterp>
+    <SourceFilename relativeToVRT="1">b1.raw</SourceFilename>
+    <ImageOffset>0</ImageOffset>
+    <PixelOffset>1</PixelOffset>
+    <LineOffset>{xsize}</LineOffset>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="2" subClass="VRTRawRasterBand">
+    <ColorInterp>Green</ColorInterp>
+    <SourceFilename relativeToVRT="1">b2.raw</SourceFilename>
+    <ImageOffset>0</ImageOffset>
+    <PixelOffset>1</PixelOffset>
+    <LineOffset>{xsize}</LineOffset>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="3" subClass="VRTRawRasterBand">
+    <ColorInterp>Blue</ColorInterp>
+    <SourceFilename relativeToVRT="1">b3.raw</SourceFilename>
+    <ImageOffset>0</ImageOffset>
+    <PixelOffset>1</PixelOffset>
+    <LineOffset>{xsize}</LineOffset>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="Byte" band="4" subClass="VRTRawRasterBand">
+    <ColorInterp>Alpha</ColorInterp>
+    <SourceFilename relativeToVRT="1">b4.raw</SourceFilename>
+    <ImageOffset>0</ImageOffset>
+    <PixelOffset>1</PixelOffset>
+    <LineOffset>{xsize}</LineOffset>
+  </VRTRasterBand>
+</VRTDataset>
+"""
+    )
+
+    dst_tif = tmp_path / "out.tif"
+    gdaltest.runexternal(
+        f"{gdalwarp_path} -q -overwrite -r lanczos -ts 11 13 "
+        f"-srcalpha -dstalpha {src_vrt} {dst_tif}"
+    )
+
+    ds = gdal.Open(str(dst_tif))
+    assert ds is not None
+    assert ds.RasterCount == 4
+    assert [ds.GetRasterBand(i + 1).Checksum() for i in range(4)] == [
+        1019,
+        1067,
+        1115,
+        1188,
+    ]
+
+
 ###############################################################################
 # Test -te
 


### PR DESCRIPTION
## Summary
- Add a scalar fast path for Lanczos resampling of Byte data with a unified source density mask, such as an alpha band, and no additional validity masks.
- Avoid the generic row staging path in that narrow case by accumulating source values and density directly.
- Add a `gdalwarp` regression test covering Byte RGBA Lanczos resampling with source alpha.

## Performance
On a 1024 x 1024 Lanczos reprojection of a Byte RGBA GeoTIFF with source alpha:
- macOS ARM64: ~31.0s before, ~22.0s after
- Ubuntu x86_64 / Ryzen 9 5950X: 36.14s before, ~21.0s after

The output GeoTIFF was byte-for-byte identical before and after the change in both runs.

## Test plan
- `cmake --build build-perf --target gdalwarp --parallel`
- `ruff check autotest/utilities/test_gdalwarp.py`
- Manual `gdalwarp -r lanczos -srcalpha -dstalpha` checksum test for the added synthetic RGBA case
- Manual byte-for-byte comparison of before/after benchmark outputs on macOS and Ubuntu


Made with [Cursor](https://cursor.com)