### PR TITLE
ogrgeometry: do not redefine SFCGAL VERSION macros if they already exist

### DIFF
--- a/ogr/ogrgeometry.cpp
+++ b/ogr/ogrgeometry.cpp
@@ -41,11 +41,15 @@
 #include "ogr_srs_api.h"
 #include "ogr_wkb.h"
 
+#ifndef SFCGAL_MAKE_VERSION
 #define SFCGAL_MAKE_VERSION(major, minor, patch)                               \
     ((major) * 10000 + (minor) * 100 + (patch))
+#endif
+#ifndef SFCGAL_VERSION_NUM
 #define SFCGAL_VERSION_NUM                                                     \
     SFCGAL_MAKE_VERSION(SFCGAL_VERSION_MAJOR, SFCGAL_VERSION_MINOR,            \
                         SFCGAL_VERSION_PATCH)
+#endif
 
 //! @cond Doxygen_Suppress
 int OGRGeometry::bGenerate_DB2_V72_BYTE_ORDER = FALSE;

--- a/ogr/ogrgeometry.cpp
+++ b/ogr/ogrgeometry.cpp
@@ -43,7 +43,7 @@
 
 #define SFCGAL_MAKE_VERSION(major, minor, patch)                               \
     ((major) * 10000 + (minor) * 100 + (patch))
-#define SFCGAL_VERSION                                                         \
+#define SFCGAL_VERSION_NUM                                                     \
     SFCGAL_MAKE_VERSION(SFCGAL_VERSION_MAJOR, SFCGAL_VERSION_MINOR,            \
                         SFCGAL_VERSION_PATCH)
 
@@ -8574,7 +8574,7 @@ OGRGeometry::OGRexportToSFCGAL(UNUSED_IF_NO_SFCGAL const OGRGeometry *poGeom)
 #ifdef HAVE_SFCGAL
 
     sfcgal_init();
-#if SFCGAL_VERSION >= SFCGAL_MAKE_VERSION(1, 5, 2)
+#if SFCGAL_VERSION_NUM >= SFCGAL_MAKE_VERSION(1, 5, 2)
 
     const auto exportToSFCGALViaWKB =
         [](const OGRGeometry *geom) -> sfcgal_geometry_t *
@@ -8732,7 +8732,7 @@ OGRGeometry *OGRGeometry::SFCGALexportToOGR(
     sfcgal_init();
     char *pabySFCGAL = nullptr;
     size_t nLength = 0;
-#if SFCGAL_VERSION >= SFCGAL_MAKE_VERSION(1, 5, 2)
+#if SFCGAL_VERSION_NUM >= SFCGAL_MAKE_VERSION(1, 5, 2)
 
     sfcgal_geometry_as_wkb(geometry, &pabySFCGAL, &nLength);
 


### PR DESCRIPTION
`SFCGAL_MAKE_VERSION` and `SFCGAL_VERSION_NUM` have been available since SFCGAL 2.3

This fixes the following warning with SFCGAL 2.3 (not released yet): 

```
/home/jean/dev/gdal/ogr/ogrgeometry.cpp:44:9: warning: ‘SFCGAL_MAKE_VERSION’ redefined
   44 | #define SFCGAL_MAKE_VERSION(major, minor, patch)                               \
      |         ^~~~~~~~~~~~~~~~~~~
In file included from /opt/sfcgal/include/SFCGAL/capi/sfcgal_c.h:10,
                 from /home/jean/dev/gdal/build/ogr/ogr_sfcgal.h:17,
                 from /home/jean/dev/gdal/ogr/ogrgeometry.cpp:37:
/opt/sfcgal/include/SFCGAL/version.h:22:9: note: this is the location of the previous definition
   22 | #define SFCGAL_MAKE_VERSION( major, minor, patch ) ( ( ( major ) * 10000 ) + ( ( minor ) * 100 ) + ( patch ) )
      |         ^~~~~~~~~~~~~~~~~~~
/home/jean/dev/gdal/ogr/ogrgeometry.cpp:46:9: warning: ‘SFCGAL_VERSION_NUM’ redefined
   46 | #define SFCGAL_VERSION_NUM                                                     \
      |         ^~~~~~~~~~~~~~~~~~
/opt/sfcgal/include/SFCGAL/version.h:25:9: note: this is the location of the previous definition
   25 | #define SFCGAL_VERSION_NUM SFCGAL_MAKE_VERSION( 2, 3, 0 )
```

cc @lbartoletti 