### PR TITLE
MRF: check max interleaved bands

### DIFF
--- a/frmts/mrf/marfa.h
+++ b/frmts/mrf/marfa.h
@@ -599,8 +599,7 @@ class MRFDataset final : public GDALPamDataset
     void *pbuffer;
     unsigned int pbsize;
     ILSize tile;  // ID of tile present in buffer
-    GIntBig
-        bdirty;  // Holds bits, to be used in pixel interleaved (up to 64 bands)
+    GUIntBig bdirty;  // used in pixel interleaved (up to 64 bands)
 
     // GeoTransform support
     GDALGeoTransform m_gt{};
@@ -763,19 +762,19 @@ class MRFRasterBand CPL_NON_FINAL : public GDALPamRasterBand
     // Read the index record itself, can be overwritten
     //    virtual CPLErr ReadTileIdx(const ILSize &, ILIdx &, GIntBig bias = 0);
 
-    static GIntBig bandbit(int b)
+    static GUInt64 bandbit(int b)
     {
-        return ((GIntBig)1) << b;
+        return ((GUInt64)1) << b;
     }
 
-    GIntBig bandbit()
+    GUInt64 bandbit()
     {
         return bandbit(nBand - 1);
     }
 
-    GIntBig AllBandMask()
+    GUInt64 AllBandMask()
     {
-        return bandbit(poMRFDS->nBands) - 1;
+        return (~GUInt64(0)) >> (64 - poMRFDS->nBands);
     }
 
     // Overview Support

--- a/frmts/mrf/marfa.h
+++ b/frmts/mrf/marfa.h
@@ -594,11 +594,9 @@ class MRFDataset final : public GDALPamDataset
     // A small int actually due to GDAL limitations
     double scale;
 
-    // A place to keep an uncompressed block, to keep from allocating it all the
-    // time
-    void *pbuffer;
+    void *pbuffer;    // A place to keep an uncompressed block
     unsigned int pbsize;
-    ILSize tile;  // ID of tile present in buffer
+    ILSize tile;      // ID of tile present in buffer
     GUIntBig bdirty;  // used in pixel interleaved (up to 64 bands)
 
     // GeoTransform support

--- a/frmts/mrf/marfa.h
+++ b/frmts/mrf/marfa.h
@@ -594,7 +594,7 @@ class MRFDataset final : public GDALPamDataset
     // A small int actually due to GDAL limitations
     double scale;
 
-    void *pbuffer;    // A place to keep an uncompressed block
+    void *pbuffer;  // A place to keep an uncompressed block
     unsigned int pbsize;
     ILSize tile;      // ID of tile present in buffer
     GUIntBig bdirty;  // used in pixel interleaved (up to 64 bands)

--- a/frmts/mrf/marfa_dataset.cpp
+++ b/frmts/mrf/marfa_dataset.cpp
@@ -991,6 +991,14 @@ static CPLErr Init_Raster(ILImage &image, MRFDataset *ds, CPLXMLNode *defimage)
             ds->SetMaxValue(pszValue);
     }
 
+    // Check that pagesize.c is 64 or less so we can use bitmasks
+    if (image.pagesize.c > 64)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "MRF: Max number of pixel interleaved bands is 64");
+        return CE_Failure;
+    }
+
     // Calculate the page size in bytes
     const int nDTSize = GDALGetDataTypeSizeBytes(image.dt);
     if (nDTSize <= 0 || image.pagesize.z <= 0 ||
@@ -1002,7 +1010,7 @@ static CPLErr Init_Raster(ILImage &image, MRFDataset *ds, CPLXMLNode *defimage)
                 image.pagesize.c >
             INT_MAX / nDTSize)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "MRF page size too big");
+        CPLError(CE_Failure, CPLE_AppDefined, "MRF page size is too large");
         return CE_Failure;
     }
     image.pageSizeBytes = nDTSize * image.pagesize.x * image.pagesize.y *

--- a/frmts/mrf/mrf_band.cpp
+++ b/frmts/mrf/mrf_band.cpp
@@ -1459,7 +1459,7 @@ CPLErr MRFRasterBand::IWriteBlock(int xblk, int yblk, void *buffer)
     // below this test This way works fine, but it does work extra for empty
     // pages
 
-    if (GIntBig(empties) == AllBandMask())
+    if (AllBandMask() == empties)
     {
         CPLFree(tbuffer);
         return poMRFDS->WriteTile(nullptr, infooffset, 0);
@@ -1467,8 +1467,8 @@ CPLErr MRFRasterBand::IWriteBlock(int xblk, int yblk, void *buffer)
 
     if (poMRFDS->bdirty != AllBandMask())
         CPLError(CE_Warning, CPLE_AppDefined,
-                 "MRF: IWrite, band dirty mask is " CPL_FRMT_GIB
-                 " instead of " CPL_FRMT_GIB,
+                 "MRF: IWrite, band dirty mask is " CPL_FRMT_GUIB
+                 " instead of " CPL_FRMT_GUIB,
                  poMRFDS->bdirty, AllBandMask());
 
     buf_mgr src;


### PR DESCRIPTION
## What does this PR do?
MRF code only handled 63 bands in pixel interleaved mode, but it didn't check. This change makes it work with up to 64 bands in pixel interleaved mode and checks that no more than 64 bands are used. In band interleaved mode more than 64 bands are supported.

## What are related issues/pull requests?

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
