### PR TITLE
Doc: Add table of contents for pipeline steps and document missing steps

### DIFF
--- a/doc/source/gdal_rtd/static/css/gdal.css
+++ b/doc/source/gdal_rtd/static/css/gdal.css
@@ -357,3 +357,7 @@ table.top-aligned-table td p {
     line-height: 140% !important;
 }
 
+/** two-column TOC used for pipeline steps */
+.steps-toc ul {
+    columns: 2;
+}

--- a/doc/source/programs/gdal_pipeline.rst
+++ b/doc/source/programs/gdal_pipeline.rst
@@ -44,50 +44,93 @@ all other steps can potentially be used several times in a pipeline.
 
         $ gdal pipeline ! read in.tif ! footprint ! buffer 20 ! write out.gpkg --overwrite
 
+Steps
+-----
+
 For steps that have both *raster* data type as input and output, consult :ref:`gdal_raster_pipeline`.
 For steps that have both *vector* data type as input and output, consult :ref:`gdal_vector_pipeline`.
 
-The following steps accept raster input and generate vector output:
+The table below lists steps that convert between raster and vector data.
 
-* contour
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Step
+     - Direction
+   * - :ref:`contour <pipeline-contour>`
+     - Raster → Vector
+   * - :ref:`footprint <pipeline-footprint>`
+     - Raster → Vector
+   * - :ref:`pixel-info <pipeline-pixel-info>`
+     - Raster → Vector
+   * - :ref:`polygonize <pipeline-polygonize>`
+     - Raster → Vector
+   * - :ref:`grid <pipeline-grid>`
+     - Vector → Raster
+   * - :ref:`rasterize <pipeline-rasterize>`
+     - Vector → Raster
+   * - :ref:`tee <pipeline-tee>`
+     - Vector → Raster
+
+.. _pipeline-contour:
+
+contour
+*******
 
 .. program-output:: gdal pipeline --help-doc=contour
 
 Details for options can be found in :ref:`gdal_raster_contour`.
 
-* footprint
+.. _pipeline-footprint:
+
+footprint
+*********
 
 .. program-output:: gdal pipeline --help-doc=footprint
 
 Details for options can be found in :ref:`gdal_raster_footprint`.
 
-* pixel-info
+.. _pipeline-grid:
 
-.. program-output:: gdal pipeline --help-doc=pixel-info
-
-Details for options can be found in :ref:`gdal_raster_pixel_info`.
-
-* polygonize
-
-.. program-output:: gdal pipeline --help-doc=polygonize
-
-Details for options can be found in :ref:`gdal_raster_polygonize`.
-
-The following steps accept raster vector and generate raster output:
-
-* grid
+grid
+****
 
 .. program-output:: gdal pipeline --help-doc=grid
 
 Details for options can be found in :ref:`gdal_vector_grid`.
 
-* rasterize
+.. _pipeline-pixel-info:
+
+pixel-info
+**********
+
+.. program-output:: gdal pipeline --help-doc=pixel-info
+
+Details for options can be found in :ref:`gdal_raster_pixel_info`.
+
+.. _pipeline-polygonize:
+
+polygonize
+**********
+
+.. program-output:: gdal pipeline --help-doc=polygonize
+
+Details for options can be found in :ref:`gdal_raster_polygonize`.
+
+.. _pipeline-rasterize:
+
+rasterize
+*********
 
 .. program-output:: gdal pipeline --help-doc=rasterize
 
 Details for options can be found in :ref:`gdal_vector_rasterize`.
 
-* tee
+.. _pipeline-tee:
+
+tee
+***
 
 .. program-output:: gdal pipeline --help-doc=tee-raster
 

--- a/doc/source/programs/gdal_raster_pipeline.rst
+++ b/doc/source/programs/gdal_raster_pipeline.rst
@@ -38,229 +38,52 @@ Each step has its own positional or non-positional arguments.
 Apart from ``read``, ``calc``, ``mosaic``, ``stack``, ``compare``, ``info``, ``tile`` and ``write``,
 all other steps can potentially be used several times in a pipeline.
 
-Potential steps are:
+Steps
+-----
 
-* read
+.. rst-class:: steps-toc
 
-.. program-output:: gdal raster pipeline --help-doc=read
+.. contents::
+    :local:
+    :depth: 1
 
-Details for options can be found in :ref:`gdal_raster_read`.
-
-* calc
-
-.. program-output:: gdal raster pipeline --help-doc=calc
-
-Details for options can be found in :ref:`gdal_raster_calc`.
-
-* create
-
-.. program-output:: gdal raster pipeline --help-doc=create
-
-Details for options can be found in :ref:`gdal_raster_create`.
-
-* mosaic
-
-.. program-output:: gdal raster pipeline --help-doc=mosaic
-
-Details for options can be found in :ref:`gdal_raster_mosaic`.
-
-* stack
-
-.. program-output:: gdal raster pipeline --help-doc=stack
-
-Details for options can be found in :ref:`gdal_raster_stack`.
-
-* aspect
+aspect
+******
 
 .. program-output:: gdal raster pipeline --help-doc=aspect
 
 Details for options can be found in :ref:`gdal_raster_aspect`.
 
-* blend
+blend
+*****
 
 .. program-output:: gdal raster pipeline --help-doc=blend
 
 Details for options can be found in :ref:`gdal_raster_blend`.
 
-* clip
+calc
+****
+
+.. program-output:: gdal raster pipeline --help-doc=calc
+
+Details for options can be found in :ref:`gdal_raster_calc`.
+
+clip
+****
 
 .. program-output:: gdal raster pipeline --help-doc=clip
 
 Details for options can be found in :ref:`gdal_raster_clip`.
 
-* color-map
+color-map
+*********
 
 .. program-output:: gdal raster pipeline --help-doc=color-map
 
 Details for options can be found in :ref:`gdal_raster_color_map`.
 
-* edit
-
-.. program-output:: gdal raster pipeline --help-doc=edit
-
-Details for options can be found in :ref:`gdal_raster_edit`.
-
-* fill-nodata
-
-.. program-output:: gdal raster pipeline --help-doc=fill-nodata
-
-Details for options can be found in :ref:`gdal_raster_fill_nodata`.
-
-* hillshade
-
-.. program-output:: gdal raster pipeline --help-doc=hillshade
-
-Details for options can be found in :ref:`gdal_raster_hillshade`.
-
-* materialize
-
-.. program-output:: gdal raster pipeline --help-doc=materialize
-
-Details for options can be found in :ref:`gdal_raster_materialize`.
-
-* neighbors
-
-.. program-output:: gdal raster pipeline --help-doc=neighbors
-
-Details for options can be found in :ref:`gdal_raster_neighbors`.
-
-* nodata-to-alpha
-
-.. program-output:: gdal raster pipeline --help-doc=nodata-to-alpha
-
-Details for options can be found in :ref:`gdal_raster_nodata_to_alpha`.
-
-* overview
-
-.. program-output:: gdal raster pipeline --help-doc=overview
-
-Details for options can be found in :ref:`gdal_raster_overview`.
-
-* pansharpen
-
-.. program-output:: gdal raster pipeline --help-doc=pansharpen
-
-Details for options can be found in :ref:`gdal_raster_pansharpen`.
-
-* proximity
-
-.. program-output:: gdal raster pipeline --help-doc=proximity
-
-Details for options can be found in :ref:`gdal_raster_proximity`.
-
-* reclassify
-
-.. program-output:: gdal raster pipeline --help-doc=reclassify
-
-Details for options can be found in :ref:`gdal_raster_reclassify`.
-
-* reproject
-
-.. program-output:: gdal raster pipeline --help-doc=reproject
-
-Details for options can be found in :ref:`gdal_raster_reproject`.
-
-* resize
-
-.. program-output:: gdal raster pipeline --help-doc=resize
-
-Details for options can be found in :ref:`gdal_raster_resize`.
-
-* rgb-to-palette
-
-.. program-output:: gdal raster pipeline --help-doc=rgb-to-palette
-
-Details for options can be found in :ref:`gdal_raster_rgb_to_palette`.
-
-* roughness
-
-.. program-output:: gdal raster pipeline --help-doc=roughness
-
-Details for options can be found in :ref:`gdal_raster_roughness`.
-
-* scale
-
-.. program-output:: gdal raster pipeline --help-doc=scale
-
-Details for options can be found in :ref:`gdal_raster_scale`.
-
-* select
-
-.. program-output:: gdal raster pipeline --help-doc=select
-
-Details for options can be found in :ref:`gdal_raster_select`.
-
-* set-type
-
-.. program-output:: gdal raster pipeline --help-doc=set-type
-
-Details for options can be found in :ref:`gdal_raster_set_type`.
-
-* sieve
-
-.. program-output:: gdal raster pipeline --help-doc=sieve
-
-Details for options can be found in :ref:`gdal_raster_sieve`.
-
-* slope
-
-.. program-output:: gdal raster pipeline --help-doc=slope
-
-Details for options can be found in :ref:`gdal_raster_slope`.
-
-* tpi
-
-.. program-output:: gdal raster pipeline --help-doc=tpi
-
-Details for options can be found in :ref:`gdal_raster_tpi`.
-
-* tri
-
-.. program-output:: gdal raster pipeline --help-doc=tri
-
-Details for options can be found in :ref:`gdal_raster_tri`.
-
-* unscale
-
-.. program-output:: gdal raster pipeline --help-doc=unscale
-
-Details for options can be found in :ref:`gdal_raster_unscale`.
-
-* update
-
-.. program-output:: gdal raster pipeline --help-doc=update
-
-Details for options can be found in :ref:`gdal_raster_update`.
-
-* viewshed
-
-.. program-output:: gdal raster pipeline --help-doc=viewshed
-
-Details for options can be found in :ref:`gdal_raster_viewshed`.
-
-* tee
-
-.. program-output:: gdal raster pipeline --help-doc=tee
-
-Details for options can be found in :ref:`gdal_output_nested_pipeline`.
-
-* info
-
-.. versionadded:: 3.12
-
-.. program-output:: gdal raster pipeline --help-doc=info
-
-Details for options can be found in :ref:`gdal_raster_info`.
-
-* tile
-
-.. versionadded:: 3.12
-
-.. program-output:: gdal raster pipeline --help-doc=tile
-
-Details for options can be found in :ref:`gdal_raster_tile`.
-
-* compare
+compare
+*******
 
 .. versionadded:: 3.12
 
@@ -268,7 +91,236 @@ Details for options can be found in :ref:`gdal_raster_tile`.
 
 Details for options can be found in :ref:`gdal_raster_compare`.
 
-* write
+create
+******
+
+.. program-output:: gdal raster pipeline --help-doc=create
+
+Details for options can be found in :ref:`gdal_raster_create`.
+
+edit
+****
+
+.. program-output:: gdal raster pipeline --help-doc=edit
+
+Details for options can be found in :ref:`gdal_raster_edit`.
+
+external
+********
+
+.. program-output:: gdal raster pipeline --help-doc=external
+
+Details for options can be found in :ref:`gdal_external`.
+
+fill-nodata
+***********
+
+.. program-output:: gdal raster pipeline --help-doc=fill-nodata
+
+Details for options can be found in :ref:`gdal_raster_fill_nodata`.
+
+hillshade
+*********
+
+.. program-output:: gdal raster pipeline --help-doc=hillshade
+
+Details for options can be found in :ref:`gdal_raster_hillshade`.
+
+info
+****
+
+.. versionadded:: 3.12
+
+.. program-output:: gdal raster pipeline --help-doc=info
+
+Details for options can be found in :ref:`gdal_raster_info`.
+
+materialize
+***********
+
+.. program-output:: gdal raster pipeline --help-doc=materialize
+
+Details for options can be found in :ref:`gdal_raster_materialize`.
+
+mosaic
+******
+
+.. program-output:: gdal raster pipeline --help-doc=mosaic
+
+Details for options can be found in :ref:`gdal_raster_mosaic`.
+
+neighbors
+*********
+
+.. program-output:: gdal raster pipeline --help-doc=neighbors
+
+Details for options can be found in :ref:`gdal_raster_neighbors`.
+
+nodata-to-alpha
+***************
+
+.. program-output:: gdal raster pipeline --help-doc=nodata-to-alpha
+
+Details for options can be found in :ref:`gdal_raster_nodata_to_alpha`.
+
+overview
+********
+
+.. program-output:: gdal raster pipeline --help-doc=overview
+
+Details for options can be found in :ref:`gdal_raster_overview`.
+
+pansharpen
+**********
+
+.. program-output:: gdal raster pipeline --help-doc=pansharpen
+
+Details for options can be found in :ref:`gdal_raster_pansharpen`.
+
+proximity
+*********
+
+.. program-output:: gdal raster pipeline --help-doc=proximity
+
+Details for options can be found in :ref:`gdal_raster_proximity`.
+
+read
+****
+
+.. program-output:: gdal raster pipeline --help-doc=read
+
+Details for options can be found in :ref:`gdal_raster_read`.
+
+reclassify
+**********
+
+.. program-output:: gdal raster pipeline --help-doc=reclassify
+
+Details for options can be found in :ref:`gdal_raster_reclassify`.
+
+reproject
+*********
+
+.. program-output:: gdal raster pipeline --help-doc=reproject
+
+Details for options can be found in :ref:`gdal_raster_reproject`.
+
+resize
+******
+
+.. program-output:: gdal raster pipeline --help-doc=resize
+
+Details for options can be found in :ref:`gdal_raster_resize`.
+
+rgb-to-palette
+**************
+
+.. program-output:: gdal raster pipeline --help-doc=rgb-to-palette
+
+Details for options can be found in :ref:`gdal_raster_rgb_to_palette`.
+
+roughness
+*********
+
+.. program-output:: gdal raster pipeline --help-doc=roughness
+
+Details for options can be found in :ref:`gdal_raster_roughness`.
+
+scale
+*****
+
+.. program-output:: gdal raster pipeline --help-doc=scale
+
+Details for options can be found in :ref:`gdal_raster_scale`.
+
+select
+******
+
+.. program-output:: gdal raster pipeline --help-doc=select
+
+Details for options can be found in :ref:`gdal_raster_select`.
+
+set-type
+********
+
+.. program-output:: gdal raster pipeline --help-doc=set-type
+
+Details for options can be found in :ref:`gdal_raster_set_type`.
+
+sieve
+*****
+
+.. program-output:: gdal raster pipeline --help-doc=sieve
+
+Details for options can be found in :ref:`gdal_raster_sieve`.
+
+slope
+*****
+
+.. program-output:: gdal raster pipeline --help-doc=slope
+
+Details for options can be found in :ref:`gdal_raster_slope`.
+
+stack
+*****
+
+.. program-output:: gdal raster pipeline --help-doc=stack
+
+Details for options can be found in :ref:`gdal_raster_stack`.
+
+tee
+***
+
+.. program-output:: gdal raster pipeline --help-doc=tee
+
+Details for options can be found in :ref:`gdal_output_nested_pipeline`.
+
+tile
+****
+
+.. versionadded:: 3.12
+
+.. program-output:: gdal raster pipeline --help-doc=tile
+
+Details for options can be found in :ref:`gdal_raster_tile`.
+
+tpi
+***
+
+.. program-output:: gdal raster pipeline --help-doc=tpi
+
+Details for options can be found in :ref:`gdal_raster_tpi`.
+
+tri
+***
+
+.. program-output:: gdal raster pipeline --help-doc=tri
+
+Details for options can be found in :ref:`gdal_raster_tri`.
+
+unscale
+*******
+
+.. program-output:: gdal raster pipeline --help-doc=unscale
+
+Details for options can be found in :ref:`gdal_raster_unscale`.
+
+update
+******
+
+.. program-output:: gdal raster pipeline --help-doc=update
+
+Details for options can be found in :ref:`gdal_raster_update`.
+
+viewshed
+********
+
+.. program-output:: gdal raster pipeline --help-doc=viewshed
+
+Details for options can be found in :ref:`gdal_raster_viewshed`.
+
+write
+*****
 
 .. program-output:: gdal raster pipeline --help-doc=write
 

--- a/doc/source/programs/gdal_vector_pipeline.rst
+++ b/doc/source/programs/gdal_vector_pipeline.rst
@@ -37,139 +37,130 @@ own positional or non-positional arguments.
 Apart from ``read``, ``concat``, ``info``, ``partition`` and ``write``,
 all other steps can potentially be used several times in a pipeline.
 
-Potential steps are:
+Steps
+-----
+.. rst-class:: steps-toc
 
-* read
+.. contents::
+    :local:
+    :depth: 1
 
-.. program-output:: gdal vector pipeline --help-doc=read
-
-Details for options can be found in :ref:`gdal_vector_read`.
-
-* buffer
+buffer
+******
 
 .. program-output:: gdal vector pipeline --help-doc=buffer
 
 Details for options can be found in :ref:`gdal_vector_buffer`.
 
-* concat
+check-coverage
+**************
 
-.. program-output:: gdal vector pipeline --help-doc=concat
+.. program-output:: gdal vector pipeline --help-doc=check-coverage
 
-Details for options can be found in :ref:`gdal_vector_concat`.
+Details for options can be found in :ref:`gdal_vector_check_coverage`.
 
-* clip
+check-geometry
+**************
+
+.. program-output:: gdal vector pipeline --help-doc=check-geometry
+
+Details for options can be found in :ref:`gdal_vector_check_geometry`.
+
+clean-coverage
+**************
+
+.. program-output:: gdal vector pipeline --help-doc=clean-coverage
+
+Details for options can be found in :ref:`gdal_vector_clean_coverage`.
+
+clip
+****
 
 .. program-output:: gdal vector pipeline --help-doc=clip
 
 Details for options can be found in :ref:`gdal_vector_clip`.
 
-* create
+combine
+*******
+
+.. program-output:: gdal vector pipeline --help-doc=combine
+
+Details for options can be found in :ref:`gdal_vector_combine`.
+
+concave-hull
+************
+
+.. program-output:: gdal vector pipeline --help-doc=concave-hull
+
+Details for options can be found in :ref:`gdal_vector_concave_hull`.
+
+concat
+******
+
+.. program-output:: gdal vector pipeline --help-doc=concat
+
+Details for options can be found in :ref:`gdal_vector_concat`.
+
+convex-hull
+***********
+
+.. program-output:: gdal vector pipeline --help-doc=convex-hull
+
+Details for options can be found in :ref:`gdal_vector_convex_hull`.
+
+create
+******
 
 .. program-output:: gdal vector pipeline --help-doc=create
 
 Details for options can be found in :ref:`gdal_vector_create`.
 
-* edit
+dissolve
+********
+
+.. program-output:: gdal vector pipeline --help-doc=dissolve
+
+Details for options can be found in :ref:`gdal_vector_dissolve`.
+
+edit
+****
 
 .. program-output:: gdal vector pipeline --help-doc=edit
 
 Details for options can be found in :ref:`gdal_vector_edit`.
 
-* explode-collections
+explode-collections
+*******************
 
 .. program-output:: gdal vector pipeline --help-doc=explode-collections
 
 Details for options can be found in :ref:`gdal_vector_explode_collections`.
 
-* filter
+export-schema
+*************
+
+.. versionadded:: 3.12
+
+.. program-output:: gdal vector pipeline --help-doc=export-schema
+
+Details for options can be found in :ref:`gdal_vector_export_schema`.
+
+external
+********
+
+.. program-output:: gdal vector pipeline --help-doc=external
+
+Details for options can be found in :ref:`gdal_external`.
+
+filter
+******
 
 .. program-output:: gdal vector pipeline --help-doc=filter
 
 Details for options can be found in :ref:`gdal_vector_filter`.
 
-* limit
-
-.. program-output:: gdal vector pipeline --help-doc=limit
-
-* make-valid
-
-.. program-output:: gdal vector pipeline --help-doc=make-valid
-
-Details for options can be found in :ref:`gdal_vector_make_valid`.
-
-* materialize
-
-.. program-output:: gdal vector pipeline --help-doc=materialize
-
-Details for options can be found in :ref:`gdal_vector_materialize`.
-
-* rename-layer
-
-.. program-output:: gdal vector pipeline --help-doc=rename-layer
-
-Details for options can be found in :ref:`gdal_vector_rename_layer`.
-
-* reproject
-
-.. program-output:: gdal vector pipeline --help-doc=reproject
-
-Details for options can be found in :ref:`gdal_vector_reproject`.
-
-* segmentize
-
-.. program-output:: gdal vector pipeline --help-doc=segmentize
-
-Details for options can be found in :ref:`gdal_vector_segmentize`.
-
-* select
-
-.. program-output:: gdal vector pipeline --help-doc=select
-
-Details for options can be found in :ref:`gdal_vector_select`.
-
-* set-field-type
-
-.. program-output:: gdal vector pipeline --help-doc=set-field-type
-
-Details for options can be found in :ref:`gdal_vector_set_field_type`.
-
-* set-geom-type
-
-.. program-output:: gdal vector pipeline --help-doc=set-geom-type
-
-Details for options can be found in :ref:`gdal_vector_set_geom_type`.
-
-* simplify
-
-.. program-output:: gdal vector pipeline --help-doc=simplify
-
-Details for options can be found in :ref:`gdal_vector_simplify`.
-
-* simplify-coverage
-
-.. program-output:: gdal vector pipeline --help-doc=simplify-coverage
-
-Details for options can be found in :ref:`gdal_vector_simplify_coverage`.
-
-* sql
-
-.. program-output:: gdal vector pipeline --help-doc=sql
-
-Details for options can be found in :ref:`gdal_vector_sql`.
-
-* update
-
-.. program-output:: gdal vector pipeline --help-doc=update
-
-Details for options can be found in :ref:`gdal_vector_update`.
-
-* swap-xy
-
-.. program-output:: gdal vector pipeline --help-doc=swap-xy
-
-Details for options can be found in :ref:`gdal_vector_swap_xy`.
-
-* info
+info
+****
 
 .. versionadded:: 3.12
 
@@ -177,7 +168,34 @@ Details for options can be found in :ref:`gdal_vector_swap_xy`.
 
 Details for options can be found in :ref:`gdal_vector_info`.
 
-* partition
+limit
+*****
+
+.. program-output:: gdal vector pipeline --help-doc=limit
+
+make-point
+**********
+
+.. program-output:: gdal vector pipeline --help-doc=make-point
+
+Details for options can be found in :ref:`gdal_vector_make_point`.
+
+make-valid
+**********
+
+.. program-output:: gdal vector pipeline --help-doc=make-valid
+
+Details for options can be found in :ref:`gdal_vector_make_valid`.
+
+materialize
+***********
+
+.. program-output:: gdal vector pipeline --help-doc=materialize
+
+Details for options can be found in :ref:`gdal_vector_materialize`.
+
+partition
+*********
 
 .. versionadded:: 3.12
 
@@ -185,7 +203,106 @@ Details for options can be found in :ref:`gdal_vector_info`.
 
 Details for options can be found in :ref:`gdal_vector_partition`.
 
-* write
+read
+****
+
+.. program-output:: gdal vector pipeline --help-doc=read
+
+Details for options can be found in :ref:`gdal_vector_read`.
+
+rename-layer
+************
+
+.. program-output:: gdal vector pipeline --help-doc=rename-layer
+
+Details for options can be found in :ref:`gdal_vector_rename_layer`.
+
+reproject
+*********
+
+.. program-output:: gdal vector pipeline --help-doc=reproject
+
+Details for options can be found in :ref:`gdal_vector_reproject`.
+
+segmentize
+**********
+
+.. program-output:: gdal vector pipeline --help-doc=segmentize
+
+Details for options can be found in :ref:`gdal_vector_segmentize`.
+
+select
+******
+
+.. program-output:: gdal vector pipeline --help-doc=select
+
+Details for options can be found in :ref:`gdal_vector_select`.
+
+set-field-type
+**************
+
+.. program-output:: gdal vector pipeline --help-doc=set-field-type
+
+Details for options can be found in :ref:`gdal_vector_set_field_type`.
+
+set-geom-type
+*************
+
+.. program-output:: gdal vector pipeline --help-doc=set-geom-type
+
+Details for options can be found in :ref:`gdal_vector_set_geom_type`.
+
+simplify
+********
+
+.. program-output:: gdal vector pipeline --help-doc=simplify
+
+Details for options can be found in :ref:`gdal_vector_simplify`.
+
+simplify-coverage
+*****************
+
+.. program-output:: gdal vector pipeline --help-doc=simplify-coverage
+
+Details for options can be found in :ref:`gdal_vector_simplify_coverage`.
+
+sort
+****
+
+.. program-output:: gdal vector pipeline --help-doc=sort
+
+Details for options can be found in :ref:`gdal_vector_sort`.
+
+sql
+***
+
+.. program-output:: gdal vector pipeline --help-doc=sql
+
+Details for options can be found in :ref:`gdal_vector_sql`.
+
+swap-xy
+*******
+
+.. program-output:: gdal vector pipeline --help-doc=swap-xy
+
+Details for options can be found in :ref:`gdal_vector_swap_xy`.
+
+tee
+***
+
+.. program-output:: gdal vector pipeline --help-doc=tee
+
+Details for options can be found in :ref:`gdal_output_nested_pipeline`.
+
+update
+******
+
+.. program-output:: gdal vector pipeline --help-doc=update
+
+Details for options can be found in :ref:`gdal_vector_update`.
+
+write
+*****
 
 .. program-output:: gdal vector pipeline --help-doc=write
 


### PR DESCRIPTION
This PR adds TOCs (tables of contents) showing the available steps for `gdal vector pipeline` and `gdal raster pipeline`, along with a combined table of mixed steps for `gdal pipeline`. This hopefully makes it easier for users to quickly see the available steps, and click on the links for further details. 

The steps have also been reordered alphabetically. For the HTML documentation, CSS has been added to display the TOCs in two columns.

See preview pages:

- [gdal pipeline](https://gdal--14688.org.readthedocs.build/en/14688/programs/gdal_pipeline.html#steps)
- [gdal raster pipeline](https://gdal--14688.org.readthedocs.build/en/14688/programs/gdal_raster_pipeline.html#steps)
- [gdal vector pipeline](https://gdal--14688.org.readthedocs.build/en/14688/programs/gdal_vector_pipeline.html#steps)

The following vector steps were missing (based on the output of `gdal vector pipeline --help`) and have now been added:

* check-coverage
* check-geometry
* clean-coverage
* combine
* concave-hull
* convex-hull
* dissolve
* export-schema
* external
* make-point
* sort
* tee

The raster steps were only missing `external`.