### PR TITLE
iso8211: fix potential heap buffer overflow on corrupted files with concatenated fields (master only)

### DIFF
--- a/frmts/iso8211/ddffield.cpp
+++ b/frmts/iso8211/ddffield.cpp
@@ -30,7 +30,7 @@
 /*                             Initialize()                             */
 /************************************************************************/
 
-void DDFField::Initialize(const DDFFieldDefn *poDefnIn, const char *pachDataIn,
+bool DDFField::Initialize(const DDFFieldDefn *poDefnIn, const char *pachDataIn,
                           int nDataSizeIn, bool bInitializeParts)
 
 {
@@ -38,17 +38,14 @@ void DDFField::Initialize(const DDFFieldDefn *poDefnIn, const char *pachDataIn,
     nDataSize = nDataSizeIn;
     poDefn = poDefnIn;
 
-    if (bInitializeParts)
-    {
-        InitializeParts();
-    }
+    return bInitializeParts ? InitializeParts() : true;
 }
 
 /************************************************************************/
 /*                          InitializeParts()                           */
 /************************************************************************/
 
-void DDFField::InitializeParts()
+bool DDFField::InitializeParts()
 {
     const bool bCreateParts = apoFieldParts.empty();
     const size_t nDefnPartsCount = poDefn->GetParts().size();
@@ -58,6 +55,13 @@ void DDFField::InitializeParts()
     for (const auto &[iPart, poFieldDefnPart] :
          cpl::enumerate(poDefn->GetParts()))
     {
+        if (iOffset > nDataSize)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Not enough bytes for part %d of field %s",
+                     static_cast<int>(iPart), poDefn->GetName());
+            return false;
+        }
         const int iOffsetBefore = iOffset;
         if (nDataSize > 0)
         {
@@ -96,6 +100,8 @@ void DDFField::InitializeParts()
                                              iOffset - iOffsetBefore, false);
         }
     }
+
+    return true;
 }
 
 /************************************************************************/

--- a/frmts/iso8211/ddfrecord.cpp
+++ b/frmts/iso8211/ddfrecord.cpp
@@ -494,10 +494,15 @@ int DDFRecord::ReadHeader()
             /* --------------------------------------------------------------------
              */
             apoFields[i] = std::make_unique<DDFField>();
-            apoFields[i]->Initialize(poFieldDefn,
-                                     osData.c_str() + _fieldAreaStart +
-                                         nFieldPos - nLeaderSize,
-                                     nFieldLength, true);
+            if (!apoFields[i]->Initialize(poFieldDefn,
+                                          osData.c_str() + _fieldAreaStart +
+                                              nFieldPos - nLeaderSize,
+                                          nFieldLength, true))
+            {
+                // Error message emitted by Initialize()
+                nFieldOffset = -1;
+                return FALSE;
+            }
 
             nLastFieldPos = nFieldPos;
             nLastFieldLength = nFieldLength;
@@ -689,10 +694,15 @@ int DDFRecord::ReadHeader()
             /* ------------------------------------------------------------- */
 
             apoFields[i] = std::make_unique<DDFField>();
-            apoFields[i]->Initialize(poFieldDefn,
-                                     osData.c_str() + _fieldAreaStart +
-                                         nFieldPos - nLeaderSize,
-                                     nFieldLength, true);
+            if (!apoFields[i]->Initialize(poFieldDefn,
+                                          osData.c_str() + _fieldAreaStart +
+                                              nFieldPos - nLeaderSize,
+                                          nFieldLength, true))
+            {
+                // Error message emitted by Initialize()
+                nFieldOffset = -1;
+                return FALSE;
+            }
 
             nLastFieldPos = nFieldPos;
             nLastFieldLength = nFieldLength;

--- a/frmts/iso8211/iso8211.h
+++ b/frmts/iso8211/iso8211.h
@@ -534,9 +534,9 @@ class CPL_DLL DDFField
     DDFField(DDFField &&) = default;
     DDFField &operator=(DDFField &&) = default;
 
-    void Initialize(const DDFFieldDefn *, const char *pszData, int nSize,
+    bool Initialize(const DDFFieldDefn *, const char *pszData, int nSize,
                     bool bInitializeParts);
-    void InitializeParts();
+    bool InitializeParts();
 
     void Dump(FILE *fp, int nNestingLevel = 0) const;
 


### PR DESCRIPTION
Fixes https://issues.oss-fuzz.com/issues/515291110
