### PR TITLE
gdal vector filter: add completion for --where

### DIFF
--- a/.github/workflows/alpine/Dockerfile.ci
+++ b/.github/workflows/alpine/Dockerfile.ci
@@ -3,6 +3,7 @@ FROM alpine:edge@sha256:732b6226a359f67fad4e38b34dd374bd62a6d282e20c493a38cc7d3a
 RUN apk add \
     apache-arrow-dev \
     armadillo-dev \
+    bash-completion \
     basisu-dev \
     blosc-dev \
     brunsli-dev \

--- a/.github/workflows/ubuntu_26.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_26.04/Dockerfile.ci
@@ -8,6 +8,7 @@ RUN apt-get update && \
     autoconf \
     automake \
     bash \
+    bash-completion \
     ccache \
     cmake \
     clang \
@@ -73,7 +74,8 @@ RUN apt-get update && \
     swig \
     unixodbc-dev \
     wget \
-    zip
+    zip \
+    zsh
 
 # Removing "libpoppler-dev libpoppler-private-dev" from above list to build from source
 

--- a/apps/gdal.cpp
+++ b/apps/gdal.cpp
@@ -39,12 +39,6 @@ static void EmitCompletion(std::unique_ptr<GDALAlgorithm> rootAlg,
     std::vector<std::string> args = argsIn;
 
     std::string ret;
-    const auto addSpace = [&ret]()
-    {
-        if (!ret.empty())
-            ret += " ";
-    };
-
     if (!args.empty() &&
         (args.back() == "--config" ||
          STARTS_WITH(args.back().c_str(), "--config=") ||
@@ -55,9 +49,8 @@ static void EmitCompletion(std::unique_ptr<GDALAlgorithm> rootAlg,
             CPLStringList aosConfigOptions(CPLGetKnownConfigOptions());
             for (const char *pszOpt : cpl::Iterate(aosConfigOptions))
             {
-                addSpace();
                 ret += pszOpt;
-                ret += '=';
+                ret += "=\n";
             }
             printf("%s", ret.c_str());
         }
@@ -67,8 +60,8 @@ static void EmitCompletion(std::unique_ptr<GDALAlgorithm> rootAlg,
     for (const auto &choice : rootAlg->GetAutoComplete(
              args, lastWordIsComplete, /*showAllOptions = */ true))
     {
-        addSpace();
-        ret += CPLString(choice).replaceAll(" ", "\\ ");
+        ret += choice;
+        ret += '\n';
     }
 
 #ifdef DEBUG_COMPLETION

--- a/apps/gdalalg_vector_filter.cpp
+++ b/apps/gdalalg_vector_filter.cpp
@@ -32,7 +32,7 @@ GDALVectorFilterAlgorithm::GDALVectorFilterAlgorithm(bool standaloneStep)
     : GDALVectorPipelineStepAlgorithm(NAME, DESCRIPTION, HELP_URL,
                                       standaloneStep)
 {
-    AddActiveLayerArg(&m_activeLayer);
+    auto &layerArg = AddActiveLayerArg(&m_activeLayer);
     AddBBOXArg(&m_bbox);
     AddArg("where", 0,
            _("Attribute query in a restricted form of the queries used in the "
@@ -40,10 +40,291 @@ GDALVectorFilterAlgorithm::GDALVectorFilterAlgorithm(bool standaloneStep)
            &m_where)
         .SetReadFromFileAtSyntaxAllowed()
         .SetMetaVar("<WHERE>|@<filename>")
-        .SetRemoveSQLCommentsEnabled();
+        .SetRemoveSQLCommentsEnabled()
+        .SetAutoCompleteFunction(
+            [this, &layerArg](const std::string &currentValue)
+            { return CompleteWhere(layerArg, currentValue); });
     AddArg("update-extent", 0,
            _("Update layer extent to take into account the filter"),
            &m_updateExtent);
+}
+
+/************************************************************************/
+/*              GDALVectorFilterAlgorithmLayerChangeExtent              */
+/************************************************************************/
+
+constexpr const char *const SQL_OPERATORS[] = {
+    "=", "<>", "<", "<=", ">", ">=", "AND", "OR", "LIKE", "BETWEEN"};
+
+static bool IsSQLOperator(const char *pszStr)
+{
+    return std::find_if(std::begin(SQL_OPERATORS), std::end(SQL_OPERATORS),
+                        [pszStr](const char *pszStr2)
+                        { return EQUAL(pszStr, pszStr2); }) !=
+           std::end(SQL_OPERATORS);
+}
+
+static std::string GetSQLIdentifier(const std::string &name)
+{
+    if (name.find_first_of("'\" ") != std::string::npos)
+    {
+        char *pszEscaped = CPLEscapeString(name.c_str(), -1, CPLES_SQLI);
+        std::string ret = std::string("\"").append(pszEscaped).append("\"");
+        CPLFree(pszEscaped);
+        return ret;
+    }
+    else
+    {
+        return name;
+    }
+}
+
+static std::string GetSQLStringLiteral(const char *val)
+{
+    char *pszEscaped = CPLEscapeString(val, -1, CPLES_SQL);
+    std::string ret = std::string("'").append(pszEscaped).append("'");
+    CPLFree(pszEscaped);
+    return ret;
+}
+
+std::vector<std::string>
+GDALVectorFilterAlgorithm::CompleteWhere(const GDALAlgorithmArg &layerArg,
+                                         const std::string &currentValue) const
+{
+    std::vector<std::string> ret;
+    if (currentValue.empty() || currentValue[0] != '"' ||
+        m_inputDataset.empty())
+        return ret;
+
+    auto poDS = std::unique_ptr<GDALDataset>(
+        GDALDataset::Open(m_inputDataset[0].GetName().c_str(),
+                          GDAL_OF_VECTOR | GDAL_OF_READONLY));
+    if (!poDS)
+        return ret;
+
+    // Collect field names
+    std::string layerName;
+    if (layerArg.IsExplicitlySet())
+        layerName = layerArg.Get<std::string>();
+    std::map<std::string, std::vector<OGRLayer *>> fieldNames;
+    if (layerName.empty())
+    {
+        for (auto *poLayer : poDS->GetLayers())
+        {
+            for (const auto *poFieldDefn : poLayer->GetLayerDefn()->GetFields())
+            {
+                fieldNames[poFieldDefn->GetNameRef()].push_back(poLayer);
+            }
+        }
+    }
+    else if (auto *poLayer = poDS->GetLayerByName(layerName.c_str()))
+    {
+        for (const auto *poFieldDefn : poLayer->GetLayerDefn()->GetFields())
+        {
+            fieldNames[poFieldDefn->GetNameRef()].push_back(poLayer);
+        }
+    }
+    if (fieldNames.empty())
+        return ret;
+
+    const CPLStringList aosTokens(CSLTokenizeString2(
+        currentValue.c_str() + 1, " ",
+        CSLT_HONOURSTRINGS | CSLT_HONOURSINGLEQUOTES | CSLT_PRESERVEQUOTES |
+            CSLT_PRESERVEESCAPES | CSLT_STRIPLEADSPACES | CSLT_STRIPENDSPACES));
+
+    std::string prefix;
+    const int nTokens = aosTokens.size();
+    if (nTokens > 0 && cpl::contains(fieldNames, aosTokens[nTokens - 1]))
+    {
+        prefix = currentValue.substr(1);
+        if (!prefix.empty() && prefix.back() != ' ')
+            prefix += ' ';
+        for (const char *op : SQL_OPERATORS)
+        {
+            if (nTokens > 1 && strcmp(op, "AND") == 0)
+                break;
+            ret.push_back(prefix + op);
+        }
+    }
+    else
+    {
+        const bool bLastTokenIsSQLOperator =
+            nTokens > 0 && IsSQLOperator(aosTokens[nTokens - 1]);
+        const int nCompleteTokens =
+            nTokens + (bLastTokenIsSQLOperator ? 0 : -1);
+        for (int i = 0; i < nCompleteTokens; ++i)
+        {
+            if (!prefix.empty())
+                prefix += ' ';
+            prefix += aosTokens[i];
+        }
+        if (!prefix.empty())
+            prefix += ' ';
+
+        const char *pszLastFieldName = nullptr;
+        OGRLayer *poLastFieldLayer = nullptr;
+        OGRFieldType eLastFieldType = OFTString;
+        if (nCompleteTokens >= 2)
+        {
+            const char *pszFieldName = aosTokens[nCompleteTokens - 2];
+            const auto oIter = fieldNames.find(pszFieldName);
+            if (oIter != fieldNames.end() && oIter->second.size() == 1)
+            {
+                const int nIdx =
+                    oIter->second[0]->GetLayerDefn()->GetFieldIndex(
+                        pszFieldName);
+                if (nIdx >= 0)
+                {
+                    pszLastFieldName = pszFieldName;
+                    poLastFieldLayer = oIter->second[0];
+                    eLastFieldType = poLastFieldLayer->GetLayerDefn()
+                                         ->GetFieldDefn(nIdx)
+                                         ->GetType();
+                }
+            }
+        }
+
+        for (const auto &[name, layers] : fieldNames)
+        {
+            bool canAdd = false;
+            if (!pszLastFieldName)
+            {
+                canAdd = true;
+            }
+            else if (name != pszLastFieldName)
+            {
+                if (layers.size() > 1)
+                {
+                    canAdd = true;
+                }
+                else if (layers[0]
+                             ->GetLayerDefn()
+                             ->GetFieldDefn(
+                                 layers[0]->GetLayerDefn()->GetFieldIndex(
+                                     name.c_str()))
+                             ->GetType() == eLastFieldType)
+                {
+                    canAdd = true;
+                }
+            }
+            if (canAdd)
+            {
+                ret.push_back(prefix + GetSQLIdentifier(name));
+            }
+        }
+
+        if (pszLastFieldName && poLastFieldLayer)
+        {
+            auto poLayer = poLastFieldLayer;
+            constexpr int NOT_TOO_LARGE = 1000;
+            const auto nFeatureCount = poLayer->GetFeatureCount();
+            if (nFeatureCount > 0 && nFeatureCount < NOT_TOO_LARGE)
+            {
+                constexpr int VALUES_COUNT = 10;
+                const std::string osSQLField =
+                    GetSQLIdentifier(pszLastFieldName);
+                const std::string osSQLLayer =
+                    GetSQLIdentifier(poLayer->GetName());
+                if (eLastFieldType == OFTString)
+                {
+                    CPLString osSQL;
+                    const char *pszDialect = nullptr;
+                    if (GetGDALDriverManager()->GetDriverByName("SQLite"))
+                    {
+                        pszDialect = "SQLite";
+                        // Find 10 most frequent strings
+                        osSQL.Printf("SELECT %s, COUNT(%s) cnt FROM %s GROUP "
+                                     "BY %s ORDER BY cnt DESC, %s ASC LIMIT %d",
+                                     osSQLField.c_str(), osSQLField.c_str(),
+                                     osSQLLayer.c_str(), osSQLField.c_str(),
+                                     osSQLField.c_str(), VALUES_COUNT + 1);
+                    }
+                    else
+                    {
+                        osSQL.Printf("SELECT DISTINCT %s FROM %s LIMIT %d",
+                                     osSQLField.c_str(), osSQLLayer.c_str(),
+                                     VALUES_COUNT + 1);
+                    }
+                    auto poSQLLayer =
+                        poDS->ExecuteSQL(osSQL.c_str(), nullptr, pszDialect);
+                    if (poSQLLayer)
+                    {
+                        int nCount = 0;
+                        for (auto &&poFeature : poSQLLayer)
+                        {
+                            if (nCount == VALUES_COUNT)
+                            {
+                                ret.push_back(prefix + "'...other values...");
+                                break;
+                            }
+                            ret.push_back(prefix +
+                                          GetSQLStringLiteral(
+                                              poFeature->GetFieldAsString(0)));
+                            nCount++;
+                        }
+                        poDS->ReleaseResultSet(poSQLLayer);
+                    }
+                }
+                else if (eLastFieldType == OFTInteger ||
+                         eLastFieldType == OFTInteger64 ||
+                         eLastFieldType == OFTReal)
+                {
+                    CPLString osSQL;
+                    const char *pszDialect = nullptr;
+                    if (nFeatureCount > VALUES_COUNT + 2 &&
+                        GetGDALDriverManager()->GetDriverByName("SQLite"))
+                    {
+                        pszDialect = "SQLite";
+                        // Collect lowest and highest values
+                        osSQL.Printf("SELECT DISTINCT %s FROM ("
+                                     "SELECT * FROM (SELECT DISTINCT %s FROM "
+                                     "%s ORDER BY %s ASC LIMIT %d) UNION ALL "
+                                     "SELECT * FROM (SELECT DISTINCT %s FROM "
+                                     "%s ORDER BY %s DESC LIMIT %d)"
+                                     ") x ORDER BY %s",
+                                     osSQLField.c_str(), osSQLField.c_str(),
+                                     osSQLLayer.c_str(), osSQLField.c_str(),
+                                     VALUES_COUNT / 2, osSQLField.c_str(),
+                                     osSQLLayer.c_str(), osSQLField.c_str(),
+                                     VALUES_COUNT / 2 + 1, osSQLField.c_str());
+                    }
+                    else
+                    {
+                        osSQL.Printf("SELECT DISTINCT %s FROM %s LIMIT %d",
+                                     osSQLField.c_str(), osSQLLayer.c_str(),
+                                     VALUES_COUNT + 1);
+                    }
+                    auto poSQLLayer =
+                        poDS->ExecuteSQL(osSQL.c_str(), nullptr, pszDialect);
+                    if (poSQLLayer)
+                    {
+                        int nCount = 0;
+                        for (auto &&poFeature : poSQLLayer)
+                        {
+                            if (nCount == VALUES_COUNT)
+                            {
+                                if (pszDialect)
+                                {
+                                    ret.erase(ret.begin() + VALUES_COUNT / 2 +
+                                              1);
+                                    ret.push_back(
+                                        prefix +
+                                        poFeature->GetFieldAsString(0));
+                                }
+                                ret.push_back(prefix + "...other values...");
+                                break;
+                            }
+                            ret.push_back(prefix +
+                                          poFeature->GetFieldAsString(0));
+                            nCount++;
+                        }
+                        poDS->ReleaseResultSet(poSQLLayer);
+                    }
+                }
+            }
+        }
+    }
+    return ret;
 }
 
 /************************************************************************/

--- a/apps/gdalalg_vector_filter.h
+++ b/apps/gdalalg_vector_filter.h
@@ -39,6 +39,10 @@ class GDALVectorFilterAlgorithm /* non final */
   private:
     bool RunStep(GDALPipelineStepRunContext &ctxt) override;
 
+    std::vector<std::string>
+    CompleteWhere(const GDALAlgorithmArg &layerArg,
+                  const std::string &currentValue) const;
+
     std::string m_activeLayer{};
     std::vector<double> m_bbox{};
     std::string m_where{};

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -2219,3 +2219,16 @@ def wkt_ds(wkts, *, geom_type=None, epsg=None):
         lyr.CreateFeature(f)
 
     return ds
+
+
+###############################################################################
+# Run cmd_line, which must be 'gdal completion' + arguments, and return its
+# output parsed as a list
+
+
+def run_and_parse_completion_output(cmd_line):
+    res = runexternal(cmd_line)
+    sep = "\r\n" if "\r\n" in res else "\n"
+    if res and res.endswith(sep):
+        res = res[0 : -len(sep)]
+    return res.split(sep)

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -1953,6 +1953,8 @@ def runexternal(
         command = cmd
     else:
         command = shlex.split(cmd)
+        if cmd.endswith('STRIP-ME"'):
+            command[-1] = '"' + command[-1][0 : -len("STRIP-ME")]
     if strin is None:
         p = subprocess.Popen(command, stdout=subprocess.PIPE)
     else:

--- a/autotest/utilities/test_gdal.py
+++ b/autotest/utilities/test_gdal.py
@@ -12,6 +12,9 @@
 ###############################################################################
 
 import json
+import os
+import subprocess
+import sys
 
 import gdaltest
 import pytest
@@ -753,3 +756,163 @@ def test_gdal_drivers():
         j = alg.Output()
         assert "GTiff" in [x["short_name"] for x in j]
         assert "ESRI Shapefile" in [x["short_name"] for x in j]
+
+
+@pytest.mark.parametrize(
+    "shell,input_args,last_arg_is_complete,expected_output",
+    [
+        (
+            "bash",
+            [],
+            True,
+            [
+                "convert",
+                "dataset",
+                "driver",
+                "info",
+                "mdim",
+                "pipeline",
+                "raster",
+                "vector",
+                "vsi",
+            ],
+        ),
+        (
+            "zsh",
+            [],
+            True,
+            [
+                "convert",
+                "dataset",
+                "driver",
+                "info",
+                "mdim",
+                "pipeline",
+                "raster",
+                "vector",
+                "vsi",
+            ],
+        ),
+        (
+            "bash",
+            ["raster", "convert", "--"],
+            False,
+            [
+                "--append",
+                "--creation-option",
+                "--input",
+                "--input-format",
+                "--open-option",
+                "--output",
+                "--output-format",
+                "--overwrite",
+                "--quiet",
+            ],
+        ),
+        (
+            "zsh",
+            ["raster", "convert", "--"],
+            False,
+            [
+                "--append",
+                "--creation-option",
+                "--input",
+                "--input-format",
+                "--open-option",
+                "--output",
+                "--output-format",
+                "--overwrite",
+                "--quiet",
+            ],
+        ),
+        (
+            "bash",
+            ["vector", "filter", "../ogr/data/poly.shp", "--where", '"'],
+            False,
+            ['"AREA', '"EAS_ID', '"PRFEDEA'],
+        ),
+        (
+            "zsh",
+            ["vector", "filter", "../ogr/data/poly.shp", "--where", '"'],
+            False,
+            ["AREA", "EAS_ID", "PRFEDEA"],
+        ),
+        ("bash", ["vector", "pipeline", "read", "!"], False, ["! info"]),
+        ("zsh", ["vector", "pipeline", "read", "!"], False, ["! info"]),
+        (
+            "bash",
+            ["raster", "convert", "--format=GTiff", "--creation-option"],
+            True,
+            ["COMPRESS="],
+        ),
+        (
+            "zsh",
+            ["raster", "convert", "--format=GTiff", "--creation-option"],
+            True,
+            ["COMPRESS="],
+        ),
+        ("bash", ["raster", "reproject", "--output-crs"], True, ["EPSG:"]),
+        ("zsh", ["raster", "reproject", "--output-crs"], True, ["EPSG:"]),
+    ],
+)
+def test_gdal_completion_shell(
+    shell, input_args, last_arg_is_complete, expected_output
+):
+    """Test running bash/zsh completion script"""
+
+    if sys.platform == "win32":
+        pytest.skip("not compatible of win32")
+
+    gdal_path = test_cli_utilities.get_gdal_path()
+    if gdal_path is None:
+        pytest.skip("gdal binary not available")
+
+    gdal_bash_completion = os.path.join(
+        os.getcwd(), "..", "..", "scripts", "gdal-bash-completion.sh"
+    )
+    if not os.path.exists(gdal_bash_completion):
+        pytest.skip(f"cannot find {gdal_bash_completion}")
+
+    bash_completion = "/usr/share/bash-completion/bash_completion"
+    if shell == "bash" and not os.path.exists(bash_completion):
+        pytest.skip(f"cannot find {bash_completion}")
+
+    input_args = [gdal_path] + input_args
+
+    command_line = " ".join(input_args)
+    command_line_escaped = command_line.replace("\\", "\\\\").replace('"', '\\"')
+    COMP_CWORD = len(input_args)
+    if not last_arg_is_complete:
+        COMP_CWORD -= 1
+    if shell == "zsh":
+        # /usr/share/zsh/functions/Completion/bashcompinit does that
+        # This set start array offset=0 and split variables on space
+        cmd = "emulate -L sh\n"
+    else:
+        cmd = f"source {bash_completion}\n"
+
+    cmd += f"""
+source {gdal_bash_completion}
+
+# Set env variables involved in completion
+COMP_LINE="{command_line_escaped}"
+COMP_POINT={len(command_line)}
+COMP_WORDS=({command_line_escaped})
+COMP_CWORD={COMP_CWORD}
+
+# Execute the completion function
+_gdal
+
+for line in "${{COMPREPLY[@]}}"; do
+  echo $line;
+done
+"""
+
+    try:
+        result = subprocess.run([shell, "-c", cmd], capture_output=True, text=True)
+
+        output = result.stdout.strip().split("\n")
+        for x in expected_output:
+            assert x in output
+    except FileNotFoundError:
+        pytest.skip(f"{shell} not available")

--- a/autotest/utilities/test_gdal.py
+++ b/autotest/utilities/test_gdal.py
@@ -145,105 +145,111 @@ def test_gdal_suggestions(gdal_path):
 
 def test_gdal_completion(gdal_path):
 
-    out = gdaltest.runexternal(f"{gdal_path} completion gdal -").split(" ")
+    out = gdaltest.run_and_parse_completion_output(f"{gdal_path} completion gdal -")
     assert "--version" in out
 
-    out = gdaltest.runexternal(f"{gdal_path} completion gdal").split(" ")
+    out = gdaltest.run_and_parse_completion_output(f"{gdal_path} completion gdal")
     assert "convert" in out
     assert "info" in out
     assert "raster" in out
     assert "vector" in out
 
-    out = gdaltest.runexternal(f"{gdal_path} completion gdal raster").split(" ")
+    out = gdaltest.run_and_parse_completion_output(
+        f"{gdal_path} completion gdal raster"
+    )
     assert "convert" in out
     assert "edit" in out
     assert "info" in out
     assert "reproject" in out
     assert "pipeline" in out
 
-    out = gdaltest.runexternal(f"{gdal_path} completion gdal raster info -").split(" ")
+    out = gdaltest.run_and_parse_completion_output(
+        f"{gdal_path} completion gdal raster info -"
+    )
     assert "-f" not in out
     assert "--of" not in out
     assert "--format" not in out
     assert "--output-format" in out
 
-    out = gdaltest.runexternal(f"{gdal_path} completion gdal raster info --").split(" ")
+    out = gdaltest.run_and_parse_completion_output(
+        f"{gdal_path} completion gdal raster info --"
+    )
     assert "-f" not in out
     assert "--of" not in out
     assert "--format" not in out
     assert "--output-format" in out
 
-    out = gdaltest.runexternal(f"{gdal_path} completion gdal raster info --o").split(
-        " "
+    out = gdaltest.run_and_parse_completion_output(
+        f"{gdal_path} completion gdal raster info --o"
     )
     assert "--of" in out
     assert "--output-format" in out
 
-    out = gdaltest.runexternal(f"{gdal_path} completion gdal raster info --form").split(
-        " "
+    out = gdaltest.run_and_parse_completion_output(
+        f"{gdal_path} completion gdal raster info --form"
     )
     assert out == ["--format"]
 
-    out = gdaltest.runexternal(f"{gdal_path} completion gdal raster info --of").split(
-        " "
+    out = gdaltest.run_and_parse_completion_output(
+        f"{gdal_path} completion gdal raster info --of"
     )
     assert "json" in out
     assert "text" in out
 
-    out = gdaltest.runexternal(f"{gdal_path} completion gdal raster info --of=").split(
-        " "
+    out = gdaltest.run_and_parse_completion_output(
+        f"{gdal_path} completion gdal raster info --of="
     )
     assert "json" in out
     assert "text" in out
 
-    out = gdaltest.runexternal(f"{gdal_path} completion gdal raster info --of=t").split(
-        " "
+    out = gdaltest.run_and_parse_completion_output(
+        f"{gdal_path} completion gdal raster info --of=t"
     )
     assert "json" in out
     assert "text" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert --of"
-    ).split(" ")
+    )
     if gdal.GetDriverByName("GTiff"):
         assert "GTiff" in out
     if gdal.GetDriverByName("HFA"):
         assert "HFA" in out
 
     # Test that config options are taken into account
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert --config GDAL_SKIP=GTiff --of"
-    ).split(" ")
+    )
     assert "GTiff" not in out
     if gdal.GetDriverByName("HFA"):
         assert "HFA" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert --input"
-    ).split(" ")
+    )
     assert "data/" in out or "data\\" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert --input data/"
-    ).split(" ")
+    )
     assert "data/whiteblackred.tif" in out or "data\\whiteblackred.tif" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert /vsizip/../gcore/data/byte.tif.zip/"
-    ).split(" ")
+    )
     assert out == ["/vsizip/../gcore/data/byte.tif.zip/byte.tif"]
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster reproject --resolution"
     )
-    assert (
-        out
-        == "** \xc2\xa0description:\\ Target\\ resolution\\ (in\\ destination\\ CRS\\ units)"
-    )
+    assert out == [
+        "**",
+        "\xc2\xa0description: Target resolution (in destination CRS units)",
+    ]
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert --input /vsi"
-    ).split(" ")
+    )
     assert "/vsimem/" in out
 
     # Just run it. Result will depend on local configuration
@@ -252,168 +258,168 @@ def test_gdal_completion(gdal_path):
 
 def test_gdal_completion_co(gdal_path):
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert in.tif out.tif --co"
-    ).split(" ")
+    )
     assert "COMPRESS=" in out
     assert "RPCTXT=" in out
     assert "TILING_SCHEME=" not in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert in.tif out.tif --co="
-    ).split(" ")
+    )
     assert "COMPRESS=" in out
     assert "RPCTXT=" in out
     assert "TILING_SCHEME=" not in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert in.tif out.tif --co COMPRESS="
-    ).split(" ")
+    )
     assert "NONE" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert in.tif out.tif --co COMPRESS=NO"
-    ).split(" ")
+    )
     assert "NONE" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert in.tif out.tif --co=COMPRESS="
-    ).split(" ")
+    )
     assert "NONE" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert in.tif out.tif --co=COMPRESS=NO"
-    ).split(" ")
+    )
     assert "NONE" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert in.tif out.tif --co TILED="
-    ).split(" ")
+    )
     assert out == ["NO", "YES"]
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert in.tif out.tif --co ZLEVEL="
-    ).split(" ")
+    )
     assert "1" in out
     assert "9" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert --of CO in.tif out.tif prev=of cur=CO"
-    ).split(" ")
+    )
     assert "COG" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert --of=CO in.tif out.tif prev== cur=CO"
-    ).split(" ")
+    )
     assert "COG" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert --of COG --co="
-    ).split(" ")
+    )
     assert "COMPRESS=" in out
     assert "RPCTXT=" not in out
     assert "TILING_SCHEME=" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert --of=COG --creation-option ZOOM_LEVEL="
     )
-    assert (
-        out
-        == "## type:\\ int,\\ description:\\ Target\\ zoom\\ level.\\ Only\\ used\\ for\\ TILING_SCHEME\\ !=\\ CUSTOM"
-    )
+    assert out == [
+        "##",
+        "type: int, description: Target zoom level. Only used for TILING_SCHEME != CUSTOM",
+    ]
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert --of COG --co BLOCKSIZE="
     )
-    assert out == "## validity\\ range:\\ >=\\ 128"
+    assert out == ["##", "validity range: >= 128"]
 
     if "JPEG_QUALITY" in gdal.GetDriverByName("GTiff").GetMetadataItem(
         "DMD_CREATIONOPTIONLIST"
     ):
-        out = gdaltest.runexternal(
+        out = gdaltest.run_and_parse_completion_output(
             f"{gdal_path} completion gdal raster convert in.tif out.tif --co JPEG_QUALITY="
         )
-        assert out == "## validity\\ range:\\ [1,100]"
+        assert out == ["##", "validity range: [1,100]"]
 
     if gdal.GetDriverByName("GPKG"):
-        out = gdaltest.runexternal(
+        out = gdaltest.run_and_parse_completion_output(
             f"{gdal_path} completion gdal raster convert --of GPKG --co="
-        ).split(" ")
+        )
         assert "APPEND_SUBDATASET=" in out
         assert "VERSION=" in out
 
-        out = gdaltest.runexternal(
+        out = gdaltest.run_and_parse_completion_output(
             f"{gdal_path} completion gdal vector convert --of GPKG --co="
-        ).split(" ")
+        )
         assert "APPEND_SUBDATASET=" not in out
         assert "VERSION=" in out
 
-        out = gdaltest.runexternal(
+        out = gdaltest.run_and_parse_completion_output(
             f"{gdal_path} completion gdal raster convert --of GPKG --co BLOCKSIZE="
         )
-        assert out == "## validity\\ range:\\ <=\\ 4096"
+        assert out == ["##", "validity range: <= 4096"]
 
 
 def test_gdal_completion_lco(gdal_path):
 
     if gdal.GetDriverByName("GPKG"):
 
-        out = gdaltest.runexternal(
+        out = gdaltest.run_and_parse_completion_output(
             f"{gdal_path} completion gdal vector convert --of GPKG --lco"
-        ).split(" ")
+        )
         assert "FID=" in out
 
-        out = gdaltest.runexternal(
+        out = gdaltest.run_and_parse_completion_output(
             f"{gdal_path} completion gdal vector convert in.shp out.gpkg --layer-creation-option="
-        ).split(" ")
+        )
         assert "FID=" in out
 
 
 def test_gdal_completion_oo(gdal_path):
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster info foo.tif --oo"
-    ).split(" ")
+    )
     assert "COLOR_TABLE_MULTIPLIER=" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster info --if GTiff --open-option"
-    ).split(" ")
+    )
     assert "COLOR_TABLE_MULTIPLIER=" in out
 
 
 def test_gdal_completion_dst_crs(gdal_path):
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster reproject --dst-crs"
-    ).split(" ")
+    )
     assert "EPSG:" in out
     assert "ESRI:" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster reproject --dst-crs EPSG:"
     )
-    assert "4326\\ --\\ WGS\\ 84" in out
+    assert "4326 -- WGS 84 (geographic 2D)" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster reproject --dst-crs=EPSG:"
     )
-    assert "4326\\ --\\ WGS\\ 84" in out
+    assert "4326 -- WGS 84 (geographic 2D)" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster reproject --dst-crs EPSG:43"
     )
-    assert "4326\\ --\\ WGS\\ 84" in out
+    assert "4326 -- WGS 84 (geographic 2D)" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster reproject --dst-crs=EPSG:43"
     )
-    assert "4326\\ --\\ WGS\\ 84" in out
+    assert "4326 -- WGS 84 (geographic 2D)" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster reproject --dst-crs EPSG:4326"
     )
-    assert out == "4326"
+    assert out == ["4326"]
 
 
 def test_gdal_completion_config(gdal_path):
@@ -436,14 +442,14 @@ def test_gdal_completion_config(gdal_path):
     assert "CPL_DEBUG=" in out
     assert err == ""
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert --config FOO="
-    ).split(" ")
+    )
     assert out == [""]
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster convert --config=FOO="
-    ).split(" ")
+    )
     assert out == [""]
 
 
@@ -456,7 +462,7 @@ def test_gdal_completion_pipeline(gdal_path, subcommand):
         pipeline_cmd += subcommand
     pipeline_cmd += " pipeline"
 
-    out = gdaltest.runexternal(f"{pipeline_cmd}").split(" ")
+    out = gdaltest.run_and_parse_completion_output(f"{pipeline_cmd}")
     if subcommand == "raster":
         assert "calc" in out
         assert "concat" not in out
@@ -466,13 +472,13 @@ def test_gdal_completion_pipeline(gdal_path, subcommand):
     assert "read" in out
     assert "write" not in out
 
-    out = gdaltest.runexternal(f"{pipeline_cmd} re").split(" ")
+    out = gdaltest.run_and_parse_completion_output(f"{pipeline_cmd} re")
     assert out == ["read"]
 
-    out = gdaltest.runexternal(f"{pipeline_cmd} read").split(" ")
+    out = gdaltest.run_and_parse_completion_output(f"{pipeline_cmd} read")
     assert out == [""]
 
-    out = gdaltest.runexternal(f"{pipeline_cmd} read -").split(" ")
+    out = gdaltest.run_and_parse_completion_output(f"{pipeline_cmd} read -")
     assert "--input" in out
     assert "--open-option" in out
     if subcommand == "raster":
@@ -480,34 +486,34 @@ def test_gdal_completion_pipeline(gdal_path, subcommand):
     else:
         assert "--input-layer" in out
 
-    out = gdaltest.runexternal(f"{pipeline_cmd} read !").split(" ")
+    out = gdaltest.run_and_parse_completion_output(f"{pipeline_cmd} read !")
     assert "reproject" in out
     assert "write" in out
     assert "read" not in out
 
-    out = gdaltest.runexternal(f"{pipeline_cmd} read ! re").split(" ")
+    out = gdaltest.run_and_parse_completion_output(f"{pipeline_cmd} read ! re")
     assert "reproject" in out
     assert "write" in out
     assert "read" not in out
 
-    out = gdaltest.runexternal(f"{pipeline_cmd} read foo ! write -").split(" ")
+    out = gdaltest.run_and_parse_completion_output(f"{pipeline_cmd} read foo ! write -")
     assert "--output" in out
     assert "--creation-option" in out
 
     if subcommand != "vector":
-        out = gdaltest.runexternal(
+        out = gdaltest.run_and_parse_completion_output(
             f"{pipeline_cmd} read foo ! foo ! reproject -"
-        ).split(" ")
+        )
         assert "--resampling" in out
 
-        out = gdaltest.runexternal(
+        out = gdaltest.run_and_parse_completion_output(
             f"{pipeline_cmd} read foo ! reproject --resampling"
-        ).split(" ")
+        )
         assert "nearest" in out
 
-        out = gdaltest.runexternal(
+        out = gdaltest.run_and_parse_completion_output(
             f"{pipeline_cmd} read ../gcore/data/byte.tif !"
-        ).split(" ")
+        )
         assert "resize" in out
         assert "make-valid" not in out
         if subcommand is None:
@@ -515,29 +521,31 @@ def test_gdal_completion_pipeline(gdal_path, subcommand):
         else:
             assert "polygonize" not in out
 
-        out = gdaltest.runexternal(
+        out = gdaltest.run_and_parse_completion_output(
             f"{pipeline_cmd} read ../gcore/data/byte.tif ! edit -"
-        ).split(" ")
+        )
         assert "--nodata" in out
         assert "--geometry-type" not in out
 
     if subcommand != "raster":
 
-        out = gdaltest.runexternal(f"{pipeline_cmd} read test_gdal.py -").split(" ")
+        out = gdaltest.run_and_parse_completion_output(
+            f"{pipeline_cmd} read test_gdal.py -"
+        )
         assert "--input-layer" in out
 
-        out = gdaltest.runexternal(
+        out = gdaltest.run_and_parse_completion_output(
             f"{pipeline_cmd} read ../ogr/data/poly.shp ! reproject -"
-        ).split(" ")
+        )
         assert "--active-layer" in out
 
-        out = gdaltest.runexternal(
+        out = gdaltest.run_and_parse_completion_output(
             f"{pipeline_cmd} read foo ! reproject --dst-crs"
-        ).split(" ")
+        )
         assert "EPSG:" in out
 
-        out = gdaltest.runexternal(f"{pipeline_cmd} read ../ogr/data/poly.shp !").split(
-            " "
+        out = gdaltest.run_and_parse_completion_output(
+            f"{pipeline_cmd} read ../ogr/data/poly.shp !"
         )
         assert "resize" not in out
         assert "make-valid" in out
@@ -546,41 +554,41 @@ def test_gdal_completion_pipeline(gdal_path, subcommand):
         else:
             assert "rasterize" not in out
 
-        out = gdaltest.runexternal(
+        out = gdaltest.run_and_parse_completion_output(
             f"{pipeline_cmd} read ../ogr/data/poly.shp ! edit -"
-        ).split(" ")
+        )
         assert "--nodata" not in out
         assert "--geometry-type" in out
 
 
 def test_gdal_completion_gdal_vector_info_layer(gdal_path):
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal vector info ../ogr/data/poly.shp --layer"
-    ).split(" ")
+    )
     assert out == ["poly"]
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal vector info ../ogr/data/poly.shp --layer p"
-    ).split(" ")
+    )
     assert out == ["poly"]
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal vector info ../ogr/data/poly.shp --layer poly"
-    ).split(" ")
+    )
     assert out == [""]
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal vector info ../ogr/data/poly.shp --layer poly XX"
-    ).split(" ")
+    )
     assert out == [""]
 
 
 def test_gdal_completion_gdal_vector_pipeline_read_layer(gdal_path):
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal vector pipeline read ../ogr/data/poly.shp --layer"
-    ).split(" ")
+    )
     assert out == ["poly"]
 
 

--- a/autotest/utilities/test_gdalalg_dataset_copy.py
+++ b/autotest/utilities/test_gdalalg_dataset_copy.py
@@ -108,9 +108,11 @@ def test_gdalalg_dataset_copy_complete():
     gdal_path = test_cli_utilities.get_gdal_path()
     if gdal_path is None:
         pytest.skip("gdal binary missing")
-    out = gdaltest.runexternal(f"{gdal_path} completion gdal dataset copy --format=")
-    assert "GTiff " in out
-    assert "ESRI\\ Shapefile " in out
+    out = gdaltest.run_and_parse_completion_output(
+        f"{gdal_path} completion gdal dataset copy --format="
+    )
+    assert "GTiff" in out
+    assert "ESRI Shapefile" in out
 
 
 def test_gdalalg_dataset_copy_shapefile_dir(tmp_vsimem):

--- a/autotest/utilities/test_gdalalg_dataset_delete.py
+++ b/autotest/utilities/test_gdalalg_dataset_delete.py
@@ -62,6 +62,8 @@ def test_gdalalg_dataset_copy_complete():
     gdal_path = test_cli_utilities.get_gdal_path()
     if gdal_path is None:
         pytest.skip("gdal binary missing")
-    out = gdaltest.runexternal(f"{gdal_path} completion gdal dataset delete --format=")
-    assert "GTiff " in out
-    assert "ESRI\\ Shapefile " in out
+    out = gdaltest.run_and_parse_completion_output(
+        f"{gdal_path} completion gdal dataset delete --format="
+    )
+    assert "GTiff" in out
+    assert "ESRI Shapefile" in out

--- a/autotest/utilities/test_gdalalg_dataset_identify.py
+++ b/autotest/utilities/test_gdalalg_dataset_identify.py
@@ -63,10 +63,10 @@ def test_gdalalg_dataset_identify_complete():
     gdal_path = test_cli_utilities.get_gdal_path()
     if gdal_path is None:
         pytest.skip("gdal binary missing")
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal dataset identify data/whiteblackred"
     )
-    assert out.replace("\\", "/") == "data/whiteblackred.tif"
+    assert out[0].replace("\\", "/") == "data/whiteblackred.tif"
 
 
 def test_gdalalg_dataset_identify_text():

--- a/autotest/utilities/test_gdalalg_mdim_convert.py
+++ b/autotest/utilities/test_gdalalg_mdim_convert.py
@@ -395,9 +395,9 @@ def test_gdalalg_mdim_convert_creation_option(tmp_path):
 @pytest.mark.require_driver("netCDF")
 def test_gdalalg_mdim_convert_completion_array(gdal_path):
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal mdim convert ../gdrivers/data/netcdf/byte.nc --array"
-    ).split(" ")
+    )
     assert out == ["/x", "/y", "/Band1"]
 
 
@@ -407,9 +407,9 @@ def test_gdalalg_mdim_convert_completion_array(gdal_path):
 @pytest.mark.require_driver("netCDF")
 def test_gdalalg_mdim_convert_completion_array_option(gdal_path):
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal mdim convert ../gdrivers/data/netcdf/byte.nc --array-option"
-    ).split(" ")
+    )
     assert "USE_DEFAULT_FILL_AS_NODATA=" in out
 
 

--- a/autotest/utilities/test_gdalalg_mdim_info.py
+++ b/autotest/utilities/test_gdalalg_mdim_info.py
@@ -324,9 +324,9 @@ def test_gdalalg_mdim_info_completion_array_invalid_ds(gdal_path):
 
 def test_gdalalg_mdim_info_completion_array(gdal_path):
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal mdim info ../gdrivers/data/netcdf/byte.nc --array"
-    ).split(" ")
+    )
     assert out == ["/x", "/y", "/Band1"]
 
 
@@ -340,9 +340,9 @@ def test_gdalalg_mdim_info_completion_array_option_invalid_ds(gdal_path):
 
 def test_gdalalg_mdim_info_completion_array_option(gdal_path):
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal mdim info ../gdrivers/data/netcdf/byte.nc --array-option"
-    ).split(" ")
+    )
     assert "USE_DEFAULT_FILL_AS_NODATA=" in out
 
 

--- a/autotest/utilities/test_gdalalg_pipeline.py
+++ b/autotest/utilities/test_gdalalg_pipeline.py
@@ -717,9 +717,9 @@ def test_gdalalg_pipeline_existing_completion(tmp_path):
         )
         f.write(j.encode("UTF-8"))
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal pipeline {pipeline_filename} -"
-    ).split(" ")
+    )
     expected_out = [
         "--input-format=",
         "--open-option=",
@@ -739,14 +739,14 @@ def test_gdalalg_pipeline_existing_completion(tmp_path):
         assert x in out
     assert "--input-layer=" not in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal pipeline {pipeline_filename} --input-format="
-    ).split(" ")
+    )
     assert "MEM" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal pipeline {pipeline_filename} --output=/vsimem/out.tif --creation-option="
-    ).split(" ")
+    )
     assert "COMPRESS=" in out
 
     with gdal.VSIFile(pipeline_filename, "wb") as f:
@@ -759,9 +759,9 @@ def test_gdalalg_pipeline_existing_completion(tmp_path):
         )
         f.write(j.encode("UTF-8"))
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal pipeline {pipeline_filename} -"
-    ).split(" ")
+    )
     expected_out = [
         "--input-format=",
         "--open-option=",
@@ -799,15 +799,15 @@ def test_gdalalg_pipeline_existing_completion(tmp_path):
         )
         f.write(j.encode("UTF-8"))
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal pipeline {pipeline_filename} -"
-    ).split(" ")
+    )
     assert "--edit[0].geometry-type=" in out
     assert "--edit[1].geometry-type=" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal pipeline {pipeline_filename} --edit[0].geometry-type="
-    ).split(" ")
+    )
     assert "GEOMETRY" in out
 
 

--- a/autotest/utilities/test_gdalalg_raster_edit.py
+++ b/autotest/utilities/test_gdalalg_raster_edit.py
@@ -672,22 +672,22 @@ def test_gdalalg_raster_edit_color_interpretation_autocomplete():
     if gdal_path is None:
         pytest.skip("gdal binary not available")
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster edit --color-interpretation last_word_is_complete=true"
-    ).split(" ")
+    )
     assert "all=" in out
     assert "Red" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster edit ../gcore/data/byte.tif --color-interpretation last_word_is_complete=true"
-    ).split(" ")
+    )
     assert "all=" in out
     assert "1=" in out
     assert "Red" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster edit --color-interpretation all= last_word_is_complete=false"
-    ).split(" ")
+    )
     assert "all=" not in out
     assert "Red" in out
 

--- a/autotest/utilities/test_gdalalg_raster_mosaic.py
+++ b/autotest/utilities/test_gdalalg_raster_mosaic.py
@@ -511,28 +511,26 @@ def test_gdalalg_raster_mosaic_pixel_function_arg_complete():
     out = gdaltest.runexternal(
         f"{gdal_path} completion gdal raster mosaic --pixel-function-arg"
     )
-    assert (
-        "Specify argument(s) to pass to the pixel function".replace(" ", "\\ ") in out
-    )
+    assert "Specify argument(s) to pass to the pixel function" in out
 
     out = gdaltest.runexternal(
         f"{gdal_path} completion gdal raster mosaic --pixel-function=invalid --pixel-function-arg"
     )
-    assert "Invalid pixel function name".replace(" ", "\\ ") in out
+    assert "Invalid pixel function name" in out
 
     out = gdaltest.runexternal(
         f"{gdal_path} completion gdal raster mosaic --pixel-function=scale --pixel-function-arg"
     )
-    assert "No pixel function arguments for pixel function".replace(" ", "\\ ") in out
+    assert "No pixel function arguments for pixel function" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster mosaic --pixel-function=mean --pixel-function-arg"
     )
-    assert out == "propagateNoData="
+    assert out == ["propagateNoData="]
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster mosaic --pixel-function=mean --pixel-function-arg propagateNoData="
-    ).split(" ")
+    )
     assert out == ["NO", "YES"]
 
     out = gdaltest.runexternal(

--- a/autotest/utilities/test_gdalalg_raster_neighbors.py
+++ b/autotest/utilities/test_gdalalg_raster_neighbors.py
@@ -505,14 +505,14 @@ def test_gdalalg_raster_neighbors_complete():
     if gdal_path is None:
         pytest.skip("gdal binary missing")
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster neighbors --kernel"
-    ).split(" ")
+    )
     assert "sharpen" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster neighbors --kernel ["
-    ).split(" ")
+    )
     assert "sharpen" not in out
 
 

--- a/autotest/utilities/test_gdalalg_raster_overview.py
+++ b/autotest/utilities/test_gdalalg_raster_overview.py
@@ -461,15 +461,15 @@ def test_gdalalg_overview_add_complete():
     if gdal_path is None:
         pytest.skip("gdal binary missing")
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster overview add ../gcore/data/byte.tif --co"
-    ).split(" ")
+    )
     assert "LOCATION=" in out
     assert "COMPRESS=" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster overview add ../gcore/data/byte.tif --co COMPRESS="
-    ).split(" ")
+    )
     assert "NONE" in out
     assert "LZW" in out
 

--- a/autotest/utilities/test_gdalalg_raster_reproject.py
+++ b/autotest/utilities/test_gdalalg_raster_reproject.py
@@ -281,8 +281,8 @@ def test_gdalalg_raster_reproject_complete_output_crs():
         f"{gdal_path} completion gdal raster reproject ../gcore/data/byte.tif --output-crs=EPSG:"
     )
 
-    assert "4326\\ --" in out
-    assert "2193\\ --" not in out  # NZGD2000
+    assert "4326 --" in out
+    assert "2193 --" not in out  # NZGD2000
 
 
 @pytest.mark.require_proj(8, 1)

--- a/autotest/utilities/test_gdalalg_raster_select.py
+++ b/autotest/utilities/test_gdalalg_raster_select.py
@@ -192,9 +192,9 @@ def test_gdalalg_raster_select_autocomplete():
     if gdal_path is None:
         pytest.skip("gdal binary not available")
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal raster select ../gcore/data/byte.tif --band last_word_is_complete=true"
-    ).split(" ")
+    )
     assert out == ["1", "mask", "gray"]
 
     out = gdaltest.runexternal(

--- a/autotest/utilities/test_gdalalg_vector_explode_collections.py
+++ b/autotest/utilities/test_gdalalg_vector_explode_collections.py
@@ -287,9 +287,9 @@ def test_gdalalg_vector_explode_collections_type_autocomplete():
     if gdal_path is None:
         pytest.skip("gdal binary not available")
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal vector explode-collections --geometry-type"
-    ).split(" ")
+    )
     assert out == [
         "GEOMETRY",
         "GEOMETRYZ",
@@ -329,9 +329,9 @@ def test_gdalalg_vector_explode_collections_type_autocomplete():
         "TINZM",
     ]
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal vector explode-collections --geometry-type COMPOUNDCURVE"
-    ).split(" ")
+    )
     assert len(out) == 4
 
 

--- a/autotest/utilities/test_gdalalg_vector_filter.py
+++ b/autotest/utilities/test_gdalalg_vector_filter.py
@@ -11,8 +11,11 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import sys
+
 import gdaltest
 import pytest
+import test_cli_utilities
 
 from osgeo import gdal, ogr
 
@@ -184,8 +187,6 @@ def test_gdalalg_vector_filter_update_extent(tmp_vsimem):
 @pytest.mark.require_driver("GDALG")
 def test_gdalalg_vector_filter_test_ogrsf(tmp_path):
 
-    import test_cli_utilities
-
     if test_cli_utilities.get_test_ogrsf_path() is None:
         pytest.skip()
 
@@ -214,3 +215,210 @@ def test_gdalalg_vector_filter_test_ogrsf(tmp_path):
     assert "INFO" in ret
     assert "ERROR" not in ret
     assert "FAILURE" not in ret
+
+
+def _make_shlex_happy(cmd):
+    # We add STRIP-ME" at the end just to make shlex.split() happy
+    return cmd + 'STRIP-ME"'
+
+
+@pytest.mark.parametrize(
+    "suffix,expected_completions",
+    [
+        ("", ["AREA", "EAS_ID", "PRFEDEA"]),
+        ("AR", ["AREA", "EAS_ID", "PRFEDEA"]),
+        (
+            "PRFEDEA ",
+            [
+                "PRFEDEA =",
+                "PRFEDEA <>",
+                "PRFEDEA <",
+                "PRFEDEA <=",
+                "PRFEDEA >",
+                "PRFEDEA >=",
+                "PRFEDEA AND",
+                "PRFEDEA OR",
+                "PRFEDEA LIKE",
+                "PRFEDEA BETWEEN",
+            ],
+        ),
+        (
+            "PRFEDEA = ",
+            [
+                "PRFEDEA = '35043369'",
+                "PRFEDEA = '35043408'",
+                "PRFEDEA = '35043409'",
+                "PRFEDEA = '35043411'",
+                "PRFEDEA = '35043412'",
+                "PRFEDEA = '35043413'",
+                "PRFEDEA = '35043414'",
+                "PRFEDEA = '35043415'",
+                "PRFEDEA = '35043416'",
+                "PRFEDEA = '35043423'",
+            ],
+        ),
+        (
+            "PRFEDEA = '3",
+            [
+                "PRFEDEA = '35043369'",
+                "PRFEDEA = '35043408'",
+                "PRFEDEA = '35043409'",
+                "PRFEDEA = '35043411'",
+                "PRFEDEA = '35043412'",
+                "PRFEDEA = '35043413'",
+                "PRFEDEA = '35043414'",
+                "PRFEDEA = '35043415'",
+                "PRFEDEA = '35043416'",
+                "PRFEDEA = '35043423'",
+            ],
+        ),
+        (
+            "EAS_ID = ",
+            [
+                "EAS_ID = 168",
+                "EAS_ID = 179",
+                "EAS_ID = 171",
+                "EAS_ID = 173",
+                "EAS_ID = 172",
+                "EAS_ID = 169",
+                "EAS_ID = 166",
+                "EAS_ID = 158",
+                "EAS_ID = 165",
+                "EAS_ID = 170",
+            ],
+        ),
+        (
+            "PRFEDEA = 'foo' AND ",
+            [
+                "PRFEDEA = 'foo' AND AREA",
+                "PRFEDEA = 'foo' AND EAS_ID",
+                "PRFEDEA = 'foo' AND PRFEDEA",
+            ],
+        ),
+    ],
+)
+def test_gdalalg_vector_filter_where_completion(suffix, expected_completions):
+
+    if sys.platform == "win32":
+        pytest.skip("not compatible of win32")
+
+    gdal_path = test_cli_utilities.get_gdal_path()
+    if gdal_path is None:
+        pytest.skip("gdal binary not available")
+
+    out = gdaltest.run_and_parse_completion_output(
+        _make_shlex_happy(
+            f'{gdal_path} completion gdal vector filter ../ogr/data/poly.shp --where "{suffix}'
+        )
+    )
+    assert out == expected_completions
+
+
+@pytest.mark.require_driver("SQLITE")
+def test_gdalalg_vector_filter_where_completion_more_ten_features(tmp_path):
+
+    if sys.platform == "win32":
+        pytest.skip("not compatible of win32")
+
+    gdal_path = test_cli_utilities.get_gdal_path()
+    if gdal_path is None:
+        pytest.skip("gdal binary not available")
+
+    with gdal.GetDriverByName("ESRI Shapefile").CreateVector(tmp_path / "tmp.db") as ds:
+        lyr = ds.CreateLayer("tmp")
+        lyr.CreateField(ogr.FieldDefn("int", ogr.OFTInteger))
+        lyr.CreateField(ogr.FieldDefn("int2", ogr.OFTInteger))
+        lyr.CreateField(ogr.FieldDefn("str", ogr.OFTString))
+        lyr.CreateField(ogr.FieldDefn("str2", ogr.OFTString))
+        for i in range(100):
+            f = ogr.Feature(lyr.GetLayerDefn())
+            f["int"] = 100 - i
+            f["str"] = (
+                "z"
+                if i < 40
+                else (
+                    "b"
+                    if i < 45
+                    else (
+                        "c"
+                        if i < 55
+                        else (
+                            "d"
+                            if i < 60
+                            else (
+                                "e"
+                                if i < 65
+                                else (
+                                    "f"
+                                    if i < 70
+                                    else (
+                                        "g"
+                                        if i < 75
+                                        else (
+                                            "h"
+                                            if i < 80
+                                            else (
+                                                "i"
+                                                if i < 85
+                                                else (
+                                                    "j"
+                                                    if i < 90
+                                                    else "k" if i < 95 else "l"
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+            lyr.CreateFeature(f)
+
+    out = gdaltest.run_and_parse_completion_output(
+        _make_shlex_happy(
+            f'{gdal_path} completion gdal vector filter {tmp_path}/tmp.db --where "str = '
+        )
+    )
+    assert out == [
+        "str = str2",
+        "str = 'z'",
+        "str = 'c'",
+        "str = 'b'",
+        "str = 'd'",
+        "str = 'e'",
+        "str = 'f'",
+        "str = 'g'",
+        "str = 'h'",
+        "str = 'i'",
+        "str = 'j'",
+        "str = '...other values...",
+    ]
+
+    out = gdaltest.run_and_parse_completion_output(
+        _make_shlex_happy(
+            f'{gdal_path} completion gdal vector filter {tmp_path}/tmp.db --active-layer tmp --where "int = '
+        )
+    )
+    assert out == [
+        "int = int2",
+        "int = 1",
+        "int = 2",
+        "int = 3",
+        "int = 4",
+        "int = 5",
+        "int = 96",
+        "int = 97",
+        "int = 98",
+        "int = 99",
+        "int = 100",
+        "int = ...other values...",
+    ]
+
+    out = gdaltest.run_and_parse_completion_output(
+        _make_shlex_happy(
+            f'{gdal_path} completion gdal vector filter {tmp_path}/tmp.db --active-layer invalid --where "int = '
+        )
+    )
+    assert out[0] == "**"

--- a/autotest/utilities/test_gdalalg_vector_grid.py
+++ b/autotest/utilities/test_gdalalg_vector_grid.py
@@ -562,16 +562,16 @@ def test_gdalalg_vector_grid_autocomplete():
     if gdal_path is None:
         pytest.skip("gdal binary not available")
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal vector grid invdist last_word_is_complete=false"
-    ).split(" ")
+    )
     assert "invdist" in out
     assert "invdistnn" in out
 
     out = gdaltest.runexternal(
         f"{gdal_path} completion gdal vector grid invdist last_word_is_complete=true"
-    ).split(" ")
-    assert out == [""]
+    )
+    assert out == ""
 
 
 @pytest.mark.require_driver("COG")

--- a/autotest/utilities/test_gdalalg_vector_reproject.py
+++ b/autotest/utilities/test_gdalalg_vector_reproject.py
@@ -109,8 +109,8 @@ def test_gdalalg_vector_reproject_complete_dst_crs():
     out = gdaltest.runexternal(
         f"{gdal_path} completion gdal vector reproject ../ogr/data/poly.shp --dst-crs=EPSG:"
     )
-    assert "4326\\ --" in out
-    assert "2193\\ --" not in out  # NZGD2000
+    assert "4326 --" in out
+    assert "2193 --" not in out  # NZGD2000
 
 
 ###############################################################################

--- a/autotest/utilities/test_gdalalg_vector_set_geom_type.py
+++ b/autotest/utilities/test_gdalalg_vector_set_geom_type.py
@@ -303,9 +303,9 @@ def test_gdalalg_vector_set_geom_type_type_autocomplete():
     if gdal_path is None:
         pytest.skip("gdal binary not available")
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal vector set-geom-type --geometry-type"
-    ).split(" ")
+    )
     assert "GEOMETRY" in out
     assert "GEOMETRYZ" in out
     assert "GEOMETRYM" in out
@@ -313,9 +313,9 @@ def test_gdalalg_vector_set_geom_type_type_autocomplete():
     assert "POINT" in out
     assert "MULTIPOINT" in out
 
-    out = gdaltest.runexternal(
+    out = gdaltest.run_and_parse_completion_output(
         f"{gdal_path} completion gdal vector set-geom-type --geometry-type GEOMETRYC"
-    ).split(" ")
+    )
     assert len(out) == 4
 
 

--- a/port/cpl_string.cpp
+++ b/port/cpl_string.cpp
@@ -784,10 +784,12 @@ char **CSLTokenizeStringComplex(const char *pszString,
  * reported by isspace());
  * - CSLT_HONOURSTRINGS: double quotes can be used to hold values that should
  * not be broken into multiple tokens;
+ * - CSLT_HONOURSINGLEQUOTES: single quotes can be used to hold values that should
+ * not be broken into multiple tokens;
  * - CSLT_PRESERVEQUOTES: string quotes are carried into the tokens when this
  * is set, otherwise they are removed;
  * - CSLT_PRESERVEESCAPES: if set backslash escapes (for backslash itself,
- * and for literal double quotes) will be preserved in the tokens, otherwise
+ * and for literal single/double quotes) will be preserved in the tokens, otherwise
  * the backslashes will be removed in processing.
  *
  * \b Example:
@@ -822,6 +824,8 @@ char **CSLTokenizeString2(const char *pszString, const char *pszDelimiters,
 
     CPLStringList oRetList;
     const bool bHonourStrings = (nCSLTFlags & CSLT_HONOURSTRINGS) != 0;
+    const bool bHonourStringsSingleQuotes =
+        (nCSLTFlags & CSLT_HONOURSINGLEQUOTES) != 0;
     const bool bAllowEmptyTokens = (nCSLTFlags & CSLT_ALLOWEMPTYTOKENS) != 0;
     const bool bStripLeadSpaces = (nCSLTFlags & CSLT_STRIPLEADSPACES) != 0;
     const bool bStripEndSpaces = (nCSLTFlags & CSLT_STRIPENDSPACES) != 0;
@@ -832,6 +836,7 @@ char **CSLTokenizeString2(const char *pszString, const char *pszDelimiters,
     while (*pszString != '\0')
     {
         bool bInString = false;
+        bool bInStringSingleQuote = false;
         bool bStartString = true;
         size_t nTokenLen = 0;
 
@@ -858,7 +863,8 @@ char **CSLTokenizeString2(const char *pszString, const char *pszDelimiters,
             }
 
             // End if this is a delimiter skip it and break.
-            if (!bInString && strchr(pszDelimiters, *pszString) != nullptr)
+            if (!bInString && !bInStringSingleQuote &&
+                strchr(pszDelimiters, *pszString) != nullptr)
             {
                 ++pszString;
                 break;
@@ -867,7 +873,7 @@ char **CSLTokenizeString2(const char *pszString, const char *pszDelimiters,
             // If this is a quote, and we are honouring constant
             // strings, then process the constant strings, with out delim
             // but don't copy over the quotes.
-            if (bHonourStrings && *pszString == '"')
+            if (bHonourStrings && !bInStringSingleQuote && *pszString == '"')
             {
                 if (nCSLTFlags & CSLT_PRESERVEQUOTES)
                 {
@@ -876,6 +882,18 @@ char **CSLTokenizeString2(const char *pszString, const char *pszDelimiters,
                 }
 
                 bInString = !bInString;
+                continue;
+            }
+            else if (bHonourStringsSingleQuotes && !bHonourStrings &&
+                     *pszString == '\'')
+            {
+                if (nCSLTFlags & CSLT_PRESERVEQUOTES)
+                {
+                    pszToken[nTokenLen] = *pszString;
+                    ++nTokenLen;
+                }
+
+                bInStringSingleQuote = !bInStringSingleQuote;
                 continue;
             }
 
@@ -897,10 +915,23 @@ char **CSLTokenizeString2(const char *pszString, const char *pszDelimiters,
                     ++pszString;
                 }
             }
+            else if (bInStringSingleQuote && pszString[0] == '\\')
+            {
+                if (pszString[1] == '\'' || pszString[1] == '\\')
+                {
+                    if (nCSLTFlags & CSLT_PRESERVEESCAPES)
+                    {
+                        pszToken[nTokenLen] = *pszString;
+                        ++nTokenLen;
+                    }
+
+                    ++pszString;
+                }
+            }
 
             // Strip spaces at the token start if requested.
-            if (!bInString && bStripLeadSpaces && bStartString &&
-                isspace(static_cast<unsigned char>(*pszString)))
+            if (!bInString && !bInStringSingleQuote && bStripLeadSpaces &&
+                bStartString && isspace(static_cast<unsigned char>(*pszString)))
                 continue;
 
             bStartString = false;
@@ -910,7 +941,7 @@ char **CSLTokenizeString2(const char *pszString, const char *pszDelimiters,
         }
 
         // Strip spaces at the token end if requested.
-        if (!bInString && bStripEndSpaces)
+        if (!bInString && !bInStringSingleQuote && bStripEndSpaces)
         {
             while (nTokenLen &&
                    isspace(static_cast<unsigned char>(pszToken[nTokenLen - 1])))

--- a/port/cpl_string.h
+++ b/port/cpl_string.h
@@ -66,7 +66,7 @@ char CPL_DLL **CSLTokenizeString2(const char *pszString,
                                   const char *pszDelimiter,
                                   int nCSLTFlags) CPL_WARN_UNUSED_RESULT;
 
-/** Flag for CSLTokenizeString2() to honour strings */
+/** Flag for CSLTokenizeString2() to honour strings delimited by double quotes */
 #define CSLT_HONOURSTRINGS 0x0001
 /** Flag for CSLTokenizeString2() to allow empty tokens */
 #define CSLT_ALLOWEMPTYTOKENS 0x0002
@@ -78,6 +78,8 @@ char CPL_DLL **CSLTokenizeString2(const char *pszString,
 #define CSLT_STRIPLEADSPACES 0x0010
 /** Flag for CSLTokenizeString2() to strip trailing spaces */
 #define CSLT_STRIPENDSPACES 0x0020
+/** Flag for CSLTokenizeString2() to honour strings delimited by single quotes (GDAL >= 3.14) */
+#define CSLT_HONOURSINGLEQUOTES 0x0040
 
 int CPL_DLL CSLPrint(CSLConstList papszStrList, FILE *fpOut);
 char CPL_DLL **CSLLoad(const char *pszFname) CPL_WARN_UNUSED_RESULT;

--- a/scripts/completionFinder.py
+++ b/scripts/completionFinder.py
@@ -351,16 +351,29 @@ _gdal()
   else
     choices=$(gdal completion ${COMP_LINE})
   fi
-  if [ "$CURRENT_SHELL" = "bash" ]; then
-    if [[ "$cur" == "=" ]]; then
-      mapfile -t COMPREPLY < <(compgen -W "$choices" --)
-    elif [[ "$cur" == ":" ]]; then
-      mapfile -t COMPREPLY < <(compgen -W "$choices" --)
-    elif [[ "$cur" == "!" ]]; then
-      mapfile -t COMPREPLY < <(compgen -W "$choices" -P "! " --)
+
+  COMPREPLY=()
+  if [ "$choices" != "" ]; then
+    CHOICES=()
+    while IFS= read -r line; do
+      CHOICES+=("$line")
+    done <<< "$choices"
+    if [ "$cur" = "=" ]; then
+      COMPREPLY=("${CHOICES[@]}")
+    elif [ "$cur" = ":" ]; then
+      COMPREPLY=("${CHOICES[@]}")
+    elif [ "$cur" = "!" ]; then
+      for line in "${CHOICES[@]}"; do
+          COMPREPLY+=("! $line")
+      done
     else
-      mapfile -t COMPREPLY < <(compgen -W "$choices" -- "$cur")
+      for line in "${CHOICES[@]}"; do
+          [[ $line == ${cur}* ]] && COMPREPLY+=("$line")
+      done
     fi
+  fi
+
+  if [ "$CURRENT_SHELL" = "bash" ]; then
     for element in "${COMPREPLY[@]}"; do
       if [[ $element == */ ]]; then
         # Do not add a space if one of the suggestion ends with slash
@@ -378,15 +391,6 @@ _gdal()
     done
   else
     # zsh
-    if [ "$cur" = "=" ]; then
-      COMPREPLY=( "$(compgen -W "$choices" --)" )
-    elif [ "$cur" = ":" ]; then
-      COMPREPLY=( "$(compgen -W "$choices" --)" )
-    elif [ "$cur" = "!" ]; then
-      COMPREPLY=( "$(compgen -W "$choices" -P "! " --)" )
-    else
-      COMPREPLY=( "$(compgen -W "$choices" -- "$cur")" )
-    fi
     for element in "${COMPREPLY[@]}"; do
       if [[ $element == */ ]]; then
         # Do not add a space if one of the suggestion ends with slash

--- a/scripts/completionFinder.py
+++ b/scripts/completionFinder.py
@@ -342,15 +342,21 @@ _gdal()
   if test "$HAS_GET_COMP_WORDS_BY_REF" = "yes"; then
     local cur prev
     _get_comp_words_by_ref cur prev
-    if test "$cur" = ""; then
-      extra="last_word_is_complete=true"
+    if [[ ${COMP_LINE} == *\\"* ]]; then
+      choices=$(gdal completion "${COMP_WORDS[@]}")
     else
-      extra="prev=${prev} cur=${cur}"
+      if test "$cur" = ""; then
+        extra="last_word_is_complete=true"
+      else
+        extra="prev=${prev} cur=${cur}"
+      fi
+      choices=$(gdal completion ${COMP_LINE} ${extra})
     fi
-    choices=$(gdal completion ${COMP_LINE} ${extra})
   else
     choices=$(gdal completion ${COMP_LINE})
   fi
+
+  ori_cur="$cur"
 
   COMPREPLY=()
   if [ "$choices" != "" ]; then
@@ -367,6 +373,10 @@ _gdal()
           COMPREPLY+=("! $line")
       done
     else
+      if [[ $ori_cur == \\"* ]]; then
+        # Strip leading double quote before doing choice matching
+        cur=${cur:1}
+      fi
       for line in "${CHOICES[@]}"; do
           [[ $line == ${cur}* ]] && COMPREPLY+=("$line")
       done
@@ -374,21 +384,29 @@ _gdal()
   fi
 
   if [ "$CURRENT_SHELL" = "bash" ]; then
-    for element in "${COMPREPLY[@]}"; do
-      if [[ $element == */ ]]; then
-        # Do not add a space if one of the suggestion ends with slash
-        compopt -o nospace
-        break
-      elif [[ $element == *= ]]; then
-        # Do not add a space if one of the suggestion ends with equal
-        compopt -o nospace
-        break
-      elif [[ $element == *: ]]; then
-        # Do not add a space if one of the suggestion ends with colon
-        compopt -o nospace
-        break
-      fi
-    done
+    if [[ $ori_cur == \\"* ]]; then
+        compopt -o filenames -o nospace -o noquote
+        # re-add opening quote
+        for i in "${!COMPREPLY[@]}"; do
+            COMPREPLY[i]="\\"${COMPREPLY[$i]}"
+        done
+    else
+      for element in "${COMPREPLY[@]}"; do
+        if [[ $element == */ ]]; then
+          # Do not add a space if one of the suggestion ends with slash
+          compopt -o nospace
+          break
+        elif [[ $element == *= ]]; then
+          # Do not add a space if one of the suggestion ends with equal
+          compopt -o nospace
+          break
+        elif [[ $element == *: ]]; then
+          # Do not add a space if one of the suggestion ends with colon
+          compopt -o nospace
+          break
+        fi
+      done
+    fi
   else
     # zsh
     for element in "${COMPREPLY[@]}"; do

--- a/scripts/gdal-bash-completion.sh
+++ b/scripts/gdal-bash-completion.sh
@@ -47,16 +47,29 @@ _gdal()
   else
     choices=$(gdal completion ${COMP_LINE})
   fi
-  if [ "$CURRENT_SHELL" = "bash" ]; then
-    if [[ "$cur" == "=" ]]; then
-      mapfile -t COMPREPLY < <(compgen -W "$choices" --)
-    elif [[ "$cur" == ":" ]]; then
-      mapfile -t COMPREPLY < <(compgen -W "$choices" --)
-    elif [[ "$cur" == "!" ]]; then
-      mapfile -t COMPREPLY < <(compgen -W "$choices" -P "! " --)
+
+  COMPREPLY=()
+  if [ "$choices" != "" ]; then
+    CHOICES=()
+    while IFS= read -r line; do
+      CHOICES+=("$line")
+    done <<< "$choices"
+    if [ "$cur" = "=" ]; then
+      COMPREPLY=("${CHOICES[@]}")
+    elif [ "$cur" = ":" ]; then
+      COMPREPLY=("${CHOICES[@]}")
+    elif [ "$cur" = "!" ]; then
+      for line in "${CHOICES[@]}"; do
+          COMPREPLY+=("! $line")
+      done
     else
-      mapfile -t COMPREPLY < <(compgen -W "$choices" -- "$cur")
+      for line in "${CHOICES[@]}"; do
+          [[ $line == ${cur}* ]] && COMPREPLY+=("$line")
+      done
     fi
+  fi
+
+  if [ "$CURRENT_SHELL" = "bash" ]; then
     for element in "${COMPREPLY[@]}"; do
       if [[ $element == */ ]]; then
         # Do not add a space if one of the suggestion ends with slash
@@ -74,15 +87,6 @@ _gdal()
     done
   else
     # zsh
-    if [ "$cur" = "=" ]; then
-      COMPREPLY=( "$(compgen -W "$choices" --)" )
-    elif [ "$cur" = ":" ]; then
-      COMPREPLY=( "$(compgen -W "$choices" --)" )
-    elif [ "$cur" = "!" ]; then
-      COMPREPLY=( "$(compgen -W "$choices" -P "! " --)" )
-    else
-      COMPREPLY=( "$(compgen -W "$choices" -- "$cur")" )
-    fi
     for element in "${COMPREPLY[@]}"; do
       if [[ $element == */ ]]; then
         # Do not add a space if one of the suggestion ends with slash

--- a/scripts/gdal-bash-completion.sh
+++ b/scripts/gdal-bash-completion.sh
@@ -38,15 +38,21 @@ _gdal()
   if test "$HAS_GET_COMP_WORDS_BY_REF" = "yes"; then
     local cur prev
     _get_comp_words_by_ref cur prev
-    if test "$cur" = ""; then
-      extra="last_word_is_complete=true"
+    if [[ ${COMP_LINE} == *\"* ]]; then
+      choices=$(gdal completion "${COMP_WORDS[@]}")
     else
-      extra="prev=${prev} cur=${cur}"
+      if test "$cur" = ""; then
+        extra="last_word_is_complete=true"
+      else
+        extra="prev=${prev} cur=${cur}"
+      fi
+      choices=$(gdal completion ${COMP_LINE} ${extra})
     fi
-    choices=$(gdal completion ${COMP_LINE} ${extra})
   else
     choices=$(gdal completion ${COMP_LINE})
   fi
+
+  ori_cur="$cur"
 
   COMPREPLY=()
   if [ "$choices" != "" ]; then
@@ -63,6 +69,10 @@ _gdal()
           COMPREPLY+=("! $line")
       done
     else
+      if [[ $ori_cur == \"* ]]; then
+        # Strip leading double quote before doing choice matching
+        cur=${cur:1}
+      fi
       for line in "${CHOICES[@]}"; do
           [[ $line == ${cur}* ]] && COMPREPLY+=("$line")
       done
@@ -70,21 +80,29 @@ _gdal()
   fi
 
   if [ "$CURRENT_SHELL" = "bash" ]; then
-    for element in "${COMPREPLY[@]}"; do
-      if [[ $element == */ ]]; then
-        # Do not add a space if one of the suggestion ends with slash
-        compopt -o nospace
-        break
-      elif [[ $element == *= ]]; then
-        # Do not add a space if one of the suggestion ends with equal
-        compopt -o nospace
-        break
-      elif [[ $element == *: ]]; then
-        # Do not add a space if one of the suggestion ends with colon
-        compopt -o nospace
-        break
-      fi
-    done
+    if [[ $ori_cur == \"* ]]; then
+        compopt -o filenames -o nospace -o noquote
+        # re-add opening quote
+        for i in "${!COMPREPLY[@]}"; do
+            COMPREPLY[i]="\"${COMPREPLY[$i]}"
+        done
+    else
+      for element in "${COMPREPLY[@]}"; do
+        if [[ $element == */ ]]; then
+          # Do not add a space if one of the suggestion ends with slash
+          compopt -o nospace
+          break
+        elif [[ $element == *= ]]; then
+          # Do not add a space if one of the suggestion ends with equal
+          compopt -o nospace
+          break
+        elif [[ $element == *: ]]; then
+          # Do not add a space if one of the suggestion ends with colon
+          compopt -o nospace
+          break
+        fi
+      done
+    fi
   else
     # zsh
     for element in "${COMPREPLY[@]}"; do


### PR DESCRIPTION
Nowhere near a full SQL parser, but can still provides useful hints

```
$ gdal vector filter autotest/ogr/data/poly.shp --where "<TAB><TAB>
"AREA     "EAS_ID   "PRFEDEA

$ gdal vector filter autotest/ogr/data/poly.shp --where "EAS_ID <TAB><TAB>
"EAS_ID =        "EAS_ID <>       "EAS_ID <        "EAS_ID <=       "EAS_ID >        "EAS_ID >=       "EAS_ID AND      "EAS_ID OR       "EAS_ID LIKE     "EAS_ID BETWEEN

$ gdal vector filter autotest/ogr/data/poly.shp --where "EAS_ID = <TAB><TAB>
==>
$ gdal vector filter autotest/ogr/data/poly.shp --where "EAS_ID = 1

$ gdal vector filter autotest/ogr/data/poly.shp --where "EAS_ID = 1<TAB><TAB>
"EAS_ID = 168  "EAS_ID = 179  "EAS_ID = 171  "EAS_ID = 173  "EAS_ID = 172  "EAS_ID = 169  "EAS_ID = 166  "EAS_ID = 158  "EAS_ID = 165  "EAS_ID = 170
```
