### PR TITLE
[Backport release/3.13] gdal vector reproject: set the help URL to vector repoject standalone instead of vector pipeline

### DIFF
--- a/apps/gdalalg_vector_reproject.h
+++ b/apps/gdalalg_vector_reproject.h
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  GDAL
- * Purpose:  "reproject" step of "vector pipeline"
+ * Purpose:  "gdal vector reproject"
  * Author:   Even Rouault <even dot rouault at spatialys.com>
  *
  ******************************************************************************
@@ -28,7 +28,7 @@ class GDALVectorReprojectAlgorithm /* non final */
     static constexpr const char *NAME = "reproject";
     static constexpr const char *DESCRIPTION = "Reproject a vector dataset.";
     static constexpr const char *HELP_URL =
-        "/programs/gdal_vector_pipeline.html";
+        "/programs/gdal_vector_reproject.html";
 
     explicit GDALVectorReprojectAlgorithm(bool standaloneStep = false);
 


### PR DESCRIPTION
Backport #14592
 **Authored by:** @ctoney