### PR TITLE
[Backport release/3.13] ogrgeometry: do not redefine SFCGAL VERSION macros if they already exist

### DIFF
--- a/ogr/ogrgeometry.cpp
+++ b/ogr/ogrgeometry.cpp
@@ -43,7 +43,7 @@
 
 #define SFCGAL_MAKE_VERSION(major, minor, patch)                               \
     ((major) * 10000 + (minor) * 100 + (patch))
-#define SFCGAL_VERSION                                                         \
+#define SFCGAL_VERSION_NUM                                                     \
     SFCGAL_MAKE_VERSION(SFCGAL_VERSION_MAJOR, SFCGAL_VERSION_MINOR,            \
                         SFCGAL_VERSION_PATCH)
 
@@ -8575,7 +8575,7 @@ OGRGeometry::OGRexportToSFCGAL(UNUSED_IF_NO_SFCGAL const OGRGeometry *poGeom)
 #ifdef HAVE_SFCGAL
 
     sfcgal_init();
-#if SFCGAL_VERSION >= SFCGAL_MAKE_VERSION(1, 5, 2)
+#if SFCGAL_VERSION_NUM >= SFCGAL_MAKE_VERSION(1, 5, 2)
 
     const auto exportToSFCGALViaWKB =
         [](const OGRGeometry *geom) -> sfcgal_geometry_t *
@@ -8733,7 +8733,7 @@ OGRGeometry *OGRGeometry::SFCGALexportToOGR(
     sfcgal_init();
     char *pabySFCGAL = nullptr;
     size_t nLength = 0;
-#if SFCGAL_VERSION >= SFCGAL_MAKE_VERSION(1, 5, 2)
+#if SFCGAL_VERSION_NUM >= SFCGAL_MAKE_VERSION(1, 5, 2)
 
     sfcgal_geometry_as_wkb(geometry, &pabySFCGAL, &nLength);
 

--- a/ogr/ogrgeometry.cpp
+++ b/ogr/ogrgeometry.cpp
@@ -41,11 +41,15 @@
 #include "ogr_srs_api.h"
 #include "ogr_wkb.h"
 
+#ifndef SFCGAL_MAKE_VERSION
 #define SFCGAL_MAKE_VERSION(major, minor, patch)                               \
     ((major) * 10000 + (minor) * 100 + (patch))
+#endif
+#ifndef SFCGAL_VERSION_NUM
 #define SFCGAL_VERSION_NUM                                                     \
     SFCGAL_MAKE_VERSION(SFCGAL_VERSION_MAJOR, SFCGAL_VERSION_MINOR,            \
                         SFCGAL_VERSION_PATCH)
+#endif
 
 //! @cond Doxygen_Suppress
 int OGRGeometry::bGenerate_DB2_V72_BYTE_ORDER = FALSE;


### PR DESCRIPTION
Backport #14667
 **Authored by:** @ptitjano