### PR TITLE
gdal vector reproject: set the help URL to vector repoject standalone instead of vector pipeline

### DIFF
--- a/apps/gdalalg_vector_reproject.h
+++ b/apps/gdalalg_vector_reproject.h
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  GDAL
- * Purpose:  "reproject" step of "vector pipeline"
+ * Purpose:  "gdal vector reproject"
  * Author:   Even Rouault <even dot rouault at spatialys.com>
  *
  ******************************************************************************
@@ -28,7 +28,7 @@ class GDALVectorReprojectAlgorithm /* non final */
     static constexpr const char *NAME = "reproject";
     static constexpr const char *DESCRIPTION = "Reproject a vector dataset.";
     static constexpr const char *HELP_URL =
-        "/programs/gdal_vector_pipeline.html";
+        "/programs/gdal_vector_reproject.html";
 
     explicit GDALVectorReprojectAlgorithm(bool standaloneStep = false);
 


### PR DESCRIPTION
Sets the help URL for "gdal vector reproject" to `/programs/gdal_vector_reproject.html` instead of `/programs/gdal_vector_pipeline.html`.

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed