### PR TITLE
GRIB: two integer overflow fixes

### DIFF
--- a/frmts/grib/degrib/degrib/degrib2.cpp
+++ b/frmts/grib/degrib/degrib/degrib2.cpp
@@ -1069,9 +1069,23 @@ int ReadGrib2Record (VSILFILE *fp, sChar f_unit, double **Grib_Data,
           * and MAX (32 * local_ns[2],SECT2_FLOATSIZE)
           * for size of section 2 unpacked.
           */
+         if (local_ns[2] > INT_MAX / 32)
+         {
+             /* Very unlikely to happen given local_ns[2] is validated against
+                the message size */
+             preErrSprintf ("Too large local_ns[2]\n");
+             free (buff);
+             return -2;
+         }
          nidat = (32 * local_ns[2] < SECT2_INIT_SIZE) ? SECT2_INIT_SIZE :
                32 * local_ns[2];
          nrdat = nidat;
+         if( nidat > INT_MAX / (int)sizeof (sInt4))
+         {
+             preErrSprintf ("Too large local_ns[2]\n");
+             free (buff);
+             return -2;
+         }
       }
       if (nidat > IS->nidat) {
          IS->idat = (sInt4 *) realloc ((void *) IS->idat,

--- a/frmts/grib/degrib/degrib/grib2api.c
+++ b/frmts/grib/degrib/degrib/grib2api.c
@@ -204,7 +204,7 @@ static int mdl_LocalUnpack(unsigned char *local, sInt4 locallen,
       bufLoc = 8;
       if (f_dataType == 0) {
          /* Floating point data. */
-         if (numVal > INT_MAX - 3 || *nrdat < numVal + 3) {
+         if (numVal > INT_MAX - 3 - curIndex || *nrdat < curIndex + numVal +  3) {
 #ifdef DEBUG
             printf("nrdat is not large enough.\n");
 #endif
@@ -225,7 +225,7 @@ static int mdl_LocalUnpack(unsigned char *local, sInt4 locallen,
          rdat[curIndex] = 0;
       } else {
          /* Integer point data. */
-         if (numVal > INT_MAX - 3 || *nidat < numVal + 3) {
+         if (numVal > INT_MAX - 3 - curIndex || *nidat <  curIndex + numVal + 3) {
 #ifdef DEBUG
             printf("nidat is not large enough.\n");
 #endif


### PR DESCRIPTION
* GRIB: mdl_LocalUnpack(): fix incomplete fix for #14455
* ReadGrib2Record(): avoid potential (unlikely) int overflows. Fixes #14622