### PR TITLE
gdal.h: add constants for standard metadata domain names and items names

### DIFF
--- a/alg/gdal_interpolateatpoint.cpp
+++ b/alg/gdal_interpolateatpoint.cpp
@@ -93,7 +93,7 @@ bool GDALInterpExtractValuesWindow(GDALRasterBand *pBand,
                                         : BLOCK_SIZE;
 
 #if 0
-            CPLDebug("RPC", "nY=%d nX=%d nBlockY=%d nBlockX=%d "
+            CPLDebug(GDAL_MDD_RPC, "nY=%d nX=%d nBlockY=%d nBlockX=%d "
                      "nFirstLineInCachedBlock=%d nFirstLineInOutput=%d nLinesToCopy=%d "
                      "nFirstColInCachedBlock=%d nFirstColInOutput=%d nColsToCopy=%d",
                      nY, nX, nBlockY, nBlockX, nFirstLineInCachedBlock, nFirstLineInOutput, nLinesToCopy,

--- a/alg/gdal_rpc.cpp
+++ b/alg/gdal_rpc.cpp
@@ -397,7 +397,7 @@ static void RPCTransformPoint(const GDALRPCTransformInfo *psRPCTransformInfo,
         {
             bWarned = true;
             CPLDebug(
-                "RPC",
+                GDAL_MDD_RPC,
                 "Normalized %s for (lon,lat,height)=(%f,%f,%f) is %f, "
                 "i.e. with an absolute value of > 1, which may cause numeric "
                 "stability problems",
@@ -407,7 +407,7 @@ static void RPCTransformPoint(const GDALRPCTransformInfo *psRPCTransformInfo,
         {
             bWarned = true;
             CPLDebug(
-                "RPC",
+                GDAL_MDD_RPC,
                 "Normalized %s for (lon,lat,height)=(%f,%f,%f) is %f, "
                 "ie with an absolute value of > 1, which may cause numeric "
                 "stability problems",
@@ -417,7 +417,7 @@ static void RPCTransformPoint(const GDALRPCTransformInfo *psRPCTransformInfo,
         {
             bWarned = true;
             CPLDebug(
-                "RPC",
+                GDAL_MDD_RPC,
                 "Normalized %s for (lon,lat,height)=(%f,%f,%f) is %f, "
                 "i.e. with an absolute value of > 1, which may cause numeric "
                 "stability problems",
@@ -430,7 +430,8 @@ static void RPCTransformPoint(const GDALRPCTransformInfo *psRPCTransformInfo,
             if (nCountWarningsAboutAboveOneNormalizedValues ==
                 MAX_ABS_VALUE_WARNINGS)
             {
-                CPLDebug("RPC", "No more such debug warnings will be emitted");
+                CPLDebug(GDAL_MDD_RPC,
+                         "No more such debug warnings will be emitted");
             }
         }
     }
@@ -728,7 +729,7 @@ void *GDALCreateRPCTransformerV1(GDALRPCInfoV1 *psRPCInfo, int bReversed,
  *
  * Debugging of the RPC inverse transformer can be done
  * by setting the RPC_INVERSE_VERBOSE configuration option to YES (in which case
- * extra debug information will be displayed in the "RPC" debug category, so
+ * extra debug information will be displayed in the GDAL_MDD_RPC debug category, so
  * requiring CPL_DEBUG to be also set) and/or by setting RPC_INVERSE_LOG to a
  * filename that will contain the content of iterations (this last option only
  * makes sense when debugging point by point, since each time
@@ -903,7 +904,8 @@ void *GDALCreateRPCTransformerV2(const GDALRPCInfoV2 *psRPCInfo, int bReversed,
     }
     else
     {
-        CPLDebug("RPC", "Unknown interpolation %s. Defaulting to bilinear",
+        CPLDebug(GDAL_MDD_RPC,
+                 "Unknown interpolation %s. Defaulting to bilinear",
                  pszDEMInterpolation);
         psTransform->eResampleAlg = DRA_Bilinear;
     }
@@ -1149,7 +1151,8 @@ static bool RPCInverseTransformPoint(GDALRPCTransformInfo *psTransform,
 
     if (psTransform->bRPCInverseVerbose)
     {
-        CPLDebug("RPC", "Computing inverse transform for (pixel,line)=(%f,%f)",
+        CPLDebug(GDAL_MDD_RPC,
+                 "Computing inverse transform for (pixel,line)=(%f,%f)",
                  dfPixel, dfLine);
     }
     VSILFILE *fpLog = nullptr;
@@ -1203,8 +1206,8 @@ static bool RPCInverseTransformPoint(GDALRPCTransformInfo *psTransform,
         {
             if (psTransform->poDS)
             {
-                CPLDebug("RPC", "DEM (pixel, line) = (%g, %g)", dfDEMPixel,
-                         dfDEMLine);
+                CPLDebug(GDAL_MDD_RPC, "DEM (pixel, line) = (%g, %g)",
+                         dfDEMPixel, dfDEMLine);
             }
 
             // The first time, the guess might be completely out of the
@@ -1227,7 +1230,7 @@ static bool RPCInverseTransformPoint(GDALRPCTransformInfo *psTransform,
                                             &dfDEMH))
                     {
                         bUseRefZ = false;
-                        CPLDebug("RPC",
+                        CPLDebug(GDAL_MDD_RPC,
                                  "Iteration %d for (pixel, line) = (%g, %g): "
                                  "No elevation value at %.15g %.15g. "
                                  "Using elevation %g at DEM (pixel, line) = "
@@ -1239,7 +1242,7 @@ static bool RPCInverseTransformPoint(GDALRPCTransformInfo *psTransform,
                 if (bUseRefZ)
                 {
                     dfDEMH = psTransform->dfRefZ;
-                    CPLDebug("RPC",
+                    CPLDebug(GDAL_MDD_RPC,
                              "Iteration %d for (pixel, line) = (%g, %g): "
                              "No elevation value at %.15g %.15g. "
                              "Using elevation %g of reference point instead",
@@ -1249,7 +1252,7 @@ static bool RPCInverseTransformPoint(GDALRPCTransformInfo *psTransform,
             }
             else
             {
-                CPLDebug("RPC",
+                CPLDebug(GDAL_MDD_RPC,
                          "Iteration %d for (pixel, line) = (%g, %g): "
                          "No elevation value at %.15g %.15g. Erroring out",
                          iIter, dfPixel, dfLine, dfResultX, dfResultY);
@@ -1267,7 +1270,7 @@ static bool RPCInverseTransformPoint(GDALRPCTransformInfo *psTransform,
 
         if (psTransform->bRPCInverseVerbose)
         {
-            CPLDebug("RPC",
+            CPLDebug(GDAL_MDD_RPC,
                      "Iter %d: dfPixelDeltaX=%.02f, dfPixelDeltaY=%.02f, "
                      "long=%f, lat=%f, height=%f",
                      iIter, dfPixelDeltaX, dfPixelDeltaY, dfResultX, dfResultY,
@@ -1288,7 +1291,7 @@ static bool RPCInverseTransformPoint(GDALRPCTransformInfo *psTransform,
             iIter = -1;
             if (psTransform->bRPCInverseVerbose)
             {
-                CPLDebug("RPC", "Converged!");
+                CPLDebug(GDAL_MDD_RPC, "Converged!");
             }
             break;
         }
@@ -1300,7 +1303,7 @@ static bool RPCInverseTransformPoint(GDALRPCTransformInfo *psTransform,
             // oscillate forever, so take a mean position as a new guess.
             if (psTransform->bRPCInverseVerbose)
             {
-                CPLDebug("RPC",
+                CPLDebug(GDAL_MDD_RPC,
                          "Oscillation detected. "
                          "Taking mean of 2 previous results as new guess");
             }
@@ -1326,7 +1329,7 @@ static bool RPCInverseTransformPoint(GDALRPCTransformInfo *psTransform,
             dfBoostFactor = 10;
             if (psTransform->bRPCInverseVerbose)
             {
-                CPLDebug("RPC", "Applying boost factor 10");
+                CPLDebug(GDAL_MDD_RPC, "Applying boost factor 10");
             }
         }
 
@@ -1361,8 +1364,9 @@ static bool RPCInverseTransformPoint(GDALRPCTransformInfo *psTransform,
 
     if (iIter != -1)
     {
-        CPLDebug("RPC", "Failed Iterations %d: Got: %.16g,%.16g  Offset=%g,%g",
-                 iIter, dfResultX, dfResultY, dfPixelDeltaX, dfPixelDeltaY);
+        CPLDebug(GDAL_MDD_RPC,
+                 "Failed Iterations %d: Got: %.16g,%.16g  Offset=%g,%g", iIter,
+                 dfResultX, dfResultY, dfPixelDeltaX, dfPixelDeltaY);
         return false;
     }
 
@@ -1772,7 +1776,7 @@ static bool GDALRPCOpenDEM(GDALRPCTransformInfo *psTransform)
                     fabs(adfX[5] - dfRefLong) < 1.0e-12 &&
                     fabs(adfY[5] - dfRefLat) < 1.0e-12)
                 {
-                    CPLDebug("RPC",
+                    CPLDebug(GDAL_MDD_RPC,
                              "Short-circuiting coordinate transformation "
                              "from DEM SRS to WGS 84 due to apparent nop");
                     delete psTransform->poCT;
@@ -1909,7 +1913,7 @@ int GDALRPCTransform(void *pTransformArg, int bDstToSrc, int nPointCount,
                     if (!bOnce)
                     {
                         bOnce = true;
-                        CPLDebug("RPC",
+                        CPLDebug(GDAL_MDD_RPC,
                                  "Using GDALRPCTransformWholeLineWithDEM");
                     }
                     return GDALRPCTransformWholeLineWithDEM(

--- a/alg/gdalgeoloc.cpp
+++ b/alg/gdalgeoloc.cpp
@@ -1672,7 +1672,8 @@ CPLStringList GDALCreateGeolocationMetadata(GDALDatasetH hBaseDS,
     }
 
     // Import the GEOLOCATION metadata from the geolocation dataset, if existing
-    auto papszGeolocMDFromGeolocDS = poGeolocDS->GetMetadata("GEOLOCATION");
+    auto papszGeolocMDFromGeolocDS =
+        poGeolocDS->GetMetadata(GDAL_MDD_GEOLOCATION);
     if (papszGeolocMDFromGeolocDS)
         aosMD = CSLDuplicate(papszGeolocMDFromGeolocDS);
 

--- a/alg/gdalpansharpen.cpp
+++ b/alg/gdalpansharpen.cpp
@@ -440,11 +440,11 @@ GDALPansharpenOperation::Initialize(const GDALPansharpenOptions *psOptionsIn)
                     return CE_Failure;
                 aMSBands[i] = poVRTBand;
                 poVRTBand->SetNoDataValue(psOptions->dfNoData);
-                const char *pszNBITS =
-                    poSrcBand->GetMetadataItem("NBITS", "IMAGE_STRUCTURE");
+                const char *pszNBITS = poSrcBand->GetMetadataItem(
+                    "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
                 if (pszNBITS)
                     poVRTBand->SetMetadataItem("NBITS", pszNBITS,
-                                               "IMAGE_STRUCTURE");
+                                               GDAL_MDD_IMAGE_STRUCTURE);
 
                 VRTSimpleSource *poSimpleSource = new VRTSimpleSource();
                 poVRTBand->ConfigureSource(
@@ -1306,10 +1306,10 @@ CPLErr GDALPansharpenOperation::ProcessRegion(int nXOff, int nYOff, int nXSize,
             poMEMDS->AddMEMBand(hMEMBand);
 
             const char *pszNBITS =
-                aMSBands[i]->GetMetadataItem("NBITS", "IMAGE_STRUCTURE");
+                aMSBands[i]->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
             if (pszNBITS)
                 poMEMDS->GetRasterBand(i + 1)->SetMetadataItem(
-                    "NBITS", pszNBITS, "IMAGE_STRUCTURE");
+                    "NBITS", pszNBITS, GDAL_MDD_IMAGE_STRUCTURE);
 
             if (psOptions->bHasNoData)
                 poMEMDS->GetRasterBand(i + 1)->SetNoDataValue(
@@ -1484,7 +1484,7 @@ CPLErr GDALPansharpenOperation::ProcessRegion(int nXOff, int nYOff, int nXSize,
             GDALRasterBand *poBand = aMSBands[i];
             int nBandBitDepth = 0;
             const char *pszNBITS =
-                poBand->GetMetadataItem("NBITS", "IMAGE_STRUCTURE");
+                poBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
             if (pszNBITS)
                 nBandBitDepth = atoi(pszNBITS);
             if (nBandBitDepth < nBitDepth)

--- a/alg/gdalpansharpen.cpp
+++ b/alg/gdalpansharpen.cpp
@@ -441,9 +441,9 @@ GDALPansharpenOperation::Initialize(const GDALPansharpenOptions *psOptionsIn)
                 aMSBands[i] = poVRTBand;
                 poVRTBand->SetNoDataValue(psOptions->dfNoData);
                 const char *pszNBITS = poSrcBand->GetMetadataItem(
-                    "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+                    GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
                 if (pszNBITS)
-                    poVRTBand->SetMetadataItem("NBITS", pszNBITS,
+                    poVRTBand->SetMetadataItem(GDALMD_NBITS, pszNBITS,
                                                GDAL_MDD_IMAGE_STRUCTURE);
 
                 VRTSimpleSource *poSimpleSource = new VRTSimpleSource();
@@ -1305,11 +1305,11 @@ CPLErr GDALPansharpenOperation::ProcessRegion(int nXOff, int nYOff, int nXSize,
                 poMEMDS, i + 1, pabyBuffer, eWorkDataType, 0, 0, false);
             poMEMDS->AddMEMBand(hMEMBand);
 
-            const char *pszNBITS =
-                aMSBands[i]->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+            const char *pszNBITS = aMSBands[i]->GetMetadataItem(
+                GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
             if (pszNBITS)
                 poMEMDS->GetRasterBand(i + 1)->SetMetadataItem(
-                    "NBITS", pszNBITS, GDAL_MDD_IMAGE_STRUCTURE);
+                    GDALMD_NBITS, pszNBITS, GDAL_MDD_IMAGE_STRUCTURE);
 
             if (psOptions->bHasNoData)
                 poMEMDS->GetRasterBand(i + 1)->SetNoDataValue(
@@ -1484,7 +1484,7 @@ CPLErr GDALPansharpenOperation::ProcessRegion(int nXOff, int nYOff, int nXSize,
             GDALRasterBand *poBand = aMSBands[i];
             int nBandBitDepth = 0;
             const char *pszNBITS =
-                poBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+                poBand->GetMetadataItem(GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
             if (pszNBITS)
                 nBandBitDepth = atoi(pszNBITS);
             if (nBandBitDepth < nBitDepth)

--- a/alg/gdalrasterize.cpp
+++ b/alg/gdalrasterize.cpp
@@ -1107,7 +1107,7 @@ static CPLErr GDALRasterizeGeometriesInternal(
         CPLStringList aosTransformerOptions;
         GDALGeoTransform gt;
         if (poDS->GetGeoTransform(gt) != CE_None && poDS->GetGCPCount() == 0 &&
-            poDS->GetMetadata("RPC") == nullptr)
+            poDS->GetMetadata(GDAL_MDD_RPC) == nullptr)
         {
             aosTransformerOptions.SetNameValue("DST_METHOD", "NO_GEOTRANSFORM");
         }
@@ -1696,7 +1696,7 @@ CPLErr GDALRasterizeLayers(GDALDatasetH hDS, int nBandCount, int *panBandList,
             {
                 if (poDS->GetSpatialRef() != nullptr ||
                     poDS->GetGCPSpatialRef() != nullptr ||
-                    poDS->GetMetadata("RPC") != nullptr)
+                    poDS->GetMetadata(GDAL_MDD_RPC) != nullptr)
                 {
                     CPLError(
                         CE_Warning, CPLE_AppDefined,
@@ -1716,7 +1716,8 @@ CPLErr GDALRasterizeLayers(GDALDatasetH hDS, int nBandCount, int *panBandList,
                 aosTransformerOptions.SetNameValue("SRC_SRS", pszProjection);
             GDALGeoTransform gt;
             if (poDS->GetGeoTransform(gt) != CE_None &&
-                poDS->GetGCPCount() == 0 && poDS->GetMetadata("RPC") == nullptr)
+                poDS->GetGCPCount() == 0 &&
+                poDS->GetMetadata(GDAL_MDD_RPC) == nullptr)
             {
                 aosTransformerOptions.SetNameValue("DST_METHOD",
                                                    "NO_GEOTRANSFORM");

--- a/alg/gdaltransformer.cpp
+++ b/alg/gdaltransformer.cpp
@@ -2539,7 +2539,8 @@ void *GDALCreateGenImgProjTransformer2(GDALDatasetH hSrcDS, GDALDatasetH hDstDS,
         }
 
         else if ((pszMethod == nullptr || EQUAL(pszMethod, "GEOLOC_ARRAY")) &&
-                 ((papszMD = GDALGetMetadata(hDS, "GEOLOCATION")) != nullptr ||
+                 ((papszMD = GDALGetMetadata(hDS, GDAL_MDD_GEOLOCATION)) !=
+                      nullptr ||
                   pszGeolocArray != nullptr))
         {
             CPLStringList aosGeolocMD;  // keep in this scope

--- a/alg/gdaltransformer.cpp
+++ b/alg/gdaltransformer.cpp
@@ -2507,8 +2507,8 @@ void *GDALCreateGenImgProjTransformer2(GDALDatasetH hSrcDS, GDALDatasetH hDstDS,
             part.pTransformer = GDALTPSTransform;
         }
 
-        else if ((pszMethod == nullptr || EQUAL(pszMethod, "RPC")) &&
-                 (papszMD = GDALGetMetadata(hDS, "RPC")) != nullptr &&
+        else if ((pszMethod == nullptr || EQUAL(pszMethod, GDAL_MDD_RPC)) &&
+                 (papszMD = GDALGetMetadata(hDS, GDAL_MDD_RPC)) != nullptr &&
                  GDALExtractRPCInfoV2(papszMD, &sRPCInfo))
         {
             CPLStringList aosOptions(papszOptions);

--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -473,7 +473,7 @@ static void SetAlphaMax(GDALWarpOptions *psOptions, GDALRasterBandH hBand,
                         const char *pszKey)
 {
     const char *pszNBits =
-        GDALGetMetadataItem(hBand, "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+        GDALGetMetadataItem(hBand, GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
     const char *pszAlphaMax = nullptr;
     if (pszNBits)
     {

--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -473,7 +473,7 @@ static void SetAlphaMax(GDALWarpOptions *psOptions, GDALRasterBandH hBand,
                         const char *pszKey)
 {
     const char *pszNBits =
-        GDALGetMetadataItem(hBand, "NBITS", "IMAGE_STRUCTURE");
+        GDALGetMetadataItem(hBand, "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
     const char *pszAlphaMax = nullptr;
     if (pszNBits)
     {

--- a/apps/gdal_footprint_lib.cpp
+++ b/apps/gdal_footprint_lib.cpp
@@ -1349,7 +1349,7 @@ GDALDatasetH GDALFootprint(const char *pszDest, GDALDatasetH hDstDS,
     {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "Input dataset has no raster band.%s",
-                 poSrcDS->GetMetadata("SUBDATASETS")
+                 poSrcDS->GetMetadata(GDAL_MDD_SUBDATASETS)
                      ? " You need to specify one subdataset."
                      : "");
         GDALFootprintOptionsFree(psOptionsToFree);

--- a/apps/gdal_rasterize_lib.cpp
+++ b/apps/gdal_rasterize_lib.cpp
@@ -538,7 +538,7 @@ static CPLErr ProcessLayer(OGRLayerH hSrcLayer, bool bSRSIsSet,
 
         if (hDstSRS)
             hDstSRS = OSRClone(hDstSRS);
-        else if (GDALGetMetadata(hDstDS, "RPC") != nullptr)
+        else if (GDALGetMetadata(hDstDS, GDAL_MDD_RPC) != nullptr)
         {
             hDstSRS = OSRNewSpatialReference(nullptr);
             CPL_IGNORE_RET_VAL(
@@ -774,7 +774,7 @@ static CPLErr ProcessLayer(OGRLayerH hSrcLayer, bool bSRSIsSet,
         CPLStringList aosTransformerOptions(CSLDuplicate(papszTO));
         GDALGeoTransform gt;
         if (poDS->GetGeoTransform(gt) != CE_None && poDS->GetGCPCount() == 0 &&
-            poDS->GetMetadata("RPC") == nullptr)
+            poDS->GetMetadata(GDAL_MDD_RPC) == nullptr)
         {
             aosTransformerOptions.SetNameValue("DST_METHOD", "NO_GEOTRANSFORM");
         }

--- a/apps/gdal_translate_bin.cpp
+++ b/apps/gdal_translate_bin.cpp
@@ -167,7 +167,7 @@ MAIN_START(argc, argv)
     /* -------------------------------------------------------------------- */
     if (!sOptionsForBinary.bCopySubDatasets &&
         GDALGetRasterCount(hDataset) == 0 &&
-        CSLCount(GDALGetMetadata(hDataset, "SUBDATASETS")) > 0 &&
+        CSLCount(GDALGetMetadata(hDataset, GDAL_MDD_SUBDATASETS)) > 0 &&
         // S104 and S111 drivers know how to handle a source dataset with subdatasets
         // and no input bands.
         !EQUAL(sOptionsForBinary.osFormat.c_str(), "S104") &&
@@ -207,7 +207,7 @@ MAIN_START(argc, argv)
          nullptr);
 
     if (sOptionsForBinary.bCopySubDatasets &&
-        CSLCount(GDALGetMetadata(hDataset, "SUBDATASETS")) > 0)
+        CSLCount(GDALGetMetadata(hDataset, GDAL_MDD_SUBDATASETS)) > 0)
     {
         if (bCopyCreateSubDatasets)
         {
@@ -220,7 +220,7 @@ MAIN_START(argc, argv)
         else
         {
             CSLConstList papszSubdatasets =
-                GDALGetMetadata(hDataset, "SUBDATASETS");
+                GDALGetMetadata(hDataset, GDAL_MDD_SUBDATASETS);
             const int nSubdatasets = CSLCount(papszSubdatasets) / 2;
             char *pszSubDest = static_cast<char *>(
                 CPLMalloc(strlen(sOptionsForBinary.osDest.c_str()) + 32));

--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -1823,9 +1823,9 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
         if (papszMD != nullptr)
             poVDS->SetMetadata(papszMD, GDAL_MDD_RPC);
 
-        papszMD = poSrcDS->GetMetadata("GEOLOCATION");
+        papszMD = poSrcDS->GetMetadata(GDAL_MDD_GEOLOCATION);
         if (papszMD != nullptr)
-            poVDS->SetMetadata(papszMD, "GEOLOCATION");
+            poVDS->SetMetadata(papszMD, GDAL_MDD_GEOLOCATION);
     }
     else
     {

--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -1756,11 +1756,11 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
                                GDAL_MDD_IMAGE_STRUCTURE);
 
     {
-        const char *pszCompression =
-            poSrcDS->GetMetadataItem("COMPRESSION", GDAL_MDD_IMAGE_STRUCTURE);
+        const char *pszCompression = poSrcDS->GetMetadataItem(
+            GDALMD_COMPRESSION, GDAL_MDD_IMAGE_STRUCTURE);
         if (pszCompression)
         {
-            poVDS->SetMetadataItem("COMPRESSION", pszCompression,
+            poVDS->SetMetadataItem(GDALMD_COMPRESSION, pszCompression,
                                    GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
@@ -2185,11 +2185,11 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
             }
         }
 
-        const char *pszCompression =
-            poSrcBand->GetMetadataItem("COMPRESSION", GDAL_MDD_IMAGE_STRUCTURE);
+        const char *pszCompression = poSrcBand->GetMetadataItem(
+            GDALMD_COMPRESSION, GDAL_MDD_IMAGE_STRUCTURE);
         if (pszCompression)
         {
-            poVRTBand->SetMetadataItem("COMPRESSION", pszCompression,
+            poVRTBand->SetMetadataItem(GDALMD_COMPRESSION, pszCompression,
                                        GDAL_MDD_IMAGE_STRUCTURE);
         }
 

--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -1750,9 +1750,9 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
                          psOptions->aosDomainMetadataOptions);
 
     const char *pszInterleave =
-        poSrcDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
+        poSrcDS->GetMetadataItem(GDALMD_INTERLEAVE, GDAL_MDD_IMAGE_STRUCTURE);
     if (pszInterleave)
-        poVDS->SetMetadataItem("INTERLEAVE", pszInterleave,
+        poVDS->SetMetadataItem(GDALMD_INTERLEAVE, pszInterleave,
                                GDAL_MDD_IMAGE_STRUCTURE);
 
     {

--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -1750,17 +1750,18 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
                          psOptions->aosDomainMetadataOptions);
 
     const char *pszInterleave =
-        poSrcDS->GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE");
+        poSrcDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
     if (pszInterleave)
-        poVDS->SetMetadataItem("INTERLEAVE", pszInterleave, "IMAGE_STRUCTURE");
+        poVDS->SetMetadataItem("INTERLEAVE", pszInterleave,
+                               GDAL_MDD_IMAGE_STRUCTURE);
 
     {
         const char *pszCompression =
-            poSrcDS->GetMetadataItem("COMPRESSION", "IMAGE_STRUCTURE");
+            poSrcDS->GetMetadataItem("COMPRESSION", GDAL_MDD_IMAGE_STRUCTURE);
         if (pszCompression)
         {
             poVDS->SetMetadataItem("COMPRESSION", pszCompression,
-                                   "IMAGE_STRUCTURE");
+                                   GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
 
@@ -2157,13 +2158,14 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
 
         // Preserve NBITS if no option change values
         const char *pszNBits =
-            poSrcBand->GetMetadataItem("NBITS", "IMAGE_STRUCTURE");
+            poSrcBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
         if (pszNBits && psOptions->nRGBExpand == 0 &&
             psOptions->asScaleParams.empty() && !psOptions->bUnscale &&
             psOptions->eOutputType == GDT_Unknown &&
             psOptions->osResampling.empty())
         {
-            poVRTBand->SetMetadataItem("NBITS", pszNBits, "IMAGE_STRUCTURE");
+            poVRTBand->SetMetadataItem("NBITS", pszNBits,
+                                       GDAL_MDD_IMAGE_STRUCTURE);
         }
 
         // Preserve PIXELTYPE if no option change values
@@ -2173,22 +2175,22 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
             psOptions->osResampling.empty())
         {
             poSrcBand->EnablePixelTypeSignedByteWarning(false);
-            const char *pszPixelType =
-                poSrcBand->GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
+            const char *pszPixelType = poSrcBand->GetMetadataItem(
+                "PIXELTYPE", GDAL_MDD_IMAGE_STRUCTURE);
             poSrcBand->EnablePixelTypeSignedByteWarning(true);
             if (pszPixelType)
             {
                 poVRTBand->SetMetadataItem("PIXELTYPE", pszPixelType,
-                                           "IMAGE_STRUCTURE");
+                                           GDAL_MDD_IMAGE_STRUCTURE);
             }
         }
 
         const char *pszCompression =
-            poSrcBand->GetMetadataItem("COMPRESSION", "IMAGE_STRUCTURE");
+            poSrcBand->GetMetadataItem("COMPRESSION", GDAL_MDD_IMAGE_STRUCTURE);
         if (pszCompression)
         {
             poVRTBand->SetMetadataItem("COMPRESSION", pszCompression,
-                                       "IMAGE_STRUCTURE");
+                                       GDAL_MDD_IMAGE_STRUCTURE);
         }
 
         /* --------------------------------------------------------------------
@@ -2466,8 +2468,8 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
                 poVRTBand->GetRasterDataType() == GDT_UInt8)
             {
                 poVRTBand->EnablePixelTypeSignedByteWarning(false);
-                pszPixelType =
-                    poVRTBand->GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
+                pszPixelType = poVRTBand->GetMetadataItem(
+                    "PIXELTYPE", GDAL_MDD_IMAGE_STRUCTURE);
                 poVRTBand->EnablePixelTypeSignedByteWarning(true);
             }
 

--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -1819,9 +1819,9 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
     /* -------------------------------------------------------------------- */
     if (bSpatialArrangementPreserved)
     {
-        CSLConstList papszMD = poSrcDS->GetMetadata("RPC");
+        CSLConstList papszMD = poSrcDS->GetMetadata(GDAL_MDD_RPC);
         if (papszMD != nullptr)
-            poVDS->SetMetadata(papszMD, "RPC");
+            poVDS->SetMetadata(papszMD, GDAL_MDD_RPC);
 
         papszMD = poSrcDS->GetMetadata("GEOLOCATION");
         if (papszMD != nullptr)
@@ -1829,7 +1829,7 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
     }
     else
     {
-        CPLStringList aosMD(poSrcDSOri->GetMetadata("RPC"));
+        CPLStringList aosMD(poSrcDSOri->GetMetadata(GDAL_MDD_RPC));
         if (!aosMD.empty())
         {
             double dfSAMP_OFF =
@@ -1878,7 +1878,7 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
             osField.Printf("%.15g", dfSAMP_SCALE);
             aosMD.SetNameValue("SAMP_SCALE", osField);
 
-            poVDS->SetMetadata(aosMD.List(), "RPC");
+            poVDS->SetMetadata(aosMD.List(), GDAL_MDD_RPC);
         }
     }
 

--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -2158,13 +2158,13 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
 
         // Preserve NBITS if no option change values
         const char *pszNBits =
-            poSrcBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+            poSrcBand->GetMetadataItem(GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
         if (pszNBits && psOptions->nRGBExpand == 0 &&
             psOptions->asScaleParams.empty() && !psOptions->bUnscale &&
             psOptions->eOutputType == GDT_Unknown &&
             psOptions->osResampling.empty())
         {
-            poVRTBand->SetMetadataItem("NBITS", pszNBits,
+            poVRTBand->SetMetadataItem(GDALMD_NBITS, pszNBits,
                                        GDAL_MDD_IMAGE_STRUCTURE);
         }
 

--- a/apps/gdalalg_abstract_pipeline.cpp
+++ b/apps/gdalalg_abstract_pipeline.cpp
@@ -243,7 +243,7 @@ static int GetDatasetType(GDALDataset *poDS)
 
     if (poDS->GetLayerCount() == 0 &&
         (poDS->GetRasterCount() > 0 ||
-         poDS->GetMetadata("SUBDATASETS") != nullptr))
+         poDS->GetMetadata(GDAL_MDD_SUBDATASETS) != nullptr))
     {
         return GDAL_OF_RASTER;
     }

--- a/apps/gdalalg_dataset_check.cpp
+++ b/apps/gdalalg_dataset_check.cpp
@@ -63,7 +63,7 @@ bool GDALDatasetCheckAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
     const CPLStringList aosAllowedDrivers(m_inputFormats);
 
     const CPLStringList aosSubdatasets(
-        CSLDuplicate(poDS->GetMetadata("SUBDATASETS")));
+        CSLDuplicate(poDS->GetMetadata(GDAL_MDD_SUBDATASETS)));
     const int nSubdatasets = aosSubdatasets.size() / 2;
 
     bool bRet = true;

--- a/apps/gdalalg_dataset_check.cpp
+++ b/apps/gdalalg_dataset_check.cpp
@@ -425,7 +425,7 @@ bool GDALDatasetCheckAlgorithm::CheckDataset(GDALDataset *poDS,
         const auto nDTSize = GDALGetDataTypeSizeBytes(eDT);
         constexpr size_t BUFFER_SIZE = 10 * 1024 * 1024;
         const char *pszInterleaving =
-            poDS->GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE");
+            poDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
         if (pszInterleaving && EQUAL(pszInterleaving, "PIXEL"))
         {
             for (const auto &oWindow :

--- a/apps/gdalalg_dataset_check.cpp
+++ b/apps/gdalalg_dataset_check.cpp
@@ -425,7 +425,7 @@ bool GDALDatasetCheckAlgorithm::CheckDataset(GDALDataset *poDS,
         const auto nDTSize = GDALGetDataTypeSizeBytes(eDT);
         constexpr size_t BUFFER_SIZE = 10 * 1024 * 1024;
         const char *pszInterleaving =
-            poDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
+            poDS->GetMetadataItem(GDALMD_INTERLEAVE, GDAL_MDD_IMAGE_STRUCTURE);
         if (pszInterleaving && EQUAL(pszInterleaving, "PIXEL"))
         {
             for (const auto &oWindow :

--- a/apps/gdalalg_dataset_identify.cpp
+++ b/apps/gdalalg_dataset_identify.cpp
@@ -145,8 +145,8 @@ bool GDALDatasetIdentifyAlgorithm::Process(const char *pszTarget,
         {
             if (EQUAL(pszDriverName, "GTiff"))
             {
-                if (const char *pszLayout =
-                        poDS->GetMetadataItem("LAYOUT", "IMAGE_STRUCTURE"))
+                if (const char *pszLayout = poDS->GetMetadataItem(
+                        "LAYOUT", GDAL_MDD_IMAGE_STRUCTURE))
                 {
                     osLayout = pszLayout;
                 }

--- a/apps/gdalalg_raster_blend.cpp
+++ b/apps/gdalalg_raster_blend.cpp
@@ -756,7 +756,7 @@ BlendDataset::BlendDataset(GDALDataset &oColorDS, GDALDataset &oOverlayDS,
                               m_oOverlayDS.GetDescription()));
     if (nBands > 1)
     {
-        SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     if (bCanCreateOvr)

--- a/apps/gdalalg_raster_blend.cpp
+++ b/apps/gdalalg_raster_blend.cpp
@@ -756,7 +756,7 @@ BlendDataset::BlendDataset(GDALDataset &oColorDS, GDALDataset &oOverlayDS,
                               m_oOverlayDS.GetDescription()));
     if (nBands > 1)
     {
-        SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     if (bCanCreateOvr)

--- a/apps/gdalalg_raster_compare.cpp
+++ b/apps/gdalalg_raster_compare.cpp
@@ -679,9 +679,9 @@ void GDALRasterCompareAlgorithm::DatasetComparison(
 
     if (!m_skipGeolocation)
     {
-        MetadataComparison(aosReport, "GEOLOCATION",
-                           poRefDS->GetMetadata("GEOLOCATION"),
-                           poInputDS->GetMetadata("GEOLOCATION"));
+        MetadataComparison(aosReport, GDAL_MDD_GEOLOCATION,
+                           poRefDS->GetMetadata(GDAL_MDD_GEOLOCATION),
+                           poInputDS->GetMetadata(GDAL_MDD_GEOLOCATION));
     }
 
     if (!ret)

--- a/apps/gdalalg_raster_compare.cpp
+++ b/apps/gdalalg_raster_compare.cpp
@@ -1313,10 +1313,11 @@ bool GDALRasterCompareAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
     }
 
     CSLConstList papszSubDSRef =
-        m_skipSubdataset ? nullptr : poRefDS->GetMetadata("SUBDATASETS");
+        m_skipSubdataset ? nullptr : poRefDS->GetMetadata(GDAL_MDD_SUBDATASETS);
     const int nCountRef = CSLCount(papszSubDSRef) / 2;
     CSLConstList papszSubDSInput =
-        m_skipSubdataset ? nullptr : poInputDS->GetMetadata("SUBDATASETS");
+        m_skipSubdataset ? nullptr
+                         : poInputDS->GetMetadata(GDAL_MDD_SUBDATASETS);
     const int nCountInput = CSLCount(papszSubDSInput) / 2;
 
     if (!m_skipSubdataset)

--- a/apps/gdalalg_raster_compare.cpp
+++ b/apps/gdalalg_raster_compare.cpp
@@ -693,10 +693,10 @@ void GDALRasterCompareAlgorithm::DatasetComparison(
     // bands as this could be extremely slow
     if (nBands > 10)
     {
-        const char *pszRefInterleave =
-            poRefDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
-        const char *pszInputInterleave =
-            poInputDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
+        const char *pszRefInterleave = poRefDS->GetMetadataItem(
+            GDALMD_INTERLEAVE, GDAL_MDD_IMAGE_STRUCTURE);
+        const char *pszInputInterleave = poInputDS->GetMetadataItem(
+            GDALMD_INTERLEAVE, GDAL_MDD_IMAGE_STRUCTURE);
         if ((pszRefInterleave && EQUAL(pszRefInterleave, "PIXEL")) ||
             (pszInputInterleave && EQUAL(pszInputInterleave, "PIXEL")))
         {

--- a/apps/gdalalg_raster_compare.cpp
+++ b/apps/gdalalg_raster_compare.cpp
@@ -694,9 +694,9 @@ void GDALRasterCompareAlgorithm::DatasetComparison(
     if (nBands > 10)
     {
         const char *pszRefInterleave =
-            poRefDS->GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE");
+            poRefDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
         const char *pszInputInterleave =
-            poInputDS->GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE");
+            poInputDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
         if ((pszRefInterleave && EQUAL(pszRefInterleave, "PIXEL")) ||
             (pszInputInterleave && EQUAL(pszInputInterleave, "PIXEL")))
         {

--- a/apps/gdalalg_raster_compare.cpp
+++ b/apps/gdalalg_raster_compare.cpp
@@ -672,8 +672,9 @@ void GDALRasterCompareAlgorithm::DatasetComparison(
 
     if (!m_skipRPC)
     {
-        MetadataComparison(aosReport, "RPC", poRefDS->GetMetadata("RPC"),
-                           poInputDS->GetMetadata("RPC"));
+        MetadataComparison(aosReport, GDAL_MDD_RPC,
+                           poRefDS->GetMetadata(GDAL_MDD_RPC),
+                           poInputDS->GetMetadata(GDAL_MDD_RPC));
     }
 
     if (!m_skipGeolocation)
@@ -1248,7 +1249,7 @@ void GDALRasterCompareAlgorithm::MetadataComparison(
 
             std::string ref = oIter->second;
             std::string input = sKeyValuePair.second;
-            if (metadataDomain == "RPC")
+            if (metadataDomain == GDAL_MDD_RPC)
             {
                 // _RPC.TXT files and in-file have a difference
                 // in white space that is not otherwise meaningful.

--- a/apps/gdalalg_raster_create.cpp
+++ b/apps/gdalalg_raster_create.cpp
@@ -370,7 +370,7 @@ bool GDALRasterCreateAlgorithm::RunStep(GDALPipelineStepRunContext &)
             const CPLStringList aosDomains(poSrcDS->GetMetadataDomainList());
             for (const char *domain : aosDomains)
             {
-                if (!EQUAL(domain, "IMAGE_STRUCTURE"))
+                if (!EQUAL(domain, GDAL_MDD_IMAGE_STRUCTURE))
                 {
                     if (poRetDS->SetMetadata(poSrcDS->GetMetadata(domain),
                                              domain) != CE_None)
@@ -388,7 +388,7 @@ bool GDALRasterCreateAlgorithm::RunStep(GDALPipelineStepRunContext &)
                 poSrcDS->GetRasterBand(i + 1)->GetMetadataDomainList());
             for (const char *domain : aosDomains)
             {
-                if (!EQUAL(domain, "IMAGE_STRUCTURE"))
+                if (!EQUAL(domain, GDAL_MDD_IMAGE_STRUCTURE))
                 {
                     if (poRetDS->GetRasterBand(i + 1)->SetMetadata(
                             poSrcDS->GetRasterBand(i + 1)->GetMetadata(domain),

--- a/apps/gdalalg_raster_info.cpp
+++ b/apps/gdalalg_raster_info.cpp
@@ -167,7 +167,8 @@ bool GDALRasterInfoAlgorithm::RunStep(GDALPipelineStepRunContext &)
 
     if (m_subDS > 0)
     {
-        CSLConstList papszSubdatasets = GDALGetMetadata(hDS, "SUBDATASETS");
+        CSLConstList papszSubdatasets =
+            GDALGetMetadata(hDS, GDAL_MDD_SUBDATASETS);
         const int nSubdatasets = CSLCount(papszSubdatasets) / 2;
         if (m_subDS > nSubdatasets)
         {

--- a/apps/gdalalg_raster_tile.cpp
+++ b/apps/gdalalg_raster_tile.cpp
@@ -4567,7 +4567,7 @@ bool GDALRasterTileAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
     {
         if (!bHasSrcGT && m_poSrcDS->GetGCPCount() == 0 &&
             m_poSrcDS->GetMetadata("GEOLOCATION") == nullptr &&
-            m_poSrcDS->GetMetadata("RPC") == nullptr)
+            m_poSrcDS->GetMetadata(GDAL_MDD_RPC) == nullptr)
         {
             ReportError(CE_Failure, CPLE_NotSupported,
                         "Ungeoreferenced datasets are not supported, unless "
@@ -4576,7 +4576,7 @@ bool GDALRasterTileAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
         }
 
         if (m_poSrcDS->GetMetadata("GEOLOCATION") == nullptr &&
-            m_poSrcDS->GetMetadata("RPC") == nullptr &&
+            m_poSrcDS->GetMetadata(GDAL_MDD_RPC) == nullptr &&
             m_poSrcDS->GetSpatialRef() == nullptr &&
             m_poSrcDS->GetGCPSpatialRef() == nullptr)
         {

--- a/apps/gdalalg_raster_tile.cpp
+++ b/apps/gdalalg_raster_tile.cpp
@@ -4566,7 +4566,7 @@ bool GDALRasterTileAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
     else
     {
         if (!bHasSrcGT && m_poSrcDS->GetGCPCount() == 0 &&
-            m_poSrcDS->GetMetadata("GEOLOCATION") == nullptr &&
+            m_poSrcDS->GetMetadata(GDAL_MDD_GEOLOCATION) == nullptr &&
             m_poSrcDS->GetMetadata(GDAL_MDD_RPC) == nullptr)
         {
             ReportError(CE_Failure, CPLE_NotSupported,
@@ -4575,7 +4575,7 @@ bool GDALRasterTileAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
             return false;
         }
 
-        if (m_poSrcDS->GetMetadata("GEOLOCATION") == nullptr &&
+        if (m_poSrcDS->GetMetadata(GDAL_MDD_GEOLOCATION) == nullptr &&
             m_poSrcDS->GetMetadata(GDAL_MDD_RPC) == nullptr &&
             m_poSrcDS->GetSpatialRef() == nullptr &&
             m_poSrcDS->GetGCPSpatialRef() == nullptr)

--- a/apps/gdalalg_raster_tile.cpp
+++ b/apps/gdalalg_raster_tile.cpp
@@ -4609,7 +4609,8 @@ bool GDALRasterTileAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
         if (const char *pszCenterWavelength = poBand->GetMetadataItem(
                 GDALMD_CENTRAL_WAVELENGTH_UM, "IMAGERY"))
             bm.osCenterWaveLength = pszCenterWavelength;
-        if (const char *pszFWHM = poBand->GetMetadataItem("FWHM_UM", "IMAGERY"))
+        if (const char *pszFWHM =
+                poBand->GetMetadataItem(GDALMD_FWHM_UM, "IMAGERY"))
             bm.osFWHM = pszFWHM;
         aoBandMetadata.emplace_back(std::move(bm));
     }

--- a/apps/gdalalg_raster_tile.cpp
+++ b/apps/gdalalg_raster_tile.cpp
@@ -4606,8 +4606,8 @@ bool GDALRasterTileAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
         bm.osDescription = poBand->GetDescription();
         bm.eDT = poBand->GetRasterDataType();
         bm.eColorInterp = poBand->GetColorInterpretation();
-        if (const char *pszCenterWavelength =
-                poBand->GetMetadataItem("CENTRAL_WAVELENGTH_UM", "IMAGERY"))
+        if (const char *pszCenterWavelength = poBand->GetMetadataItem(
+                GDALMD_CENTRAL_WAVELENGTH_UM, "IMAGERY"))
             bm.osCenterWaveLength = pszCenterWavelength;
         if (const char *pszFWHM = poBand->GetMetadataItem("FWHM_UM", "IMAGERY"))
             bm.osFWHM = pszFWHM;

--- a/apps/gdalalg_raster_tile.cpp
+++ b/apps/gdalalg_raster_tile.cpp
@@ -2065,7 +2065,7 @@ class MosaicDataset : public GDALDataset
                            nTileMinY, oTM, convention, directory, extension,
                            pdfDstNoData, poCT));
         }
-        SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
         const CPLStringList aosMD(metadata);
         for (const auto [key, value] : cpl::IterateNameValue(aosMD))
         {

--- a/apps/gdalalg_raster_tile.cpp
+++ b/apps/gdalalg_raster_tile.cpp
@@ -3475,7 +3475,7 @@ bool GDALRasterTileAlgorithm::ValidateOutputFormat(GDALDataType eSrcDT) const
         {
             if (const char *pszNBITS =
                     m_poSrcDS->GetRasterBand(1)->GetMetadataItem(
-                        "NBITS", GDAL_MDD_IMAGE_STRUCTURE))
+                        GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE))
             {
                 if (atoi(pszNBITS) > 12)
                 {

--- a/apps/gdalalg_raster_tile.cpp
+++ b/apps/gdalalg_raster_tile.cpp
@@ -2065,7 +2065,7 @@ class MosaicDataset : public GDALDataset
                            nTileMinY, oTM, convention, directory, extension,
                            pdfDstNoData, poCT));
         }
-        SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
         const CPLStringList aosMD(metadata);
         for (const auto [key, value] : cpl::IterateNameValue(aosMD))
         {
@@ -3475,7 +3475,7 @@ bool GDALRasterTileAlgorithm::ValidateOutputFormat(GDALDataType eSrcDT) const
         {
             if (const char *pszNBITS =
                     m_poSrcDS->GetRasterBand(1)->GetMetadataItem(
-                        "NBITS", "IMAGE_STRUCTURE"))
+                        "NBITS", GDAL_MDD_IMAGE_STRUCTURE))
             {
                 if (atoi(pszNBITS) > 12)
                 {

--- a/apps/gdalalg_raster_tile.cpp
+++ b/apps/gdalalg_raster_tile.cpp
@@ -4607,10 +4607,10 @@ bool GDALRasterTileAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
         bm.eDT = poBand->GetRasterDataType();
         bm.eColorInterp = poBand->GetColorInterpretation();
         if (const char *pszCenterWavelength = poBand->GetMetadataItem(
-                GDALMD_CENTRAL_WAVELENGTH_UM, "IMAGERY"))
+                GDALMD_CENTRAL_WAVELENGTH_UM, GDAL_MDD_IMAGERY))
             bm.osCenterWaveLength = pszCenterWavelength;
         if (const char *pszFWHM =
-                poBand->GetMetadataItem(GDALMD_FWHM_UM, "IMAGERY"))
+                poBand->GetMetadataItem(GDALMD_FWHM_UM, GDAL_MDD_IMAGERY))
             bm.osFWHM = pszFWHM;
         aoBandMetadata.emplace_back(std::move(bm));
     }

--- a/apps/gdalbuildvrt_lib.cpp
+++ b/apps/gdalbuildvrt_lib.cpp
@@ -478,7 +478,7 @@ std::string VRTBuilder::AnalyseRaster(GDALDatasetH hDS,
 {
     GDALDataset *poDS = GDALDataset::FromHandle(hDS);
     const char *dsFileName = poDS->GetDescription();
-    CSLConstList papszMetadata = poDS->GetMetadata("SUBDATASETS");
+    CSLConstList papszMetadata = poDS->GetMetadata(GDAL_MDD_SUBDATASETS);
     if (CSLCount(papszMetadata) > 0 && poDS->GetRasterCount() == 0)
     {
         ppszInputFilenames = static_cast<char **>(CPLRealloc(

--- a/apps/gdalinfo_bin.cpp
+++ b/apps/gdalinfo_bin.cpp
@@ -191,7 +191,7 @@ MAIN_START(argc, argv)
         if (sOptionsForBinary.nSubdataset > 0)
         {
             CSLConstList papszSubdatasets =
-                GDALGetMetadata(hDataset, "SUBDATASETS");
+                GDALGetMetadata(hDataset, GDAL_MDD_SUBDATASETS);
             const int nSubdatasets = CSLCount(papszSubdatasets) / 2;
 
             if (nSubdatasets > 0 &&

--- a/apps/gdalinfo_lib.cpp
+++ b/apps/gdalinfo_lib.cpp
@@ -1092,7 +1092,7 @@ char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
 
         // Include eo:cloud_cover in stac output
         const char *pszCloudCover =
-            GDALGetMetadataItem(hDataset, "CLOUDCOVER", "IMAGERY");
+            GDALGetMetadataItem(hDataset, "CLOUDCOVER", GDAL_MDD_IMAGERY);
         json_object *poValue = nullptr;
         if (pszCloudCover)
         {
@@ -2523,8 +2523,8 @@ static void GDALInfoReportMetadata(const GDALInfoOptions *psOptions,
                               pszIndent, bJson, poMetadata, osStr);
     }
 
-    GDALInfoPrintMetadata(psOptions, hObject, "IMAGERY", "Imagery", pszIndent,
-                          bJson, poMetadata, osStr);
+    GDALInfoPrintMetadata(psOptions, hObject, GDAL_MDD_IMAGERY, "Imagery",
+                          pszIndent, bJson, poMetadata, osStr);
 }
 
 /************************************************************************/

--- a/apps/gdalinfo_lib.cpp
+++ b/apps/gdalinfo_lib.cpp
@@ -2471,7 +2471,7 @@ static void GDALInfoReportMetadata(const GDALInfoOptions *psOptions,
                 if (!EQUAL(pszDomain, "") &&
                     !EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE) &&
                     !EQUAL(pszDomain, "TILING_SCHEME") &&
-                    !EQUAL(pszDomain, "SUBDATASETS") &&
+                    !EQUAL(pszDomain, GDAL_MDD_SUBDATASETS) &&
                     !EQUAL(pszDomain, GDAL_MDD_GEOLOCATION) &&
                     !EQUAL(pszDomain, GDAL_MDD_RPC))
                 {
@@ -2515,8 +2515,9 @@ static void GDALInfoReportMetadata(const GDALInfoOptions *psOptions,
         GDALInfoPrintMetadata(psOptions, hObject, "TILING_SCHEME",
                               "Tiling Scheme", pszIndent, bJson, poMetadata,
                               osStr);
-        GDALInfoPrintMetadata(psOptions, hObject, "SUBDATASETS", "Subdatasets",
-                              pszIndent, bJson, poMetadata, osStr);
+        GDALInfoPrintMetadata(psOptions, hObject, GDAL_MDD_SUBDATASETS,
+                              "Subdatasets", pszIndent, bJson, poMetadata,
+                              osStr);
         GDALInfoPrintMetadata(psOptions, hObject, GDAL_MDD_GEOLOCATION,
                               "Geolocation", pszIndent, bJson, poMetadata,
                               osStr);

--- a/apps/gdalinfo_lib.cpp
+++ b/apps/gdalinfo_lib.cpp
@@ -2472,7 +2472,7 @@ static void GDALInfoReportMetadata(const GDALInfoOptions *psOptions,
                     !EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE) &&
                     !EQUAL(pszDomain, "TILING_SCHEME") &&
                     !EQUAL(pszDomain, "SUBDATASETS") &&
-                    !EQUAL(pszDomain, "GEOLOCATION") &&
+                    !EQUAL(pszDomain, GDAL_MDD_GEOLOCATION) &&
                     !EQUAL(pszDomain, GDAL_MDD_RPC))
                 {
                     aosExtraMDDomainsExpanded.AddString(pszDomain);
@@ -2517,8 +2517,9 @@ static void GDALInfoReportMetadata(const GDALInfoOptions *psOptions,
                               osStr);
         GDALInfoPrintMetadata(psOptions, hObject, "SUBDATASETS", "Subdatasets",
                               pszIndent, bJson, poMetadata, osStr);
-        GDALInfoPrintMetadata(psOptions, hObject, "GEOLOCATION", "Geolocation",
-                              pszIndent, bJson, poMetadata, osStr);
+        GDALInfoPrintMetadata(psOptions, hObject, GDAL_MDD_GEOLOCATION,
+                              "Geolocation", pszIndent, bJson, poMetadata,
+                              osStr);
         GDALInfoPrintMetadata(psOptions, hObject, GDAL_MDD_RPC, "RPC Metadata",
                               pszIndent, bJson, poMetadata, osStr);
     }

--- a/apps/gdalinfo_lib.cpp
+++ b/apps/gdalinfo_lib.cpp
@@ -2473,7 +2473,7 @@ static void GDALInfoReportMetadata(const GDALInfoOptions *psOptions,
                     !EQUAL(pszDomain, "TILING_SCHEME") &&
                     !EQUAL(pszDomain, "SUBDATASETS") &&
                     !EQUAL(pszDomain, "GEOLOCATION") &&
-                    !EQUAL(pszDomain, "RPC"))
+                    !EQUAL(pszDomain, GDAL_MDD_RPC))
                 {
                     aosExtraMDDomainsExpanded.AddString(pszDomain);
                 }
@@ -2519,7 +2519,7 @@ static void GDALInfoReportMetadata(const GDALInfoOptions *psOptions,
                               pszIndent, bJson, poMetadata, osStr);
         GDALInfoPrintMetadata(psOptions, hObject, "GEOLOCATION", "Geolocation",
                               pszIndent, bJson, poMetadata, osStr);
-        GDALInfoPrintMetadata(psOptions, hObject, "RPC", "RPC Metadata",
+        GDALInfoPrintMetadata(psOptions, hObject, GDAL_MDD_RPC, "RPC Metadata",
                               pszIndent, bJson, poMetadata, osStr);
     }
 

--- a/apps/gdalinfo_lib.cpp
+++ b/apps/gdalinfo_lib.cpp
@@ -2469,7 +2469,7 @@ static void GDALInfoReportMetadata(const GDALInfoOptions *psOptions,
             for (const char *pszDomain : aosMDDList)
             {
                 if (!EQUAL(pszDomain, "") &&
-                    !EQUAL(pszDomain, "IMAGE_STRUCTURE") &&
+                    !EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE) &&
                     !EQUAL(pszDomain, "TILING_SCHEME") &&
                     !EQUAL(pszDomain, "SUBDATASETS") &&
                     !EQUAL(pszDomain, "GEOLOCATION") &&
@@ -2506,7 +2506,7 @@ static void GDALInfoReportMetadata(const GDALInfoOptions *psOptions,
     /* -------------------------------------------------------------------- */
     /*      Report various named metadata domains.                          */
     /* -------------------------------------------------------------------- */
-    GDALInfoPrintMetadata(psOptions, hObject, "IMAGE_STRUCTURE",
+    GDALInfoPrintMetadata(psOptions, hObject, GDAL_MDD_IMAGE_STRUCTURE,
                           "Image Structure Metadata", pszIndent, bJson,
                           poMetadata, osStr);
 

--- a/apps/gdaltindex_lib.cpp
+++ b/apps/gdaltindex_lib.cpp
@@ -2481,7 +2481,7 @@ GDALDatasetH GDALTileIndexInternal(const char *pszDest,
                     bandsCenterWavelengthArray->length++;
 
                     if (const char *pszFWHM =
-                            poBand->GetMetadataItem("FWHM_UM", "IMAGERY"))
+                            poBand->GetMetadataItem(GDALMD_FWHM_UM, "IMAGERY"))
                     {
                         float *values = static_cast<float *>(const_cast<void *>(
                             bandsFWHMArray->buffers[ARROW_BUF_DATA]));

--- a/apps/gdaltindex_lib.cpp
+++ b/apps/gdaltindex_lib.cpp
@@ -2464,7 +2464,7 @@ GDALDatasetH GDALTileIndexInternal(const char *pszDest,
 
                     if (const char *pszCenterWavelength =
                             poBand->GetMetadataItem(
-                                GDALMD_CENTRAL_WAVELENGTH_UM, "IMAGERY"))
+                                GDALMD_CENTRAL_WAVELENGTH_UM, GDAL_MDD_IMAGERY))
                     {
                         float *values = static_cast<float *>(
                             const_cast<void *>(bandsCenterWavelengthArray
@@ -2480,8 +2480,8 @@ GDALDatasetH GDALTileIndexInternal(const char *pszDest,
                     }
                     bandsCenterWavelengthArray->length++;
 
-                    if (const char *pszFWHM =
-                            poBand->GetMetadataItem(GDALMD_FWHM_UM, "IMAGERY"))
+                    if (const char *pszFWHM = poBand->GetMetadataItem(
+                            GDALMD_FWHM_UM, GDAL_MDD_IMAGERY))
                     {
                         float *values = static_cast<float *>(const_cast<void *>(
                             bandsFWHMArray->buffers[ARROW_BUF_DATA]));

--- a/apps/gdaltindex_lib.cpp
+++ b/apps/gdaltindex_lib.cpp
@@ -1854,7 +1854,7 @@ GDALDatasetH GDALTileIndexInternal(const char *pszDest,
         if (poSrcDS->GetRasterCount() > 1)
         {
             const char *pszInterleaving = poSrcDS->GetMetadataItem(
-                "INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
+                GDALMD_INTERLEAVE, GDAL_MDD_IMAGE_STRUCTURE);
             if (pszInterleaving)
             {
                 if (EQUAL(pszInterleaving, "BAND"))
@@ -2863,14 +2863,14 @@ GDALDatasetH GDALTileIndexInternal(const char *pszDest,
         if (psRoot)
             CPLCreateXMLElementAndValue(psRoot.get(), "Interleave", "Band");
         else
-            poLayer->SetMetadataItem("INTERLEAVE", "BAND");
+            poLayer->SetMetadataItem(GDALMD_INTERLEAVE, "BAND");
     }
     else if (nPixelInterleavedCount > 0)
     {
         if (psRoot)
             CPLCreateXMLElementAndValue(psRoot.get(), "Interleave", "Pixel");
         else
-            poLayer->SetMetadataItem("INTERLEAVE", "PIXEL");
+            poLayer->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL");
     }
 
     if (!psOptions->osGTIFilename.empty())

--- a/apps/gdaltindex_lib.cpp
+++ b/apps/gdaltindex_lib.cpp
@@ -1853,8 +1853,8 @@ GDALDatasetH GDALTileIndexInternal(const char *pszDest,
 
         if (poSrcDS->GetRasterCount() > 1)
         {
-            const char *pszInterleaving =
-                poSrcDS->GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE");
+            const char *pszInterleaving = poSrcDS->GetMetadataItem(
+                "INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
             if (pszInterleaving)
             {
                 if (EQUAL(pszInterleaving, "BAND"))
@@ -2262,8 +2262,8 @@ GDALDatasetH GDALTileIndexInternal(const char *pszDest,
             // Write "assets.image.type"
             if (pszDriverName && EQUAL(pszDriverName, "GTiff"))
             {
-                const char *pszLayout =
-                    poSrcDS->GetMetadataItem("LAYOUT", "IMAGE_STRUCTURE");
+                const char *pszLayout = poSrcDS->GetMetadataItem(
+                    "LAYOUT", GDAL_MDD_IMAGE_STRUCTURE);
                 if (pszLayout && EQUAL(pszLayout, "COG"))
                 {
                     constexpr const char TYPE[] =

--- a/apps/gdaltindex_lib.cpp
+++ b/apps/gdaltindex_lib.cpp
@@ -2463,8 +2463,8 @@ GDALDatasetH GDALTileIndexInternal(const char *pszDest,
                     bandsCommonNameArray->length++;
 
                     if (const char *pszCenterWavelength =
-                            poBand->GetMetadataItem("CENTRAL_WAVELENGTH_UM",
-                                                    "IMAGERY"))
+                            poBand->GetMetadataItem(
+                                GDALMD_CENTRAL_WAVELENGTH_UM, "IMAGERY"))
                     {
                         float *values = static_cast<float *>(
                             const_cast<void *>(bandsCenterWavelengthArray

--- a/apps/gdaltransform.cpp
+++ b/apps/gdaltransform.cpp
@@ -203,7 +203,7 @@ MAIN_START(argc, argv)
         }
         else if (EQUAL(argv[i], "-rpc"))
         {
-            aosTO.SetNameValue("METHOD", "RPC");
+            aosTO.SetNameValue("METHOD", GDAL_MDD_RPC);
         }
         else if (EQUAL(argv[i], "-geoloc"))
         {

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -4598,7 +4598,7 @@ static GDALDatasetH GDALWarpCreateOutput(
             {
                 const char *pszAlpha =
                     GDALGetMetadataItem(GDALGetRasterBand(pahSrcDS[0], 4),
-                                        "ALPHA", "IMAGE_STRUCTURE");
+                                        "ALPHA", GDAL_MDD_IMAGE_STRUCTURE);
                 if (pszAlpha)
                 {
                     aosCreateOptions.SetNameValue("ALPHA", pszAlpha);

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -401,7 +401,8 @@ static CPLString GetSrcDSProjection(GDALDatasetH hDS, CSLConstList papszTO)
     {
         pszProjection = SRS_WKT_WGS84_LAT_LONG;
     }
-    else if ((papszMD = GDALGetMetadata(hDS, "GEOLOCATION")) != nullptr &&
+    else if ((papszMD = GDALGetMetadata(hDS, GDAL_MDD_GEOLOCATION)) !=
+                 nullptr &&
              (pszMethod == nullptr || EQUAL(pszMethod, "GEOLOC_ARRAY")))
     {
         pszProjection = CSLFetchNameValue(papszMD, "SRS");
@@ -5149,7 +5150,7 @@ static CPLErr TransformCutlineToSource(GDALDataset *poSrcDS,
     bool bMayNeedDensify = true;
     if (poRasterSRS && poCutlineSRS && poRasterSRS->IsSame(poCutlineSRS) &&
         poSrcDS->GetGCPCount() == 0 && !poSrcDS->GetMetadata(GDAL_MDD_RPC) &&
-        !poSrcDS->GetMetadata("GEOLOCATION") &&
+        !poSrcDS->GetMetadata(GDAL_MDD_GEOLOCATION) &&
         !CSLFetchNameValue(papszTO_In, "GEOLOC_ARRAY") &&
         !CSLFetchNameValue(papszTO_In, "SRC_GEOLOC_ARRAY"))
     {

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -396,8 +396,8 @@ static CPLString GetSrcDSProjection(GDALDatasetH hDS, CSLConstList papszTO)
     {
         pszProjection = GDALGetGCPProjection(hDS);
     }
-    else if (GDALGetMetadata(hDS, "RPC") != nullptr &&
-             (pszMethod == nullptr || EQUAL(pszMethod, "RPC")))
+    else if (GDALGetMetadata(hDS, GDAL_MDD_RPC) != nullptr &&
+             (pszMethod == nullptr || EQUAL(pszMethod, GDAL_MDD_RPC)))
     {
         pszProjection = SRS_WKT_WGS84_LAT_LONG;
     }
@@ -2234,8 +2234,9 @@ static bool AdjustOutputExtentForRPC(GDALDatasetH hSrcDS, GDALDatasetH hDstDS,
 {
     if (CPLTestBool(CSLFetchNameValueDef(psWO->papszWarpOptions,
                                          "SKIP_NOSOURCE", "NO")) &&
-        GDALGetMetadata(hSrcDS, "RPC") != nullptr &&
-        EQUAL(FetchSrcMethod(psOptions->aosTransformerOptions, "RPC"), "RPC") &&
+        GDALGetMetadata(hSrcDS, GDAL_MDD_RPC) != nullptr &&
+        EQUAL(FetchSrcMethod(psOptions->aosTransformerOptions, GDAL_MDD_RPC),
+              GDAL_MDD_RPC) &&
         CPLTestBool(
             CPLGetConfigOption("RESTRICT_OUTPUT_DATASET_UPDATE", "YES")))
     {
@@ -2547,8 +2548,9 @@ GDALWarpDirect(const char *pszDest, GDALDatasetH hDstDS, int nSrcCount,
 
         // For RPC warping add a few extra source pixels by default
         // (probably mostly needed in the RPC DEM case)
-        if (iSrc == 0 && (GDALGetMetadata(hSrcDS, "RPC") != nullptr &&
-                          (pszMethod == nullptr || EQUAL(pszMethod, "RPC"))))
+        if (iSrc == 0 &&
+            (GDALGetMetadata(hSrcDS, GDAL_MDD_RPC) != nullptr &&
+             (pszMethod == nullptr || EQUAL(pszMethod, GDAL_MDD_RPC))))
         {
             if (!psOptions->aosWarpOptions.FetchNameValue("SOURCE_EXTRA"))
             {
@@ -3395,7 +3397,7 @@ static GDALDatasetH GDALWarpCreateOutput(
             ((GetMaxLat() > MAX_LAT && GetMinLat() < MAX_LAT) ||
              (GetMaxLat() > -MAX_LAT && GetMinLat() < -MAX_LAT)) &&
             GDALGetMetadata(hSrcDS, "GEOLOC_ARRAY") == nullptr &&
-            GDALGetMetadata(hSrcDS, "RPC") == nullptr)
+            GDALGetMetadata(hSrcDS, GDAL_MDD_RPC) == nullptr)
         {
             auto poCT = std::unique_ptr<OGRCoordinateTransformation>(
                 OGRCreateCoordinateTransformation(&oSrcSRS, &oDstSRS));
@@ -4096,7 +4098,7 @@ static GDALDatasetH GDALWarpCreateOutput(
             adfThisGeoTransformTmp[2] == 0 && adfThisGeoTransformTmp[4] == 0 &&
             adfThisGeoTransformTmp[5] < 0 &&
             GDALGetMetadata(hSrcDS, "GEOLOC_ARRAY") == nullptr &&
-            GDALGetMetadata(hSrcDS, "RPC") == nullptr)
+            GDALGetMetadata(hSrcDS, GDAL_MDD_RPC) == nullptr)
         {
             bool bIsSameHorizontal = osThisSourceSRS == osThisTargetSRS;
             if (!bIsSameHorizontal)
@@ -5146,7 +5148,7 @@ static CPLErr TransformCutlineToSource(GDALDataset *poSrcDS,
     /* -------------------------------------------------------------------- */
     bool bMayNeedDensify = true;
     if (poRasterSRS && poCutlineSRS && poRasterSRS->IsSame(poCutlineSRS) &&
-        poSrcDS->GetGCPCount() == 0 && !poSrcDS->GetMetadata("RPC") &&
+        poSrcDS->GetGCPCount() == 0 && !poSrcDS->GetMetadata(GDAL_MDD_RPC) &&
         !poSrcDS->GetMetadata("GEOLOCATION") &&
         !CSLFetchNameValue(papszTO_In, "GEOLOC_ARRAY") &&
         !CSLFetchNameValue(papszTO_In, "SRC_GEOLOC_ARRAY"))
@@ -5708,7 +5710,7 @@ GDALWarpAppOptionsGetParser(GDALWarpAppOptions *psOptions,
                 {
                     CheckSingleMethod();
                     psOptions->aosTransformerOptions.SetNameValue("SRC_METHOD",
-                                                                  "RPC");
+                                                                  GDAL_MDD_RPC);
                 })
             .help(_("Force use of RPCs."));
 

--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -5123,7 +5123,7 @@ SetupTargetLayer::Setup(OGRLayer *poSrcLayer, const char *pszNewLayerName,
             const CPLStringList aosDomains(poSrcLayer->GetMetadataDomainList());
             for (const char *pszMD : aosDomains)
             {
-                if (!EQUAL(pszMD, "IMAGE_STRUCTURE") &&
+                if (!EQUAL(pszMD, GDAL_MDD_IMAGE_STRUCTURE) &&
                     !EQUAL(pszMD, "SUBDATASETS"))
                 {
                     if (CSLConstList papszMD = poSrcLayer->GetMetadata(pszMD))

--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -5124,7 +5124,7 @@ SetupTargetLayer::Setup(OGRLayer *poSrcLayer, const char *pszNewLayerName,
             for (const char *pszMD : aosDomains)
             {
                 if (!EQUAL(pszMD, GDAL_MDD_IMAGE_STRUCTURE) &&
-                    !EQUAL(pszMD, "SUBDATASETS"))
+                    !EQUAL(pszMD, GDAL_MDD_SUBDATASETS))
                 {
                     if (CSLConstList papszMD = poSrcLayer->GetMetadata(pszMD))
                     {

--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -774,7 +774,8 @@ static void GDALVectorInfoReportMetadata(CPLString &osRet, CPLJSONObject &oRoot,
             const CPLStringList aosMDDList(GDALGetMetadataDomainList(hObject));
             for (const char *pszDomain : aosMDDList)
             {
-                if (!EQUAL(pszDomain, "") && !EQUAL(pszDomain, "SUBDATASETS"))
+                if (!EQUAL(pszDomain, "") &&
+                    !EQUAL(pszDomain, GDAL_MDD_SUBDATASETS))
                 {
                     aosExtraMDDomainsExpanded.AddString(pszDomain);
                 }
@@ -795,7 +796,7 @@ static void GDALVectorInfoReportMetadata(CPLString &osRet, CPLJSONObject &oRoot,
         }
     }
     GDALVectorInfoPrintMetadata(osRet, oMetadata, psOptions, hObject,
-                                "SUBDATASETS", "Subdatasets", pszIndent);
+                                GDAL_MDD_SUBDATASETS, "Subdatasets", pszIndent);
 }
 
 /************************************************************************/

--- a/frmts/adrg/adrgdataset.cpp
+++ b/frmts/adrg/adrgdataset.cpp
@@ -289,7 +289,7 @@ void ADRGDataset::AddSubDataset(const char *pszGENFileName,
 char **ADRGDataset::GetMetadataDomainList()
 {
     return BuildMetadataDomainList(GDALPamDataset::GetMetadataDomainList(),
-                                   TRUE, "SUBDATASETS", nullptr);
+                                   TRUE, GDAL_MDD_SUBDATASETS, nullptr);
 }
 
 /************************************************************************/
@@ -299,7 +299,7 @@ char **ADRGDataset::GetMetadataDomainList()
 CSLConstList ADRGDataset::GetMetadata(const char *pszDomain)
 
 {
-    if (pszDomain != nullptr && EQUAL(pszDomain, "SUBDATASETS"))
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_SUBDATASETS))
         return papszSubDatasets;
 
     return GDALPamDataset::GetMetadata(pszDomain);

--- a/frmts/adrg/srpdataset.cpp
+++ b/frmts/adrg/srpdataset.cpp
@@ -906,7 +906,7 @@ void SRPDataset::AddSubDataset(const char *pszGENFileName,
 CSLConstList SRPDataset::GetMetadata(const char *pszDomain)
 
 {
-    if (pszDomain != nullptr && EQUAL(pszDomain, "SUBDATASETS"))
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_SUBDATASETS))
         return papszSubDatasets;
 
     return GDALPamDataset::GetMetadata(pszDomain);

--- a/frmts/avif/avifdataset.cpp
+++ b/frmts/avif/avifdataset.cpp
@@ -260,7 +260,7 @@ GDALAVIFRasterBand::GDALAVIFRasterBand(GDALAVIFDataset *poDSIn, int nBandIn,
     if (nBits != 8 && nBits != 16)
     {
         GDALRasterBand::SetMetadataItem("NBITS", CPLSPrintf("%d", nBits),
-                                        "IMAGE_STRUCTURE");
+                                        GDAL_MDD_IMAGE_STRUCTURE);
     }
 }
 
@@ -551,13 +551,13 @@ bool GDALAVIFDataset::Init(GDALOpenInfo *poOpenInfo)
 
     if (m_decoder->image->yuvFormat == AVIF_PIXEL_FORMAT_YUV444)
         GDALDataset::SetMetadataItem("YUV_SUBSAMPLING", "444",
-                                     "IMAGE_STRUCTURE");
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     else if (m_decoder->image->yuvFormat == AVIF_PIXEL_FORMAT_YUV422)
         GDALDataset::SetMetadataItem("YUV_SUBSAMPLING", "422",
-                                     "IMAGE_STRUCTURE");
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     else if (m_decoder->image->yuvFormat == AVIF_PIXEL_FORMAT_YUV420)
         GDALDataset::SetMetadataItem("YUV_SUBSAMPLING", "420",
-                                     "IMAGE_STRUCTURE");
+                                     GDAL_MDD_IMAGE_STRUCTURE);
 
     for (int i = 0; i < l_nBands; ++i)
     {
@@ -775,7 +775,8 @@ GDALAVIFDataset::CreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
     }
     else if (eDT == GDT_UInt16)
     {
-        pszNBITS = poFirstBand->GetMetadataItem("NBITS", "IMAGE_STRUCTURE");
+        pszNBITS =
+            poFirstBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
         if (pszNBITS)
         {
             nBits = atoi(pszNBITS);

--- a/frmts/avif/avifdataset.cpp
+++ b/frmts/avif/avifdataset.cpp
@@ -259,7 +259,7 @@ GDALAVIFRasterBand::GDALAVIFRasterBand(GDALAVIFDataset *poDSIn, int nBandIn,
 {
     if (nBits != 8 && nBits != 16)
     {
-        GDALRasterBand::SetMetadataItem("NBITS", CPLSPrintf("%d", nBits),
+        GDALRasterBand::SetMetadataItem(GDALMD_NBITS, CPLSPrintf("%d", nBits),
                                         GDAL_MDD_IMAGE_STRUCTURE);
     }
 }
@@ -768,15 +768,15 @@ GDALAVIFDataset::CreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
                                  16
 #endif
         ;
-    const char *pszNBITS = CSLFetchNameValue(papszOptions, "NBITS");
+    const char *pszNBITS = CSLFetchNameValue(papszOptions, GDALMD_NBITS);
     if (pszNBITS)
     {
         nBits = atoi(pszNBITS);
     }
     else if (eDT == GDT_UInt16)
     {
-        pszNBITS =
-            poFirstBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+        pszNBITS = poFirstBand->GetMetadataItem(GDALMD_NBITS,
+                                                GDAL_MDD_IMAGE_STRUCTURE);
         if (pszNBITS)
         {
             nBits = atoi(pszNBITS);
@@ -1258,7 +1258,7 @@ void GDALAVIFDriver::InitMetadata()
 
     {
         auto psOption = CPLCreateXMLNode(oTree.get(), CXT_Element, "Option");
-        CPLAddXMLAttributeAndValue(psOption, "name", "NBITS");
+        CPLAddXMLAttributeAndValue(psOption, "name", GDALMD_NBITS);
         CPLAddXMLAttributeAndValue(psOption, "type", "int");
 #if AVIF_VERSION >= 1040000
         CPLAddXMLAttributeAndValue(

--- a/frmts/avif/avifdataset.cpp
+++ b/frmts/avif/avifdataset.cpp
@@ -583,7 +583,7 @@ bool GDALAVIFDataset::Init(GDALOpenInfo *poOpenInfo)
                 aosSubDS.SetNameValue(CPLSPrintf("SUBDATASET_%d_DESC", i + 1),
                                       CPLSPrintf("Subdataset %d", i + 1));
             }
-            GDALDataset::SetMetadata(aosSubDS.List(), "SUBDATASETS");
+            GDALDataset::SetMetadata(aosSubDS.List(), GDAL_MDD_SUBDATASETS);
         }
     }
     else if (m_iPart > m_decoder->imageCount)

--- a/frmts/basisu_ktx2/basisudataset.cpp
+++ b/frmts/basisu_ktx2/basisudataset.cpp
@@ -314,10 +314,12 @@ GDALDataset *BASISUDataset::Open(GDALOpenInfo *poOpenInfo)
     switch (file_info.m_tex_format)
     {
         case basist::basis_tex_format::cETC1S:
-            poDS->SetMetadataItem("COMPRESSION", "ETC1S", "IMAGE_STRUCTURE");
+            poDS->SetMetadataItem("COMPRESSION", "ETC1S",
+                                  GDAL_MDD_IMAGE_STRUCTURE);
             break;
         case basist::basis_tex_format::cUASTC4x4:
-            poDS->SetMetadataItem("COMPRESSION", "UASTC", "IMAGE_STRUCTURE");
+            poDS->SetMetadataItem("COMPRESSION", "UASTC",
+                                  GDAL_MDD_IMAGE_STRUCTURE);
             break;
     }
 

--- a/frmts/basisu_ktx2/basisudataset.cpp
+++ b/frmts/basisu_ktx2/basisudataset.cpp
@@ -314,11 +314,11 @@ GDALDataset *BASISUDataset::Open(GDALOpenInfo *poOpenInfo)
     switch (file_info.m_tex_format)
     {
         case basist::basis_tex_format::cETC1S:
-            poDS->SetMetadataItem("COMPRESSION", "ETC1S",
+            poDS->SetMetadataItem(GDALMD_COMPRESSION, "ETC1S",
                                   GDAL_MDD_IMAGE_STRUCTURE);
             break;
         case basist::basis_tex_format::cUASTC4x4:
-            poDS->SetMetadataItem("COMPRESSION", "UASTC",
+            poDS->SetMetadataItem(GDALMD_COMPRESSION, "UASTC",
                                   GDAL_MDD_IMAGE_STRUCTURE);
             break;
     }

--- a/frmts/basisu_ktx2/basisudataset.cpp
+++ b/frmts/basisu_ktx2/basisudataset.cpp
@@ -293,7 +293,7 @@ GDALDataset *BASISUDataset::Open(GDALOpenInfo *poOpenInfo)
         }
         poDS->nRasterXSize = 0;
         poDS->nRasterYSize = 0;
-        poDS->SetMetadata(aosSubdatasets.List(), "SUBDATASETS");
+        poDS->SetMetadata(aosSubdatasets.List(), GDAL_MDD_SUBDATASETS);
 
         poDS->SetPamFlags(poDS->GetPamFlags() & ~GPF_DIRTY);
 

--- a/frmts/basisu_ktx2/common.cpp
+++ b/frmts/basisu_ktx2/common.cpp
@@ -138,8 +138,9 @@ bool GDAL_KTX2_BASISU_CreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
         params.m_out_filename = pszFilename;
     }
 
-    params.m_uastc = EQUAL(
-        CSLFetchNameValueDef(papszOptions, "COMPRESSION", "ETC1S"), "UASTC");
+    params.m_uastc =
+        EQUAL(CSLFetchNameValueDef(papszOptions, GDALMD_COMPRESSION, "ETC1S"),
+              "UASTC");
     if (params.m_uastc)
     {
         if (bIsKTX2)

--- a/frmts/basisu_ktx2/ktx2dataset.cpp
+++ b/frmts/basisu_ktx2/ktx2dataset.cpp
@@ -303,10 +303,12 @@ GDALDataset *KTX2Dataset::Open(GDALOpenInfo *poOpenInfo)
     switch (transcoder.get_format())
     {
         case basist::basis_tex_format::cETC1S:
-            poDS->SetMetadataItem("COMPRESSION", "ETC1S", "IMAGE_STRUCTURE");
+            poDS->SetMetadataItem("COMPRESSION", "ETC1S",
+                                  GDAL_MDD_IMAGE_STRUCTURE);
             break;
         case basist::basis_tex_format::cUASTC4x4:
-            poDS->SetMetadataItem("COMPRESSION", "UASTC", "IMAGE_STRUCTURE");
+            poDS->SetMetadataItem("COMPRESSION", "UASTC",
+                                  GDAL_MDD_IMAGE_STRUCTURE);
             break;
     }
 

--- a/frmts/basisu_ktx2/ktx2dataset.cpp
+++ b/frmts/basisu_ktx2/ktx2dataset.cpp
@@ -303,11 +303,11 @@ GDALDataset *KTX2Dataset::Open(GDALOpenInfo *poOpenInfo)
     switch (transcoder.get_format())
     {
         case basist::basis_tex_format::cETC1S:
-            poDS->SetMetadataItem("COMPRESSION", "ETC1S",
+            poDS->SetMetadataItem(GDALMD_COMPRESSION, "ETC1S",
                                   GDAL_MDD_IMAGE_STRUCTURE);
             break;
         case basist::basis_tex_format::cUASTC4x4:
-            poDS->SetMetadataItem("COMPRESSION", "UASTC",
+            poDS->SetMetadataItem(GDALMD_COMPRESSION, "UASTC",
                                   GDAL_MDD_IMAGE_STRUCTURE);
             break;
     }

--- a/frmts/basisu_ktx2/ktx2dataset.cpp
+++ b/frmts/basisu_ktx2/ktx2dataset.cpp
@@ -333,7 +333,7 @@ GDALDataset *KTX2Dataset::Open(GDALOpenInfo *poOpenInfo)
         }
         poDS->nRasterXSize = 0;
         poDS->nRasterYSize = 0;
-        poDS->SetMetadata(aosSubdatasets.List(), "SUBDATASETS");
+        poDS->SetMetadata(aosSubdatasets.List(), GDAL_MDD_SUBDATASETS);
 
         poDS->SetPamFlags(poDS->GetPamFlags() & ~GPF_DIRTY);
 

--- a/frmts/bmp/bmpdataset.cpp
+++ b/frmts/bmp/bmpdataset.cpp
@@ -292,7 +292,7 @@ BMPRasterBand::BMPRasterBand(BMPDataset *poDSIn, int nBandIn)
     eDataType = GDT_UInt8;
 
     if (poDSIn->sInfoHeader.iBitCount < 8)
-        SetMetadataItem("NBITS",
+        SetMetadataItem(GDALMD_NBITS,
                         CPLSPrintf("%d", poDSIn->sInfoHeader.iBitCount),
                         GDAL_MDD_IMAGE_STRUCTURE);
 
@@ -727,11 +727,11 @@ BMPComprRasterBand::BMPComprRasterBand(BMPDataset *poDSIn, int nBandIn)
     }
 
     if (poDSIn->sInfoHeader.iClrUsed <= 2)
-        SetMetadataItem("NBITS", "1", GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem(GDALMD_NBITS, "1", GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDSIn->sInfoHeader.iClrUsed <= 4)
-        SetMetadataItem("NBITS", "2", GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem(GDALMD_NBITS, "2", GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDSIn->sInfoHeader.iClrUsed <= 16)
-        SetMetadataItem("NBITS", "4", GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem(GDALMD_NBITS, "4", GDAL_MDD_IMAGE_STRUCTURE);
 
     const GUInt32 iComprSize = static_cast<GUInt32>(
         poDSIn->m_nFileSize - poDSIn->sFileHeader.iOffBits);

--- a/frmts/bmp/bmpdataset.cpp
+++ b/frmts/bmp/bmpdataset.cpp
@@ -294,7 +294,7 @@ BMPRasterBand::BMPRasterBand(BMPDataset *poDSIn, int nBandIn)
     if (poDSIn->sInfoHeader.iBitCount < 8)
         SetMetadataItem("NBITS",
                         CPLSPrintf("%d", poDSIn->sInfoHeader.iBitCount),
-                        "IMAGE_STRUCTURE");
+                        GDAL_MDD_IMAGE_STRUCTURE);
 
     // We will read one scanline per time. Scanlines in BMP aligned at 4-byte
     // boundary
@@ -727,11 +727,11 @@ BMPComprRasterBand::BMPComprRasterBand(BMPDataset *poDSIn, int nBandIn)
     }
 
     if (poDSIn->sInfoHeader.iClrUsed <= 2)
-        SetMetadataItem("NBITS", "1", "IMAGE_STRUCTURE");
+        SetMetadataItem("NBITS", "1", GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDSIn->sInfoHeader.iClrUsed <= 4)
-        SetMetadataItem("NBITS", "2", "IMAGE_STRUCTURE");
+        SetMetadataItem("NBITS", "2", GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDSIn->sInfoHeader.iClrUsed <= 16)
-        SetMetadataItem("NBITS", "4", "IMAGE_STRUCTURE");
+        SetMetadataItem("NBITS", "4", GDAL_MDD_IMAGE_STRUCTURE);
 
     const GUInt32 iComprSize = static_cast<GUInt32>(
         poDSIn->m_nFileSize - poDSIn->sFileHeader.iOffBits);

--- a/frmts/cals/calsdataset.cpp
+++ b/frmts/cals/calsdataset.cpp
@@ -131,7 +131,7 @@ class CALSWrapperSrcBand final : public GDALPamRasterBand
     explicit CALSWrapperSrcBand(GDALDataset *poSrcDSIn)
     {
         poSrcDS = poSrcDSIn;
-        SetMetadataItem("NBITS", "1", GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem(GDALMD_NBITS, "1", GDAL_MDD_IMAGE_STRUCTURE);
         poSrcDS->GetRasterBand(1)->GetBlockSize(&nBlockXSize, &nBlockYSize);
         eDataType = GDT_UInt8;
         bInvertValues = true;
@@ -439,9 +439,9 @@ GDALDataset *CALSDataset::CreateCopy(const char *pszFilename,
         return nullptr;
     }
     if (poSrcDS->GetRasterBand(1)->GetMetadataItem(
-            "NBITS", GDAL_MDD_IMAGE_STRUCTURE) == nullptr ||
+            GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE) == nullptr ||
         !EQUAL(poSrcDS->GetRasterBand(1)->GetMetadataItem(
-                   "NBITS", GDAL_MDD_IMAGE_STRUCTURE),
+                   GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE),
                "1"))
     {
         CPLError(bStrict ? CE_Failure : CE_Warning, CPLE_NotSupported,
@@ -474,7 +474,7 @@ GDALDataset *CALSDataset::CreateCopy(const char *pszFilename,
         VSIMemGenerateHiddenFilename("tmp_tif_header"));
     char **papszOptions = nullptr;
     papszOptions = CSLSetNameValue(papszOptions, "COMPRESS", "CCITTFAX4");
-    papszOptions = CSLSetNameValue(papszOptions, "NBITS", "1");
+    papszOptions = CSLSetNameValue(papszOptions, GDALMD_NBITS, "1");
     papszOptions = CSLSetNameValue(papszOptions, "BLOCKYSIZE",
                                    CPLSPrintf("%d", poSrcDS->GetRasterYSize()));
     papszOptions = CSLSetNameValue(papszOptions, "SPARSE_OK", "YES");

--- a/frmts/cals/calsdataset.cpp
+++ b/frmts/cals/calsdataset.cpp
@@ -131,7 +131,7 @@ class CALSWrapperSrcBand final : public GDALPamRasterBand
     explicit CALSWrapperSrcBand(GDALDataset *poSrcDSIn)
     {
         poSrcDS = poSrcDSIn;
-        SetMetadataItem("NBITS", "1", "IMAGE_STRUCTURE");
+        SetMetadataItem("NBITS", "1", GDAL_MDD_IMAGE_STRUCTURE);
         poSrcDS->GetRasterBand(1)->GetBlockSize(&nBlockXSize, &nBlockYSize);
         eDataType = GDT_UInt8;
         bInvertValues = true;
@@ -439,9 +439,9 @@ GDALDataset *CALSDataset::CreateCopy(const char *pszFilename,
         return nullptr;
     }
     if (poSrcDS->GetRasterBand(1)->GetMetadataItem(
-            "NBITS", "IMAGE_STRUCTURE") == nullptr ||
-        !EQUAL(poSrcDS->GetRasterBand(1)->GetMetadataItem("NBITS",
-                                                          "IMAGE_STRUCTURE"),
+            "NBITS", GDAL_MDD_IMAGE_STRUCTURE) == nullptr ||
+        !EQUAL(poSrcDS->GetRasterBand(1)->GetMetadataItem(
+                   "NBITS", GDAL_MDD_IMAGE_STRUCTURE),
                "1"))
     {
         CPLError(bStrict ? CE_Failure : CE_Warning, CPLE_NotSupported,

--- a/frmts/daas/daasdataset.cpp
+++ b/frmts/daas/daasdataset.cpp
@@ -945,7 +945,7 @@ bool GDALDAASDataset::GetImageMetadata()
                    &iMonth, &iDay, &iHours, &iMin, &iSec);
         if (r == 6)
         {
-            SetMetadataItem(MD_NAME_ACQDATETIME,
+            SetMetadataItem(GDALMD_ACQUISITIONDATETIME,
                             CPLSPrintf("%04d-%02d-%02d %02d:%02d:%02d", iYear,
                                        iMonth, iDay, iHours, iMin, iSec),
                             GDAL_MDD_IMAGERY);

--- a/frmts/daas/daasdataset.cpp
+++ b/frmts/daas/daasdataset.cpp
@@ -289,7 +289,8 @@ void GDALDAASDataset::InstantiateBands()
     if (nBands > 1)
     {
         // Hint for users of the driver
-        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
 }
 
@@ -1387,7 +1388,7 @@ GDALDAASRasterBand::GDALDAASRasterBand(GDALDAASDataset *poDSIn, int nBandIn,
         poDSIn->m_nActualBitDepth != 64)
     {
         SetMetadataItem("NBITS", CPLSPrintf("%d", poDSIn->m_nActualBitDepth),
-                        "IMAGE_STRUCTURE");
+                        GDAL_MDD_IMAGE_STRUCTURE);
     }
 }
 

--- a/frmts/daas/daasdataset.cpp
+++ b/frmts/daas/daasdataset.cpp
@@ -289,7 +289,7 @@ void GDALDAASDataset::InstantiateBands()
     if (nBands > 1)
     {
         // Hint for users of the driver
-        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+        GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                      GDAL_MDD_IMAGE_STRUCTURE);
     }
 }

--- a/frmts/daas/daasdataset.cpp
+++ b/frmts/daas/daasdataset.cpp
@@ -957,7 +957,7 @@ bool GDALDAASDataset::GetImageMetadata()
         GetDouble(oProperties, "cloudCover", false, bIgnoredError);
     if (!bIgnoredError)
     {
-        SetMetadataItem(MD_NAME_CLOUDCOVER, CPLSPrintf("%.2f", dfCloudCover),
+        SetMetadataItem(GDALMD_CLOUDCOVER, CPLSPrintf("%.2f", dfCloudCover),
                         GDAL_MDD_IMAGERY);
     }
 

--- a/frmts/daas/daasdataset.cpp
+++ b/frmts/daas/daasdataset.cpp
@@ -1387,7 +1387,8 @@ GDALDAASRasterBand::GDALDAASRasterBand(GDALDAASDataset *poDSIn, int nBandIn,
         poDSIn->m_nActualBitDepth != 16 && poDSIn->m_nActualBitDepth != 32 &&
         poDSIn->m_nActualBitDepth != 64)
     {
-        SetMetadataItem("NBITS", CPLSPrintf("%d", poDSIn->m_nActualBitDepth),
+        SetMetadataItem(GDALMD_NBITS,
+                        CPLSPrintf("%d", poDSIn->m_nActualBitDepth),
                         GDAL_MDD_IMAGE_STRUCTURE);
     }
 }

--- a/frmts/daas/daasdataset.cpp
+++ b/frmts/daas/daasdataset.cpp
@@ -965,7 +965,7 @@ bool GDALDAASDataset::GetImageMetadata()
         GetString(oProperties, "satellite", false, bIgnoredError));
     if (!osSatellite.empty())
     {
-        SetMetadataItem(MD_NAME_SATELLITE, osSatellite.c_str(),
+        SetMetadataItem(GDALMD_SATELLITEID, osSatellite.c_str(),
                         GDAL_MDD_IMAGERY);
     }
 

--- a/frmts/daas/daasdataset.cpp
+++ b/frmts/daas/daasdataset.cpp
@@ -948,7 +948,7 @@ bool GDALDAASDataset::GetImageMetadata()
             SetMetadataItem(MD_NAME_ACQDATETIME,
                             CPLSPrintf("%04d-%02d-%02d %02d:%02d:%02d", iYear,
                                        iMonth, iDay, iHours, iMin, iSec),
-                            MD_DOMAIN_IMAGERY);
+                            GDAL_MDD_IMAGERY);
         }
     }
 
@@ -958,7 +958,7 @@ bool GDALDAASDataset::GetImageMetadata()
     if (!bIgnoredError)
     {
         SetMetadataItem(MD_NAME_CLOUDCOVER, CPLSPrintf("%.2f", dfCloudCover),
-                        MD_DOMAIN_IMAGERY);
+                        GDAL_MDD_IMAGERY);
     }
 
     CPLString osSatellite(
@@ -966,7 +966,7 @@ bool GDALDAASDataset::GetImageMetadata()
     if (!osSatellite.empty())
     {
         SetMetadataItem(MD_NAME_SATELLITE, osSatellite.c_str(),
-                        MD_DOMAIN_IMAGERY);
+                        GDAL_MDD_IMAGERY);
     }
 
     return !bError;

--- a/frmts/daas/daasdataset.cpp
+++ b/frmts/daas/daasdataset.cpp
@@ -243,7 +243,7 @@ GDALDAASDataset::GDALDAASDataset(GDALDAASDataset *poParentDS, int iOvrLevel)
     InstantiateBands();
 
     SetMetadata(m_poParentDS->GetMetadata());
-    SetMetadata(m_poParentDS->GetMetadata("RPC"), "RPC");
+    SetMetadata(m_poParentDS->GetMetadata(GDAL_MDD_RPC), GDAL_MDD_RPC);
 }
 
 /************************************************************************/
@@ -1112,7 +1112,7 @@ void GDALDAASDataset::ReadRPCs(const CPLJSONObject &oProperties)
         }
         if (!bRPCError)
         {
-            SetMetadata(aoRPC.List(), "RPC");
+            SetMetadata(aoRPC.List(), GDAL_MDD_RPC);
         }
     }
 }

--- a/frmts/dds/ddsdataset.cpp
+++ b/frmts/dds/ddsdataset.cpp
@@ -336,7 +336,7 @@ GDALDataset *DDSDataset::Open(GDALOpenInfo *poOpenInfo)
     poDS->nRasterYSize = static_cast<int>(ddsDesc.dwHeight);
     poDS->GDALDataset::SetMetadataItem(
         "COMPRESSION", crn_get_format_string(fmt), GDAL_MDD_IMAGE_STRUCTURE);
-    poDS->GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+    poDS->GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                        GDAL_MDD_IMAGE_STRUCTURE);
     for (int i = 0; i < l_nBands; i++)
     {
@@ -434,7 +434,7 @@ GDALDataset *DDSDatasetAllDecoded::Open(GDALOpenInfo *poOpenInfo)
     poDS->m_tex_desc = tex_desc;
     poDS->m_pImages = std::move(pImages);
     constexpr int NBANDS = 4;
-    poDS->GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+    poDS->GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                        GDAL_MDD_IMAGE_STRUCTURE);
     for (int i = 0; i < NBANDS; i++)
     {

--- a/frmts/dds/ddsdataset.cpp
+++ b/frmts/dds/ddsdataset.cpp
@@ -334,8 +334,9 @@ GDALDataset *DDSDataset::Open(GDALOpenInfo *poOpenInfo)
     poDS->pUncompressedBuffer = pUncompressedBuffer;
     poDS->nRasterXSize = static_cast<int>(ddsDesc.dwWidth);
     poDS->nRasterYSize = static_cast<int>(ddsDesc.dwHeight);
-    poDS->GDALDataset::SetMetadataItem(
-        "COMPRESSION", crn_get_format_string(fmt), GDAL_MDD_IMAGE_STRUCTURE);
+    poDS->GDALDataset::SetMetadataItem(GDALMD_COMPRESSION,
+                                       crn_get_format_string(fmt),
+                                       GDAL_MDD_IMAGE_STRUCTURE);
     poDS->GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                        GDAL_MDD_IMAGE_STRUCTURE);
     for (int i = 0; i < l_nBands; i++)

--- a/frmts/dds/ddsdataset.cpp
+++ b/frmts/dds/ddsdataset.cpp
@@ -335,9 +335,9 @@ GDALDataset *DDSDataset::Open(GDALOpenInfo *poOpenInfo)
     poDS->nRasterXSize = static_cast<int>(ddsDesc.dwWidth);
     poDS->nRasterYSize = static_cast<int>(ddsDesc.dwHeight);
     poDS->GDALDataset::SetMetadataItem(
-        "COMPRESSION", crn_get_format_string(fmt), "IMAGE_STRUCTURE");
+        "COMPRESSION", crn_get_format_string(fmt), GDAL_MDD_IMAGE_STRUCTURE);
     poDS->GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
-                                       "IMAGE_STRUCTURE");
+                                       GDAL_MDD_IMAGE_STRUCTURE);
     for (int i = 0; i < l_nBands; i++)
     {
         poDS->SetBand(i + 1, new DDSRasterBand(poDS, i + 1));
@@ -435,7 +435,7 @@ GDALDataset *DDSDatasetAllDecoded::Open(GDALOpenInfo *poOpenInfo)
     poDS->m_pImages = std::move(pImages);
     constexpr int NBANDS = 4;
     poDS->GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
-                                       "IMAGE_STRUCTURE");
+                                       GDAL_MDD_IMAGE_STRUCTURE);
     for (int i = 0; i < NBANDS; i++)
     {
         poDS->SetBand(i + 1, new DDSRasterBandAllDecoded(poDS, i + 1));

--- a/frmts/derived/deriveddataset.cpp
+++ b/frmts/derived/deriveddataset.cpp
@@ -130,10 +130,10 @@ GDALDataset *DerivedDataset::Open(GDALOpenInfo *poOpenInfo)
     // Transfer metadata
     poDS->SetMetadata(poTmpDS->GetMetadata());
 
-    CSLConstList papszRPC = poTmpDS->GetMetadata("RPC");
+    CSLConstList papszRPC = poTmpDS->GetMetadata(GDAL_MDD_RPC);
     if (papszRPC)
     {
-        poDS->SetMetadata(papszRPC, "RPC");
+        poDS->SetMetadata(papszRPC, GDAL_MDD_RPC);
     }
 
     // Transfer projection

--- a/frmts/dimap/dimapdataset.cpp
+++ b/frmts/dimap/dimapdataset.cpp
@@ -1744,9 +1744,10 @@ int DIMAPDataset::ReadImageInformation2()
                 CPLAtof(SPECTRAL_RANGE_FWHM_MAX) * dfFactorToMicrometer;
             poBand->SetMetadataItem(GDALMD_CENTRAL_WAVELENGTH_UM,
                                     CPLSPrintf("%.3f", (dfMin + dfMax) / 2),
-                                    "IMAGERY");
-            poBand->SetMetadataItem(
-                GDALMD_FWHM_UM, CPLSPrintf("%.3f", dfMax - dfMin), "IMAGERY");
+                                    GDAL_MDD_IMAGERY);
+            poBand->SetMetadataItem(GDALMD_FWHM_UM,
+                                    CPLSPrintf("%.3f", dfMax - dfMin),
+                                    GDAL_MDD_IMAGERY);
         }
     }
 

--- a/frmts/dimap/dimapdataset.cpp
+++ b/frmts/dimap/dimapdataset.cpp
@@ -1742,7 +1742,7 @@ int DIMAPDataset::ReadImageInformation2()
                 CPLAtof(SPECTRAL_RANGE_FWHM_MIN) * dfFactorToMicrometer;
             const double dfMax =
                 CPLAtof(SPECTRAL_RANGE_FWHM_MAX) * dfFactorToMicrometer;
-            poBand->SetMetadataItem("CENTRAL_WAVELENGTH_UM",
+            poBand->SetMetadataItem(GDALMD_CENTRAL_WAVELENGTH_UM,
                                     CPLSPrintf("%.3f", (dfMin + dfMax) / 2),
                                     "IMAGERY");
             poBand->SetMetadataItem(

--- a/frmts/dimap/dimapdataset.cpp
+++ b/frmts/dimap/dimapdataset.cpp
@@ -1122,7 +1122,8 @@ int DIMAPDataset::ReadImageInformation2()
         CPLGetXMLValue(psDoc, "Raster_Data.Data_Access.DATA_FILE_FORMAT", "");
     if (osDataFormat == "image/jp2")
     {
-        SetMetadataItem("COMPRESSION", "JPEG2000", GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem(GDALMD_COMPRESSION, "JPEG2000",
+                        GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     // For VHR2020: SPECTRAL_PROCESSING = PAN, MS, MS-FS, PMS, PMS-N, PMS-X,

--- a/frmts/dimap/dimapdataset.cpp
+++ b/frmts/dimap/dimapdataset.cpp
@@ -1577,7 +1577,7 @@ int DIMAPDataset::ReadImageInformation2()
         char **papszRPC = poReader->LoadRPCXmlFile(psDoc);
         delete poReader;
         if (papszRPC)
-            SetMetadata(papszRPC, "RPC");
+            SetMetadata(papszRPC, GDAL_MDD_RPC);
         CSLDestroy(papszRPC);
     }
 

--- a/frmts/dimap/dimapdataset.cpp
+++ b/frmts/dimap/dimapdataset.cpp
@@ -1122,7 +1122,7 @@ int DIMAPDataset::ReadImageInformation2()
         CPLGetXMLValue(psDoc, "Raster_Data.Data_Access.DATA_FILE_FORMAT", "");
     if (osDataFormat == "image/jp2")
     {
-        SetMetadataItem("COMPRESSION", "JPEG2000", "IMAGE_STRUCTURE");
+        SetMetadataItem("COMPRESSION", "JPEG2000", GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     // For VHR2020: SPECTRAL_PROCESSING = PAN, MS, MS-FS, PMS, PMS-N, PMS-X,
@@ -1319,7 +1319,7 @@ int DIMAPDataset::ReadImageInformation2()
         if (nBits > 0 && nBits != 8 && nBits != 16)
         {
             poVRTBand->SetMetadataItem("NBITS", CPLSPrintf("%d", nBits),
-                                       "IMAGE_STRUCTURE");
+                                       GDAL_MDD_IMAGE_STRUCTURE);
         }
 
         for (const auto &oTileIdxNameTuple : oMapTileIdxToName)
@@ -1405,7 +1405,7 @@ int DIMAPDataset::ReadImageInformation2()
         if (nBits > 0 && nBits != 8 && nBits != 16)
         {
             poBand->SetMetadataItem("NBITS", CPLSPrintf("%d", nBits),
-                                    "IMAGE_STRUCTURE");
+                                    GDAL_MDD_IMAGE_STRUCTURE);
         }
         if (bTwoDataFilesPerTile)
         {

--- a/frmts/dimap/dimapdataset.cpp
+++ b/frmts/dimap/dimapdataset.cpp
@@ -1319,7 +1319,7 @@ int DIMAPDataset::ReadImageInformation2()
                 poVRTDS->GetRasterBand(iBand + 1));
         if (nBits > 0 && nBits != 8 && nBits != 16)
         {
-            poVRTBand->SetMetadataItem("NBITS", CPLSPrintf("%d", nBits),
+            poVRTBand->SetMetadataItem(GDALMD_NBITS, CPLSPrintf("%d", nBits),
                                        GDAL_MDD_IMAGE_STRUCTURE);
         }
 
@@ -1405,7 +1405,7 @@ int DIMAPDataset::ReadImageInformation2()
             static_cast<VRTSourcedRasterBand *>(poVRTDS->GetRasterBand(iBand)));
         if (nBits > 0 && nBits != 8 && nBits != 16)
         {
-            poBand->SetMetadataItem("NBITS", CPLSPrintf("%d", nBits),
+            poBand->SetMetadataItem(GDALMD_NBITS, CPLSPrintf("%d", nBits),
                                     GDAL_MDD_IMAGE_STRUCTURE);
         }
         if (bTwoDataFilesPerTile)

--- a/frmts/dimap/dimapdataset.cpp
+++ b/frmts/dimap/dimapdataset.cpp
@@ -779,7 +779,8 @@ GDALDataset *DIMAPDataset::Open(GDALOpenInfo *poOpenInfo)
 
     if (osSelectedSubdataset.empty() && aosSubdatasets.size() > 2)
     {
-        poDS->GDALDataset::SetMetadata(aosSubdatasets.List(), "SUBDATASETS");
+        poDS->GDALDataset::SetMetadata(aosSubdatasets.List(),
+                                       GDAL_MDD_SUBDATASETS);
     }
     poDS->psProduct = psProduct.release();
     poDS->psProductDim = psProductDim.release();

--- a/frmts/dimap/dimapdataset.cpp
+++ b/frmts/dimap/dimapdataset.cpp
@@ -1746,7 +1746,7 @@ int DIMAPDataset::ReadImageInformation2()
                                     CPLSPrintf("%.3f", (dfMin + dfMax) / 2),
                                     "IMAGERY");
             poBand->SetMetadataItem(
-                "FWHM_UM", CPLSPrintf("%.3f", dfMax - dfMin), "IMAGERY");
+                GDALMD_FWHM_UM, CPLSPrintf("%.3f", dfMax - dfMin), "IMAGERY");
         }
     }
 

--- a/frmts/e57/e57driver.cpp
+++ b/frmts/e57/e57driver.cpp
@@ -831,7 +831,7 @@ GDALDataset *GDAL_E57Dataset::Open(GDALOpenInfo *poOpenInfo)
                 CPLString().Printf("SUBDATASET_%u_DESC", i + 1),
                 osDesc.c_str());
         }
-        poDS->SetMetadata(aosSubDS.List(), "SUBDATASETS");
+        poDS->SetMetadata(aosSubDS.List(), GDAL_MDD_SUBDATASETS);
         CPLStringList aosXMLE57;
         aosXMLE57.AddString(osXML.c_str());
         poDS->SetMetadata(aosXMLE57.List(), "xml:E57");

--- a/frmts/ecw/ecwcreatecopy.cpp
+++ b/frmts/ecw/ecwcreatecopy.cpp
@@ -1208,7 +1208,8 @@ static GDALDataset *ECWCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
             pszFilename, papszOptions, nXSize, nYSize, nBands,
             aosBandDescriptions.List(), bRGBColorSpace, eType, poSRS, gt,
             poSrcDS->GetGCPCount(), poSrcDS->GetGCPs(), bIsJPEG2000,
-            bPixelIsPoint, poSrcDS->GetMetadata("RPC"), poSrcDS) != CE_None)
+            bPixelIsPoint, poSrcDS->GetMetadata(GDAL_MDD_RPC),
+            poSrcDS) != CE_None)
     {
         return nullptr;
     }

--- a/frmts/ecw/ecwcreatecopy.cpp
+++ b/frmts/ecw/ecwcreatecopy.cpp
@@ -588,7 +588,7 @@ CPLErr GDALECWCompressor::Initialize(
         (NCSFileBandInfo *)NCSMalloc(sizeof(NCSFileBandInfo) * nBands, true);
     for (iBand = 0; iBand < nBands; iBand++)
     {
-        const char *pszNBITS = CSLFetchNameValue(papszOptions, "NBITS");
+        const char *pszNBITS = CSLFetchNameValue(papszOptions, GDALMD_NBITS);
         if (pszNBITS && atoi(pszNBITS) > 0)
             psClient->pBands[iBand].nBits = (UINT8)atoi(pszNBITS);
         else

--- a/frmts/ecw/ecwdataset.cpp
+++ b/frmts/ecw/ecwdataset.cpp
@@ -217,7 +217,7 @@ ECWRasterBand::ECWRasterBand(ECWDataset *poDSIn, int nBandIn, int iOverviewIn,
     if ((poDSIn->psFileInfo->pBands[nBand - 1].nBits % 8) != 0 &&
         !bPromoteTo8Bit)
         GDALPamRasterBand::SetMetadataItem(
-            "NBITS",
+            GDALMD_NBITS,
             CPLString().Printf("%d",
                                poDSIn->psFileInfo->pBands[nBand - 1].nBits),
             GDAL_MDD_IMAGE_STRUCTURE);
@@ -2125,10 +2125,10 @@ CPLErr ECWDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
                 poMEMDS->AddMEMBand(hBand);
 
                 const char *pszNBITS = GetRasterBand(i + 1)->GetMetadataItem(
-                    "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+                    GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
                 if (pszNBITS)
                     poMEMDS->GetRasterBand(i + 1)->SetMetadataItem(
-                        "NBITS", pszNBITS, GDAL_MDD_IMAGE_STRUCTURE);
+                        GDALMD_NBITS, pszNBITS, GDAL_MDD_IMAGE_STRUCTURE);
             }
 
             GDALRasterIOExtraArg sExtraArgTmp;

--- a/frmts/ecw/ecwdataset.cpp
+++ b/frmts/ecw/ecwdataset.cpp
@@ -220,7 +220,7 @@ ECWRasterBand::ECWRasterBand(ECWDataset *poDSIn, int nBandIn, int iOverviewIn,
             "NBITS",
             CPLString().Printf("%d",
                                poDSIn->psFileInfo->pBands[nBand - 1].nBits),
-            "IMAGE_STRUCTURE");
+            GDAL_MDD_IMAGE_STRUCTURE);
 
     GDALRasterBand::SetDescription(
         poDSIn->psFileInfo->pBands[nBand - 1].szDesc);
@@ -2125,10 +2125,10 @@ CPLErr ECWDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
                 poMEMDS->AddMEMBand(hBand);
 
                 const char *pszNBITS = GetRasterBand(i + 1)->GetMetadataItem(
-                    "NBITS", "IMAGE_STRUCTURE");
+                    "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
                 if (pszNBITS)
                     poMEMDS->GetRasterBand(i + 1)->SetMetadataItem(
-                        "NBITS", pszNBITS, "IMAGE_STRUCTURE");
+                        "NBITS", pszNBITS, GDAL_MDD_IMAGE_STRUCTURE);
             }
 
             GDALRasterIOExtraArg sExtraArgTmp;

--- a/frmts/eeda/eedaidataset.cpp
+++ b/frmts/eeda/eedaidataset.cpp
@@ -1380,7 +1380,7 @@ bool GDALEEDAIDataset::Open(GDALOpenInfo *poOpenInfo)
                            oIter->second.size() > 1 ? "s" : "",
                            osSubDSSuffix.c_str(), m_osAsset.c_str()));
         }
-        SetMetadata(aoSubDSList.List(), "SUBDATASETS");
+        SetMetadata(aoSubDSList.List(), GDAL_MDD_SUBDATASETS);
     }
 
     // Attach metadata to dataset or bands

--- a/frmts/eeda/eedaidataset.cpp
+++ b/frmts/eeda/eedaidataset.cpp
@@ -1351,7 +1351,7 @@ bool GDALEEDAIDataset::Open(GDALOpenInfo *poOpenInfo)
     if (nBands > 1)
     {
         SetMetadataItem("INTERLEAVE", m_bQueryMultipleBands ? "PIXEL" : "BAND",
-                        "IMAGE_STRUCTURE");
+                        GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     // Build subdataset list

--- a/frmts/eeda/eedaidataset.cpp
+++ b/frmts/eeda/eedaidataset.cpp
@@ -1350,7 +1350,8 @@ bool GDALEEDAIDataset::Open(GDALOpenInfo *poOpenInfo)
 
     if (nBands > 1)
     {
-        SetMetadataItem("INTERLEAVE", m_bQueryMultipleBands ? "PIXEL" : "BAND",
+        SetMetadataItem(GDALMD_INTERLEAVE,
+                        m_bQueryMultipleBands ? "PIXEL" : "BAND",
                         GDAL_MDD_IMAGE_STRUCTURE);
     }
 

--- a/frmts/esric/esric_dataset.cpp
+++ b/frmts/esric/esric_dataset.cpp
@@ -332,7 +332,7 @@ CPLErr ECDataset::Initialize(CPLXMLNode *CacheInfo, bool ignoreOversizedLods)
         nRasterXSize = int(std::min(dxsz, double(INT32_MAX)));
         nRasterYSize = int(std::min(dysz, double(INT32_MAX)));
 
-        SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
         compression =
             CPLGetXMLValue(CacheInfo, "TileImageInfo.CacheTileFormat", "JPEG");
         SetMetadataItem("COMPRESS", compression.c_str(),
@@ -502,7 +502,7 @@ CPLErr ECDataset::InitializeFromJSON(const CPLJSONObject &oRoot,
         nRasterXSize = int(std::min(dxsz, double(INT32_MAX)));
         nRasterYSize = int(std::min(dysz, double(INT32_MAX)));
 
-        SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
         compression = oRoot.GetString("tileImageInfo/format");
         SetMetadataItem("COMPRESS", compression.c_str(),
                         GDAL_MDD_IMAGE_STRUCTURE);

--- a/frmts/esric/esric_dataset.cpp
+++ b/frmts/esric/esric_dataset.cpp
@@ -332,10 +332,11 @@ CPLErr ECDataset::Initialize(CPLXMLNode *CacheInfo, bool ignoreOversizedLods)
         nRasterXSize = int(std::min(dxsz, double(INT32_MAX)));
         nRasterYSize = int(std::min(dysz, double(INT32_MAX)));
 
-        SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
         compression =
             CPLGetXMLValue(CacheInfo, "TileImageInfo.CacheTileFormat", "JPEG");
-        SetMetadataItem("COMPRESS", compression.c_str(), "IMAGE_STRUCTURE");
+        SetMetadataItem("COMPRESS", compression.c_str(),
+                        GDAL_MDD_IMAGE_STRUCTURE);
 
         nBands = EQUAL(compression, "JPEG") ? 3 : 4;
         for (int i = 1; i <= nBands; i++)
@@ -501,9 +502,10 @@ CPLErr ECDataset::InitializeFromJSON(const CPLJSONObject &oRoot,
         nRasterXSize = int(std::min(dxsz, double(INT32_MAX)));
         nRasterYSize = int(std::min(dysz, double(INT32_MAX)));
 
-        SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
         compression = oRoot.GetString("tileImageInfo/format");
-        SetMetadataItem("COMPRESS", compression.c_str(), "IMAGE_STRUCTURE");
+        SetMetadataItem("COMPRESS", compression.c_str(),
+                        GDAL_MDD_IMAGE_STRUCTURE);
 
         auto oInitialExtent = oRoot.GetObj("initialExtent");
         if (oInitialExtent.IsValid() &&

--- a/frmts/exr/exrdataset.cpp
+++ b/frmts/exr/exrdataset.cpp
@@ -807,7 +807,7 @@ GDALDataset *GDALEXRDataset::Open(GDALOpenInfo *poOpenInfo)
                                       CPLSPrintf("EXR:PREVIEW:%d:%s", iPart + 1,
                                                  osFilename.c_str()));
                 aosSubDS.SetNameValue("SUBDATASET_1_DESC", "Preview image");
-                poDS->SetMetadata(aosSubDS.List(), "SUBDATASETS");
+                poDS->SetMetadata(aosSubDS.List(), GDAL_MDD_SUBDATASETS);
             }
         }
         else
@@ -822,7 +822,7 @@ GDALDataset *GDALEXRDataset::Open(GDALOpenInfo *poOpenInfo)
                 aosSubDS.SetNameValue(CPLSPrintf("SUBDATASET_%d_DESC", i + 1),
                                       header.name().c_str());
             }
-            poDS->SetMetadata(aosSubDS.List(), "SUBDATASETS");
+            poDS->SetMetadata(aosSubDS.List(), GDAL_MDD_SUBDATASETS);
         }
 
         poDS->SetPamFlags(poDS->GetPamFlags() & ~GPF_DIRTY);

--- a/frmts/exr/exrdataset.cpp
+++ b/frmts/exr/exrdataset.cpp
@@ -667,9 +667,10 @@ GDALDataset *GDALEXRDataset::Open(GDALOpenInfo *poOpenInfo)
                 {
                     poDS->SetBand(i, new GDALEXRRGBARasterBand(poDS.get(), i));
                 }
-                poDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+                poDS->SetMetadataItem("INTERLEAVE", "PIXEL",
+                                      GDAL_MDD_IMAGE_STRUCTURE);
                 poDS->SetMetadataItem("SOURCE_COLOR_SPACE", "YCbCr",
-                                      "IMAGE_STRUCTURE");
+                                      GDAL_MDD_IMAGE_STRUCTURE);
             }
             else if (BGR || ABGR)
             {
@@ -792,7 +793,7 @@ GDALDataset *GDALEXRDataset::Open(GDALOpenInfo *poOpenInfo)
             {
                 poDS->SetMetadataItem("COMPRESSION",
                                       apszCompressions[compression],
-                                      "IMAGE_STRUCTURE");
+                                      GDAL_MDD_IMAGE_STRUCTURE);
             }
             else
             {
@@ -2021,7 +2022,7 @@ GDALDataset *GDALEXRDataset::Create(const char *pszFilename, int nXSize,
     if (nBandsIn > 1)
     {
         poDS->GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
-                                           "IMAGE_STRUCTURE");
+                                           GDAL_MDD_IMAGE_STRUCTURE);
     }
     for (int i = 0; i < nBandsIn; i++)
     {

--- a/frmts/exr/exrdataset.cpp
+++ b/frmts/exr/exrdataset.cpp
@@ -667,7 +667,7 @@ GDALDataset *GDALEXRDataset::Open(GDALOpenInfo *poOpenInfo)
                 {
                     poDS->SetBand(i, new GDALEXRRGBARasterBand(poDS.get(), i));
                 }
-                poDS->SetMetadataItem("INTERLEAVE", "PIXEL",
+                poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                       GDAL_MDD_IMAGE_STRUCTURE);
                 poDS->SetMetadataItem("SOURCE_COLOR_SPACE", "YCbCr",
                                       GDAL_MDD_IMAGE_STRUCTURE);
@@ -2021,7 +2021,7 @@ GDALDataset *GDALEXRDataset::Create(const char *pszFilename, int nXSize,
 
     if (nBandsIn > 1)
     {
-        poDS->GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+        poDS->GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                            GDAL_MDD_IMAGE_STRUCTURE);
     }
     for (int i = 0; i < nBandsIn; i++)

--- a/frmts/exr/exrdataset.cpp
+++ b/frmts/exr/exrdataset.cpp
@@ -791,7 +791,7 @@ GDALDataset *GDALEXRDataset::Open(GDALOpenInfo *poOpenInfo)
             }
             else if (compression < CPL_ARRAYSIZE(apszCompressions))
             {
-                poDS->SetMetadataItem("COMPRESSION",
+                poDS->SetMetadataItem(GDALMD_COMPRESSION,
                                       apszCompressions[compression],
                                       GDAL_MDD_IMAGE_STRUCTURE);
             }

--- a/frmts/fits/fitsdataset.cpp
+++ b/frmts/fits/fitsdataset.cpp
@@ -2265,7 +2265,7 @@ void FITSDataset::LoadMetadata(GDALMajorObject *poTarget)
 CSLConstList FITSDataset::GetMetadata(const char *pszDomain)
 
 {
-    if (pszDomain != nullptr && EQUAL(pszDomain, "SUBDATASETS"))
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_SUBDATASETS))
     {
         return m_aosSubdatasets.List();
     }

--- a/frmts/gdalg/gdalgdriver.cpp
+++ b/frmts/gdalg/gdalgdriver.cpp
@@ -292,7 +292,7 @@ void GDALGRasterBand::UnrefUnderlyingRasterBand(GDALRasterBand *) const
                 // Don't return if asked for a raster dataset but the
                 // underlying one is not.
                 if (poUnderlyingDS->GetRasterCount() == 0 &&
-                    !poUnderlyingDS->GetMetadata("SUBDATASETS"))
+                    !poUnderlyingDS->GetMetadata(GDAL_MDD_SUBDATASETS))
                 {
                     return nullptr;
                 }

--- a/frmts/georaster/georaster_dataset.cpp
+++ b/frmts/georaster/georaster_dataset.cpp
@@ -2559,7 +2559,7 @@ CPLErr GeoRasterDataset::SetSpatialRef(const OGRSpatialReference *poSRS)
 char **GeoRasterDataset::GetMetadataDomainList()
 {
     return BuildMetadataDomainList(GDALDataset::GetMetadataDomainList(), TRUE,
-                                   "SUBDATASETS", nullptr);
+                                   GDAL_MDD_SUBDATASETS, nullptr);
 }
 
 //  ---------------------------------------------------------------------------
@@ -2568,7 +2568,7 @@ char **GeoRasterDataset::GetMetadataDomainList()
 
 CSLConstList GeoRasterDataset::GetMetadata(const char *pszDomain)
 {
-    if (pszDomain != nullptr && STARTS_WITH_CI(pszDomain, "SUBDATASETS"))
+    if (pszDomain != nullptr && STARTS_WITH_CI(pszDomain, GDAL_MDD_SUBDATASETS))
         return papszSubdatasets;
     else
         return GDALDataset::GetMetadata(pszDomain);

--- a/frmts/georaster/georaster_dataset.cpp
+++ b/frmts/georaster/georaster_dataset.cpp
@@ -318,23 +318,24 @@ GeoRasterDataset::OpenDataset(const char *pszFilenameIn, GDALAccess eAccessIn,
 
     if (poGRW->nBandBlockSize == 1)
     {
-        poGRD->SetMetadataItem("INTERLEAVE", "BSQ", GDAL_MDD_IMAGE_STRUCTURE);
+        poGRD->SetMetadataItem(GDALMD_INTERLEAVE, "BSQ",
+                               GDAL_MDD_IMAGE_STRUCTURE);
     }
     else
     {
         if (EQUAL(poGRW->sInterleaving.c_str(), "BSQ"))
         {
-            poGRD->SetMetadataItem("INTERLEAVE", "BSQ",
+            poGRD->SetMetadataItem(GDALMD_INTERLEAVE, "BSQ",
                                    GDAL_MDD_IMAGE_STRUCTURE);
         }
         else if (EQUAL(poGRW->sInterleaving.c_str(), "BIP"))
         {
-            poGRD->SetMetadataItem("INTERLEAVE", "PIB",
+            poGRD->SetMetadataItem(GDALMD_INTERLEAVE, "PIB",
                                    GDAL_MDD_IMAGE_STRUCTURE);
         }
         else if (EQUAL(poGRW->sInterleaving.c_str(), "BIL"))
         {
-            poGRD->SetMetadataItem("INTERLEAVE", "BIL",
+            poGRD->SetMetadataItem(GDALMD_INTERLEAVE, "BIL",
                                    GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
@@ -1052,7 +1053,7 @@ GDALDataset *GeoRasterDataset::Create(const char *pszFilename, int nXSize,
         nQuality = poGRW->nCompressQuality;
     }
 
-    pszFetched = CSLFetchNameValue(papszOptions, "INTERLEAVE");
+    pszFetched = CSLFetchNameValue(papszOptions, GDALMD_INTERLEAVE);
 
     bool bInterleve_ind = false;
 

--- a/frmts/georaster/georaster_dataset.cpp
+++ b/frmts/georaster/georaster_dataset.cpp
@@ -357,17 +357,17 @@ GeoRasterDataset::OpenDataset(const char *pszFilenameIn, GDALAccess eAccessIn,
 
     if (EQUAL(poGRW->sCellDepth.c_str(), "1BIT"))
     {
-        poGRD->SetMetadataItem("NBITS", "1", GDAL_MDD_IMAGE_STRUCTURE);
+        poGRD->SetMetadataItem(GDALMD_NBITS, "1", GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     if (EQUAL(poGRW->sCellDepth.c_str(), "2BIT"))
     {
-        poGRD->SetMetadataItem("NBITS", "2", GDAL_MDD_IMAGE_STRUCTURE);
+        poGRD->SetMetadataItem(GDALMD_NBITS, "2", GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     if (EQUAL(poGRW->sCellDepth.c_str(), "4BIT"))
     {
-        poGRD->SetMetadataItem("NBITS", "4", GDAL_MDD_IMAGE_STRUCTURE);
+        poGRD->SetMetadataItem(GDALMD_NBITS, "4", GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     //  -------------------------------------------------------------------
@@ -1025,7 +1025,7 @@ GDALDataset *GeoRasterDataset::Create(const char *pszFilename, int nXSize,
         poGRW->nRowBlockSize = atoi(pszFetched);
     }
 
-    pszFetched = CSLFetchNameValue(papszOptions, "NBITS");
+    pszFetched = CSLFetchNameValue(papszOptions, GDALMD_NBITS);
 
     if (pszFetched != nullptr)
     {

--- a/frmts/georaster/georaster_dataset.cpp
+++ b/frmts/georaster/georaster_dataset.cpp
@@ -253,7 +253,7 @@ GeoRasterDataset::OpenDataset(const char *pszFilenameIn, GDALAccess eAccessIn,
             papszSanitazed = CSLAddString(papszSanitazed, papszRPC_MD[i]);
         }
 
-        poGRD->SetMetadata(papszSanitazed, "RPC");
+        poGRD->SetMetadata(papszSanitazed, GDAL_MDD_RPC);
 
         CSLDestroy(papszRPC_MD);
         CSLDestroy(papszSanitazed);
@@ -1550,7 +1550,7 @@ GDALDataset *GeoRasterDataset::CreateCopy(const char *pszFilename,
     //      Copy RPC
     // --------------------------------------------------------------------
 
-    CSLConstList papszRPCMetadata = GDALGetMetadata(poSrcDS, "RPC");
+    CSLConstList papszRPCMetadata = GDALGetMetadata(poSrcDS, GDAL_MDD_RPC);
 
     if (papszRPCMetadata != nullptr)
     {

--- a/frmts/georaster/georaster_dataset.cpp
+++ b/frmts/georaster/georaster_dataset.cpp
@@ -340,7 +340,7 @@ GeoRasterDataset::OpenDataset(const char *pszFilenameIn, GDALAccess eAccessIn,
         }
     }
 
-    poGRD->SetMetadataItem("COMPRESSION",
+    poGRD->SetMetadataItem(GDALMD_COMPRESSION,
                            CPLGetXMLValue(poGRW->phMetadata,
                                           "rasterInfo.compression.type",
                                           "NONE"),
@@ -393,7 +393,7 @@ GeoRasterDataset::OpenDataset(const char *pszFilenameIn, GDALAccess eAccessIn,
 
     poGRD->SetMetadataItem("WKT", poGRW->sWKText.c_str(), "ORACLE");
 
-    poGRD->SetMetadataItem("COMPRESSION", poGRW->sCompressionType.c_str(),
+    poGRD->SetMetadataItem(GDALMD_COMPRESSION, poGRW->sCompressionType.c_str(),
                            "ORACLE");
 
     poGRD->SetMetadataItem("METADATA", pszDoc, "ORACLE");

--- a/frmts/georaster/georaster_dataset.cpp
+++ b/frmts/georaster/georaster_dataset.cpp
@@ -318,21 +318,24 @@ GeoRasterDataset::OpenDataset(const char *pszFilenameIn, GDALAccess eAccessIn,
 
     if (poGRW->nBandBlockSize == 1)
     {
-        poGRD->SetMetadataItem("INTERLEAVE", "BSQ", "IMAGE_STRUCTURE");
+        poGRD->SetMetadataItem("INTERLEAVE", "BSQ", GDAL_MDD_IMAGE_STRUCTURE);
     }
     else
     {
         if (EQUAL(poGRW->sInterleaving.c_str(), "BSQ"))
         {
-            poGRD->SetMetadataItem("INTERLEAVE", "BSQ", "IMAGE_STRUCTURE");
+            poGRD->SetMetadataItem("INTERLEAVE", "BSQ",
+                                   GDAL_MDD_IMAGE_STRUCTURE);
         }
         else if (EQUAL(poGRW->sInterleaving.c_str(), "BIP"))
         {
-            poGRD->SetMetadataItem("INTERLEAVE", "PIB", "IMAGE_STRUCTURE");
+            poGRD->SetMetadataItem("INTERLEAVE", "PIB",
+                                   GDAL_MDD_IMAGE_STRUCTURE);
         }
         else if (EQUAL(poGRW->sInterleaving.c_str(), "BIL"))
         {
-            poGRD->SetMetadataItem("INTERLEAVE", "BIL", "IMAGE_STRUCTURE");
+            poGRD->SetMetadataItem("INTERLEAVE", "BIL",
+                                   GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
 
@@ -340,7 +343,7 @@ GeoRasterDataset::OpenDataset(const char *pszFilenameIn, GDALAccess eAccessIn,
                            CPLGetXMLValue(poGRW->phMetadata,
                                           "rasterInfo.compression.type",
                                           "NONE"),
-                           "IMAGE_STRUCTURE");
+                           GDAL_MDD_IMAGE_STRUCTURE);
 
     if (STARTS_WITH_CI(poGRW->sCompressionType.c_str(), "JPEG"))
     {
@@ -348,22 +351,22 @@ GeoRasterDataset::OpenDataset(const char *pszFilenameIn, GDALAccess eAccessIn,
                                CPLGetXMLValue(poGRW->phMetadata,
                                               "rasterInfo.compression.quality",
                                               "undefined"),
-                               "IMAGE_STRUCTURE");
+                               GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     if (EQUAL(poGRW->sCellDepth.c_str(), "1BIT"))
     {
-        poGRD->SetMetadataItem("NBITS", "1", "IMAGE_STRUCTURE");
+        poGRD->SetMetadataItem("NBITS", "1", GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     if (EQUAL(poGRW->sCellDepth.c_str(), "2BIT"))
     {
-        poGRD->SetMetadataItem("NBITS", "2", "IMAGE_STRUCTURE");
+        poGRD->SetMetadataItem("NBITS", "2", GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     if (EQUAL(poGRW->sCellDepth.c_str(), "4BIT"))
     {
-        poGRD->SetMetadataItem("NBITS", "4", "IMAGE_STRUCTURE");
+        poGRD->SetMetadataItem("NBITS", "4", GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     //  -------------------------------------------------------------------

--- a/frmts/gif/gifabstractdataset.cpp
+++ b/frmts/gif/gifabstractdataset.cpp
@@ -407,7 +407,8 @@ GIFAbstractRasterBand::GIFAbstractRasterBand(GIFAbstractDataset *poDSIn,
         int iLine = 0;
 
         if (bAdvertiseInterlacedMDI)
-            poDS->SetMetadataItem("INTERLACED", "YES", "IMAGE_STRUCTURE");
+            poDS->SetMetadataItem("INTERLACED", "YES",
+                                  GDAL_MDD_IMAGE_STRUCTURE);
 
         panInterlaceMap = (int *)CPLCalloc(poDSIn->nRasterYSize, sizeof(int));
 
@@ -420,7 +421,7 @@ GIFAbstractRasterBand::GIFAbstractRasterBand(GIFAbstractDataset *poDSIn,
     }
     else if (bAdvertiseInterlacedMDI)
     {
-        poDS->SetMetadataItem("INTERLACED", "NO", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("INTERLACED", "NO", GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     /* -------------------------------------------------------------------- */

--- a/frmts/grib/gribcreatecopy.cpp
+++ b/frmts/grib/gribcreatecopy.cpp
@@ -1653,7 +1653,7 @@ bool GRIB2Section567Writer::WritePNG()
     CPLFree(pafData);
 
     CPLStringList aosPNGOptions;
-    aosPNGOptions.SetNameValue("NBITS", CPLSPrintf("%d", m_nBits));
+    aosPNGOptions.SetNameValue(GDALMD_NBITS, CPLSPrintf("%d", m_nBits));
 
     const GDALDataType eReducedDT = (m_nBits <= 8) ? GDT_UInt8 : GDT_UInt16;
     GDALDataset *poMEMDS =
@@ -1839,7 +1839,7 @@ bool GRIB2Section567Writer::WriteJPEG2000(CSLConstList papszOptions)
                 "TARGET", CPLSPrintf("%f", 100.0 - 100.0 / nCompressionRatio));
         }
     }
-    aosJ2KOptions.SetNameValue("NBITS", CPLSPrintf("%d", m_nBits));
+    aosJ2KOptions.SetNameValue(GDALMD_NBITS, CPLSPrintf("%d", m_nBits));
 
     const GDALDataType eReducedDT = (m_nBits <= 8) ? GDT_UInt8 : GDT_UInt16;
     GDALDataset *poMEMDS =
@@ -2025,7 +2025,7 @@ bool GRIB2Section567Writer::Write(float fValOffset, CSLConstList papszOptions,
     }
 
     const char *pszBits =
-        GetBandOption(papszOptions, nullptr, m_nBand, "NBITS", nullptr);
+        GetBandOption(papszOptions, nullptr, m_nBand, GDALMD_NBITS, nullptr);
     if (pszBits == nullptr && eDataEncoding != IEEE_FLOATING_POINT)
     {
         pszBits = m_poSrcDS->GetRasterBand(m_nBand)->GetMetadataItem(

--- a/frmts/gta/gtadataset.cpp
+++ b/frmts/gta/gtadataset.cpp
@@ -1231,29 +1231,41 @@ GDALDataset *GTADataset::Open(GDALOpenInfo *poOpenInfo)
                               GDAL_MDD_IMAGE_STRUCTURE);
     }
     if (poDS->oHeader.compression() == gta::bzip2)
-        poDS->SetMetadataItem("COMPRESSION", "BZIP2", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_COMPRESSION, "BZIP2",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::xz)
-        poDS->SetMetadataItem("COMPRESSION", "XZ", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_COMPRESSION, "XZ",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::zlib)
-        poDS->SetMetadataItem("COMPRESSION", "ZLIB", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_COMPRESSION, "ZLIB",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::zlib1)
-        poDS->SetMetadataItem("COMPRESSION", "ZLIB1", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_COMPRESSION, "ZLIB1",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::zlib2)
-        poDS->SetMetadataItem("COMPRESSION", "ZLIB2", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_COMPRESSION, "ZLIB2",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::zlib3)
-        poDS->SetMetadataItem("COMPRESSION", "ZLIB3", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_COMPRESSION, "ZLIB3",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::zlib4)
-        poDS->SetMetadataItem("COMPRESSION", "ZLIB4", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_COMPRESSION, "ZLIB4",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::zlib5)
-        poDS->SetMetadataItem("COMPRESSION", "ZLIB5", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_COMPRESSION, "ZLIB5",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::zlib6)
-        poDS->SetMetadataItem("COMPRESSION", "ZLIB6", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_COMPRESSION, "ZLIB6",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::zlib7)
-        poDS->SetMetadataItem("COMPRESSION", "ZLIB7", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_COMPRESSION, "ZLIB7",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::zlib8)
-        poDS->SetMetadataItem("COMPRESSION", "ZLIB8", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_COMPRESSION, "ZLIB8",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::zlib9)
-        poDS->SetMetadataItem("COMPRESSION", "ZLIB9", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_COMPRESSION, "ZLIB9",
+                              GDAL_MDD_IMAGE_STRUCTURE);
 
     /* -------------------------------------------------------------------- */
     /*      Create band information objects.                                */

--- a/frmts/gta/gtadataset.cpp
+++ b/frmts/gta/gtadataset.cpp
@@ -1227,32 +1227,32 @@ GDALDataset *GTADataset::Open(GDALOpenInfo *poOpenInfo)
 
     if (poDS->nBands > 0)
     {
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
     }
     if (poDS->oHeader.compression() == gta::bzip2)
-        poDS->SetMetadataItem("COMPRESSION", "BZIP2", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("COMPRESSION", "BZIP2", GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::xz)
-        poDS->SetMetadataItem("COMPRESSION", "XZ", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("COMPRESSION", "XZ", GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::zlib)
-        poDS->SetMetadataItem("COMPRESSION", "ZLIB", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("COMPRESSION", "ZLIB", GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::zlib1)
-        poDS->SetMetadataItem("COMPRESSION", "ZLIB1", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("COMPRESSION", "ZLIB1", GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::zlib2)
-        poDS->SetMetadataItem("COMPRESSION", "ZLIB2", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("COMPRESSION", "ZLIB2", GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::zlib3)
-        poDS->SetMetadataItem("COMPRESSION", "ZLIB3", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("COMPRESSION", "ZLIB3", GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::zlib4)
-        poDS->SetMetadataItem("COMPRESSION", "ZLIB4", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("COMPRESSION", "ZLIB4", GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::zlib5)
-        poDS->SetMetadataItem("COMPRESSION", "ZLIB5", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("COMPRESSION", "ZLIB5", GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::zlib6)
-        poDS->SetMetadataItem("COMPRESSION", "ZLIB6", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("COMPRESSION", "ZLIB6", GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::zlib7)
-        poDS->SetMetadataItem("COMPRESSION", "ZLIB7", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("COMPRESSION", "ZLIB7", GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::zlib8)
-        poDS->SetMetadataItem("COMPRESSION", "ZLIB8", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("COMPRESSION", "ZLIB8", GDAL_MDD_IMAGE_STRUCTURE);
     else if (poDS->oHeader.compression() == gta::zlib9)
-        poDS->SetMetadataItem("COMPRESSION", "ZLIB9", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("COMPRESSION", "ZLIB9", GDAL_MDD_IMAGE_STRUCTURE);
 
     /* -------------------------------------------------------------------- */
     /*      Create band information objects.                                */
@@ -1351,8 +1351,8 @@ static GDALDataset *GTACreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
         {
             case GDT_UInt8:
             {
-                const char *pszPixelType =
-                    poSrcBand->GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
+                const char *pszPixelType = poSrcBand->GetMetadataItem(
+                    "PIXELTYPE", GDAL_MDD_IMAGE_STRUCTURE);
                 if (pszPixelType && EQUAL(pszPixelType, "SIGNEDBYTE"))
                     peGTATypes[i] = gta::int8;
                 else

--- a/frmts/gta/gtadataset.cpp
+++ b/frmts/gta/gtadataset.cpp
@@ -1227,7 +1227,8 @@ GDALDataset *GTADataset::Open(GDALOpenInfo *poOpenInfo)
 
     if (poDS->nBands > 0)
     {
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     }
     if (poDS->oHeader.compression() == gta::bzip2)
         poDS->SetMetadataItem("COMPRESSION", "BZIP2", GDAL_MDD_IMAGE_STRUCTURE);

--- a/frmts/gta/gtadataset.cpp
+++ b/frmts/gta/gtadataset.cpp
@@ -1448,7 +1448,8 @@ static GDALDataset *GTACreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
         {
             oHeader.global_taglist().set("DESCRIPTION", pszDescription);
         }
-        const char *papszMetadataDomains[] = {nullptr /* default */, "RPC"};
+        const char *papszMetadataDomains[] = {nullptr /* default */,
+                                              GDAL_MDD_RPC};
         size_t nMetadataDomains =
             sizeof(papszMetadataDomains) / sizeof(papszMetadataDomains[0]);
         for (size_t iDomain = 0; iDomain < nMetadataDomains; iDomain++)

--- a/frmts/gti/gdaltileindexdataset.cpp
+++ b/frmts/gti/gdaltileindexdataset.cpp
@@ -2719,12 +2719,13 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
     if (pszInterleave)
     {
         GDALDataset::SetMetadataItem("INTERLEAVE", pszInterleave,
-                                     "IMAGE_STRUCTURE");
+                                     GDAL_MDD_IMAGE_STRUCTURE);
         m_bBandInterleave = EQUAL(pszInterleave, "BAND");
     }
-    else if (nBandCount > 1 && !GetMetadata("IMAGE_STRUCTURE"))
+    else if (nBandCount > 1 && !GetMetadata(GDAL_MDD_IMAGE_STRUCTURE))
     {
-        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     /* -------------------------------------------------------------------- */

--- a/frmts/gti/gdaltileindexdataset.cpp
+++ b/frmts/gti/gdaltileindexdataset.cpp
@@ -2547,7 +2547,8 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
             adfFullWidthHalfMax[i] != 0)
         {
             poBand->GDALRasterBand::SetMetadataItem(
-                "FWHM_UM", CPLSPrintf("%g", adfFullWidthHalfMax[i]), "IMAGERY");
+                GDALMD_FWHM_UM, CPLSPrintf("%g", adfFullWidthHalfMax[i]),
+                "IMAGERY");
         }
     }
 

--- a/frmts/gti/gdaltileindexdataset.cpp
+++ b/frmts/gti/gdaltileindexdataset.cpp
@@ -974,7 +974,7 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
         }
         if (m_poVectorDS->GetLayerCount() == 0 &&
             (m_poVectorDS->GetRasterCount() != 0 ||
-             m_poVectorDS->GetMetadata("SUBDATASETS") != nullptr))
+             m_poVectorDS->GetMetadata(GDAL_MDD_SUBDATASETS) != nullptr))
         {
             return false;
         }

--- a/frmts/gti/gdaltileindexdataset.cpp
+++ b/frmts/gti/gdaltileindexdataset.cpp
@@ -2540,7 +2540,7 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
         {
             poBand->GDALRasterBand::SetMetadataItem(
                 GDALMD_CENTRAL_WAVELENGTH_UM,
-                CPLSPrintf("%g", adfCenterWavelength[i]), "IMAGERY");
+                CPLSPrintf("%g", adfCenterWavelength[i]), GDAL_MDD_IMAGERY);
         }
 
         if (static_cast<int>(adfFullWidthHalfMax.size()) == nBandCount &&
@@ -2548,7 +2548,7 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
         {
             poBand->GDALRasterBand::SetMetadataItem(
                 GDALMD_FWHM_UM, CPLSPrintf("%g", adfFullWidthHalfMax[i]),
-                "IMAGERY");
+                GDAL_MDD_IMAGERY);
         }
     }
 

--- a/frmts/gti/gdaltileindexdataset.cpp
+++ b/frmts/gti/gdaltileindexdataset.cpp
@@ -88,7 +88,7 @@ constexpr const char *MD_BLOCK_X_SIZE = "BLOCKXSIZE";
 constexpr const char *MD_BLOCK_Y_SIZE = "BLOCKYSIZE";
 constexpr const char *MD_MASK_BAND = "MASK_BAND";
 constexpr const char *MD_RESAMPLING = "RESAMPLING";
-constexpr const char *MD_INTERLEAVE = "INTERLEAVE";
+constexpr const char *MD_INTERLEAVE = GDALMD_INTERLEAVE;
 
 constexpr const char *const apszTIOptions[] = {MD_RESX,
                                                MD_RESY,
@@ -2718,13 +2718,13 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
     const char *pszInterleave = GetOption(MD_INTERLEAVE);
     if (pszInterleave)
     {
-        GDALDataset::SetMetadataItem("INTERLEAVE", pszInterleave,
+        GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, pszInterleave,
                                      GDAL_MDD_IMAGE_STRUCTURE);
         m_bBandInterleave = EQUAL(pszInterleave, "BAND");
     }
     else if (nBandCount > 1 && !GetMetadata(GDAL_MDD_IMAGE_STRUCTURE))
     {
-        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+        GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                      GDAL_MDD_IMAGE_STRUCTURE);
     }
 

--- a/frmts/gti/gdaltileindexdataset.cpp
+++ b/frmts/gti/gdaltileindexdataset.cpp
@@ -2539,7 +2539,7 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
             adfCenterWavelength[i] != 0)
         {
             poBand->GDALRasterBand::SetMetadataItem(
-                "CENTRAL_WAVELENGTH_UM",
+                GDALMD_CENTRAL_WAVELENGTH_UM,
                 CPLSPrintf("%g", adfCenterWavelength[i]), "IMAGERY");
         }
 

--- a/frmts/gtiff/cogdriver.cpp
+++ b/frmts/gtiff/cogdriver.cpp
@@ -1278,7 +1278,8 @@ GDALCOGCreator::Create(const char *pszFilename, GDALDataset *const poSrcDS,
                             CSLFetchNameValue(papszOptions, "GEOTIFF_VERSION"));
     aosOptions.SetNameValue("SPARSE_OK",
                             CSLFetchNameValue(papszOptions, "SPARSE_OK"));
-    aosOptions.SetNameValue("NBITS", CSLFetchNameValue(papszOptions, "NBITS"));
+    aosOptions.SetNameValue(GDALMD_NBITS,
+                            CSLFetchNameValue(papszOptions, GDALMD_NBITS));
 
     if (EQUAL(osOverviews, "NONE"))
     {

--- a/frmts/gtiff/cogdriver.cpp
+++ b/frmts/gtiff/cogdriver.cpp
@@ -771,7 +771,7 @@ GDALCOGCreator::Create(const char *pszFilename, GDALDataset *const poSrcDS,
         papszOptions, "COMPRESS", gbHasLZW ? "LZW" : "NONE");
 
     const char *pszInterleave =
-        CSLFetchNameValueDef(papszOptions, "INTERLEAVE", "PIXEL");
+        CSLFetchNameValueDef(papszOptions, GDALMD_INTERLEAVE, "PIXEL");
     if (EQUAL(osCompress, "WEBP"))
     {
         if (!EQUAL(pszInterleave, "PIXEL"))
@@ -1178,7 +1178,7 @@ GDALCOGCreator::Create(const char *pszFilename, GDALDataset *const poSrcDS,
 
         if (nBands > 1)
         {
-            aosOverviewOptions.SetNameValue("INTERLEAVE", "PIXEL");
+            aosOverviewOptions.SetNameValue(GDALMD_INTERLEAVE, "PIXEL");
         }
         if (!m_osTmpMskOverviewFilename.empty())
         {
@@ -1382,12 +1382,12 @@ GDALCOGCreator::Create(const char *pszFilename, GDALDataset *const poSrcDS,
 
     if (EQUAL(pszInterleave, "TILE"))
     {
-        aosOptions.SetNameValue("INTERLEAVE", "BAND");
+        aosOptions.SetNameValue(GDALMD_INTERLEAVE, "BAND");
         aosOptions.SetNameValue("@TILE_INTERLEAVE", "YES");
     }
     else
     {
-        aosOptions.SetNameValue("INTERLEAVE", pszInterleave);
+        aosOptions.SetNameValue(GDALMD_INTERLEAVE, pszInterleave);
     }
 
     aosOptions.SetNameValue("@FLUSHCACHE", "YES");

--- a/frmts/gtiff/generate_quant_table_md5sum.cpp
+++ b/frmts/gtiff/generate_quant_table_md5sum.cpp
@@ -64,7 +64,7 @@ void generate(int nBands, uint16_t nPhotometric, uint16_t nBitsPerSample)
         papszOpts = CSLSetNameValue(papszOpts, "PHOTOMETRIC", "CMYK");
     papszOpts = CSLSetNameValue(papszOpts, "BLOCKYSIZE", "16");
     if (nBitsPerSample == 12)
-        papszOpts = CSLSetNameValue(papszOpts, "NBITS", "12");
+        papszOpts = CSLSetNameValue(papszOpts, GDALMD_NBITS, "12");
 
     CPLString osTmpFilename;
     osTmpFilename.Printf("gtiffdataset_guess_jpeg_quality_tmp");

--- a/frmts/gtiff/geotiff.cpp
+++ b/frmts/gtiff/geotiff.cpp
@@ -645,7 +645,7 @@ void GTiffWriteJPEGTables(TIFF *hTIFF, const char *pszPhotometric,
     }
     papszLocalParameters = CSLSetNameValue(papszLocalParameters, "BLOCKYSIZE",
                                            CPLSPrintf("%u", nInMemImageHeight));
-    papszLocalParameters = CSLSetNameValue(papszLocalParameters, "NBITS",
+    papszLocalParameters = CSLSetNameValue(papszLocalParameters, GDALMD_NBITS,
                                            CPLSPrintf("%u", l_nBitsPerSample));
     papszLocalParameters = CSLSetNameValue(papszLocalParameters,
                                            "JPEGTABLESMODE", pszJPEGTablesMode);

--- a/frmts/gtiff/gt_jpeg_copy.cpp
+++ b/frmts/gtiff/gt_jpeg_copy.cpp
@@ -145,10 +145,10 @@ int GTIFF_CanDirectCopyFromJPEG(GDALDataset *poSrcDS,
 
         if (poSrcDS->GetRasterBand(1)->GetRasterDataType() != GDT_UInt8)
             papszCreateOptions =
-                CSLSetNameValue(papszCreateOptions, "NBITS", "12");
+                CSLSetNameValue(papszCreateOptions, GDALMD_NBITS, "12");
         else
             papszCreateOptions =
-                CSLSetNameValue(papszCreateOptions, "NBITS", NULL);
+                CSLSetNameValue(papszCreateOptions, GDALMD_NBITS, NULL);
 
         papszCreateOptions = CSLSetNameValue(papszCreateOptions, "TILED", NULL);
         papszCreateOptions =
@@ -326,7 +326,7 @@ int GTIFF_CanCopyFromJPEG(GDALDataset *poSrcDS, char **&papszCreateOptions)
     if ((nBlockXSize == nXSize || (nBlockXSize % nMCUSize) == 0) &&
         (nBlockYSize == nYSize || (nBlockYSize % nMCUSize) == 0) &&
         poSrcDS->GetRasterBand(1)->GetRasterDataType() == GDT_UInt8 &&
-        CSLFetchNameValue(papszCreateOptions, "NBITS") == nullptr &&
+        CSLFetchNameValue(papszCreateOptions, GDALMD_NBITS) == nullptr &&
         CSLFetchNameValue(papszCreateOptions, "JPEG_QUALITY") == nullptr)
     {
         if (nMCUSize == 16 && pszPhotometric == nullptr)

--- a/frmts/gtiff/gt_jpeg_copy.cpp
+++ b/frmts/gtiff/gt_jpeg_copy.cpp
@@ -309,7 +309,7 @@ int GTIFF_CanCopyFromJPEG(GDALDataset *poSrcDS, char **&papszCreateOptions)
     }
 
     const char *pszInterleave =
-        CSLFetchNameValue(papszCreateOptions, "INTERLEAVE");
+        CSLFetchNameValue(papszCreateOptions, GDALMD_INTERLEAVE);
 
     const bool bCompatibleInterleave =
         pszInterleave == nullptr ||

--- a/frmts/gtiff/gt_jpeg_copy.cpp
+++ b/frmts/gtiff/gt_jpeg_copy.cpp
@@ -113,8 +113,8 @@ int GTIFF_CanDirectCopyFromJPEG(GDALDataset *poSrcDS,
     if (pszCompress != NULL && !EQUAL(pszCompress, "JPEG"))
         return FALSE;
 
-    const char *pszSrcColorSpace =
-        poSrcDS->GetMetadataItem("SOURCE_COLOR_SPACE", "IMAGE_STRUCTURE");
+    const char *pszSrcColorSpace = poSrcDS->GetMetadataItem(
+        "SOURCE_COLOR_SPACE", GDAL_MDD_IMAGE_STRUCTURE);
     if (pszSrcColorSpace != NULL &&
         (EQUAL(pszSrcColorSpace, "CMYK") || EQUAL(pszSrcColorSpace, "YCbCrK")))
         return FALSE;
@@ -269,8 +269,8 @@ int GTIFF_CanCopyFromJPEG(GDALDataset *poSrcDS, char **&papszCreateOptions)
     const int nBlockYSize =
         atoi(CSLFetchNameValueDef(papszCreateOptions, "BLOCKYSIZE", "0"));
     int nMCUSize = 8;
-    const char *pszSrcColorSpace =
-        poSrcDS->GetMetadataItem("SOURCE_COLOR_SPACE", "IMAGE_STRUCTURE");
+    const char *pszSrcColorSpace = poSrcDS->GetMetadataItem(
+        "SOURCE_COLOR_SPACE", GDAL_MDD_IMAGE_STRUCTURE);
     if (pszSrcColorSpace != nullptr && EQUAL(pszSrcColorSpace, "YCbCr"))
         nMCUSize = 16;
 
@@ -319,7 +319,7 @@ int GTIFF_CanCopyFromJPEG(GDALDataset *poSrcDS, char **&papszCreateOptions)
 
     // We don't want to apply lossy JPEG on a source using lossless JPEG !
     const char *pszReversibility = poSrcDS->GetMetadataItem(
-        "COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE");
+        "COMPRESSION_REVERSIBILITY", GDAL_MDD_IMAGE_STRUCTURE);
     if (pszReversibility && EQUAL(pszReversibility, "LOSSLESS"))
         return FALSE;
 

--- a/frmts/gtiff/gt_overview.cpp
+++ b/frmts/gtiff/gt_overview.cpp
@@ -421,10 +421,10 @@ CPLErr GTIFFBuildOverviewsEx(const char *pszFilename, int nBands,
                 return CE_Failure;
         }
 
-        if (hBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE))
+        if (hBand->GetMetadataItem(GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE))
         {
-            nBandBits =
-                atoi(hBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE));
+            nBandBits = atoi(
+                hBand->GetMetadataItem(GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE));
 
             if (nBandBits == 1 && STARTS_WITH_CI(pszResampling, "AVERAGE_BIT2"))
                 nBandBits = 8;

--- a/frmts/gtiff/gt_overview.cpp
+++ b/frmts/gtiff/gt_overview.cpp
@@ -520,7 +520,7 @@ CPLErr GTIFFBuildOverviewsEx(const char *pszFilename, int nBands,
         if (poSrcDS)
         {
             const char *pszSrcInterleave = poSrcDS->GetMetadataItem(
-                "INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
+                GDALMD_INTERLEAVE, GDAL_MDD_IMAGE_STRUCTURE);
             if (pszSrcInterleave && EQUAL(pszSrcInterleave, "PIXEL"))
             {
                 bSourceIsPixelInterleaved = true;
@@ -546,7 +546,7 @@ CPLErr GTIFFBuildOverviewsEx(const char *pszFilename, int nBands,
     }
 
     const char *pszInterleave =
-        GetOptionValue("INTERLEAVE", "INTERLEAVE_OVERVIEW");
+        GetOptionValue(GDALMD_INTERLEAVE, "INTERLEAVE_OVERVIEW");
     if (pszInterleave != nullptr && pszInterleave[0] != '\0')
     {
         if (EQUAL(pszInterleave, "PIXEL"))

--- a/frmts/gtiff/gt_overview.cpp
+++ b/frmts/gtiff/gt_overview.cpp
@@ -421,10 +421,10 @@ CPLErr GTIFFBuildOverviewsEx(const char *pszFilename, int nBands,
                 return CE_Failure;
         }
 
-        if (hBand->GetMetadataItem("NBITS", "IMAGE_STRUCTURE"))
+        if (hBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE))
         {
             nBandBits =
-                atoi(hBand->GetMetadataItem("NBITS", "IMAGE_STRUCTURE"));
+                atoi(hBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE));
 
             if (nBandBits == 1 && STARTS_WITH_CI(pszResampling, "AVERAGE_BIT2"))
                 nBandBits = 8;
@@ -519,16 +519,16 @@ CPLErr GTIFFBuildOverviewsEx(const char *pszFilename, int nBands,
         GDALDataset *poSrcDS = papoBandList[0]->GetDataset();
         if (poSrcDS)
         {
-            const char *pszSrcInterleave =
-                poSrcDS->GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE");
+            const char *pszSrcInterleave = poSrcDS->GetMetadataItem(
+                "INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
             if (pszSrcInterleave && EQUAL(pszSrcInterleave, "PIXEL"))
             {
                 bSourceIsPixelInterleaved = true;
             }
         }
 
-        const char *pszSrcCompression =
-            papoBandList[0]->GetMetadataItem("COMPRESSION", "IMAGE_STRUCTURE");
+        const char *pszSrcCompression = papoBandList[0]->GetMetadataItem(
+            "COMPRESSION", GDAL_MDD_IMAGE_STRUCTURE);
         if (pszSrcCompression)
         {
             bSourceIsJPEG2000 = EQUAL(pszSrcCompression, "JPEG2000");

--- a/frmts/gtiff/gt_overview.cpp
+++ b/frmts/gtiff/gt_overview.cpp
@@ -528,7 +528,7 @@ CPLErr GTIFFBuildOverviewsEx(const char *pszFilename, int nBands,
         }
 
         const char *pszSrcCompression = papoBandList[0]->GetMetadataItem(
-            "COMPRESSION", GDAL_MDD_IMAGE_STRUCTURE);
+            GDALMD_COMPRESSION, GDAL_MDD_IMAGE_STRUCTURE);
         if (pszSrcCompression)
         {
             bSourceIsJPEG2000 = EQUAL(pszSrcCompression, "JPEG2000");

--- a/frmts/gtiff/gtiffdataset.cpp
+++ b/frmts/gtiff/gtiffdataset.cpp
@@ -1396,7 +1396,7 @@ void GTiffDataset::ScanDirectories()
     /* -------------------------------------------------------------------- */
     if (aosSubdatasets.size() > 2)
     {
-        m_oGTiffMDMD.SetMetadata(aosSubdatasets.List(), "SUBDATASETS");
+        m_oGTiffMDMD.SetMetadata(aosSubdatasets.List(), GDAL_MDD_SUBDATASETS);
     }
 }
 

--- a/frmts/gtiff/gtiffdataset.cpp
+++ b/frmts/gtiff/gtiffdataset.cpp
@@ -1175,8 +1175,9 @@ void GTiffDataset::ScanDirectories()
                     // poODS->m_nZSTDLevel = m_nZSTDLevel;
 
                     if (const char *pszOverviewResampling =
-                            m_oGTiffMDMD.GetMetadataItem("OVERVIEW_RESAMPLING",
-                                                         "IMAGE_STRUCTURE"))
+                            m_oGTiffMDMD.GetMetadataItem(
+                                "OVERVIEW_RESAMPLING",
+                                GDAL_MDD_IMAGE_STRUCTURE))
                     {
                         for (int iBand = 1; iBand <= poODS->GetRasterCount();
                              ++iBand)

--- a/frmts/gtiff/gtiffdataset_read.cpp
+++ b/frmts/gtiff/gtiffdataset_read.cpp
@@ -5430,10 +5430,10 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
     }
 
     if (m_nPlanarConfig == PLANARCONFIG_CONTIG && nBands != 1)
-        m_oGTiffMDMD.SetMetadataItem("INTERLEAVE", "PIXEL",
+        m_oGTiffMDMD.SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                      GDAL_MDD_IMAGE_STRUCTURE);
     else
-        m_oGTiffMDMD.SetMetadataItem("INTERLEAVE", "BAND",
+        m_oGTiffMDMD.SetMetadataItem(GDALMD_INTERLEAVE, "BAND",
                                      GDAL_MDD_IMAGE_STRUCTURE);
 
     if ((GetRasterBand(1)->GetRasterDataType() == GDT_UInt8 &&
@@ -5517,12 +5517,12 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
                     m_oGTiffMDMD.SetMetadataItem(pszKey, pszValue,
                                                  GDAL_MDD_IMAGE_STRUCTURE);
                 }
-                else if (EQUAL(pszKey, "INTERLEAVE"))
+                else if (EQUAL(pszKey, GDALMD_INTERLEAVE))
                 {
                     if (EQUAL(pszValue, "TILE"))
                     {
                         m_bTileInterleave = true;
-                        m_oGTiffMDMD.SetMetadataItem("INTERLEAVE", "TILE",
+                        m_oGTiffMDMD.SetMetadataItem(GDALMD_INTERLEAVE, "TILE",
                                                      GDAL_MDD_IMAGE_STRUCTURE);
                     }
                     else

--- a/frmts/gtiff/gtiffdataset_read.cpp
+++ b/frmts/gtiff/gtiffdataset_read.cpp
@@ -63,8 +63,8 @@ int GTiffDataset::GetJPEGOverviewCount()
     {
         return 0;
     }
-    const char *pszSourceColorSpace =
-        m_oGTiffMDMD.GetMetadataItem("SOURCE_COLOR_SPACE", "IMAGE_STRUCTURE");
+    const char *pszSourceColorSpace = m_oGTiffMDMD.GetMetadataItem(
+        "SOURCE_COLOR_SPACE", GDAL_MDD_IMAGE_STRUCTURE);
     if (pszSourceColorSpace != nullptr && EQUAL(pszSourceColorSpace, "CMYK"))
     {
         // We cannot handle implicit overviews on JPEG CMYK datasets converted
@@ -3936,7 +3936,7 @@ GDALDataset *GTiffDataset::Open(GDALOpenInfo *poOpenInfo)
                 return nullptr;
             }
             poDS->m_oGTiffMDMD.SetMetadataItem("LAYOUT", "COG",
-                                               "IMAGE_STRUCTURE");
+                                               GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
 
@@ -4504,10 +4504,10 @@ void GTiffDataset::ApplyPamInfo()
     {
         const char *pszDomain = papszPamDomains[iDomain];
         // We skip IMAGE_STRUCTURE as PAM content is not supposed to modify
-        // it and it could cause consistency issues if doing GetMetadata("IMAGE_STRUCTURE")
+        // it and it could cause consistency issues if doing GetMetadata(GDAL_MDD_IMAGE_STRUCTURE)
         // which doesn't load PAM, then GetMetadata(other_domain) and
-        // GetMetadata("IMAGE_STRUCTURE")
-        if (!EQUAL(pszDomain, "IMAGE_STRUCTURE"))
+        // GetMetadata(GDAL_MDD_IMAGE_STRUCTURE)
+        if (!EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE))
         {
             char **papszGT_MD =
                 CSLDuplicate(m_oGTiffMDMD.GetMetadata(pszDomain));
@@ -4946,7 +4946,7 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
         CPLTestBool(CPLGetConfigOption("CONVERT_YCBCR_TO_RGB", "YES")))
     {
         m_oGTiffMDMD.SetMetadataItem("SOURCE_COLOR_SPACE", "YCbCr",
-                                     "IMAGE_STRUCTURE");
+                                     GDAL_MDD_IMAGE_STRUCTURE);
         int nColorMode = 0;
         if (!TIFFGetField(m_hTIFF, TIFFTAG_JPEGCOLORMODE, &nColorMode) ||
             nColorMode != JPEGCOLORMODE_RGB)
@@ -5060,7 +5060,7 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
             if (pszSourceColorSpace)
                 m_oGTiffMDMD.SetMetadataItem("SOURCE_COLOR_SPACE",
                                              pszSourceColorSpace,
-                                             "IMAGE_STRUCTURE");
+                                             GDAL_MDD_IMAGE_STRUCTURE);
             bTreatAsRGBA = true;
         }
         else
@@ -5368,8 +5368,9 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
             GTIFFGetCompressionMethodName(m_nCompression);
         if (pszCompressionMethodName)
         {
-            m_oGTiffMDMD.SetMetadataItem(
-                "COMPRESSION", pszCompressionMethodName, "IMAGE_STRUCTURE");
+            m_oGTiffMDMD.SetMetadataItem("COMPRESSION",
+                                         pszCompressionMethodName,
+                                         GDAL_MDD_IMAGE_STRUCTURE);
         }
         else
         {
@@ -5383,7 +5384,7 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
         m_nPhotometric == PHOTOMETRIC_YCBCR)
     {
         m_oGTiffMDMD.SetMetadataItem("COMPRESSION", "YCbCr JPEG",
-                                     "IMAGE_STRUCTURE");
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (m_nCompression == COMPRESSION_LERC)
     {
@@ -5404,12 +5405,12 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
             if (nAddVersion == LERC_ADD_COMPRESSION_DEFLATE)
             {
                 m_oGTiffMDMD.SetMetadataItem("COMPRESSION", "LERC_DEFLATE",
-                                             "IMAGE_STRUCTURE");
+                                             GDAL_MDD_IMAGE_STRUCTURE);
             }
             else if (nAddVersion == LERC_ADD_COMPRESSION_ZSTD)
             {
                 m_oGTiffMDMD.SetMetadataItem("COMPRESSION", "LERC_ZSTD",
-                                             "IMAGE_STRUCTURE");
+                                             GDAL_MDD_IMAGE_STRUCTURE);
             }
         }
         uint32_t nLercVersion = LERC_VERSION_2_4;
@@ -5418,7 +5419,7 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
             if (nLercVersion == LERC_VERSION_2_4)
             {
                 m_oGTiffMDMD.SetMetadataItem("LERC_VERSION", "2.4",
-                                             "IMAGE_STRUCTURE");
+                                             GDAL_MDD_IMAGE_STRUCTURE);
             }
             else
             {
@@ -5429,9 +5430,11 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
     }
 
     if (m_nPlanarConfig == PLANARCONFIG_CONTIG && nBands != 1)
-        m_oGTiffMDMD.SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        m_oGTiffMDMD.SetMetadataItem("INTERLEAVE", "PIXEL",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     else
-        m_oGTiffMDMD.SetMetadataItem("INTERLEAVE", "BAND", "IMAGE_STRUCTURE");
+        m_oGTiffMDMD.SetMetadataItem("INTERLEAVE", "BAND",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
 
     if ((GetRasterBand(1)->GetRasterDataType() == GDT_UInt8 &&
          m_nBitsPerSample != 8) ||
@@ -5447,11 +5450,12 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
                     "NBITS",
                     CPLString().Printf("%d",
                                        static_cast<int>(m_nBitsPerSample)),
-                    "IMAGE_STRUCTURE");
+                    GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     if (bMinIsWhite)
-        m_oGTiffMDMD.SetMetadataItem("MINISWHITE", "YES", "IMAGE_STRUCTURE");
+        m_oGTiffMDMD.SetMetadataItem("MINISWHITE", "YES",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
 
     if (TIFFGetField(m_hTIFF, TIFFTAG_GDAL_METADATA, &pszText))
     {
@@ -5506,12 +5510,12 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
 
             if (pszKey == nullptr || pszValue == nullptr)
                 continue;
-            if (EQUAL(pszDomain, "IMAGE_STRUCTURE"))
+            if (EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE))
             {
                 if (EQUAL(pszKey, "OVERVIEW_RESAMPLING"))
                 {
                     m_oGTiffMDMD.SetMetadataItem(pszKey, pszValue,
-                                                 "IMAGE_STRUCTURE");
+                                                 GDAL_MDD_IMAGE_STRUCTURE);
                 }
                 else if (EQUAL(pszKey, "INTERLEAVE"))
                 {
@@ -5519,7 +5523,7 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
                     {
                         m_bTileInterleave = true;
                         m_oGTiffMDMD.SetMetadataItem("INTERLEAVE", "TILE",
-                                                     "IMAGE_STRUCTURE");
+                                                     GDAL_MDD_IMAGE_STRUCTURE);
                     }
                     else
                     {
@@ -5545,7 +5549,7 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
                     {
                         m_oGTiffMDMD.SetMetadataItem(
                             "COMPRESSION_REVERSIBILITY", "LOSSY",
-                            "IMAGE_STRUCTURE");
+                            GDAL_MDD_IMAGE_STRUCTURE);
                         m_bWebPLossless = false;
                         m_nWebPLevel = static_cast<signed char>(nLevel);
                     }
@@ -5581,7 +5585,7 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
                     {
                         m_oGTiffMDMD.SetMetadataItem(
                             "COMPRESSION_REVERSIBILITY", "LOSSY",
-                            "IMAGE_STRUCTURE");
+                            GDAL_MDD_IMAGE_STRUCTURE);
                         m_bJXLLossless = false;
                         m_fJXLDistance = static_cast<float>(dfVal);
                     }
@@ -5595,7 +5599,7 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
                     {
                         m_oGTiffMDMD.SetMetadataItem(
                             "COMPRESSION_REVERSIBILITY", "LOSSY",
-                            "IMAGE_STRUCTURE");
+                            GDAL_MDD_IMAGE_STRUCTURE);
                         m_fJXLAlphaDistance = static_cast<float>(dfVal);
                     }
                 }
@@ -5741,8 +5745,9 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
             GuessJPEGQuality(bHasQuantizationTable, bHasHuffmanTable);
         if (nQuality > 0)
         {
-            m_oGTiffMDMD.SetMetadataItem(
-                "JPEG_QUALITY", CPLSPrintf("%d", nQuality), "IMAGE_STRUCTURE");
+            m_oGTiffMDMD.SetMetadataItem("JPEG_QUALITY",
+                                         CPLSPrintf("%d", nQuality),
+                                         GDAL_MDD_IMAGE_STRUCTURE);
             int nJpegTablesMode = JPEGTABLESMODE_QUANT;
             if (bHasHuffmanTable)
             {
@@ -5750,7 +5755,7 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
             }
             m_oGTiffMDMD.SetMetadataItem("JPEGTABLESMODE",
                                          CPLSPrintf("%d", nJpegTablesMode),
-                                         "IMAGE_STRUCTURE");
+                                         GDAL_MDD_IMAGE_STRUCTURE);
         }
         if (eAccess == GA_Update)
         {
@@ -5760,12 +5765,12 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
     }
     else if (eAccess == GA_Update &&
              m_oGTiffMDMD.GetMetadataItem("COMPRESSION_REVERSIBILITY",
-                                          "IMAGE_STRUCTURE") == nullptr)
+                                          GDAL_MDD_IMAGE_STRUCTURE) == nullptr)
     {
         if (m_nCompression == COMPRESSION_WEBP)
         {
-            const char *pszReversibility =
-                GetMetadataItem("COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE");
+            const char *pszReversibility = GetMetadataItem(
+                "COMPRESSION_REVERSIBILITY", GDAL_MDD_IMAGE_STRUCTURE);
             if (pszReversibility && strstr(pszReversibility, "LOSSLESS"))
             {
                 m_bWebPLossless = true;
@@ -5779,8 +5784,8 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
         else if (m_nCompression == COMPRESSION_JXL ||
                  m_nCompression == COMPRESSION_JXL_DNG_1_7)
         {
-            const char *pszReversibility =
-                GetMetadataItem("COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE");
+            const char *pszReversibility = GetMetadataItem(
+                "COMPRESSION_REVERSIBILITY", GDAL_MDD_IMAGE_STRUCTURE);
             if (pszReversibility && strstr(pszReversibility, "LOSSLESS"))
             {
                 m_bJXLLossless = true;
@@ -5799,8 +5804,9 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
         if (TIFFGetField(m_hTIFF, TIFFTAG_PREDICTOR, &nPredictor) &&
             nPredictor > 1)
         {
-            m_oGTiffMDMD.SetMetadataItem(
-                "PREDICTOR", CPLSPrintf("%d", nPredictor), "IMAGE_STRUCTURE");
+            m_oGTiffMDMD.SetMetadataItem("PREDICTOR",
+                                         CPLSPrintf("%d", nPredictor),
+                                         GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
 
@@ -6313,7 +6319,7 @@ char **GTiffDataset::GetMetadataDomainList()
 CSLConstList GTiffDataset::GetMetadata(const char *pszDomain)
 
 {
-    if (pszDomain != nullptr && EQUAL(pszDomain, "IMAGE_STRUCTURE"))
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE))
     {
         GTiffDataset::GetMetadataItem("COMPRESSION_REVERSIBILITY", pszDomain);
         GTiffDataset::GetMetadataItem("LAYOUT", pszDomain);
@@ -6359,14 +6365,14 @@ const char *GTiffDataset::GetMetadataItem(const char *pszName,
                                           const char *pszDomain)
 
 {
-    if (pszDomain != nullptr && EQUAL(pszDomain, "IMAGE_STRUCTURE"))
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE))
     {
         if ((m_nCompression == COMPRESSION_WEBP ||
              m_nCompression == COMPRESSION_JXL ||
              m_nCompression == COMPRESSION_JXL_DNG_1_7) &&
             EQUAL(pszName, "COMPRESSION_REVERSIBILITY") &&
             m_oGTiffMDMD.GetMetadataItem("COMPRESSION_REVERSIBILITY",
-                                         "IMAGE_STRUCTURE") == nullptr)
+                                         GDAL_MDD_IMAGE_STRUCTURE) == nullptr)
         {
             const char *pszDriverName =
                 m_nCompression == COMPRESSION_WEBP ? "WEBP" : "JPEGXL";
@@ -6393,11 +6399,12 @@ const char *GTiffDataset::GetMetadataItem(const char *pszName,
                     {
                         const char *pszReversibility =
                             poWebPDataset->GetMetadataItem(
-                                "COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE");
+                                "COMPRESSION_REVERSIBILITY",
+                                GDAL_MDD_IMAGE_STRUCTURE);
                         if (pszReversibility)
                             m_oGTiffMDMD.SetMetadataItem(
                                 "COMPRESSION_REVERSIBILITY", pszReversibility,
-                                "IMAGE_STRUCTURE");
+                                GDAL_MDD_IMAGE_STRUCTURE);
                     }
                 }
             }
@@ -6406,12 +6413,12 @@ const char *GTiffDataset::GetMetadataItem(const char *pszName,
         if (!m_bLayoutChecked && m_poBaseDS == nullptr)
         {
             m_bLayoutChecked = true;
-            const char *pszLayout =
-                m_oGTiffMDMD.GetMetadataItem("LAYOUT", "IMAGE_STRUCTURE");
+            const char *pszLayout = m_oGTiffMDMD.GetMetadataItem(
+                "LAYOUT", GDAL_MDD_IMAGE_STRUCTURE);
             if (eAccess == GA_ReadOnly && !pszLayout && CheckCOGLayout())
             {
                 m_oGTiffMDMD.SetMetadataItem("LAYOUT", "COG",
-                                             "IMAGE_STRUCTURE");
+                                             GDAL_MDD_IMAGE_STRUCTURE);
             }
         }
     }

--- a/frmts/gtiff/gtiffdataset_read.cpp
+++ b/frmts/gtiff/gtiffdataset_read.cpp
@@ -36,7 +36,7 @@
 #include "cpl_vsi_virtual.h"
 #include "cpl_worker_thread_pool.h"
 #include "fetchbufferdirectio.h"
-#include "gdal_mdreader.h"  // MD_DOMAIN_RPC
+#include "gdal_mdreader.h"  // GDAL_MDD_RPC
 #include "gdal_priv.h"
 #include "geovalues.h"        // RasterPixelIsPoint
 #include "gt_wkt_srs_priv.h"  // GDALGTIFKeyGetSHORT()
@@ -6307,7 +6307,7 @@ char **GTiffDataset::GetMetadataDomainList()
     CSLDestroy(papszBaseList);
 
     return BuildMetadataDomainList(papszDomainList, TRUE, "",
-                                   "ProxyOverviewRequest", MD_DOMAIN_RPC,
+                                   "ProxyOverviewRequest", GDAL_MDD_RPC,
                                    GDAL_MDD_IMD, "SUBDATASETS", "EXIF",
                                    "xml:XMP", "COLOR_PROFILE", nullptr);
 }
@@ -6337,7 +6337,7 @@ CSLConstList GTiffDataset::GetMetadata(const char *pszDomain)
         return GDALDataset::GetMetadata(pszDomain);
     }
 
-    else if (pszDomain != nullptr && (EQUAL(pszDomain, MD_DOMAIN_RPC) ||
+    else if (pszDomain != nullptr && (EQUAL(pszDomain, GDAL_MDD_RPC) ||
                                       EQUAL(pszDomain, GDAL_MDD_IMD) ||
                                       EQUAL(pszDomain, MD_DOMAIN_IMAGERY)))
         LoadMetadata();
@@ -6431,7 +6431,7 @@ const char *GTiffDataset::GetMetadataItem(const char *pszName,
     {
         return GDALPamDataset::GetMetadataItem(pszName, pszDomain);
     }
-    else if (pszDomain != nullptr && (EQUAL(pszDomain, MD_DOMAIN_RPC) ||
+    else if (pszDomain != nullptr && (EQUAL(pszDomain, GDAL_MDD_RPC) ||
                                       EQUAL(pszDomain, GDAL_MDD_IMD) ||
                                       EQUAL(pszDomain, MD_DOMAIN_IMAGERY)))
     {
@@ -6711,12 +6711,12 @@ void GTiffDataset::LoadMetadata()
     {
         mdreader->FillMetadata(&m_oGTiffMDMD);
 
-        if (mdreader->GetMetadataDomain(MD_DOMAIN_RPC) == nullptr)
+        if (mdreader->GetMetadataDomain(GDAL_MDD_RPC) == nullptr)
         {
             char **papszRPCMD = GTiffDatasetReadRPCTag(m_hTIFF);
             if (papszRPCMD)
             {
-                m_oGTiffMDMD.SetMetadata(papszRPCMD, MD_DOMAIN_RPC);
+                m_oGTiffMDMD.SetMetadata(papszRPCMD, GDAL_MDD_RPC);
                 CSLDestroy(papszRPCMD);
             }
         }
@@ -6728,7 +6728,7 @@ void GTiffDataset::LoadMetadata()
         char **papszRPCMD = GTiffDatasetReadRPCTag(m_hTIFF);
         if (papszRPCMD)
         {
-            m_oGTiffMDMD.SetMetadata(papszRPCMD, MD_DOMAIN_RPC);
+            m_oGTiffMDMD.SetMetadata(papszRPCMD, GDAL_MDD_RPC);
             CSLDestroy(papszRPCMD);
         }
     }

--- a/frmts/gtiff/gtiffdataset_read.cpp
+++ b/frmts/gtiff/gtiffdataset_read.cpp
@@ -6308,7 +6308,7 @@ char **GTiffDataset::GetMetadataDomainList()
 
     return BuildMetadataDomainList(papszDomainList, TRUE, "",
                                    "ProxyOverviewRequest", MD_DOMAIN_RPC,
-                                   MD_DOMAIN_IMD, "SUBDATASETS", "EXIF",
+                                   GDAL_MDD_IMD, "SUBDATASETS", "EXIF",
                                    "xml:XMP", "COLOR_PROFILE", nullptr);
 }
 
@@ -6338,7 +6338,7 @@ CSLConstList GTiffDataset::GetMetadata(const char *pszDomain)
     }
 
     else if (pszDomain != nullptr && (EQUAL(pszDomain, MD_DOMAIN_RPC) ||
-                                      EQUAL(pszDomain, MD_DOMAIN_IMD) ||
+                                      EQUAL(pszDomain, GDAL_MDD_IMD) ||
                                       EQUAL(pszDomain, MD_DOMAIN_IMAGERY)))
         LoadMetadata();
 
@@ -6432,7 +6432,7 @@ const char *GTiffDataset::GetMetadataItem(const char *pszName,
         return GDALPamDataset::GetMetadataItem(pszName, pszDomain);
     }
     else if (pszDomain != nullptr && (EQUAL(pszDomain, MD_DOMAIN_RPC) ||
-                                      EQUAL(pszDomain, MD_DOMAIN_IMD) ||
+                                      EQUAL(pszDomain, GDAL_MDD_IMD) ||
                                       EQUAL(pszDomain, MD_DOMAIN_IMAGERY)))
     {
         LoadMetadata();

--- a/frmts/gtiff/gtiffdataset_read.cpp
+++ b/frmts/gtiff/gtiffdataset_read.cpp
@@ -5368,7 +5368,7 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
             GTIFFGetCompressionMethodName(m_nCompression);
         if (pszCompressionMethodName)
         {
-            m_oGTiffMDMD.SetMetadataItem("COMPRESSION",
+            m_oGTiffMDMD.SetMetadataItem(GDALMD_COMPRESSION,
                                          pszCompressionMethodName,
                                          GDAL_MDD_IMAGE_STRUCTURE);
         }
@@ -5376,14 +5376,14 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
         {
             CPLString oComp;
             oComp.Printf("%d", m_nCompression);
-            m_oGTiffMDMD.SetMetadataItem("COMPRESSION", oComp.c_str());
+            m_oGTiffMDMD.SetMetadataItem(GDALMD_COMPRESSION, oComp.c_str());
         }
     }
 
     if (m_nCompression == COMPRESSION_JPEG &&
         m_nPhotometric == PHOTOMETRIC_YCBCR)
     {
-        m_oGTiffMDMD.SetMetadataItem("COMPRESSION", "YCbCr JPEG",
+        m_oGTiffMDMD.SetMetadataItem(GDALMD_COMPRESSION, "YCbCr JPEG",
                                      GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (m_nCompression == COMPRESSION_LERC)
@@ -5404,12 +5404,12 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
         {
             if (nAddVersion == LERC_ADD_COMPRESSION_DEFLATE)
             {
-                m_oGTiffMDMD.SetMetadataItem("COMPRESSION", "LERC_DEFLATE",
+                m_oGTiffMDMD.SetMetadataItem(GDALMD_COMPRESSION, "LERC_DEFLATE",
                                              GDAL_MDD_IMAGE_STRUCTURE);
             }
             else if (nAddVersion == LERC_ADD_COMPRESSION_ZSTD)
             {
-                m_oGTiffMDMD.SetMetadataItem("COMPRESSION", "LERC_ZSTD",
+                m_oGTiffMDMD.SetMetadataItem(GDALMD_COMPRESSION, "LERC_ZSTD",
                                              GDAL_MDD_IMAGE_STRUCTURE);
             }
         }

--- a/frmts/gtiff/gtiffdataset_read.cpp
+++ b/frmts/gtiff/gtiffdataset_read.cpp
@@ -6339,7 +6339,7 @@ CSLConstList GTiffDataset::GetMetadata(const char *pszDomain)
 
     else if (pszDomain != nullptr && (EQUAL(pszDomain, GDAL_MDD_RPC) ||
                                       EQUAL(pszDomain, GDAL_MDD_IMD) ||
-                                      EQUAL(pszDomain, MD_DOMAIN_IMAGERY)))
+                                      EQUAL(pszDomain, GDAL_MDD_IMAGERY)))
         LoadMetadata();
 
     else if (pszDomain != nullptr && EQUAL(pszDomain, "SUBDATASETS"))
@@ -6433,7 +6433,7 @@ const char *GTiffDataset::GetMetadataItem(const char *pszName,
     }
     else if (pszDomain != nullptr && (EQUAL(pszDomain, GDAL_MDD_RPC) ||
                                       EQUAL(pszDomain, GDAL_MDD_IMD) ||
-                                      EQUAL(pszDomain, MD_DOMAIN_IMAGERY)))
+                                      EQUAL(pszDomain, GDAL_MDD_IMAGERY)))
     {
         LoadMetadata();
     }

--- a/frmts/gtiff/gtiffdataset_read.cpp
+++ b/frmts/gtiff/gtiffdataset_read.cpp
@@ -5447,7 +5447,7 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
         for (int i = 0; i < nBands; ++i)
             cpl::down_cast<GTiffRasterBand *>(GetRasterBand(i + 1))
                 ->m_oGTiffMDMD.SetMetadataItem(
-                    "NBITS",
+                    GDALMD_NBITS,
                     CPLString().Printf("%d",
                                        static_cast<int>(m_nBitsPerSample)),
                     GDAL_MDD_IMAGE_STRUCTURE);

--- a/frmts/gtiff/gtiffdataset_read.cpp
+++ b/frmts/gtiff/gtiffdataset_read.cpp
@@ -6308,7 +6308,7 @@ char **GTiffDataset::GetMetadataDomainList()
 
     return BuildMetadataDomainList(papszDomainList, TRUE, "",
                                    "ProxyOverviewRequest", GDAL_MDD_RPC,
-                                   GDAL_MDD_IMD, "SUBDATASETS", "EXIF",
+                                   GDAL_MDD_IMD, GDAL_MDD_SUBDATASETS, "EXIF",
                                    "xml:XMP", "COLOR_PROFILE", nullptr);
 }
 
@@ -6342,7 +6342,7 @@ CSLConstList GTiffDataset::GetMetadata(const char *pszDomain)
                                       EQUAL(pszDomain, GDAL_MDD_IMAGERY)))
         LoadMetadata();
 
-    else if (pszDomain != nullptr && EQUAL(pszDomain, "SUBDATASETS"))
+    else if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_SUBDATASETS))
         ScanDirectories();
 
     else if (pszDomain != nullptr && EQUAL(pszDomain, "EXIF"))
@@ -6437,7 +6437,7 @@ const char *GTiffDataset::GetMetadataItem(const char *pszName,
     {
         LoadMetadata();
     }
-    else if (pszDomain != nullptr && EQUAL(pszDomain, "SUBDATASETS"))
+    else if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_SUBDATASETS))
     {
         ScanDirectories();
     }

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -4120,7 +4120,7 @@ static void WriteMDMetadata(GDALMultiDomainMetadata *poMDMD, TIFF *hTIFF,
         CSLConstList papszMD = poMDMD->GetMetadata(papszDomainList[iDomain]);
         bool bIsXMLOrJSON = false;
 
-        if (EQUAL(papszDomainList[iDomain], "IMAGE_STRUCTURE") ||
+        if (EQUAL(papszDomainList[iDomain], GDAL_MDD_IMAGE_STRUCTURE) ||
             EQUAL(papszDomainList[iDomain], "DERIVED_SUBDATASETS"))
             continue;  // Ignored.
         if (EQUAL(papszDomainList[iDomain], "COLOR_PROFILE"))
@@ -4482,7 +4482,7 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
                      cpl::Iterate(CSLConstList(papszDomainList)))
                 {
                     if (pszDomain[0] != 0 &&
-                        !EQUAL(pszDomain, "IMAGE_STRUCTURE") &&
+                        !EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE) &&
                         (!papszSrcMDD ||
                          CSLFindString(papszSrcMDD, pszDomain) >= 0))
                     {
@@ -4597,7 +4597,7 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
     {
         AppendMetadataItem(&psRoot, &psTail, "OVERVIEW_RESAMPLING",
                            pszOverviewResampling, 0, nullptr,
-                           "IMAGE_STRUCTURE");
+                           GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     /* -------------------------------------------------------------------- */
@@ -4611,7 +4611,7 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
         if (pszTileInterleave && CPLTestBool(pszTileInterleave))
         {
             AppendMetadataItem(&psRoot, &psTail, "INTERLEAVE", "TILE", 0,
-                               nullptr, "IMAGE_STRUCTURE");
+                               nullptr, GDAL_MDD_IMAGE_STRUCTURE);
         }
 
         const char *pszCompress =
@@ -4622,14 +4622,14 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
             {
                 AppendMetadataItem(&psRoot, &psTail,
                                    "COMPRESSION_REVERSIBILITY", "LOSSLESS", 0,
-                                   nullptr, "IMAGE_STRUCTURE");
+                                   nullptr, GDAL_MDD_IMAGE_STRUCTURE);
             }
             else
             {
                 AppendMetadataItem(
                     &psRoot, &psTail, "WEBP_LEVEL",
                     CPLSPrintf("%d", GTiffGetWebPLevel(papszCreationOptions)),
-                    0, nullptr, "IMAGE_STRUCTURE");
+                    0, nullptr, GDAL_MDD_IMAGE_STRUCTURE);
             }
         }
         else if (pszCompress && STARTS_WITH_CI(pszCompress, "LERC"))
@@ -4642,21 +4642,21 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
             {
                 AppendMetadataItem(&psRoot, &psTail,
                                    "COMPRESSION_REVERSIBILITY", "LOSSLESS", 0,
-                                   nullptr, "IMAGE_STRUCTURE");
+                                   nullptr, GDAL_MDD_IMAGE_STRUCTURE);
             }
             else
             {
                 AppendMetadataItem(&psRoot, &psTail, "MAX_Z_ERROR",
                                    CSLFetchNameValueDef(papszCreationOptions,
                                                         "MAX_Z_ERROR", ""),
-                                   0, nullptr, "IMAGE_STRUCTURE");
+                                   0, nullptr, GDAL_MDD_IMAGE_STRUCTURE);
                 if (dfMaxZError != dfMaxZErrorOverview)
                 {
                     AppendMetadataItem(
                         &psRoot, &psTail, "MAX_Z_ERROR_OVERVIEW",
                         CSLFetchNameValueDef(papszCreationOptions,
                                              "MAX_Z_ERROR_OVERVIEW", ""),
-                        0, nullptr, "IMAGE_STRUCTURE");
+                        0, nullptr, GDAL_MDD_IMAGE_STRUCTURE);
                 }
             }
         }
@@ -4668,7 +4668,7 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
             {
                 AppendMetadataItem(&psRoot, &psTail,
                                    "COMPRESSION_REVERSIBILITY", "LOSSLESS", 0,
-                                   nullptr, "IMAGE_STRUCTURE");
+                                   nullptr, GDAL_MDD_IMAGE_STRUCTURE);
             }
             else
             {
@@ -4676,7 +4676,7 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
                 AppendMetadataItem(
                     &psRoot, &psTail, "JXL_DISTANCE",
                     CPLSPrintf("%f", static_cast<double>(fDistance)), 0,
-                    nullptr, "IMAGE_STRUCTURE");
+                    nullptr, GDAL_MDD_IMAGE_STRUCTURE);
             }
             const float fAlphaDistance =
                 GTiffGetJXLAlphaDistance(papszCreationOptions);
@@ -4685,12 +4685,12 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
                 AppendMetadataItem(
                     &psRoot, &psTail, "JXL_ALPHA_DISTANCE",
                     CPLSPrintf("%f", static_cast<double>(fAlphaDistance)), 0,
-                    nullptr, "IMAGE_STRUCTURE");
+                    nullptr, GDAL_MDD_IMAGE_STRUCTURE);
             }
             AppendMetadataItem(
                 &psRoot, &psTail, "JXL_EFFORT",
                 CPLSPrintf("%d", GTiffGetJXLEffort(papszCreationOptions)), 0,
-                nullptr, "IMAGE_STRUCTURE");
+                nullptr, GDAL_MDD_IMAGE_STRUCTURE);
         }
 #endif
     }
@@ -4816,7 +4816,7 @@ void GTiffDataset::PushMetadataToPam()
             if (EQUAL(papszDomainList[iDomain], MD_DOMAIN_RPC) ||
                 EQUAL(papszDomainList[iDomain], MD_DOMAIN_IMD) ||
                 EQUAL(papszDomainList[iDomain], "_temporary_") ||
-                EQUAL(papszDomainList[iDomain], "IMAGE_STRUCTURE") ||
+                EQUAL(papszDomainList[iDomain], GDAL_MDD_IMAGE_STRUCTURE) ||
                 EQUAL(papszDomainList[iDomain], "COLOR_PROFILE"))
                 continue;
 
@@ -6873,7 +6873,8 @@ GDALDataset *GTiffDataset::Create(const char *pszFilename, int nXSize,
     {
         int nColorMode = 0;
 
-        poDS->SetMetadataItem("SOURCE_COLOR_SPACE", "YCbCr", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("SOURCE_COLOR_SPACE", "YCbCr",
+                              GDAL_MDD_IMAGE_STRUCTURE);
         if (!TIFFGetField(l_hTIFF, TIFFTAG_JPEGCOLORMODE, &nColorMode) ||
             nColorMode != JPEGCOLORMODE_RGB)
             TIFFSetField(l_hTIFF, TIFFTAG_JPEGCOLORMODE, JPEGCOLORMODE_RGB);
@@ -6989,16 +6990,16 @@ GDALDataset *GTiffDataset::Create(const char *pszFilename, int nXSize,
                                          poDS.get(), iBand + 1));
             poDS->GetRasterBand(iBand + 1)->SetMetadataItem(
                 "NBITS", CPLString().Printf("%d", poDS->m_nBitsPerSample),
-                "IMAGE_STRUCTURE");
+                GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
 
     poDS->GetDiscardLsbOption(papszParamList);
 
     if (poDS->m_nPlanarConfig == PLANARCONFIG_CONTIG && l_nBands != 1)
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
     else
-        poDS->SetMetadataItem("INTERLEAVE", "BAND", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("INTERLEAVE", "BAND", GDAL_MDD_IMAGE_STRUCTURE);
 
     poDS->oOvManager.Initialize(poDS.get(), pszFilename);
 
@@ -7377,13 +7378,14 @@ GDALDataset *GTiffDataset::CreateCopy(const char *pszFilename,
     /* -------------------------------------------------------------------- */
     char **papszCreateOptions = CSLDuplicate(papszOptions);
 
-    if (poPBand->GetMetadataItem("NBITS", "IMAGE_STRUCTURE") != nullptr &&
-        atoi(poPBand->GetMetadataItem("NBITS", "IMAGE_STRUCTURE")) > 0 &&
+    if (poPBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE) !=
+            nullptr &&
+        atoi(poPBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE)) > 0 &&
         CSLFetchNameValue(papszCreateOptions, "NBITS") == nullptr)
     {
         papszCreateOptions = CSLSetNameValue(
             papszCreateOptions, "NBITS",
-            poPBand->GetMetadataItem("NBITS", "IMAGE_STRUCTURE"));
+            poPBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE));
     }
 
     if (CSLFetchNameValue(papszOptions, "PIXELTYPE") == nullptr &&
@@ -7391,7 +7393,7 @@ GDALDataset *GTiffDataset::CreateCopy(const char *pszFilename,
     {
         poPBand->EnablePixelTypeSignedByteWarning(false);
         const char *pszPixelType =
-            poPBand->GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
+            poPBand->GetMetadataItem("PIXELTYPE", GDAL_MDD_IMAGE_STRUCTURE);
         poPBand->EnablePixelTypeSignedByteWarning(true);
         if (pszPixelType)
         {
@@ -7691,7 +7693,8 @@ GDALDataset *GTiffDataset::CreateCopy(const char *pszFilename,
                     pasNewExtraSamples[iExtraBand - nBaseSamples - 1] =
                         GTiffGetAlphaValue(
                             poSrcDS->GetRasterBand(iExtraBand)
-                                ->GetMetadataItem("ALPHA", "IMAGE_STRUCTURE"),
+                                ->GetMetadataItem("ALPHA",
+                                                  GDAL_MDD_IMAGE_STRUCTURE),
                             nAlpha);
                 }
             }
@@ -8225,7 +8228,7 @@ GDALDataset *GTiffDataset::CreateCopy(const char *pszFilename,
     if (bTileInterleaving)
     {
         poDS->m_oGTiffMDMD.SetMetadataItem("INTERLEAVE", "TILE",
-                                           "IMAGE_STRUCTURE");
+                                           GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     const bool bAppend = CPLFetchBool(papszOptions, "APPEND_SUBDATASET", false);
@@ -8256,7 +8259,7 @@ GDALDataset *GTiffDataset::CreateCopy(const char *pszFilename,
             poBand->eDataType = GDT_UInt8;
             poBand->EnablePixelTypeSignedByteWarning(false);
             poBand->SetMetadataItem("PIXELTYPE", "SIGNEDBYTE",
-                                    "IMAGE_STRUCTURE");
+                                    GDAL_MDD_IMAGE_STRUCTURE);
             poBand->EnablePixelTypeSignedByteWarning(true);
         }
     }

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -5571,11 +5571,12 @@ TIFF *GTiffDataset::CreateLL(const char *pszFilename, int nXSize, int nYSize,
     /*      specified for GDT_UInt8, GDT_UInt16, GDT_UInt32.                 */
     /* -------------------------------------------------------------------- */
     int l_nBitsPerSample = GDALGetDataTypeSizeBits(eType);
-    if (CSLFetchNameValue(papszParamList, "NBITS") != nullptr)
+    if (CSLFetchNameValue(papszParamList, GDALMD_NBITS) != nullptr)
     {
         int nMinBits = 0;
         int nMaxBits = 0;
-        l_nBitsPerSample = atoi(CSLFetchNameValue(papszParamList, "NBITS"));
+        l_nBitsPerSample =
+            atoi(CSLFetchNameValue(papszParamList, GDALMD_NBITS));
         if (eType == GDT_UInt8)
         {
             nMinBits = 1;
@@ -6592,7 +6593,7 @@ int GTiffDataset::GuessJPEGQuality(bool &bOutHasQuantizationTable,
         CSLSetNameValue(papszLocalParameters, "BLOCKYSIZE", "16");
     if (m_nBitsPerSample == 12)
         papszLocalParameters =
-            CSLSetNameValue(papszLocalParameters, "NBITS", "12");
+            CSLSetNameValue(papszLocalParameters, GDALMD_NBITS, "12");
 
     const CPLString osTmpFilenameIn(
         VSIMemGenerateHiddenFilename("gtiffdataset_guess_jpeg_quality_tmp"));
@@ -6989,7 +6990,7 @@ GDALDataset *GTiffDataset::Create(const char *pszFilename, int nXSize,
             poDS->SetBand(iBand + 1, std::make_unique<GTiffOddBitsBand>(
                                          poDS.get(), iBand + 1));
             poDS->GetRasterBand(iBand + 1)->SetMetadataItem(
-                "NBITS", CPLString().Printf("%d", poDS->m_nBitsPerSample),
+                GDALMD_NBITS, CPLString().Printf("%d", poDS->m_nBitsPerSample),
                 GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
@@ -7380,14 +7381,15 @@ GDALDataset *GTiffDataset::CreateCopy(const char *pszFilename,
     /* -------------------------------------------------------------------- */
     char **papszCreateOptions = CSLDuplicate(papszOptions);
 
-    if (poPBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE) !=
+    if (poPBand->GetMetadataItem(GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE) !=
             nullptr &&
-        atoi(poPBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE)) > 0 &&
-        CSLFetchNameValue(papszCreateOptions, "NBITS") == nullptr)
+        atoi(poPBand->GetMetadataItem(GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE)) >
+            0 &&
+        CSLFetchNameValue(papszCreateOptions, GDALMD_NBITS) == nullptr)
     {
         papszCreateOptions = CSLSetNameValue(
-            papszCreateOptions, "NBITS",
-            poPBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE));
+            papszCreateOptions, GDALMD_NBITS,
+            poPBand->GetMetadataItem(GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE));
     }
 
     if (CSLFetchNameValue(papszOptions, "PIXELTYPE") == nullptr &&

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -4125,7 +4125,7 @@ static void WriteMDMetadata(GDALMultiDomainMetadata *poMDMD, TIFF *hTIFF,
             continue;  // Ignored.
         if (EQUAL(papszDomainList[iDomain], "COLOR_PROFILE"))
             continue;  // Handled elsewhere.
-        if (EQUAL(papszDomainList[iDomain], MD_DOMAIN_RPC))
+        if (EQUAL(papszDomainList[iDomain], GDAL_MDD_RPC))
             continue;  // Handled elsewhere.
         if (EQUAL(papszDomainList[iDomain], "xml:ESRI") &&
             CPLTestBool(CPLGetConfigOption("ESRI_XML_PAM", "NO")))
@@ -4293,7 +4293,7 @@ void GTiffDataset::WriteRPC(GDALDataset *poSrcDS, TIFF *l_hTIFF,
     /*      Handle RPC data written to TIFF RPCCoefficient tag, RPB file,   */
     /*      RPCTEXT file or PAM.                                            */
     /* -------------------------------------------------------------------- */
-    CSLConstList papszRPCMD = poSrcDS->GetMetadata(MD_DOMAIN_RPC);
+    CSLConstList papszRPCMD = poSrcDS->GetMetadata(GDAL_MDD_RPC);
     if (papszRPCMD != nullptr)
     {
         bool bRPCSerializedOtherWay = false;
@@ -4330,7 +4330,7 @@ void GTiffDataset::WriteRPC(GDALDataset *poSrcDS, TIFF *l_hTIFF,
 
         if (!bRPCSerializedOtherWay && bWriteOnlyInPAMIfNeeded && bSrcIsGeoTIFF)
             cpl::down_cast<GTiffDataset *>(poSrcDS)
-                ->GDALPamDataset::SetMetadata(papszRPCMD, MD_DOMAIN_RPC);
+                ->GDALPamDataset::SetMetadata(papszRPCMD, GDAL_MDD_RPC);
     }
 }
 
@@ -4813,7 +4813,7 @@ void GTiffDataset::PushMetadataToPam()
         {
             char **papszMD = poSrcMDMD->GetMetadata(papszDomainList[iDomain]);
 
-            if (EQUAL(papszDomainList[iDomain], MD_DOMAIN_RPC) ||
+            if (EQUAL(papszDomainList[iDomain], GDAL_MDD_RPC) ||
                 EQUAL(papszDomainList[iDomain], GDAL_MDD_IMD) ||
                 EQUAL(papszDomainList[iDomain], "_temporary_") ||
                 EQUAL(papszDomainList[iDomain], GDAL_MDD_IMAGE_STRUCTURE) ||
@@ -9228,7 +9228,7 @@ CPLErr GTiffDataset::SetMetadata(CSLConstList papszMD, const char *pszDomain)
     CPLErr eErr = CE_None;
     if (eAccess == GA_Update)
     {
-        if (pszDomain != nullptr && EQUAL(pszDomain, MD_DOMAIN_RPC))
+        if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_RPC))
         {
             // So that a subsequent GetMetadata() wouldn't override our new
             // values

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -4426,7 +4426,7 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
         /* ------------------------------------------------------------------ */
         /*      Handle metadata data written to an IMD file. */
         /* ------------------------------------------------------------------ */
-        CSLConstList papszIMDMD = poSrcDS->GetMetadata(MD_DOMAIN_IMD);
+        CSLConstList papszIMDMD = poSrcDS->GetMetadata(GDAL_MDD_IMD);
         if (papszIMDMD != nullptr)
         {
             GDALWriteIMDFile(pszTIFFFilename, papszIMDMD);
@@ -4814,7 +4814,7 @@ void GTiffDataset::PushMetadataToPam()
             char **papszMD = poSrcMDMD->GetMetadata(papszDomainList[iDomain]);
 
             if (EQUAL(papszDomainList[iDomain], MD_DOMAIN_RPC) ||
-                EQUAL(papszDomainList[iDomain], MD_DOMAIN_IMD) ||
+                EQUAL(papszDomainList[iDomain], GDAL_MDD_IMD) ||
                 EQUAL(papszDomainList[iDomain], "_temporary_") ||
                 EQUAL(papszDomainList[iDomain], GDAL_MDD_IMAGE_STRUCTURE) ||
                 EQUAL(papszDomainList[iDomain], "COLOR_PROFILE"))

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -2731,7 +2731,7 @@ bool GTiffDataset::GetOverviewParameters(
         nPlanarConfig = PLANARCONFIG_CONTIG;
     }
     const char *pszInterleave =
-        GetOptionValue("INTERLEAVE", "INTERLEAVE_OVERVIEW", &pszOptionKey);
+        GetOptionValue(GDALMD_INTERLEAVE, "INTERLEAVE_OVERVIEW", &pszOptionKey);
     if (pszInterleave != nullptr && pszInterleave[0] != '\0')
     {
         if (EQUAL(pszInterleave, "PIXEL"))
@@ -4610,7 +4610,7 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
             CSLFetchNameValue(papszCreationOptions, "@TILE_INTERLEAVE");
         if (pszTileInterleave && CPLTestBool(pszTileInterleave))
         {
-            AppendMetadataItem(&psRoot, &psTail, "INTERLEAVE", "TILE", 0,
+            AppendMetadataItem(&psRoot, &psTail, GDALMD_INTERLEAVE, "TILE", 0,
                                nullptr, GDAL_MDD_IMAGE_STRUCTURE);
         }
 
@@ -5483,7 +5483,7 @@ TIFF *GTiffDataset::CreateLL(const char *pszFilename, int nXSize, int nYSize,
     else
     {
         if (const char *pszValue =
-                CSLFetchNameValue(papszParamList, "INTERLEAVE"))
+                CSLFetchNameValue(papszParamList, GDALMD_INTERLEAVE))
         {
             if (EQUAL(pszValue, "PIXEL"))
             {
@@ -6997,9 +6997,11 @@ GDALDataset *GTiffDataset::Create(const char *pszFilename, int nXSize,
     poDS->GetDiscardLsbOption(papszParamList);
 
     if (poDS->m_nPlanarConfig == PLANARCONFIG_CONTIG && l_nBands != 1)
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     else
-        poDS->SetMetadataItem("INTERLEAVE", "BAND", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_INTERLEAVE, "BAND",
+                              GDAL_MDD_IMAGE_STRUCTURE);
 
     poDS->oOvManager.Initialize(poDS.get(), pszFilename);
 
@@ -7851,7 +7853,7 @@ GDALDataset *GTiffDataset::CreateCopy(const char *pszFilename,
     bool bCreateMask = false;
     CPLString osHiddenStructuralMD;
     const char *pszInterleave =
-        CSLFetchNameValueDef(papszOptions, "INTERLEAVE", "PIXEL");
+        CSLFetchNameValueDef(papszOptions, GDALMD_INTERLEAVE, "PIXEL");
     if (bCopySrcOverviews &&
         CPLTestBool(CSLFetchNameValueDef(papszOptions, "TILED", "NO")))
     {
@@ -8227,7 +8229,7 @@ GDALDataset *GTiffDataset::CreateCopy(const char *pszFilename,
 
     if (bTileInterleaving)
     {
-        poDS->m_oGTiffMDMD.SetMetadataItem("INTERLEAVE", "TILE",
+        poDS->m_oGTiffMDMD.SetMetadataItem(GDALMD_INTERLEAVE, "TILE",
                                            GDAL_MDD_IMAGE_STRUCTURE);
     }
 

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -4463,7 +4463,7 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
 
             if (EQUAL(pszCopySrcMDD, "AUTO") && !papszSrcMDD)
             {
-                for (const char *pszDomain : {"", "IMAGERY"})
+                for (const char *pszDomain : {"", GDAL_MDD_IMAGERY})
                 {
                     if (CSLConstList papszMD = poBand->GetMetadata(pszDomain))
                     {

--- a/frmts/gtiff/gtiffjpegoverviewds.cpp
+++ b/frmts/gtiff/gtiffjpegoverviewds.cpp
@@ -80,7 +80,7 @@ GTiffJPEGOverviewDS::GTiffJPEGOverviewDS(GTiffDataset *poParentDSIn,
     for (int i = 1; i <= m_poParentDS->nBands; ++i)
         SetBand(i, new GTiffJPEGOverviewBand(this, i));
 
-    SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+    SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
     if (m_poParentDS->m_nPhotometric == PHOTOMETRIC_YCBCR)
         SetMetadataItem("COMPRESSION", "YCbCr JPEG", GDAL_MDD_IMAGE_STRUCTURE);
     else

--- a/frmts/gtiff/gtiffjpegoverviewds.cpp
+++ b/frmts/gtiff/gtiffjpegoverviewds.cpp
@@ -82,9 +82,10 @@ GTiffJPEGOverviewDS::GTiffJPEGOverviewDS(GTiffDataset *poParentDSIn,
 
     SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
     if (m_poParentDS->m_nPhotometric == PHOTOMETRIC_YCBCR)
-        SetMetadataItem("COMPRESSION", "YCbCr JPEG", GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem(GDALMD_COMPRESSION, "YCbCr JPEG",
+                        GDAL_MDD_IMAGE_STRUCTURE);
     else
-        SetMetadataItem("COMPRESSION", "JPEG", GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem(GDALMD_COMPRESSION, "JPEG", GDAL_MDD_IMAGE_STRUCTURE);
 }
 
 /************************************************************************/

--- a/frmts/gtiff/gtiffjpegoverviewds.cpp
+++ b/frmts/gtiff/gtiffjpegoverviewds.cpp
@@ -80,11 +80,11 @@ GTiffJPEGOverviewDS::GTiffJPEGOverviewDS(GTiffDataset *poParentDSIn,
     for (int i = 1; i <= m_poParentDS->nBands; ++i)
         SetBand(i, new GTiffJPEGOverviewBand(this, i));
 
-    SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+    SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
     if (m_poParentDS->m_nPhotometric == PHOTOMETRIC_YCBCR)
-        SetMetadataItem("COMPRESSION", "YCbCr JPEG", "IMAGE_STRUCTURE");
+        SetMetadataItem("COMPRESSION", "YCbCr JPEG", GDAL_MDD_IMAGE_STRUCTURE);
     else
-        SetMetadataItem("COMPRESSION", "JPEG", "IMAGE_STRUCTURE");
+        SetMetadataItem("COMPRESSION", "JPEG", GDAL_MDD_IMAGE_STRUCTURE);
 }
 
 /************************************************************************/

--- a/frmts/gtiff/gtiffrasterband.cpp
+++ b/frmts/gtiff/gtiffrasterband.cpp
@@ -174,7 +174,7 @@ GTiffRasterBand::GTiffRasterBand(GTiffDataset *poDSIn, int nBandIn)
             {
                 if (v[nBand - nBaseSamples - 1] == EXTRASAMPLE_ASSOCALPHA)
                     m_oGTiffMDMD.SetMetadataItem("ALPHA", "PREMULTIPLIED",
-                                                 "IMAGE_STRUCTURE");
+                                                 GDAL_MDD_IMAGE_STRUCTURE);
                 m_eBandInterp = GCI_AlphaBand;
             }
             else

--- a/frmts/gtiff/gtiffrasterband_read.cpp
+++ b/frmts/gtiff/gtiffrasterband_read.cpp
@@ -1074,7 +1074,7 @@ char **GTiffRasterBand::GetMetadataDomainList()
 CSLConstList GTiffRasterBand::GetMetadata(const char *pszDomain)
 
 {
-    if (pszDomain == nullptr || !EQUAL(pszDomain, "IMAGE_STRUCTURE"))
+    if (pszDomain == nullptr || !EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE))
     {
         m_poGDS->LoadGeoreferencingAndPamIfNeeded();
 
@@ -1175,7 +1175,8 @@ const char *GTiffRasterBand::GetMetadataItem(const char *pszName,
         if (EQUAL(pszName, "HAS_BLOCK_CACHE"))
             return HasBlockCache() ? "1" : "0";
     }
-    else if (pszDomain == nullptr || !EQUAL(pszDomain, "IMAGE_STRUCTURE"))
+    else if (pszDomain == nullptr ||
+             !EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE))
     {
         m_poGDS->LoadGeoreferencingAndPamIfNeeded();
 
@@ -1189,7 +1190,8 @@ const char *GTiffRasterBand::GetMetadataItem(const char *pszName,
     const char *pszRet = m_oGTiffMDMD.GetMetadataItem(pszName, pszDomain);
 
     if (pszRet == nullptr && eDataType == GDT_UInt8 && pszName && pszDomain &&
-        EQUAL(pszDomain, "IMAGE_STRUCTURE") && EQUAL(pszName, "PIXELTYPE"))
+        EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE) &&
+        EQUAL(pszName, "PIXELTYPE"))
     {
         // to get a chance of emitting the warning about this legacy usage
         pszRet = GDALRasterBand::GetMetadataItem(pszName, pszDomain);

--- a/frmts/gtiff/gtiffrasterband_read.cpp
+++ b/frmts/gtiff/gtiffrasterband_read.cpp
@@ -1080,7 +1080,7 @@ CSLConstList GTiffRasterBand::GetMetadata(const char *pszDomain)
 
         m_poGDS->LoadENVIHdrIfNeeded();
     }
-    else if (EQUAL(pszDomain, MD_DOMAIN_IMAGERY))
+    else if (EQUAL(pszDomain, GDAL_MDD_IMAGERY))
     {
         m_poGDS->LoadENVIHdrIfNeeded();
     }
@@ -1182,7 +1182,7 @@ const char *GTiffRasterBand::GetMetadataItem(const char *pszName,
 
         m_poGDS->LoadENVIHdrIfNeeded();
     }
-    else if (EQUAL(pszDomain, MD_DOMAIN_IMAGERY))
+    else if (EQUAL(pszDomain, GDAL_MDD_IMAGERY))
     {
         m_poGDS->LoadENVIHdrIfNeeded();
     }

--- a/frmts/hdf4/hdf4dataset.cpp
+++ b/frmts/hdf4/hdf4dataset.cpp
@@ -76,7 +76,7 @@ HDF4Dataset::~HDF4Dataset()
 char **HDF4Dataset::GetMetadataDomainList()
 {
     return BuildMetadataDomainList(GDALPamDataset::GetMetadataDomainList(),
-                                   TRUE, "SUBDATASETS", nullptr);
+                                   TRUE, GDAL_MDD_SUBDATASETS, nullptr);
 }
 
 /************************************************************************/
@@ -86,7 +86,7 @@ char **HDF4Dataset::GetMetadataDomainList()
 CSLConstList HDF4Dataset::GetMetadata(const char *pszDomain)
 
 {
-    if (pszDomain != nullptr && STARTS_WITH_CI(pszDomain, "SUBDATASETS"))
+    if (pszDomain != nullptr && STARTS_WITH_CI(pszDomain, GDAL_MDD_SUBDATASETS))
         return papszSubDatasets;
 
     return GDALDataset::GetMetadata(pszDomain);

--- a/frmts/hdf4/hdf4imagedataset.cpp
+++ b/frmts/hdf4/hdf4imagedataset.cpp
@@ -1937,24 +1937,26 @@ void HDF4ImageDataset::ProcessModisSDSGeolocation(void)
     /*      We found geolocation information.  Record it as metadata.       */
     /* -------------------------------------------------------------------- */
 
-    SetMetadataItem("SRS", SRS_WKT_WGS84_LAT_LONG, "GEOLOCATION");
+    SetMetadataItem("SRS", SRS_WKT_WGS84_LAT_LONG, GDAL_MDD_GEOLOCATION);
 
     CPLString osWrk;
     osWrk.Printf("HDF4_SDS:UNKNOWN:\"%s\":%d", pszFilename, iXIndex);
-    SetMetadataItem("X_DATASET", osWrk, "GEOLOCATION");
-    SetMetadataItem("X_BAND", "1", "GEOLOCATION");
+    SetMetadataItem("X_DATASET", osWrk, GDAL_MDD_GEOLOCATION);
+    SetMetadataItem("X_BAND", "1", GDAL_MDD_GEOLOCATION);
 
     osWrk.Printf("HDF4_SDS:UNKNOWN:\"%s\":%d", pszFilename, iYIndex);
-    SetMetadataItem("Y_DATASET", osWrk, "GEOLOCATION");
-    SetMetadataItem("Y_BAND", "1", "GEOLOCATION");
+    SetMetadataItem("Y_DATASET", osWrk, GDAL_MDD_GEOLOCATION);
+    SetMetadataItem("Y_BAND", "1", GDAL_MDD_GEOLOCATION);
 
     SetMetadataItem("PIXEL_OFFSET", CPLSPrintf("%d", nPixelOffset),
-                    "GEOLOCATION");
-    SetMetadataItem("PIXEL_STEP", CPLSPrintf("%d", nPixelStep), "GEOLOCATION");
+                    GDAL_MDD_GEOLOCATION);
+    SetMetadataItem("PIXEL_STEP", CPLSPrintf("%d", nPixelStep),
+                    GDAL_MDD_GEOLOCATION);
 
     SetMetadataItem("LINE_OFFSET", CPLSPrintf("%d", nLineOffset),
-                    "GEOLOCATION");
-    SetMetadataItem("LINE_STEP", CPLSPrintf("%d", nLineStep), "GEOLOCATION");
+                    GDAL_MDD_GEOLOCATION);
+    SetMetadataItem("LINE_STEP", CPLSPrintf("%d", nLineStep),
+                    GDAL_MDD_GEOLOCATION);
 }
 
 /************************************************************************/
@@ -2561,31 +2563,31 @@ int HDF4ImageDataset::ProcessSwathGeolocation(int32 hSW, char **papszDimList)
             char *pszWKT = nullptr;
             m_oGCPSRS.exportToWkt(&pszWKT);
             if (pszWKT)
-                SetMetadataItem("SRS", pszWKT, "GEOLOCATION");
+                SetMetadataItem("SRS", pszWKT, GDAL_MDD_GEOLOCATION);
             CPLFree(pszWKT);
 
             CPLString osWrk;
             osWrk.Printf("HDF4_EOS:EOS_SWATH_GEOL:\"%s\":%s:%s", pszFilename,
                          pszSubdatasetName, papszGeolocations[iLongDim]);
-            SetMetadataItem("X_DATASET", osWrk, "GEOLOCATION");
-            SetMetadataItem("X_BAND", "1", "GEOLOCATION");
+            SetMetadataItem("X_DATASET", osWrk, GDAL_MDD_GEOLOCATION);
+            SetMetadataItem("X_BAND", "1", GDAL_MDD_GEOLOCATION);
 
             osWrk.Printf("HDF4_EOS:EOS_SWATH_GEOL:\"%s\":%s:%s", pszFilename,
                          pszSubdatasetName, papszGeolocations[iLatDim]);
-            SetMetadataItem("Y_DATASET", osWrk, "GEOLOCATION");
-            SetMetadataItem("Y_BAND", "1", "GEOLOCATION");
+            SetMetadataItem("Y_DATASET", osWrk, GDAL_MDD_GEOLOCATION);
+            SetMetadataItem("Y_BAND", "1", GDAL_MDD_GEOLOCATION);
 
             if (paiOffset && paiIncrement)
             {
                 osWrk.Printf("%ld", static_cast<long>(paiOffset[iPixelDim]));
-                SetMetadataItem("PIXEL_OFFSET", osWrk, "GEOLOCATION");
+                SetMetadataItem("PIXEL_OFFSET", osWrk, GDAL_MDD_GEOLOCATION);
                 osWrk.Printf("%ld", static_cast<long>(paiIncrement[iPixelDim]));
-                SetMetadataItem("PIXEL_STEP", osWrk, "GEOLOCATION");
+                SetMetadataItem("PIXEL_STEP", osWrk, GDAL_MDD_GEOLOCATION);
 
                 osWrk.Printf("%ld", static_cast<long>(paiOffset[iLineDim]));
-                SetMetadataItem("LINE_OFFSET", osWrk, "GEOLOCATION");
+                SetMetadataItem("LINE_OFFSET", osWrk, GDAL_MDD_GEOLOCATION);
                 osWrk.Printf("%ld", static_cast<long>(paiIncrement[iLineDim]));
-                SetMetadataItem("LINE_STEP", osWrk, "GEOLOCATION");
+                SetMetadataItem("LINE_STEP", osWrk, GDAL_MDD_GEOLOCATION);
             }
         }
 

--- a/frmts/hdf5/bagdataset.cpp
+++ b/frmts/hdf5/bagdataset.cpp
@@ -2501,7 +2501,7 @@ void BAGDataset::InitOverviewDS(BAGDataset *poParentDS, int nXSize, int nYSize)
 
     if (poParentDS->GetRasterCount() > 1)
     {
-        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+        GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                      GDAL_MDD_IMAGE_STRUCTURE);
     }
 }
@@ -3300,7 +3300,7 @@ bool BAGDataset::OpenRaster(GDALOpenInfo *poOpenInfo,
 
         if (GetRasterCount() > 1)
         {
-            GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+            GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                          GDAL_MDD_IMAGE_STRUCTURE);
         }
 
@@ -3466,7 +3466,7 @@ bool BAGDataset::OpenRaster(GDALOpenInfo *poOpenInfo,
                                                     fNoDataValue));
             }
 
-            GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+            GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                          GDAL_MDD_IMAGE_STRUCTURE);
         }
 

--- a/frmts/hdf5/bagdataset.cpp
+++ b/frmts/hdf5/bagdataset.cpp
@@ -537,16 +537,16 @@ bool BAGRasterBand::Initialize(hid_t hDatasetIDIn, const char *pszName)
                 listid, i, &flags, &cd_nelmts, cd_values, sizeof(name), name);
             if (filter == H5Z_FILTER_DEFLATE)
                 poDS->GDALDataset::SetMetadataItem("COMPRESSION", "DEFLATE",
-                                                   "IMAGE_STRUCTURE");
+                                                   GDAL_MDD_IMAGE_STRUCTURE);
             else if (filter == H5Z_FILTER_NBIT)
                 poDS->GDALDataset::SetMetadataItem("COMPRESSION", "NBIT",
-                                                   "IMAGE_STRUCTURE");
+                                                   GDAL_MDD_IMAGE_STRUCTURE);
             else if (filter == H5Z_FILTER_SCALEOFFSET)
                 poDS->GDALDataset::SetMetadataItem("COMPRESSION", "SCALEOFFSET",
-                                                   "IMAGE_STRUCTURE");
+                                                   GDAL_MDD_IMAGE_STRUCTURE);
             else if (filter == H5Z_FILTER_SZIP)
                 poDS->GDALDataset::SetMetadataItem("COMPRESSION", "SZIP",
-                                                   "IMAGE_STRUCTURE");
+                                                   GDAL_MDD_IMAGE_STRUCTURE);
         }
 
         H5Pclose(listid);
@@ -2501,7 +2501,8 @@ void BAGDataset::InitOverviewDS(BAGDataset *poParentDS, int nXSize, int nYSize)
 
     if (poParentDS->GetRasterCount() > 1)
     {
-        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
 }
 
@@ -3300,7 +3301,7 @@ bool BAGDataset::OpenRaster(GDALOpenInfo *poOpenInfo,
         if (GetRasterCount() > 1)
         {
             GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
-                                         "IMAGE_STRUCTURE");
+                                         GDAL_MDD_IMAGE_STRUCTURE);
         }
 
         const bool bCanUseLowResAsOvr = nRasterXSize > m_nLowResWidth &&
@@ -3466,7 +3467,7 @@ bool BAGDataset::OpenRaster(GDALOpenInfo *poOpenInfo,
             }
 
             GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
-                                         "IMAGE_STRUCTURE");
+                                         GDAL_MDD_IMAGE_STRUCTURE);
         }
 
         SetPhysicalFilename(osFilename);

--- a/frmts/hdf5/bagdataset.cpp
+++ b/frmts/hdf5/bagdataset.cpp
@@ -5008,7 +5008,7 @@ CSLConstList BAGDataset::GetMetadata(const char *pszDomain)
         return apszMDList;
     }
 
-    if (pszDomain != nullptr && EQUAL(pszDomain, "SUBDATASETS"))
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_SUBDATASETS))
     {
         return m_aosSubdatasets.List();
     }

--- a/frmts/hdf5/bagdataset.cpp
+++ b/frmts/hdf5/bagdataset.cpp
@@ -536,16 +536,17 @@ bool BAGRasterBand::Initialize(hid_t hDatasetIDIn, const char *pszName)
             const H5Z_filter_t filter = H5Pget_filter(
                 listid, i, &flags, &cd_nelmts, cd_values, sizeof(name), name);
             if (filter == H5Z_FILTER_DEFLATE)
-                poDS->GDALDataset::SetMetadataItem("COMPRESSION", "DEFLATE",
-                                                   GDAL_MDD_IMAGE_STRUCTURE);
+                poDS->GDALDataset::SetMetadataItem(
+                    GDALMD_COMPRESSION, "DEFLATE", GDAL_MDD_IMAGE_STRUCTURE);
             else if (filter == H5Z_FILTER_NBIT)
-                poDS->GDALDataset::SetMetadataItem("COMPRESSION", "NBIT",
+                poDS->GDALDataset::SetMetadataItem(GDALMD_COMPRESSION, "NBIT",
                                                    GDAL_MDD_IMAGE_STRUCTURE);
             else if (filter == H5Z_FILTER_SCALEOFFSET)
-                poDS->GDALDataset::SetMetadataItem("COMPRESSION", "SCALEOFFSET",
+                poDS->GDALDataset::SetMetadataItem(GDALMD_COMPRESSION,
+                                                   "SCALEOFFSET",
                                                    GDAL_MDD_IMAGE_STRUCTURE);
             else if (filter == H5Z_FILTER_SZIP)
-                poDS->GDALDataset::SetMetadataItem("COMPRESSION", "SZIP",
+                poDS->GDALDataset::SetMetadataItem(GDALMD_COMPRESSION, "SZIP",
                                                    GDAL_MDD_IMAGE_STRUCTURE);
         }
 

--- a/frmts/hdf5/hdf5dataset.cpp
+++ b/frmts/hdf5/hdf5dataset.cpp
@@ -556,7 +556,7 @@ GDALDataset *HDF5Dataset::Open(GDALOpenInfo *poOpenInfo)
     poDS->SetMetadata(poDS->m_aosMetadata.List());
 
     if (CSLCount(poDS->papszSubDatasets) / 2 >= 1)
-        poDS->SetMetadata(poDS->papszSubDatasets, "SUBDATASETS");
+        poDS->SetMetadata(poDS->papszSubDatasets, GDAL_MDD_SUBDATASETS);
 
     // Make sure we don't try to do any pam stuff with this dataset.
     poDS->nPamFlags |= GPF_NOSAVE;

--- a/frmts/hdf5/hdf5imagedataset.cpp
+++ b/frmts/hdf5/hdf5imagedataset.cpp
@@ -1285,11 +1285,11 @@ GDALDataset *HDF5ImageDataset::Open(GDALOpenInfo *poOpenInfo)
 
                 if (poDS->m_nBandChunkSize > 1)
                     poDS->SetMetadataItem("INTERLEAVE", "PIXEL",
-                                          "IMAGE_STRUCTURE");
+                                          GDAL_MDD_IMAGE_STRUCTURE);
 
                 poDS->SetMetadataItem("BAND_CHUNK_SIZE",
                                       CPLSPrintf("%d", poDS->m_nBandChunkSize),
-                                      "IMAGE_STRUCTURE");
+                                      GDAL_MDD_IMAGE_STRUCTURE);
             }
         }
 
@@ -1304,11 +1304,12 @@ GDALDataset *HDF5ImageDataset::Open(GDALOpenInfo *poOpenInfo)
             if (eFilter == H5Z_FILTER_DEFLATE)
             {
                 poDS->SetMetadataItem("COMPRESSION", "DEFLATE",
-                                      "IMAGE_STRUCTURE");
+                                      GDAL_MDD_IMAGE_STRUCTURE);
             }
             else if (eFilter == H5Z_FILTER_SZIP)
             {
-                poDS->SetMetadataItem("COMPRESSION", "SZIP", "IMAGE_STRUCTURE");
+                poDS->SetMetadataItem("COMPRESSION", "SZIP",
+                                      GDAL_MDD_IMAGE_STRUCTURE);
             }
         }
 

--- a/frmts/hdf5/hdf5imagedataset.cpp
+++ b/frmts/hdf5/hdf5imagedataset.cpp
@@ -1284,7 +1284,7 @@ GDALDataset *HDF5ImageDataset::Open(GDALOpenInfo *poOpenInfo)
                     static_cast<int>(panChunkDims[poDS->m_nOtherDimIndex]);
 
                 if (poDS->m_nBandChunkSize > 1)
-                    poDS->SetMetadataItem("INTERLEAVE", "PIXEL",
+                    poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                           GDAL_MDD_IMAGE_STRUCTURE);
 
                 poDS->SetMetadataItem("BAND_CHUNK_SIZE",

--- a/frmts/hdf5/hdf5imagedataset.cpp
+++ b/frmts/hdf5/hdf5imagedataset.cpp
@@ -1303,12 +1303,12 @@ GDALDataset *HDF5ImageDataset::Open(GDALOpenInfo *poOpenInfo)
                                                nullptr, 64, szName);
             if (eFilter == H5Z_FILTER_DEFLATE)
             {
-                poDS->SetMetadataItem("COMPRESSION", "DEFLATE",
+                poDS->SetMetadataItem(GDALMD_COMPRESSION, "DEFLATE",
                                       GDAL_MDD_IMAGE_STRUCTURE);
             }
             else if (eFilter == H5Z_FILTER_SZIP)
             {
-                poDS->SetMetadataItem("COMPRESSION", "SZIP",
+                poDS->SetMetadataItem(GDALMD_COMPRESSION, "SZIP",
                                       GDAL_MDD_IMAGE_STRUCTURE);
             }
         }

--- a/frmts/hdf5/hdf5imagedataset.cpp
+++ b/frmts/hdf5/hdf5imagedataset.cpp
@@ -1184,7 +1184,8 @@ GDALDataset *HDF5ImageDataset::Open(GDALOpenInfo *poOpenInfo)
                     // Not totally sure about that
                     aosGeolocation.AddNameValue("GEOREFERENCING_CONVENTION",
                                                 "PIXEL_CENTER");
-                    poDS->SetMetadata(aosGeolocation.List(), "GEOLOCATION");
+                    poDS->SetMetadata(aosGeolocation.List(),
+                                      GDAL_MDD_GEOLOCATION);
                 }
             }
         }
@@ -1333,7 +1334,7 @@ GDALDataset *HDF5ImageDataset::Open(GDALOpenInfo *poOpenInfo)
         poDS->SetBand(i + 1, std::move(poBand));
     }
 
-    if (!poDS->GetMetadata("GEOLOCATION"))
+    if (!poDS->GetMetadata(GDAL_MDD_GEOLOCATION))
         poDS->CreateProjections();
 
     // Setup/check for pam .aux.xml.
@@ -1347,7 +1348,7 @@ GDALDataset *HDF5ImageDataset::Open(GDALOpenInfo *poOpenInfo)
     // Or scenarios like https://github.com/OSGeo/gdal/issues/12824 mixing
     // native Windows and WSL use.
     CSLConstList papszGeoLocationAfterLoadXML =
-        poDS->GetMetadata("GEOLOCATION");
+        poDS->GetMetadata(GDAL_MDD_GEOLOCATION);
     if (papszGeoLocationAfterLoadXML)
     {
         for (const char *pszItem : {"X_DATASET", "Y_DATASET"})
@@ -1368,7 +1369,7 @@ GDALDataset *HDF5ImageDataset::Open(GDALOpenInfo *poOpenInfo)
                         char *pszNewVal = GDALSubdatasetInfoModifyPathComponent(
                             hSubDSInfo, osFilename.c_str());
                         poDS->SetMetadataItem(pszItem, pszNewVal,
-                                              "GEOLOCATION");
+                                              GDAL_MDD_GEOLOCATION);
                         CPLFree(pszNewVal);
                     }
                     CPLFree(pszOriPath);

--- a/frmts/hdf5/hdf5multidim.cpp
+++ b/frmts/hdf5/hdf5multidim.cpp
@@ -1916,7 +1916,7 @@ static CPLStringList GetFilterInfo(hid_t hArray, unsigned nFilterMask)
         }
         H5Pclose(nListId);
         if (pszCompression)
-            aosInfo.SetNameValue("COMPRESSION", pszCompression);
+            aosInfo.SetNameValue(GDALMD_COMPRESSION, pszCompression);
         if (!osFilters.empty())
             aosInfo.SetNameValue("FILTER", osFilters.c_str());
     }

--- a/frmts/hdf5/s102dataset.cpp
+++ b/frmts/hdf5/s102dataset.cpp
@@ -316,7 +316,7 @@ GDALDataset *S102Dataset::Open(GDALOpenInfo *poOpenInfo)
                 }
 
                 poDS->GDALDataset::SetMetadata(aosSubDSList.List(),
-                                               "SUBDATASETS");
+                                               GDAL_MDD_SUBDATASETS);
 
                 // Setup/check for pam .aux.xml.
                 poDS->SetDescription(osFilename.c_str());
@@ -561,19 +561,20 @@ GDALDataset *S102Dataset::Open(GDALOpenInfo *poOpenInfo)
                 "SUBDATASET_1_NAME",
                 CPLSPrintf("S102:\"%s\":BathymetryCoverage",
                            osFilename.c_str()),
-                "SUBDATASETS");
-            poDS->GDALDataset::SetMetadataItem(
-                "SUBDATASET_1_DESC", "Bathymetric gridded data", "SUBDATASETS");
+                GDAL_MDD_SUBDATASETS);
+            poDS->GDALDataset::SetMetadataItem("SUBDATASET_1_DESC",
+                                               "Bathymetric gridded data",
+                                               GDAL_MDD_SUBDATASETS);
 
             poDS->GDALDataset::SetMetadataItem(
                 "SUBDATASET_2_NAME",
                 CPLSPrintf("S102:\"%s\":%s", osFilename.c_str(),
                            pszNameOfQualityGroup),
-                "SUBDATASETS");
+                GDAL_MDD_SUBDATASETS);
             poDS->GDALDataset::SetMetadataItem(
                 "SUBDATASET_2_DESC",
                 CPLSPrintf("Georeferenced metadata %s", pszNameOfQualityGroup),
-                "SUBDATASETS");
+                GDAL_MDD_SUBDATASETS);
         }
     }
 
@@ -856,8 +857,8 @@ bool S102Creator::Create(GDALProgressFunc pfnProgress, void *pProgressData)
     const GDALRasterAttributeTable *poRAT = nullptr;
     if (!pszQualityDataset && !bAppendSubdataset)
     {
-        const char *pszSubDSName =
-            m_poSrcDS->GetMetadataItem("SUBDATASET_2_NAME", "SUBDATASETS");
+        const char *pszSubDSName = m_poSrcDS->GetMetadataItem(
+            "SUBDATASET_2_NAME", GDAL_MDD_SUBDATASETS);
         if (pszSubDSName &&
             cpl::starts_with(std::string_view(pszSubDSName), "S102:") &&
             cpl::ends_with(std::string_view(pszSubDSName),

--- a/frmts/hdf5/s104dataset.cpp
+++ b/frmts/hdf5/s104dataset.cpp
@@ -319,7 +319,8 @@ GDALDataset *S104Dataset::Open(GDALOpenInfo *poOpenInfo)
             }
         }
 
-        poDS->GDALDataset::SetMetadata(aosSubDSList.List(), "SUBDATASETS");
+        poDS->GDALDataset::SetMetadata(aosSubDSList.List(),
+                                       GDAL_MDD_SUBDATASETS);
 
         // Setup/check for pam .aux.xml.
         poDS->SetDescription(osFilename.c_str());
@@ -401,7 +402,7 @@ GDALDataset *S104Dataset::Open(GDALOpenInfo *poOpenInfo)
                     CPLSPrintf("SUBDATASET_%d_NAME", iSubDS),
                     CPLSPrintf("S104:\"%s\":%s", osFilename.c_str(),
                                osSubGroup.c_str()),
-                    "SUBDATASETS");
+                    GDAL_MDD_SUBDATASETS);
                 std::string osSubDSDesc = "Values for group ";
                 osSubDSDesc += osSubGroup;
                 const auto poTimePoint = poSubGroup->GetAttribute("timePoint");
@@ -416,7 +417,7 @@ GDALDataset *S104Dataset::Open(GDALOpenInfo *poOpenInfo)
                 }
                 poDS->GDALDataset::SetMetadataItem(
                     CPLSPrintf("SUBDATASET_%d_DESC", iSubDS),
-                    osSubDSDesc.c_str(), "SUBDATASETS");
+                    osSubDSDesc.c_str(), GDAL_MDD_SUBDATASETS);
                 ++iSubDS;
             }
         }
@@ -691,7 +692,8 @@ bool S104Creator::Create(GDALProgressFunc pfnProgress, void *pProgressData)
     if (m_poSrcDS->GetRasterCount() == 0 && aosDatasets.empty())
     {
         // Deal with S104 -> S104 translation;
-        CSLConstList papszSubdatasets = m_poSrcDS->GetMetadata("SUBDATASETS");
+        CSLConstList papszSubdatasets =
+            m_poSrcDS->GetMetadata(GDAL_MDD_SUBDATASETS);
         if (papszSubdatasets)
         {
             int iSubDS = 0;

--- a/frmts/hdf5/s111dataset.cpp
+++ b/frmts/hdf5/s111dataset.cpp
@@ -367,7 +367,8 @@ GDALDataset *S111Dataset::Open(GDALOpenInfo *poOpenInfo)
             }
         }
 
-        poDS->GDALDataset::SetMetadata(aosSubDSList.List(), "SUBDATASETS");
+        poDS->GDALDataset::SetMetadata(aosSubDSList.List(),
+                                       GDAL_MDD_SUBDATASETS);
 
         // Setup/check for pam .aux.xml.
         poDS->SetDescription(osFilename.c_str());
@@ -501,7 +502,7 @@ GDALDataset *S111Dataset::Open(GDALOpenInfo *poOpenInfo)
                     CPLSPrintf("SUBDATASET_%d_NAME", iSubDS),
                     CPLSPrintf("S111:\"%s\":%s", osFilename.c_str(),
                                osSubGroup.c_str()),
-                    "SUBDATASETS");
+                    GDAL_MDD_SUBDATASETS);
                 std::string osSubDSDesc = "Values for group ";
                 osSubDSDesc += osSubGroup;
                 const auto poTimePoint = poSubGroup->GetAttribute("timePoint");
@@ -516,7 +517,7 @@ GDALDataset *S111Dataset::Open(GDALOpenInfo *poOpenInfo)
                 }
                 poDS->GDALDataset::SetMetadataItem(
                     CPLSPrintf("SUBDATASET_%d_DESC", iSubDS),
-                    osSubDSDesc.c_str(), "SUBDATASETS");
+                    osSubDSDesc.c_str(), GDAL_MDD_SUBDATASETS);
                 ++iSubDS;
             }
         }
@@ -792,7 +793,8 @@ bool S111Creator::Create(GDALProgressFunc pfnProgress, void *pProgressData)
     if (m_poSrcDS->GetRasterCount() == 0 && aosDatasets.empty())
     {
         // Deal with S111 -> S111 translation;
-        CSLConstList papszSubdatasets = m_poSrcDS->GetMetadata("SUBDATASETS");
+        CSLConstList papszSubdatasets =
+            m_poSrcDS->GetMetadata(GDAL_MDD_SUBDATASETS);
         if (papszSubdatasets)
         {
             int iSubDS = 0;

--- a/frmts/heif/heifdataset.cpp
+++ b/frmts/heif/heifdataset.cpp
@@ -319,7 +319,7 @@ bool GDALHEIFDataset::Init(GDALOpenInfo *poOpenInfo)
                 aosSubDS.SetNameValue(CPLSPrintf("SUBDATASET_%d_DESC", i + 1),
                                       CPLSPrintf("Subdataset %d", i + 1));
             }
-            GDALDataset::SetMetadata(aosSubDS.List(), "SUBDATASETS");
+            GDALDataset::SetMetadata(aosSubDS.List(), GDAL_MDD_SUBDATASETS);
         }
     }
     else if (iPart > nSubdatasets)

--- a/frmts/heif/heifdataset.cpp
+++ b/frmts/heif/heifdataset.cpp
@@ -838,7 +838,7 @@ GDALHEIFRasterBand::GDALHEIFRasterBand(GDALHEIFDataset *poDSIn, int nBandIn)
     if (nBits != 8 && nBits != 16)
     {
         GDALRasterBand::SetMetadataItem("NBITS", CPLSPrintf("%d", nBits),
-                                        "IMAGE_STRUCTURE");
+                                        GDAL_MDD_IMAGE_STRUCTURE);
     }
 #endif
 

--- a/frmts/heif/heifdataset.cpp
+++ b/frmts/heif/heifdataset.cpp
@@ -837,7 +837,7 @@ GDALHEIFRasterBand::GDALHEIFRasterBand(GDALHEIFDataset *poDSIn, int nBandIn)
     }
     if (nBits != 8 && nBits != 16)
     {
-        GDALRasterBand::SetMetadataItem("NBITS", CPLSPrintf("%d", nBits),
+        GDALRasterBand::SetMetadataItem(GDALMD_NBITS, CPLSPrintf("%d", nBits),
                                         GDAL_MDD_IMAGE_STRUCTURE);
     }
 #endif

--- a/frmts/hfa/hfadataset.cpp
+++ b/frmts/hfa/hfadataset.cpp
@@ -1913,7 +1913,7 @@ HFARasterBand::HFARasterBand(HFADataset *poDSIn, int nBandIn, int iOverview)
     // Set some other information.
     if (nCompression != 0)
         GDALMajorObject::SetMetadataItem("COMPRESSION", "RLE",
-                                         "IMAGE_STRUCTURE");
+                                         GDAL_MDD_IMAGE_STRUCTURE);
 
     switch (eHFADataType)
     {
@@ -1973,7 +1973,7 @@ HFARasterBand::HFARasterBand(HFADataset *poDSIn, int nBandIn, int iOverview)
     {
         GDALMajorObject::SetMetadataItem(
             "NBITS", CPLString().Printf("%d", HFAGetDataTypeBits(eHFADataType)),
-            "IMAGE_STRUCTURE");
+            GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     // Collect color table if present.
@@ -5260,7 +5260,7 @@ GDALDataset *HFADataset::CreateCopy(const char *pszFilename,
         auto poSrcBand = poSrcDS->GetRasterBand(1);
         poSrcBand->EnablePixelTypeSignedByteWarning(false);
         const char *pszPixelType =
-            poSrcBand->GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
+            poSrcBand->GetMetadataItem("PIXELTYPE", GDAL_MDD_IMAGE_STRUCTURE);
         poSrcBand->EnablePixelTypeSignedByteWarning(true);
         if (pszPixelType)
         {

--- a/frmts/hfa/hfadataset.cpp
+++ b/frmts/hfa/hfadataset.cpp
@@ -1905,7 +1905,7 @@ HFARasterBand::HFARasterBand(HFADataset *poDSIn, int nBandIn, int iOverview)
         {
             GDALMajorObject::SetMetadataItem("RESAMPLING",
                                              "AVERAGE_BIT2GRAYSCALE");
-            GDALMajorObject::SetMetadataItem("NBITS", "8");
+            GDALMajorObject::SetMetadataItem(GDALMD_NBITS, "8");
         }
         eHFADataType = eHFADataTypeO;
     }
@@ -1972,7 +1972,8 @@ HFARasterBand::HFARasterBand(HFADataset *poDSIn, int nBandIn, int iOverview)
     if (HFAGetDataTypeBits(eHFADataType) < 8)
     {
         GDALMajorObject::SetMetadataItem(
-            "NBITS", CPLString().Printf("%d", HFAGetDataTypeBits(eHFADataType)),
+            GDALMD_NBITS,
+            CPLString().Printf("%d", HFAGetDataTypeBits(eHFADataType)),
             GDAL_MDD_IMAGE_STRUCTURE);
     }
 
@@ -5021,9 +5022,10 @@ GDALDataset *HFADataset::Create(const char *pszFilenameIn, int nXSize,
                                 CSLConstList papszParamList)
 
 {
-    const int nBits = CSLFetchNameValue(papszParamList, "NBITS") != nullptr
-                          ? atoi(CSLFetchNameValue(papszParamList, "NBITS"))
-                          : 0;
+    const int nBits =
+        CSLFetchNameValue(papszParamList, GDALMD_NBITS) != nullptr
+            ? atoi(CSLFetchNameValue(papszParamList, GDALMD_NBITS))
+            : 0;
 
     const char *pszPixelType = CSLFetchNameValue(papszParamList, "PIXELTYPE");
     if (pszPixelType == nullptr)

--- a/frmts/hfa/hfadataset.cpp
+++ b/frmts/hfa/hfadataset.cpp
@@ -1912,7 +1912,7 @@ HFARasterBand::HFARasterBand(HFADataset *poDSIn, int nBandIn, int iOverview)
 
     // Set some other information.
     if (nCompression != 0)
-        GDALMajorObject::SetMetadataItem("COMPRESSION", "RLE",
+        GDALMajorObject::SetMetadataItem(GDALMD_COMPRESSION, "RLE",
                                          GDAL_MDD_IMAGE_STRUCTURE);
 
     switch (eHFADataType)

--- a/frmts/jp2kak/jp2kakdataset.cpp
+++ b/frmts/jp2kak/jp2kakdataset.cpp
@@ -96,7 +96,7 @@ JP2KAKRasterBand::JP2KAKRasterBand(int nBandIn, kdu_codestream oCodeStreamIn,
         !poBaseDSIn->bPromoteTo8Bit)
     {
         SetMetadataItem(
-            "NBITS",
+            GDALMD_NBITS,
             CPLString().Printf("%d", oCodeStream.get_bit_depth(nBand - 1)),
             GDAL_MDD_IMAGE_STRUCTURE);
     }
@@ -2322,10 +2322,10 @@ static GDALDataset *JP2KAKCreateCopy(const char *pszFilename,
     // Work out the precision.
     int nBits = 0;
 
-    const char *pszNBITS = CSLFetchNameValue(papszOptions, "NBITS");
+    const char *pszNBITS = CSLFetchNameValue(papszOptions, GDALMD_NBITS);
     if (pszNBITS == nullptr)
-        pszNBITS =
-            poPrototypeBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+        pszNBITS = poPrototypeBand->GetMetadataItem(GDALMD_NBITS,
+                                                    GDAL_MDD_IMAGE_STRUCTURE);
     if (pszNBITS != nullptr)
     {
         nBits = atoi(pszNBITS);

--- a/frmts/jp2kak/jp2kakdataset.cpp
+++ b/frmts/jp2kak/jp2kakdataset.cpp
@@ -2690,7 +2690,8 @@ static GDALDataset *JP2KAKCreateCopy(const char *pszFilename,
         ((poSrcDS->GetGeoTransform(gt) == CE_None &&
           (gt.xorig != 0.0 || gt.xscale != 1.0 || gt.xrot != 0.0 ||
            gt.yorig != 0.0 || gt.yrot != 0.0 || std::abs(gt.yscale) != 1.0)) ||
-         poSrcDS->GetGCPCount() > 0 || poSrcDS->GetMetadata("RPC") != nullptr))
+         poSrcDS->GetGCPCount() > 0 ||
+         poSrcDS->GetMetadata(GDAL_MDD_RPC) != nullptr))
     {
         GDALJP2Metadata oJP2MD;
 
@@ -2705,7 +2706,7 @@ static GDALDataset *JP2KAKCreateCopy(const char *pszFilename,
             oJP2MD.SetGeoTransform(gt);
         }
 
-        oJP2MD.SetRPCMD(poSrcDS->GetMetadata("RPC"));
+        oJP2MD.SetRPCMD(poSrcDS->GetMetadata(GDAL_MDD_RPC));
 
         const char *const pszAreaOrPoint =
             poSrcDS->GetMetadataItem(GDALMD_AREA_OR_POINT);

--- a/frmts/jp2kak/jp2kakdataset.cpp
+++ b/frmts/jp2kak/jp2kakdataset.cpp
@@ -98,9 +98,9 @@ JP2KAKRasterBand::JP2KAKRasterBand(int nBandIn, kdu_codestream oCodeStreamIn,
         SetMetadataItem(
             "NBITS",
             CPLString().Printf("%d", oCodeStream.get_bit_depth(nBand - 1)),
-            "IMAGE_STRUCTURE");
+            GDAL_MDD_IMAGE_STRUCTURE);
     }
-    SetMetadataItem("COMPRESSION", "JP2000", "IMAGE_STRUCTURE");
+    SetMetadataItem("COMPRESSION", "JP2000", GDAL_MDD_IMAGE_STRUCTURE);
 
     // Use tile dimension as block size, unless it is too big
     kdu_dims valid_tiles;
@@ -1023,7 +1023,7 @@ GDALDataset *JP2KAKDataset::Open(GDALOpenInfo *poOpenInfo)
         }
         if (pszOrder)
         {
-            poDS->SetMetadataItem("Corder", pszOrder, "IMAGE_STRUCTURE");
+            poDS->SetMetadataItem("Corder", pszOrder, GDAL_MDD_IMAGE_STRUCTURE);
         }
 
         poDS->bUseYCC = false;
@@ -2324,7 +2324,8 @@ static GDALDataset *JP2KAKCreateCopy(const char *pszFilename,
 
     const char *pszNBITS = CSLFetchNameValue(papszOptions, "NBITS");
     if (pszNBITS == nullptr)
-        pszNBITS = poPrototypeBand->GetMetadataItem("NBITS", "IMAGE_STRUCTURE");
+        pszNBITS =
+            poPrototypeBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
     if (pszNBITS != nullptr)
     {
         nBits = atoi(pszNBITS);

--- a/frmts/jp2kak/jp2kakdataset.cpp
+++ b/frmts/jp2kak/jp2kakdataset.cpp
@@ -100,7 +100,7 @@ JP2KAKRasterBand::JP2KAKRasterBand(int nBandIn, kdu_codestream oCodeStreamIn,
             CPLString().Printf("%d", oCodeStream.get_bit_depth(nBand - 1)),
             GDAL_MDD_IMAGE_STRUCTURE);
     }
-    SetMetadataItem("COMPRESSION", "JP2000", GDAL_MDD_IMAGE_STRUCTURE);
+    SetMetadataItem(GDALMD_COMPRESSION, "JP2000", GDAL_MDD_IMAGE_STRUCTURE);
 
     // Use tile dimension as block size, unless it is too big
     kdu_dims valid_tiles;

--- a/frmts/jpeg/jpgdataset.cpp
+++ b/frmts/jpeg/jpgdataset.cpp
@@ -3629,7 +3629,8 @@ JPGDatasetCommon *JPGDataset::OpenStage2(JPGDatasetOpenArgs *psArgs,
     // More metadata.
     if (poDS->nBands > 1)
     {
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
+                              GDAL_MDD_IMAGE_STRUCTURE);
         poDS->SetMetadataItem("COMPRESSION", "JPEG", GDAL_MDD_IMAGE_STRUCTURE);
     }
 

--- a/frmts/jpeg/jpgdataset.cpp
+++ b/frmts/jpeg/jpgdataset.cpp
@@ -1753,7 +1753,7 @@ JPGRasterBand::JPGRasterBand(JPGDatasetCommon *poDSIn, int nBandIn)
     GDALMajorObject::SetMetadataItem(GDALMD_COMPRESSION, "JPEG",
                                      GDAL_MDD_IMAGE_STRUCTURE);
     if (eDataType == GDT_UInt16)
-        GDALMajorObject::SetMetadataItem("NBITS", "12",
+        GDALMajorObject::SetMetadataItem(GDALMD_NBITS, "12",
                                          GDAL_MDD_IMAGE_STRUCTURE);
 }
 

--- a/frmts/jpeg/jpgdataset.cpp
+++ b/frmts/jpeg/jpgdataset.cpp
@@ -659,10 +659,10 @@ void JPGDatasetCommon::ReadDJIMetadata()
                 CPLSPrintf("SUBDATASET_%d_NAME", m_nSubdatasetCount),
                 CPLSPrintf("JPEG:\"%s\":DJI_RAW_THERMAL_IMAGE",
                            GetDescription()),
-                "SUBDATASETS");
+                GDAL_MDD_SUBDATASETS);
             GDALDataset::SetMetadataItem(
                 CPLSPrintf("SUBDATASET_%d_DESC", m_nSubdatasetCount),
-                "DJI raw thermal image", "SUBDATASETS");
+                "DJI raw thermal image", GDAL_MDD_SUBDATASETS);
         }
     }
 }
@@ -912,10 +912,10 @@ void JPGDatasetCommon::ReadFLIRMetadata()
                 CPLSPrintf("SUBDATASET_%d_NAME", m_nSubdatasetCount),
                 CPLSPrintf("JPEG:\"%s\":FLIR_RAW_THERMAL_IMAGE",
                            GetDescription()),
-                "SUBDATASETS");
+                GDAL_MDD_SUBDATASETS);
             SetMetadataItem(
                 CPLSPrintf("SUBDATASET_%d_DESC", m_nSubdatasetCount),
-                "FLIR raw thermal image", "SUBDATASETS");
+                "FLIR raw thermal image", GDAL_MDD_SUBDATASETS);
         }
     };
 
@@ -946,10 +946,10 @@ void JPGDatasetCommon::ReadFLIRMetadata()
             SetMetadataItem(
                 CPLSPrintf("SUBDATASET_%d_NAME", m_nSubdatasetCount),
                 CPLSPrintf("JPEG:\"%s\":FLIR_EMBEDDED_IMAGE", GetDescription()),
-                "SUBDATASETS");
+                GDAL_MDD_SUBDATASETS);
             SetMetadataItem(
                 CPLSPrintf("SUBDATASET_%d_DESC", m_nSubdatasetCount),
-                "FLIR embedded image", "SUBDATASETS");
+                "FLIR embedded image", GDAL_MDD_SUBDATASETS);
         }
     };
 
@@ -1319,7 +1319,7 @@ void JPGDatasetCommon::LoadForMetadataDomain(const char *pszDomain)
     if (eAccess == GA_ReadOnly && !bHasReadDJIMetadata &&
         pszDomain != nullptr && EQUAL(pszDomain, "DJI"))
         ReadDJIMetadata();
-    if (pszDomain != nullptr && EQUAL(pszDomain, "SUBDATASETS"))
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_SUBDATASETS))
         ReadThermalMetadata();
 }
 

--- a/frmts/jpeg/jpgdataset.cpp
+++ b/frmts/jpeg/jpgdataset.cpp
@@ -1750,7 +1750,7 @@ JPGRasterBand::JPGRasterBand(JPGDatasetCommon *poDSIn, int nBandIn)
     nBlockXSize = poDSIn->nRasterXSize;
     nBlockYSize = 1;
 
-    GDALMajorObject::SetMetadataItem("COMPRESSION", "JPEG",
+    GDALMajorObject::SetMetadataItem(GDALMD_COMPRESSION, "JPEG",
                                      GDAL_MDD_IMAGE_STRUCTURE);
     if (eDataType == GDT_UInt16)
         GDALMajorObject::SetMetadataItem("NBITS", "12",
@@ -3631,7 +3631,8 @@ JPGDatasetCommon *JPGDataset::OpenStage2(JPGDatasetOpenArgs *psArgs,
     {
         poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                               GDAL_MDD_IMAGE_STRUCTURE);
-        poDS->SetMetadataItem("COMPRESSION", "JPEG", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_COMPRESSION, "JPEG",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     if (psArgs->bIsLossless)

--- a/frmts/jpeg/jpgdataset.cpp
+++ b/frmts/jpeg/jpgdataset.cpp
@@ -329,8 +329,9 @@ void JPGDatasetCommon::ReadImageStructureMetadata()
             (!bIsYCbCr &&
              memcmp(md5JPEGQuantTable_generic_8bit[i], digest, 16) == 0))
         {
-            GDALDataset::SetMetadataItem(
-                "JPEG_QUALITY", CPLSPrintf("%d", i + 1), "IMAGE_STRUCTURE");
+            GDALDataset::SetMetadataItem("JPEG_QUALITY",
+                                         CPLSPrintf("%d", i + 1),
+                                         GDAL_MDD_IMAGE_STRUCTURE);
             break;
         }
     }
@@ -1293,7 +1294,7 @@ void JPGDatasetCommon::LoadForMetadataDomain(const char *pszDomain)
         (pszDomain == nullptr || EQUAL(pszDomain, "")))
         ReadEXIFMetadata();
     if (eAccess == GA_ReadOnly && !bHasReadImageStructureMetadata &&
-        pszDomain != nullptr && EQUAL(pszDomain, "IMAGE_STRUCTURE"))
+        pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE))
         ReadImageStructureMetadata();
     if (eAccess == GA_ReadOnly && pszDomain != nullptr &&
         EQUAL(pszDomain, "xml:XMP"))
@@ -1337,7 +1338,7 @@ CSLConstList JPGDatasetCommon::GetMetadata(const char *pszDomain)
 const char *JPGDatasetCommon::GetMetadataItem(const char *pszName,
                                               const char *pszDomain)
 {
-    if (pszDomain != nullptr && EQUAL(pszDomain, "IMAGE_STRUCTURE"))
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE))
     {
         if (EQUAL(pszName, "JPEG_QUALITY"))
             LoadForMetadataDomain(pszDomain);
@@ -1749,9 +1750,11 @@ JPGRasterBand::JPGRasterBand(JPGDatasetCommon *poDSIn, int nBandIn)
     nBlockXSize = poDSIn->nRasterXSize;
     nBlockYSize = 1;
 
-    GDALMajorObject::SetMetadataItem("COMPRESSION", "JPEG", "IMAGE_STRUCTURE");
+    GDALMajorObject::SetMetadataItem("COMPRESSION", "JPEG",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     if (eDataType == GDT_UInt16)
-        GDALMajorObject::SetMetadataItem("NBITS", "12", "IMAGE_STRUCTURE");
+        GDALMajorObject::SetMetadataItem("NBITS", "12",
+                                         GDAL_MDD_IMAGE_STRUCTURE);
 }
 
 /************************************************************************/
@@ -3573,7 +3576,7 @@ JPGDatasetCommon *JPGDataset::OpenStage2(JPGDatasetOpenArgs *psArgs,
             poDS->sDInfo.out_color_space = JCS_RGB;
             poDS->eGDALColorSpace = JCS_RGB;
             poDS->SetMetadataItem("SOURCE_COLOR_SPACE", "YCbCr",
-                                  "IMAGE_STRUCTURE");
+                                  GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
     else if (poDS->sDInfo.jpeg_color_space == JCS_CMYK)
@@ -3584,7 +3587,7 @@ JPGDatasetCommon *JPGDataset::OpenStage2(JPGDatasetOpenArgs *psArgs,
             poDS->eGDALColorSpace = JCS_RGB;
             poDS->nBands = 3;
             poDS->SetMetadataItem("SOURCE_COLOR_SPACE", "CMYK",
-                                  "IMAGE_STRUCTURE");
+                                  GDAL_MDD_IMAGE_STRUCTURE);
         }
         else
         {
@@ -3599,7 +3602,7 @@ JPGDatasetCommon *JPGDataset::OpenStage2(JPGDatasetOpenArgs *psArgs,
             poDS->eGDALColorSpace = JCS_RGB;
             poDS->nBands = 3;
             poDS->SetMetadataItem("SOURCE_COLOR_SPACE", "YCbCrK",
-                                  "IMAGE_STRUCTURE");
+                                  GDAL_MDD_IMAGE_STRUCTURE);
 
             // libjpeg does the translation from YCrCbK -> CMYK internally
             // and we'll do the translation to RGB in IReadBlock().
@@ -3626,14 +3629,14 @@ JPGDatasetCommon *JPGDataset::OpenStage2(JPGDatasetOpenArgs *psArgs,
     // More metadata.
     if (poDS->nBands > 1)
     {
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
-        poDS->SetMetadataItem("COMPRESSION", "JPEG", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem("COMPRESSION", "JPEG", GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     if (psArgs->bIsLossless)
     {
         poDS->SetMetadataItem("COMPRESSION_REVERSIBILITY", "LOSSLESS",
-                              "IMAGE_STRUCTURE");
+                              GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     // Initialize any PAM information.

--- a/frmts/jpegxl/jpegxl.cpp
+++ b/frmts/jpegxl/jpegxl.cpp
@@ -178,7 +178,7 @@ JPEGXLRasterBand::JPEGXLRasterBand(JPEGXLDataset *poDSIn, int nBandIn,
     if ((eDataType == GDT_UInt8 && nBitsPerSample < 8) ||
         (eDataType == GDT_UInt16 && nBitsPerSample < 16))
     {
-        SetMetadataItem("NBITS", CPLSPrintf("%d", nBitsPerSample),
+        SetMetadataItem(GDALMD_NBITS, CPLSPrintf("%d", nBitsPerSample),
                         GDAL_MDD_IMAGE_STRUCTURE);
     }
 }
@@ -2201,10 +2201,10 @@ GDALDataset *JPEGXLDataset::CreateCopy(const char *pszFilename,
         return nullptr;
     }
 
-    const char *pszNBits = CSLFetchNameValue(papszOptions, "NBITS");
+    const char *pszNBits = CSLFetchNameValue(papszOptions, GDALMD_NBITS);
     if (pszNBits == nullptr)
         pszNBits = poSrcDS->GetRasterBand(1)->GetMetadataItem(
-            "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+            GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
     const int nBits =
         ((eDT == GDT_UInt8 || eDT == GDT_UInt16) && pszNBits != nullptr)
             ? atoi(pszNBits)

--- a/frmts/jpegxl/jpegxl.cpp
+++ b/frmts/jpegxl/jpegxl.cpp
@@ -179,7 +179,7 @@ JPEGXLRasterBand::JPEGXLRasterBand(JPEGXLDataset *poDSIn, int nBandIn,
         (eDataType == GDT_UInt16 && nBitsPerSample < 16))
     {
         SetMetadataItem("NBITS", CPLSPrintf("%d", nBitsPerSample),
-                        "IMAGE_STRUCTURE");
+                        GDAL_MDD_IMAGE_STRUCTURE);
     }
 }
 
@@ -803,12 +803,12 @@ bool JPEGXLDataset::Open(GDALOpenInfo *poOpenInfo)
 #endif
                                      ? "LOSSLESS (possibly)"
                                      : "LOSSY",
-                                 "IMAGE_STRUCTURE");
+                                 GDAL_MDD_IMAGE_STRUCTURE);
 #ifdef HAVE_JXL_BOX_API
     if (m_bHasJPEGReconstructionData)
     {
         GDALDataset::SetMetadataItem("ORIGINAL_COMPRESSION", "JPEG",
-                                     "IMAGE_STRUCTURE");
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
 #endif
 
@@ -914,7 +914,7 @@ bool JPEGXLDataset::Open(GDALOpenInfo *poOpenInfo)
 
     if (l_nBands > 1)
     {
-        SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     // Initialize any PAM information.
@@ -2204,7 +2204,7 @@ GDALDataset *JPEGXLDataset::CreateCopy(const char *pszFilename,
     const char *pszNBits = CSLFetchNameValue(papszOptions, "NBITS");
     if (pszNBits == nullptr)
         pszNBits = poSrcDS->GetRasterBand(1)->GetMetadataItem(
-            "NBITS", "IMAGE_STRUCTURE");
+            "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
     const int nBits =
         ((eDT == GDT_UInt8 || eDT == GDT_UInt16) && pszNBits != nullptr)
             ? atoi(pszNBits)

--- a/frmts/jpegxl/jpegxl.cpp
+++ b/frmts/jpegxl/jpegxl.cpp
@@ -914,7 +914,7 @@ bool JPEGXLDataset::Open(GDALOpenInfo *poOpenInfo)
 
     if (l_nBands > 1)
     {
-        SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     // Initialize any PAM information.

--- a/frmts/jpegxl/jpegxl.cpp
+++ b/frmts/jpegxl/jpegxl.cpp
@@ -1782,7 +1782,7 @@ GDALDataset *JPEGXLDataset::CreateCopy(const char *pszFilename,
     const bool bHasGeoTransform = poSrcDS->GetGeoTransform(gt) == CE_None;
     const OGRSpatialReference *poSRS = poSrcDS->GetSpatialRef();
     const int nGCPCount = poSrcDS->GetGCPCount();
-    CSLConstList papszRPCMD = poSrcDS->GetMetadata("RPC");
+    CSLConstList papszRPCMD = poSrcDS->GetMetadata(GDAL_MDD_RPC);
     std::unique_ptr<GDALJP2Box> poJUMBFBox;
     if (bWriteGeoJP2 &&
         (poSRS != nullptr || bHasGeoTransform || nGCPCount || papszRPCMD))

--- a/frmts/jpipkak/jpipkakdataset.cpp
+++ b/frmts/jpipkak/jpipkakdataset.cpp
@@ -642,7 +642,7 @@ int JPIPKAKDataset::Initialize(const char *pszDatasetName, int bReinitializing)
             SetMetadataItem(
                 "NBITS",
                 CPLString().Printf("%d", poCodestream->get_bit_depth(0)),
-                "IMAGE_STRUCTURE");
+                GDAL_MDD_IMAGE_STRUCTURE);
 
         // TODO add color interpretation
 

--- a/frmts/jpipkak/jpipkakdataset.cpp
+++ b/frmts/jpipkak/jpipkakdataset.cpp
@@ -640,7 +640,7 @@ int JPIPKAKDataset::Initialize(const char *pszDatasetName, int bReinitializing)
         if ((poCodestream->get_bit_depth(0) % 8) != 0 &&
             poCodestream->get_bit_depth(0) < 16)
             SetMetadataItem(
-                "NBITS",
+                GDALMD_NBITS,
                 CPLString().Printf("%d", poCodestream->get_bit_depth(0)),
                 GDAL_MDD_IMAGE_STRUCTURE);
 

--- a/frmts/kmlsuperoverlay/kmlsuperoverlaydataset.cpp
+++ b/frmts/kmlsuperoverlay/kmlsuperoverlaydataset.cpp
@@ -2115,7 +2115,7 @@ void KmlSingleDocRasterDataset::BuildOverviews()
             poOvrDS->SetBand(iBand,
                              std::make_unique<KmlSingleDocRasterRasterBand>(
                                  poOvrDS.get(), iBand));
-        poOvrDS->SetMetadataItem("INTERLEAVE", "PIXEL",
+        poOvrDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                  GDAL_MDD_IMAGE_STRUCTURE);
 
         m_apoOverviews.push_back(std::move(poOvrDS));
@@ -2471,7 +2471,7 @@ GDALDataset *KmlSingleDocRasterDataset::Open(const char *pszFilename,
         poDS->SetBand(iBand, std::make_unique<KmlSingleDocRasterRasterBand>(
                                  poDS.get(), iBand));
     poDS->SetDescription(pszFilename);
-    poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+    poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
     poDS->aosDescs = std::move(aosDescs);
 
     return poDS.release();
@@ -2811,7 +2811,7 @@ KmlSuperOverlayReadDataset::Open(const char *pszFilename,
         poDS->SetBand(i + 1, std::make_unique<KmlSuperOverlayRasterBand>(
                                  poDS.get(), i + 1));
     poDS->SetDescription(pszFilename);
-    poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+    poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
 
     while (poDS->poParent == nullptr && nFactor > 1)
     {
@@ -2838,7 +2838,7 @@ KmlSuperOverlayReadDataset::Open(const char *pszFilename,
             poOvrDS->SetBand(i + 1, std::make_unique<KmlSuperOverlayRasterBand>(
                                         poOvrDS.get(), i + 1));
         poOvrDS->SetDescription(pszFilename);
-        poOvrDS->SetMetadataItem("INTERLEAVE", "PIXEL",
+        poOvrDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                  GDAL_MDD_IMAGE_STRUCTURE);
 
         poDS->m_apoOverviewDS.push_back(std::move(poOvrDS));

--- a/frmts/kmlsuperoverlay/kmlsuperoverlaydataset.cpp
+++ b/frmts/kmlsuperoverlay/kmlsuperoverlaydataset.cpp
@@ -2115,7 +2115,8 @@ void KmlSingleDocRasterDataset::BuildOverviews()
             poOvrDS->SetBand(iBand,
                              std::make_unique<KmlSingleDocRasterRasterBand>(
                                  poOvrDS.get(), iBand));
-        poOvrDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        poOvrDS->SetMetadataItem("INTERLEAVE", "PIXEL",
+                                 GDAL_MDD_IMAGE_STRUCTURE);
 
         m_apoOverviews.push_back(std::move(poOvrDS));
     }
@@ -2470,7 +2471,7 @@ GDALDataset *KmlSingleDocRasterDataset::Open(const char *pszFilename,
         poDS->SetBand(iBand, std::make_unique<KmlSingleDocRasterRasterBand>(
                                  poDS.get(), iBand));
     poDS->SetDescription(pszFilename);
-    poDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+    poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
     poDS->aosDescs = std::move(aosDescs);
 
     return poDS.release();
@@ -2810,7 +2811,7 @@ KmlSuperOverlayReadDataset::Open(const char *pszFilename,
         poDS->SetBand(i + 1, std::make_unique<KmlSuperOverlayRasterBand>(
                                  poDS.get(), i + 1));
     poDS->SetDescription(pszFilename);
-    poDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+    poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
 
     while (poDS->poParent == nullptr && nFactor > 1)
     {
@@ -2837,7 +2838,8 @@ KmlSuperOverlayReadDataset::Open(const char *pszFilename,
             poOvrDS->SetBand(i + 1, std::make_unique<KmlSuperOverlayRasterBand>(
                                         poOvrDS.get(), i + 1));
         poOvrDS->SetDescription(pszFilename);
-        poOvrDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        poOvrDS->SetMetadataItem("INTERLEAVE", "PIXEL",
+                                 GDAL_MDD_IMAGE_STRUCTURE);
 
         poDS->m_apoOverviewDS.push_back(std::move(poOvrDS));
     }

--- a/frmts/l1b/l1bdataset.cpp
+++ b/frmts/l1b/l1bdataset.cpp
@@ -3525,34 +3525,35 @@ GDALDataset *L1BDataset::Open(GDALOpenInfo *poOpenInfo)
 
         char *pszWKT = nullptr;
         poDS->m_oGCPSRS.exportToWkt(&pszWKT);
-        poOutDS->SetMetadataItem("SRS", pszWKT,
-                                 "GEOLOCATION"); /* unused by gdalgeoloc.cpp */
+        poOutDS->SetMetadataItem(
+            "SRS", pszWKT, GDAL_MDD_GEOLOCATION); /* unused by gdalgeoloc.cpp */
         CPLFree(pszWKT);
 
         if (bInterpol)
             osTMP.Printf("L1BGCPS_INTERPOL:\"%s\"", osFilename.c_str());
         else
             osTMP.Printf("L1BGCPS:\"%s\"", osFilename.c_str());
-        poOutDS->SetMetadataItem("X_DATASET", osTMP, "GEOLOCATION");
-        poOutDS->SetMetadataItem("X_BAND", "1", "GEOLOCATION");
-        poOutDS->SetMetadataItem("Y_DATASET", osTMP, "GEOLOCATION");
-        poOutDS->SetMetadataItem("Y_BAND", "2", "GEOLOCATION");
+        poOutDS->SetMetadataItem("X_DATASET", osTMP, GDAL_MDD_GEOLOCATION);
+        poOutDS->SetMetadataItem("X_BAND", "1", GDAL_MDD_GEOLOCATION);
+        poOutDS->SetMetadataItem("Y_DATASET", osTMP, GDAL_MDD_GEOLOCATION);
+        poOutDS->SetMetadataItem("Y_BAND", "2", GDAL_MDD_GEOLOCATION);
 
         if (bInterpol)
         {
-            poOutDS->SetMetadataItem("PIXEL_OFFSET", "0", "GEOLOCATION");
-            poOutDS->SetMetadataItem("PIXEL_STEP", "1", "GEOLOCATION");
+            poOutDS->SetMetadataItem("PIXEL_OFFSET", "0", GDAL_MDD_GEOLOCATION);
+            poOutDS->SetMetadataItem("PIXEL_STEP", "1", GDAL_MDD_GEOLOCATION);
         }
         else
         {
             osTMP.Printf("%d", poDS->iGCPStart);
-            poOutDS->SetMetadataItem("PIXEL_OFFSET", osTMP, "GEOLOCATION");
+            poOutDS->SetMetadataItem("PIXEL_OFFSET", osTMP,
+                                     GDAL_MDD_GEOLOCATION);
             osTMP.Printf("%d", poDS->iGCPStep);
-            poOutDS->SetMetadataItem("PIXEL_STEP", osTMP, "GEOLOCATION");
+            poOutDS->SetMetadataItem("PIXEL_STEP", osTMP, GDAL_MDD_GEOLOCATION);
         }
 
-        poOutDS->SetMetadataItem("LINE_OFFSET", "0", "GEOLOCATION");
-        poOutDS->SetMetadataItem("LINE_STEP", "1", "GEOLOCATION");
+        poOutDS->SetMetadataItem("LINE_OFFSET", "0", GDAL_MDD_GEOLOCATION);
+        poOutDS->SetMetadataItem("LINE_STEP", "1", GDAL_MDD_GEOLOCATION);
     }
 
     if (poOutDS != poDS)

--- a/frmts/l1b/l1bdataset.cpp
+++ b/frmts/l1b/l1bdataset.cpp
@@ -3567,7 +3567,7 @@ GDALDataset *L1BDataset::Open(GDALOpenInfo *poOpenInfo)
             CPLSPrintf("L1B_SOLAR_ZENITH_ANGLES:\"%s\"", osFilename.c_str()));
         papszSubdatasets = CSLSetNameValue(
             papszSubdatasets, "SUBDATASET_1_DESC", "Solar zenith angles");
-        poDS->SetMetadata(papszSubdatasets, "SUBDATASETS");
+        poDS->SetMetadata(papszSubdatasets, GDAL_MDD_SUBDATASETS);
         CSLDestroy(papszSubdatasets);
     }
     else
@@ -3591,7 +3591,7 @@ GDALDataset *L1BDataset::Open(GDALOpenInfo *poOpenInfo)
                                 "Clouds from AVHRR (CLAVR)");
         }
 
-        poDS->SetMetadata(papszSubdatasets, "SUBDATASETS");
+        poDS->SetMetadata(papszSubdatasets, GDAL_MDD_SUBDATASETS);
         CSLDestroy(papszSubdatasets);
     }
 

--- a/frmts/libertiff/libertiffdataset.cpp
+++ b/frmts/libertiff/libertiffdataset.cpp
@@ -2654,7 +2654,7 @@ bool LIBERTIFFDataset::Open(GDALOpenInfo *poOpenInfo)
             papoBands = nullptr;
             nRasterXSize = 0;
             nRasterYSize = 0;
-            GDALDataset::SetMetadata(aosList.List(), "SUBDATASETS");
+            GDALDataset::SetMetadata(aosList.List(), GDAL_MDD_SUBDATASETS);
             return true;
         }
         else if (!m_image)

--- a/frmts/libertiff/libertiffdataset.cpp
+++ b/frmts/libertiff/libertiffdataset.cpp
@@ -2023,14 +2023,14 @@ bool LIBERTIFFDataset::ProcessCompressionMethod()
     if (m_image->compression() == LIBERTIFF_NS::Compression::PackBits)
     {
         GDALDataset::SetMetadataItem("COMPRESSION", "PACKBITS",
-                                     "IMAGE_STRUCTURE");
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (m_image->compression() == LIBERTIFF_NS::Compression::Deflate ||
              m_image->compression() == LIBERTIFF_NS::Compression::LegacyDeflate)
     {
         m_decompressor = CPLGetDecompressor("zlib");
         GDALDataset::SetMetadataItem("COMPRESSION", "DEFLATE",
-                                     "IMAGE_STRUCTURE");
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (m_image->compression() == LIBERTIFF_NS::Compression::ZSTD)
     {
@@ -2042,7 +2042,8 @@ bool LIBERTIFFDataset::ProcessCompressionMethod()
                         "has not been built against libzstd");
             return false;
         }
-        GDALDataset::SetMetadataItem("COMPRESSION", "ZSTD", "IMAGE_STRUCTURE");
+        GDALDataset::SetMetadataItem("COMPRESSION", "ZSTD",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (m_image->compression() == LIBERTIFF_NS::Compression::LZMA)
     {
@@ -2054,11 +2055,13 @@ bool LIBERTIFFDataset::ProcessCompressionMethod()
                         "has not been built against liblzma");
             return false;
         }
-        GDALDataset::SetMetadataItem("COMPRESSION", "LZMA", "IMAGE_STRUCTURE");
+        GDALDataset::SetMetadataItem("COMPRESSION", "LZMA",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (m_image->compression() == LIBERTIFF_NS::Compression::LZW)
     {
-        GDALDataset::SetMetadataItem("COMPRESSION", "LZW", "IMAGE_STRUCTURE");
+        GDALDataset::SetMetadataItem("COMPRESSION", "LZW",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (m_image->compression() == LIBERTIFF_NS::Compression::JPEG)
     {
@@ -2074,14 +2077,14 @@ bool LIBERTIFFDataset::ProcessCompressionMethod()
             m_image->samplesPerPixel() == 3)
         {
             GDALDataset::SetMetadataItem("SOURCE_COLOR_SPACE", "YCbCr",
-                                         "IMAGE_STRUCTURE");
+                                         GDAL_MDD_IMAGE_STRUCTURE);
             GDALDataset::SetMetadataItem("COMPRESSION", "YCbCr JPEG",
-                                         "IMAGE_STRUCTURE");
+                                         GDAL_MDD_IMAGE_STRUCTURE);
         }
         else
         {
             GDALDataset::SetMetadataItem("COMPRESSION", "JPEG",
-                                         "IMAGE_STRUCTURE");
+                                         GDAL_MDD_IMAGE_STRUCTURE);
         }
         if (m_image->samplesPerPixel() != 1 &&
             m_image->samplesPerPixel() != 3 &&
@@ -2137,7 +2140,8 @@ bool LIBERTIFFDataset::ProcessCompressionMethod()
                 "Compression = WEBP not supported because WEBP driver missing");
             return false;
         }
-        GDALDataset::SetMetadataItem("COMPRESSION", "WEBP", "IMAGE_STRUCTURE");
+        GDALDataset::SetMetadataItem("COMPRESSION", "WEBP",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (m_image->compression() == LIBERTIFF_NS::Compression::JXL ||
              m_image->compression() == LIBERTIFF_NS::Compression::JXL_DNG_1_7)
@@ -2149,7 +2153,8 @@ bool LIBERTIFFDataset::ProcessCompressionMethod()
                 "Compression = JXL not supported because JXL driver missing");
             return false;
         }
-        GDALDataset::SetMetadataItem("COMPRESSION", "JXL", "IMAGE_STRUCTURE");
+        GDALDataset::SetMetadataItem("COMPRESSION", "JXL",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (m_image->compression() == LIBERTIFF_NS::Compression::LERC)
     {
@@ -2195,12 +2200,12 @@ bool LIBERTIFFDataset::ProcessCompressionMethod()
             : m_lercAdditionalCompression == LERC_ADD_COMPRESSION_ZSTD
                 ? "LERC_ZSTD"
                 : "LERC",
-            "IMAGE_STRUCTURE");
+            GDAL_MDD_IMAGE_STRUCTURE);
 
         if (m_lercVersion == LERC_VERSION_2_4)
         {
             GDALDataset::SetMetadataItem("LERC_VERSION", "2.4",
-                                         "IMAGE_STRUCTURE");
+                                         GDAL_MDD_IMAGE_STRUCTURE);
         }
 #endif
     }
@@ -2291,7 +2296,8 @@ bool LIBERTIFFDataset::Open(std::unique_ptr<const LIBERTIFF_NS::Image> image)
     // Deal with Predictor tag
     if (m_image->predictor() == 2)
     {
-        GDALDataset::SetMetadataItem("PREDICTOR", "2", "IMAGE_STRUCTURE");
+        GDALDataset::SetMetadataItem("PREDICTOR", "2",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (m_image->predictor() == 3)
     {
@@ -2300,7 +2306,8 @@ bool LIBERTIFFDataset::Open(std::unique_ptr<const LIBERTIFF_NS::Image> image)
             CPLDebug("LIBERTIFF", "Unhandled predictor=3 with non-float data");
             return false;
         }
-        GDALDataset::SetMetadataItem("PREDICTOR", "3", "IMAGE_STRUCTURE");
+        GDALDataset::SetMetadataItem("PREDICTOR", "3",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (m_image->predictor() > 3)
     {
@@ -2312,9 +2319,11 @@ bool LIBERTIFFDataset::Open(std::unique_ptr<const LIBERTIFF_NS::Image> image)
     if (m_image->planarConfiguration() ==
             LIBERTIFF_NS::PlanarConfiguration::Separate ||
         m_image->samplesPerPixel() == 1)
-        GDALDataset::SetMetadataItem("INTERLEAVE", "BAND", "IMAGE_STRUCTURE");
+        GDALDataset::SetMetadataItem("INTERLEAVE", "BAND",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     else
-        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
 
     const int nNativeDTSize = GDALGetDataTypeSizeBytes(eDT);
     const bool bSeparate = m_image->planarConfiguration() ==
@@ -2445,7 +2454,7 @@ bool LIBERTIFFDataset::Open(std::unique_ptr<const LIBERTIFF_NS::Image> image)
             {
                 poBand->m_eColorInterp = GCI_AlphaBand;
                 poBand->GDALRasterBand::SetMetadataItem(
-                    "ALPHA", "PREMULTIPLIED", "IMAGE_STRUCTURE");
+                    "ALPHA", "PREMULTIPLIED", GDAL_MDD_IMAGE_STRUCTURE);
                 if (!m_poAlphaBand)
                     m_poAlphaBand = poBand.get();
             }
@@ -2457,7 +2466,7 @@ bool LIBERTIFFDataset::Open(std::unique_ptr<const LIBERTIFF_NS::Image> image)
         {
             poBand->GDALRasterBand::SetMetadataItem(
                 "NBITS", CPLSPrintf("%u", m_image->bitsPerSample()),
-                "IMAGE_STRUCTURE");
+                GDAL_MDD_IMAGE_STRUCTURE);
         }
 
         if (l_nBands == 1 && eDT == GDT_UInt8)
@@ -2469,7 +2478,7 @@ bool LIBERTIFFDataset::Open(std::unique_ptr<const LIBERTIFF_NS::Image> image)
             LIBERTIFF_NS::PhotometricInterpretation::MinIsWhite)
         {
             GDALDataset::SetMetadataItem("MINISWHITE", "YES",
-                                         "IMAGE_STRUCTURE");
+                                         GDAL_MDD_IMAGE_STRUCTURE);
         }
 
         if (m_image->bitsPerSample() == 1 && !poBand->m_poColorTable)
@@ -2590,7 +2599,8 @@ bool LIBERTIFFDataset::Open(GDALOpenInfo *poOpenInfo)
         else if (bLayoutIFDSBeforeData && bBlockOrderRowMajor &&
                  bLeaderSizeAsUInt4 && bTrailerRepeatedLast4BytesRepeated)
         {
-            GDALDataset::SetMetadataItem("LAYOUT", "COG", "IMAGE_STRUCTURE");
+            GDALDataset::SetMetadataItem("LAYOUT", "COG",
+                                         GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
 
@@ -2806,7 +2816,7 @@ bool LIBERTIFFDataset::Open(GDALOpenInfo *poOpenInfo)
 
                     if (pszKey == nullptr || pszValue == nullptr)
                         continue;
-                    if (EQUAL(pszDomain, "IMAGE_STRUCTURE"))
+                    if (EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE))
                     {
                         if (m_image->compression() ==
                                 LIBERTIFF_NS::Compression::WEBP &&
@@ -2823,7 +2833,7 @@ bool LIBERTIFFDataset::Open(GDALOpenInfo *poOpenInfo)
                             {
                                 GDALDataset::SetMetadataItem(
                                     "COMPRESSION_REVERSIBILITY", "LOSSY",
-                                    "IMAGE_STRUCTURE");
+                                    GDAL_MDD_IMAGE_STRUCTURE);
                             }
                         }
                         else if (m_image->compression() ==
@@ -2853,7 +2863,7 @@ bool LIBERTIFFDataset::Open(GDALOpenInfo *poOpenInfo)
                             {
                                 GDALDataset::SetMetadataItem(
                                     "COMPRESSION_REVERSIBILITY", "LOSSY",
-                                    "IMAGE_STRUCTURE");
+                                    GDAL_MDD_IMAGE_STRUCTURE);
                             }
                         }
                         else if (m_image->compression() ==
@@ -2865,7 +2875,7 @@ bool LIBERTIFFDataset::Open(GDALOpenInfo *poOpenInfo)
                             {
                                 GDALDataset::SetMetadataItem(
                                     "COMPRESSION_REVERSIBILITY", "LOSSY",
-                                    "IMAGE_STRUCTURE");
+                                    GDAL_MDD_IMAGE_STRUCTURE);
                             }
                         }
                         else if (m_image->compression() ==
@@ -2972,8 +2982,8 @@ bool LIBERTIFFDataset::Open(GDALOpenInfo *poOpenInfo)
     if ((m_image->compression() == LIBERTIFF_NS::Compression::WEBP ||
          m_image->compression() == LIBERTIFF_NS::Compression::JXL ||
          m_image->compression() == LIBERTIFF_NS::Compression::JXL_DNG_1_7) &&
-        GetMetadataItem("COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE") ==
-            nullptr)
+        GetMetadataItem("COMPRESSION_REVERSIBILITY",
+                        GDAL_MDD_IMAGE_STRUCTURE) == nullptr)
     {
         const char *pszDriverName =
             m_image->compression() == LIBERTIFF_NS::Compression::WEBP
@@ -3001,11 +3011,12 @@ bool LIBERTIFFDataset::Open(GDALOpenInfo *poOpenInfo)
                 {
                     const char *pszReversibility =
                         poTileDataset->GetMetadataItem(
-                            "COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE");
+                            "COMPRESSION_REVERSIBILITY",
+                            GDAL_MDD_IMAGE_STRUCTURE);
                     if (pszReversibility)
                         GDALDataset::SetMetadataItem(
                             "COMPRESSION_REVERSIBILITY", pszReversibility,
-                            "IMAGE_STRUCTURE");
+                            GDAL_MDD_IMAGE_STRUCTURE);
                 }
             }
         }

--- a/frmts/libertiff/libertiffdataset.cpp
+++ b/frmts/libertiff/libertiffdataset.cpp
@@ -3363,7 +3363,7 @@ void LIBERTIFFDataset::ReadRPCTag()
             GDALDataset::SetMetadata(
                 gdal::tiff_common::TIFFRPCTagToRPCMetadata(adfRPC.data())
                     .List(),
-                "RPC");
+                GDAL_MDD_RPC);
         }
     }
 }

--- a/frmts/libertiff/libertiffdataset.cpp
+++ b/frmts/libertiff/libertiffdataset.cpp
@@ -2465,7 +2465,7 @@ bool LIBERTIFFDataset::Open(std::unique_ptr<const LIBERTIFF_NS::Image> image)
             m_image->bitsPerSample() != 128)
         {
             poBand->GDALRasterBand::SetMetadataItem(
-                "NBITS", CPLSPrintf("%u", m_image->bitsPerSample()),
+                GDALMD_NBITS, CPLSPrintf("%u", m_image->bitsPerSample()),
                 GDAL_MDD_IMAGE_STRUCTURE);
         }
 

--- a/frmts/libertiff/libertiffdataset.cpp
+++ b/frmts/libertiff/libertiffdataset.cpp
@@ -2022,14 +2022,14 @@ bool LIBERTIFFDataset::ProcessCompressionMethod()
 {
     if (m_image->compression() == LIBERTIFF_NS::Compression::PackBits)
     {
-        GDALDataset::SetMetadataItem("COMPRESSION", "PACKBITS",
+        GDALDataset::SetMetadataItem(GDALMD_COMPRESSION, "PACKBITS",
                                      GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (m_image->compression() == LIBERTIFF_NS::Compression::Deflate ||
              m_image->compression() == LIBERTIFF_NS::Compression::LegacyDeflate)
     {
         m_decompressor = CPLGetDecompressor("zlib");
-        GDALDataset::SetMetadataItem("COMPRESSION", "DEFLATE",
+        GDALDataset::SetMetadataItem(GDALMD_COMPRESSION, "DEFLATE",
                                      GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (m_image->compression() == LIBERTIFF_NS::Compression::ZSTD)
@@ -2042,7 +2042,7 @@ bool LIBERTIFFDataset::ProcessCompressionMethod()
                         "has not been built against libzstd");
             return false;
         }
-        GDALDataset::SetMetadataItem("COMPRESSION", "ZSTD",
+        GDALDataset::SetMetadataItem(GDALMD_COMPRESSION, "ZSTD",
                                      GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (m_image->compression() == LIBERTIFF_NS::Compression::LZMA)
@@ -2055,12 +2055,12 @@ bool LIBERTIFFDataset::ProcessCompressionMethod()
                         "has not been built against liblzma");
             return false;
         }
-        GDALDataset::SetMetadataItem("COMPRESSION", "LZMA",
+        GDALDataset::SetMetadataItem(GDALMD_COMPRESSION, "LZMA",
                                      GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (m_image->compression() == LIBERTIFF_NS::Compression::LZW)
     {
-        GDALDataset::SetMetadataItem("COMPRESSION", "LZW",
+        GDALDataset::SetMetadataItem(GDALMD_COMPRESSION, "LZW",
                                      GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (m_image->compression() == LIBERTIFF_NS::Compression::JPEG)
@@ -2078,12 +2078,12 @@ bool LIBERTIFFDataset::ProcessCompressionMethod()
         {
             GDALDataset::SetMetadataItem("SOURCE_COLOR_SPACE", "YCbCr",
                                          GDAL_MDD_IMAGE_STRUCTURE);
-            GDALDataset::SetMetadataItem("COMPRESSION", "YCbCr JPEG",
+            GDALDataset::SetMetadataItem(GDALMD_COMPRESSION, "YCbCr JPEG",
                                          GDAL_MDD_IMAGE_STRUCTURE);
         }
         else
         {
-            GDALDataset::SetMetadataItem("COMPRESSION", "JPEG",
+            GDALDataset::SetMetadataItem(GDALMD_COMPRESSION, "JPEG",
                                          GDAL_MDD_IMAGE_STRUCTURE);
         }
         if (m_image->samplesPerPixel() != 1 &&
@@ -2140,7 +2140,7 @@ bool LIBERTIFFDataset::ProcessCompressionMethod()
                 "Compression = WEBP not supported because WEBP driver missing");
             return false;
         }
-        GDALDataset::SetMetadataItem("COMPRESSION", "WEBP",
+        GDALDataset::SetMetadataItem(GDALMD_COMPRESSION, "WEBP",
                                      GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (m_image->compression() == LIBERTIFF_NS::Compression::JXL ||
@@ -2153,7 +2153,7 @@ bool LIBERTIFFDataset::ProcessCompressionMethod()
                 "Compression = JXL not supported because JXL driver missing");
             return false;
         }
-        GDALDataset::SetMetadataItem("COMPRESSION", "JXL",
+        GDALDataset::SetMetadataItem(GDALMD_COMPRESSION, "JXL",
                                      GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (m_image->compression() == LIBERTIFF_NS::Compression::LERC)
@@ -2194,7 +2194,7 @@ bool LIBERTIFFDataset::ProcessCompressionMethod()
         }
 
         GDALDataset::SetMetadataItem(
-            "COMPRESSION",
+            GDALMD_COMPRESSION,
             m_lercAdditionalCompression == LERC_ADD_COMPRESSION_DEFLATE
                 ? "LERC_DEFLATE"
             : m_lercAdditionalCompression == LERC_ADD_COMPRESSION_ZSTD

--- a/frmts/libertiff/libertiffdataset.cpp
+++ b/frmts/libertiff/libertiffdataset.cpp
@@ -2319,10 +2319,10 @@ bool LIBERTIFFDataset::Open(std::unique_ptr<const LIBERTIFF_NS::Image> image)
     if (m_image->planarConfiguration() ==
             LIBERTIFF_NS::PlanarConfiguration::Separate ||
         m_image->samplesPerPixel() == 1)
-        GDALDataset::SetMetadataItem("INTERLEAVE", "BAND",
+        GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "BAND",
                                      GDAL_MDD_IMAGE_STRUCTURE);
     else
-        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+        GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                      GDAL_MDD_IMAGE_STRUCTURE);
 
     const int nNativeDTSize = GDALGetDataTypeSizeBytes(eDT);

--- a/frmts/mbtiles/mbtilesdataset.cpp
+++ b/frmts/mbtiles/mbtilesdataset.cpp
@@ -1268,7 +1268,8 @@ bool MBTilesDataset::InitRaster(MBTilesDataset *poParentDS, int nZoomLevel,
 
     ComputeTileAndPixelShifts();
 
-    GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+    GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+                                 GDAL_MDD_IMAGE_STRUCTURE);
     GDALDataset::SetMetadataItem("ZOOM_LEVEL", CPLSPrintf("%d", m_nZoomLevel));
 
     if (poParentDS)

--- a/frmts/mbtiles/mbtilesdataset.cpp
+++ b/frmts/mbtiles/mbtilesdataset.cpp
@@ -1268,7 +1268,7 @@ bool MBTilesDataset::InitRaster(MBTilesDataset *poParentDS, int nZoomLevel,
 
     ComputeTileAndPixelShifts();
 
-    GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+    GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                  GDAL_MDD_IMAGE_STRUCTURE);
     GDALDataset::SetMetadataItem("ZOOM_LEVEL", CPLSPrintf("%d", m_nZoomLevel));
 

--- a/frmts/mem/memdataset.cpp
+++ b/frmts/mem/memdataset.cpp
@@ -145,7 +145,7 @@ MEMRasterBand::MEMRasterBand(GDALDataset *poDSIn, int nBandIn,
         nLineOffset = nPixelOffset * static_cast<size_t>(nBlockXSize);
 
     if (pszPixelType && EQUAL(pszPixelType, "SIGNEDBYTE"))
-        SetMetadataItem("PIXELTYPE", "SIGNEDBYTE", "IMAGE_STRUCTURE");
+        SetMetadataItem("PIXELTYPE", "SIGNEDBYTE", GDAL_MDD_IMAGE_STRUCTURE);
 
     PamInitializeNoParent();
 }
@@ -1485,14 +1485,17 @@ MEMDataset *MEMDataset::Create(const char * /* pszFilename */, int nXSize,
 
     const char *pszPixelType = CSLFetchNameValue(papszOptions, "PIXELTYPE");
     if (pszPixelType && EQUAL(pszPixelType, "SIGNEDBYTE"))
-        poDS->SetMetadataItem("PIXELTYPE", "SIGNEDBYTE", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("PIXELTYPE", "SIGNEDBYTE",
+                              GDAL_MDD_IMAGE_STRUCTURE);
 
     if (nXSize != 0 && nYSize != 0)
     {
         if (bPixelInterleaved)
-            poDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+            poDS->SetMetadataItem("INTERLEAVE", "PIXEL",
+                                  GDAL_MDD_IMAGE_STRUCTURE);
         else
-            poDS->SetMetadataItem("INTERLEAVE", "BAND", "IMAGE_STRUCTURE");
+            poDS->SetMetadataItem("INTERLEAVE", "BAND",
+                                  GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     /* -------------------------------------------------------------------- */
@@ -1512,7 +1515,8 @@ MEMDataset *MEMDataset::Create(const char * /* pszFilename */, int nXSize,
 
         if (const char *pszNBITS = CSLFetchNameValue(papszOptions, "NBITS"))
         {
-            poNewBand->SetMetadataItem("NBITS", pszNBITS, "IMAGE_STRUCTURE");
+            poNewBand->SetMetadataItem("NBITS", pszNBITS,
+                                       GDAL_MDD_IMAGE_STRUCTURE);
         }
 
         poDS->SetBand(iBand + 1, poNewBand);

--- a/frmts/mem/memdataset.cpp
+++ b/frmts/mem/memdataset.cpp
@@ -1513,9 +1513,10 @@ MEMDataset *MEMDataset::Create(const char * /* pszFilename */, int nXSize,
             poNewBand = new MEMRasterBand(poDS, iBand + 1, apbyBandData[iBand],
                                           eType, 0, 0, iBand == 0);
 
-        if (const char *pszNBITS = CSLFetchNameValue(papszOptions, "NBITS"))
+        if (const char *pszNBITS =
+                CSLFetchNameValue(papszOptions, GDALMD_NBITS))
         {
-            poNewBand->SetMetadataItem("NBITS", pszNBITS,
+            poNewBand->SetMetadataItem(GDALMD_NBITS, pszNBITS,
                                        GDAL_MDD_IMAGE_STRUCTURE);
         }
 

--- a/frmts/mem/memdataset.cpp
+++ b/frmts/mem/memdataset.cpp
@@ -1415,7 +1415,7 @@ MEMDataset *MEMDataset::Create(const char * /* pszFilename */, int nXSize,
     /*      some apps.                                                      */
     /* -------------------------------------------------------------------- */
     bool bPixelInterleaved = false;
-    const char *pszOption = CSLFetchNameValue(papszOptions, "INTERLEAVE");
+    const char *pszOption = CSLFetchNameValue(papszOptions, GDALMD_INTERLEAVE);
     if (pszOption && EQUAL(pszOption, "PIXEL"))
         bPixelInterleaved = true;
 
@@ -1491,10 +1491,10 @@ MEMDataset *MEMDataset::Create(const char * /* pszFilename */, int nXSize,
     if (nXSize != 0 && nYSize != 0)
     {
         if (bPixelInterleaved)
-            poDS->SetMetadataItem("INTERLEAVE", "PIXEL",
+            poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                   GDAL_MDD_IMAGE_STRUCTURE);
         else
-            poDS->SetMetadataItem("INTERLEAVE", "BAND",
+            poDS->SetMetadataItem(GDALMD_INTERLEAVE, "BAND",
                                   GDAL_MDD_IMAGE_STRUCTURE);
     }
 

--- a/frmts/miramon/miramon_dataset.cpp
+++ b/frmts/miramon/miramon_dataset.cpp
@@ -595,7 +595,7 @@ void MMRDataset::CreateSubdatasetsFromBands()
     if (oSubdatasetList.Count() > 0)
     {
         // Add metadata to the main dataset
-        SetMetadata(oSubdatasetList.List(), "SUBDATASETS");
+        SetMetadata(oSubdatasetList.List(), GDAL_MDD_SUBDATASETS);
         oSubdatasetList.Clear();
     }
 }

--- a/frmts/mrf/marfa_dataset.cpp
+++ b/frmts/mrf/marfa_dataset.cpp
@@ -2554,7 +2554,7 @@ CPLErr MRFDataset::GetGeoTransform(GDALGeoTransform &gt) const
 {
     gt = m_gt;
     MRFDataset *nonConstThis = const_cast<MRFDataset *>(this);
-    if (nonConstThis->GetMetadata("RPC") || nonConstThis->GetGCPCount())
+    if (nonConstThis->GetMetadata(GDAL_MDD_RPC) || nonConstThis->GetGCPCount())
         bGeoTransformValid = FALSE;
     if (!bGeoTransformValid)
         return CE_Failure;

--- a/frmts/mrf/marfa_dataset.cpp
+++ b/frmts/mrf/marfa_dataset.cpp
@@ -768,7 +768,7 @@ CPLErr MRFDataset::LevelInit(const int l)
 
     SetMetadataItem(GDALMD_INTERLEAVE, OrderName(current.order),
                     GDAL_MDD_IMAGE_STRUCTURE);
-    SetMetadataItem("COMPRESSION", CompName(current.comp),
+    SetMetadataItem(GDALMD_COMPRESSION, CompName(current.comp),
                     GDAL_MDD_IMAGE_STRUCTURE);
 
     bGeoTransformValid = (CE_None == cds->GetGeoTransform(m_gt));
@@ -1496,7 +1496,7 @@ CPLErr MRFDataset::Initialize(CPLXMLNode *config)
     // Dataset metadata setup
     SetMetadataItem(GDALMD_INTERLEAVE, OrderName(current.order),
                     GDAL_MDD_IMAGE_STRUCTURE);
-    SetMetadataItem("COMPRESSION", CompName(current.comp),
+    SetMetadataItem(GDALMD_COMPRESSION, CompName(current.comp),
                     GDAL_MDD_IMAGE_STRUCTURE);
 
     if (is_Endianness_Dependent(current.dt, current.comp))

--- a/frmts/mrf/marfa_dataset.cpp
+++ b/frmts/mrf/marfa_dataset.cpp
@@ -766,7 +766,7 @@ CPLErr MRFDataset::LevelInit(const int l)
     if (poSRS)
         m_oSRS = *poSRS;
 
-    SetMetadataItem("INTERLEAVE", OrderName(current.order),
+    SetMetadataItem(GDALMD_INTERLEAVE, OrderName(current.order),
                     GDAL_MDD_IMAGE_STRUCTURE);
     SetMetadataItem("COMPRESSION", CompName(current.comp),
                     GDAL_MDD_IMAGE_STRUCTURE);
@@ -1494,7 +1494,7 @@ CPLErr MRFDataset::Initialize(CPLXMLNode *config)
     }
 
     // Dataset metadata setup
-    SetMetadataItem("INTERLEAVE", OrderName(current.order),
+    SetMetadataItem(GDALMD_INTERLEAVE, OrderName(current.order),
                     GDAL_MDD_IMAGE_STRUCTURE);
     SetMetadataItem("COMPRESSION", CompName(current.comp),
                     GDAL_MDD_IMAGE_STRUCTURE);
@@ -1768,9 +1768,9 @@ GDALDataset *MRFDataset::CreateCopy(const char *pszFilename,
     char **options = CSLDuplicate(papszOptions);
 
     const char *pszValue =
-        poSrcDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
-    options =
-        CSLAddIfMissing(options, "INTERLEAVE", pszValue ? pszValue : "PIXEL");
+        poSrcDS->GetMetadataItem(GDALMD_INTERLEAVE, GDAL_MDD_IMAGE_STRUCTURE);
+    options = CSLAddIfMissing(options, GDALMD_INTERLEAVE,
+                              pszValue ? pszValue : "PIXEL");
     int xb, yb;
     poSrcBand1->GetBlockSize(&xb, &yb);
 
@@ -2138,7 +2138,7 @@ void MRFDataset::ProcessCreateOptions(CSLConstList papszOptions)
     if (val && IL_ERR_COMP == (img.comp = CompToken(val)))
         throw CPLString("GDAL MRF: Error setting compression");
 
-    val = opt.FetchNameValue("INTERLEAVE");
+    val = opt.FetchNameValue(GDALMD_INTERLEAVE);
     if (val && IL_ERR_ORD == (img.order = OrderToken(val)))
         throw CPLString("GDAL MRF: Error setting interleave");
 

--- a/frmts/mrf/marfa_dataset.cpp
+++ b/frmts/mrf/marfa_dataset.cpp
@@ -766,8 +766,10 @@ CPLErr MRFDataset::LevelInit(const int l)
     if (poSRS)
         m_oSRS = *poSRS;
 
-    SetMetadataItem("INTERLEAVE", OrderName(current.order), "IMAGE_STRUCTURE");
-    SetMetadataItem("COMPRESSION", CompName(current.comp), "IMAGE_STRUCTURE");
+    SetMetadataItem("INTERLEAVE", OrderName(current.order),
+                    GDAL_MDD_IMAGE_STRUCTURE);
+    SetMetadataItem("COMPRESSION", CompName(current.comp),
+                    GDAL_MDD_IMAGE_STRUCTURE);
 
     bGeoTransformValid = (CE_None == cds->GetGeoTransform(m_gt));
     for (int i = 0; i < l + 1; i++)
@@ -1469,8 +1471,9 @@ CPLErr MRFDataset::Initialize(CPLXMLNode *config)
     if (current.size.z != 1)
     {
         SetMetadataItem("ZSIZE", CPLOPrintf("%d", current.size.z),
-                        "IMAGE_STRUCTURE");
-        SetMetadataItem("ZSLICE", CPLOPrintf("%d", zslice), "IMAGE_STRUCTURE");
+                        GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem("ZSLICE", CPLOPrintf("%d", zslice),
+                        GDAL_MDD_IMAGE_STRUCTURE);
         // Capture the zslice in pagesize.l
         current.pagesize.l = zslice;
         // Adjust offset for base image
@@ -1491,12 +1494,14 @@ CPLErr MRFDataset::Initialize(CPLXMLNode *config)
     }
 
     // Dataset metadata setup
-    SetMetadataItem("INTERLEAVE", OrderName(current.order), "IMAGE_STRUCTURE");
-    SetMetadataItem("COMPRESSION", CompName(current.comp), "IMAGE_STRUCTURE");
+    SetMetadataItem("INTERLEAVE", OrderName(current.order),
+                    GDAL_MDD_IMAGE_STRUCTURE);
+    SetMetadataItem("COMPRESSION", CompName(current.comp),
+                    GDAL_MDD_IMAGE_STRUCTURE);
 
     if (is_Endianness_Dependent(current.dt, current.comp))
         SetMetadataItem("NETBYTEORDER", current.nbo ? "TRUE" : "FALSE",
-                        "IMAGE_STRUCTURE");
+                        GDAL_MDD_IMAGE_STRUCTURE);
 
     // Open the files for the current image, either RW or RO
     nRasterXSize = current.size.x;
@@ -1527,7 +1532,8 @@ CPLErr MRFDataset::Initialize(CPLXMLNode *config)
         if (std::string::npos != nSepPos)
         {
             s.resize(nSepPos);
-            SetMetadataItem(s, optlist.FetchNameValue(s), "IMAGE_STRUCTURE");
+            SetMetadataItem(s, optlist.FetchNameValue(s),
+                            GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
 
@@ -1762,7 +1768,7 @@ GDALDataset *MRFDataset::CreateCopy(const char *pszFilename,
     char **options = CSLDuplicate(papszOptions);
 
     const char *pszValue =
-        poSrcDS->GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE");
+        poSrcDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
     options =
         CSLAddIfMissing(options, "INTERLEAVE", pszValue ? pszValue : "PIXEL");
     int xb, yb;
@@ -1810,9 +1816,9 @@ GDALDataset *MRFDataset::CreateCopy(const char *pszFilename,
                 poDS->vMax.push_back(dfData);
 
             // Copy the band metadata, PAM will handle it
-            CSLConstList meta = srcBand->GetMetadata("IMAGE_STRUCTURE");
+            CSLConstList meta = srcBand->GetMetadata(GDAL_MDD_IMAGE_STRUCTURE);
             if (CSLCount(meta))
-                mBand->SetMetadata(meta, "IMAGE_STRUCTURE");
+                mBand->SetMetadata(meta, GDAL_MDD_IMAGE_STRUCTURE);
 
             meta = srcBand->GetMetadata();
             if (CSLCount(meta))

--- a/frmts/mrsid/mrsiddataset.cpp
+++ b/frmts/mrsid/mrsiddataset.cpp
@@ -3267,7 +3267,7 @@ static GDALDataset *MrSIDCreateCopy(const char *pszFilename,
 
             // check for compression option
             const char *pszValue =
-                CSLFetchNameValue(papszOptions, "COMPRESSION");
+                CSLFetchNameValue(papszOptions, GDALMD_COMPRESSION);
             if (pszValue != nullptr)
                 poMG2ImageWriter->params().setCompressionRatio(
                     (float)CPLAtof(pszValue));
@@ -3512,7 +3512,7 @@ static GDALDataset *JP2CreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
         oImageWriter.setWorldFileSupport(true);
 
     // check for compression option
-    const char *pszValue = CSLFetchNameValue(papszOptions, "COMPRESSION");
+    const char *pszValue = CSLFetchNameValue(papszOptions, GDALMD_COMPRESSION);
     if (pszValue != nullptr)
         oImageWriter.params().setCompressionRatio((float)CPLAtof(pszValue));
 

--- a/frmts/mrsid/mrsiddataset.cpp
+++ b/frmts/mrsid/mrsiddataset.cpp
@@ -1622,7 +1622,7 @@ GDALDataset *MrSIDDataset::Open(GDALOpenInfo *poOpenInfo, int bIsJP2)
              poDS->nRasterXSize, poDS->nRasterYSize, poDS->nBands);
 
     if (poDS->nBands > 1)
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
 
     if (bIsJP2)
     {

--- a/frmts/mrsid/mrsiddataset.cpp
+++ b/frmts/mrsid/mrsiddataset.cpp
@@ -1622,7 +1622,8 @@ GDALDataset *MrSIDDataset::Open(GDALOpenInfo *poOpenInfo, int bIsJP2)
              poDS->nRasterXSize, poDS->nRasterYSize, poDS->nBands);
 
     if (poDS->nBands > 1)
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
+                              GDAL_MDD_IMAGE_STRUCTURE);
 
     if (bIsJP2)
     {

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -4342,35 +4342,41 @@ void netCDFDataset::SetProjectionFromVar(
         if (bSwitchedXY)
         {
             std::swap(pszGeolocXFullName, pszGeolocYFullName);
-            GDALPamDataset::SetMetadataItem("SWAP_XY", "YES", "GEOLOCATION");
+            GDALPamDataset::SetMetadataItem("SWAP_XY", "YES",
+                                            GDAL_MDD_GEOLOCATION);
         }
 
         CPLDebug("GDAL_netCDF", "using variables %s and %s for GEOLOCATION",
                  pszGeolocXFullName, pszGeolocYFullName);
 
         GDALPamDataset::SetMetadataItem("SRS", osGeolocWKT.c_str(),
-                                        "GEOLOCATION");
+                                        GDAL_MDD_GEOLOCATION);
 
         CPLString osTMP;
         osTMP.Printf("NETCDF:\"%s\":%s", osFilename.c_str(),
                      pszGeolocXFullName);
 
-        GDALPamDataset::SetMetadataItem("X_DATASET", osTMP, "GEOLOCATION");
-        GDALPamDataset::SetMetadataItem("X_BAND", "1", "GEOLOCATION");
+        GDALPamDataset::SetMetadataItem("X_DATASET", osTMP,
+                                        GDAL_MDD_GEOLOCATION);
+        GDALPamDataset::SetMetadataItem("X_BAND", "1", GDAL_MDD_GEOLOCATION);
         osTMP.Printf("NETCDF:\"%s\":%s", osFilename.c_str(),
                      pszGeolocYFullName);
 
-        GDALPamDataset::SetMetadataItem("Y_DATASET", osTMP, "GEOLOCATION");
-        GDALPamDataset::SetMetadataItem("Y_BAND", "1", "GEOLOCATION");
+        GDALPamDataset::SetMetadataItem("Y_DATASET", osTMP,
+                                        GDAL_MDD_GEOLOCATION);
+        GDALPamDataset::SetMetadataItem("Y_BAND", "1", GDAL_MDD_GEOLOCATION);
 
-        GDALPamDataset::SetMetadataItem("PIXEL_OFFSET", "0", "GEOLOCATION");
-        GDALPamDataset::SetMetadataItem("PIXEL_STEP", "1", "GEOLOCATION");
+        GDALPamDataset::SetMetadataItem("PIXEL_OFFSET", "0",
+                                        GDAL_MDD_GEOLOCATION);
+        GDALPamDataset::SetMetadataItem("PIXEL_STEP", "1",
+                                        GDAL_MDD_GEOLOCATION);
 
-        GDALPamDataset::SetMetadataItem("LINE_OFFSET", "0", "GEOLOCATION");
-        GDALPamDataset::SetMetadataItem("LINE_STEP", "1", "GEOLOCATION");
+        GDALPamDataset::SetMetadataItem("LINE_OFFSET", "0",
+                                        GDAL_MDD_GEOLOCATION);
+        GDALPamDataset::SetMetadataItem("LINE_STEP", "1", GDAL_MDD_GEOLOCATION);
 
         GDALPamDataset::SetMetadataItem("GEOREFERENCING_CONVENTION",
-                                        "PIXEL_CENTER", "GEOLOCATION");
+                                        "PIXEL_CENTER", GDAL_MDD_GEOLOCATION);
     }
 
     // Set GeoTransform if we got a complete one - after projection has been set
@@ -4598,33 +4604,33 @@ bool netCDFDataset::ProcessNASAL2OceanGeoLocation(int nGroupId, int nVarId)
     if (bSwitchedXY)
     {
         std::swap(pszGeolocXFullName, pszGeolocYFullName);
-        GDALPamDataset::SetMetadataItem("SWAP_XY", "YES", "GEOLOCATION");
+        GDALPamDataset::SetMetadataItem("SWAP_XY", "YES", GDAL_MDD_GEOLOCATION);
     }
 
     CPLDebug("GDAL_netCDF", "using variables %s and %s for GEOLOCATION",
              pszGeolocXFullName, pszGeolocYFullName);
 
     GDALPamDataset::SetMetadataItem("SRS", SRS_WKT_WGS84_LAT_LONG,
-                                    "GEOLOCATION");
+                                    GDAL_MDD_GEOLOCATION);
 
     CPLString osTMP;
     osTMP.Printf("NETCDF:\"%s\":%s", osFilename.c_str(), pszGeolocXFullName);
 
-    GDALPamDataset::SetMetadataItem("X_DATASET", osTMP, "GEOLOCATION");
-    GDALPamDataset::SetMetadataItem("X_BAND", "1", "GEOLOCATION");
+    GDALPamDataset::SetMetadataItem("X_DATASET", osTMP, GDAL_MDD_GEOLOCATION);
+    GDALPamDataset::SetMetadataItem("X_BAND", "1", GDAL_MDD_GEOLOCATION);
     osTMP.Printf("NETCDF:\"%s\":%s", osFilename.c_str(), pszGeolocYFullName);
 
-    GDALPamDataset::SetMetadataItem("Y_DATASET", osTMP, "GEOLOCATION");
-    GDALPamDataset::SetMetadataItem("Y_BAND", "1", "GEOLOCATION");
+    GDALPamDataset::SetMetadataItem("Y_DATASET", osTMP, GDAL_MDD_GEOLOCATION);
+    GDALPamDataset::SetMetadataItem("Y_BAND", "1", GDAL_MDD_GEOLOCATION);
 
-    GDALPamDataset::SetMetadataItem("PIXEL_OFFSET", "0", "GEOLOCATION");
-    GDALPamDataset::SetMetadataItem("PIXEL_STEP", "1", "GEOLOCATION");
+    GDALPamDataset::SetMetadataItem("PIXEL_OFFSET", "0", GDAL_MDD_GEOLOCATION);
+    GDALPamDataset::SetMetadataItem("PIXEL_STEP", "1", GDAL_MDD_GEOLOCATION);
 
-    GDALPamDataset::SetMetadataItem("LINE_OFFSET", "0", "GEOLOCATION");
-    GDALPamDataset::SetMetadataItem("LINE_STEP", "1", "GEOLOCATION");
+    GDALPamDataset::SetMetadataItem("LINE_OFFSET", "0", GDAL_MDD_GEOLOCATION);
+    GDALPamDataset::SetMetadataItem("LINE_STEP", "1", GDAL_MDD_GEOLOCATION);
 
     GDALPamDataset::SetMetadataItem("GEOREFERENCING_CONVENTION", "PIXEL_CENTER",
-                                    "GEOLOCATION");
+                                    GDAL_MDD_GEOLOCATION);
     return true;
 }
 
@@ -4736,26 +4742,26 @@ bool netCDFDataset::ProcessNASAEMITGeoLocation(int nGroupId, int nVarId)
              pszGeolocXFullName, pszGeolocYFullName);
 
     GDALPamDataset::SetMetadataItem("SRS", SRS_WKT_WGS84_LAT_LONG,
-                                    "GEOLOCATION");
+                                    GDAL_MDD_GEOLOCATION);
 
     CPLString osTMP;
     osTMP.Printf("NETCDF:\"%s\":%s", osFilename.c_str(), pszGeolocXFullName);
 
-    GDALPamDataset::SetMetadataItem("X_DATASET", osTMP, "GEOLOCATION");
-    GDALPamDataset::SetMetadataItem("X_BAND", "1", "GEOLOCATION");
+    GDALPamDataset::SetMetadataItem("X_DATASET", osTMP, GDAL_MDD_GEOLOCATION);
+    GDALPamDataset::SetMetadataItem("X_BAND", "1", GDAL_MDD_GEOLOCATION);
     osTMP.Printf("NETCDF:\"%s\":%s", osFilename.c_str(), pszGeolocYFullName);
 
-    GDALPamDataset::SetMetadataItem("Y_DATASET", osTMP, "GEOLOCATION");
-    GDALPamDataset::SetMetadataItem("Y_BAND", "1", "GEOLOCATION");
+    GDALPamDataset::SetMetadataItem("Y_DATASET", osTMP, GDAL_MDD_GEOLOCATION);
+    GDALPamDataset::SetMetadataItem("Y_BAND", "1", GDAL_MDD_GEOLOCATION);
 
-    GDALPamDataset::SetMetadataItem("PIXEL_OFFSET", "0", "GEOLOCATION");
-    GDALPamDataset::SetMetadataItem("PIXEL_STEP", "1", "GEOLOCATION");
+    GDALPamDataset::SetMetadataItem("PIXEL_OFFSET", "0", GDAL_MDD_GEOLOCATION);
+    GDALPamDataset::SetMetadataItem("PIXEL_STEP", "1", GDAL_MDD_GEOLOCATION);
 
-    GDALPamDataset::SetMetadataItem("LINE_OFFSET", "0", "GEOLOCATION");
-    GDALPamDataset::SetMetadataItem("LINE_STEP", "1", "GEOLOCATION");
+    GDALPamDataset::SetMetadataItem("LINE_OFFSET", "0", GDAL_MDD_GEOLOCATION);
+    GDALPamDataset::SetMetadataItem("LINE_STEP", "1", GDAL_MDD_GEOLOCATION);
 
     GDALPamDataset::SetMetadataItem("GEOREFERENCING_CONVENTION", "PIXEL_CENTER",
-                                    "GEOLOCATION");
+                                    GDAL_MDD_GEOLOCATION);
     return true;
 }
 
@@ -4874,7 +4880,7 @@ int netCDFDataset::ProcessCFGeolocation(int nGroupId, int nVarId,
                     {
                         std::swap(osGeolocXFullName, osGeolocYFullName);
                         GDALPamDataset::SetMetadataItem("SWAP_XY", "YES",
-                                                        "GEOLOCATION");
+                                                        GDAL_MDD_GEOLOCATION);
                     }
 
                     bAddGeoloc = true;
@@ -4884,37 +4890,37 @@ int netCDFDataset::ProcessCFGeolocation(int nGroupId, int nVarId,
                              osGeolocYFullName.c_str());
 
                     GDALPamDataset::SetMetadataItem("SRS", osGeolocWKT.c_str(),
-                                                    "GEOLOCATION");
+                                                    GDAL_MDD_GEOLOCATION);
 
                     CPLString osTMP;
                     osTMP.Printf("NETCDF:\"%s\":%s", osFilename.c_str(),
                                  osGeolocXFullName.c_str());
 
                     GDALPamDataset::SetMetadataItem("X_DATASET", osTMP,
-                                                    "GEOLOCATION");
+                                                    GDAL_MDD_GEOLOCATION);
                     GDALPamDataset::SetMetadataItem("X_BAND", "1",
-                                                    "GEOLOCATION");
+                                                    GDAL_MDD_GEOLOCATION);
                     osTMP.Printf("NETCDF:\"%s\":%s", osFilename.c_str(),
                                  osGeolocYFullName.c_str());
 
                     GDALPamDataset::SetMetadataItem("Y_DATASET", osTMP,
-                                                    "GEOLOCATION");
+                                                    GDAL_MDD_GEOLOCATION);
                     GDALPamDataset::SetMetadataItem("Y_BAND", "1",
-                                                    "GEOLOCATION");
+                                                    GDAL_MDD_GEOLOCATION);
 
                     GDALPamDataset::SetMetadataItem("PIXEL_OFFSET", "0",
-                                                    "GEOLOCATION");
+                                                    GDAL_MDD_GEOLOCATION);
                     GDALPamDataset::SetMetadataItem("PIXEL_STEP", "1",
-                                                    "GEOLOCATION");
+                                                    GDAL_MDD_GEOLOCATION);
 
                     GDALPamDataset::SetMetadataItem("LINE_OFFSET", "0",
-                                                    "GEOLOCATION");
+                                                    GDAL_MDD_GEOLOCATION);
                     GDALPamDataset::SetMetadataItem("LINE_STEP", "1",
-                                                    "GEOLOCATION");
+                                                    GDAL_MDD_GEOLOCATION);
 
                     GDALPamDataset::SetMetadataItem("GEOREFERENCING_CONVENTION",
                                                     "PIXEL_CENTER",
-                                                    "GEOLOCATION");
+                                                    GDAL_MDD_GEOLOCATION);
                 }
                 else
                 {
@@ -5389,7 +5395,7 @@ CPLErr netCDFDataset::AddProjectionVars(bool bDefsOnly,
 
     // Check GEOLOCATION information.
     CSLConstList papszGeolocationInfo =
-        netCDFDataset::GetMetadata("GEOLOCATION");
+        netCDFDataset::GetMetadata(GDAL_MDD_GEOLOCATION);
     if (papszGeolocationInfo != nullptr)
     {
         // Look for geolocation datasets.
@@ -6168,8 +6174,8 @@ CPLErr netCDFDataset::AddProjectionVars(bool bDefsOnly,
                                                                        VSIFree);
             double *padLatVal = nullptr;
             // Override lat values with the ones in GEOLOCATION/Y_VALUES.
-            if (netCDFDataset::GetMetadataItem("Y_VALUES", "GEOLOCATION") !=
-                nullptr)
+            if (netCDFDataset::GetMetadataItem("Y_VALUES",
+                                               GDAL_MDD_GEOLOCATION) != nullptr)
             {
                 int nTemp = 0;
                 adLatValKeeper.reset(Get1DGeolocation("Y_VALUES", nTemp));
@@ -9719,9 +9725,11 @@ netCDFDataset::CreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
     // Copy GeoTransform and Projection.
 
     // Copy geolocation info.
-    CSLConstList papszGeolocationInfo = poSrcDS->GetMetadata("GEOLOCATION");
+    CSLConstList papszGeolocationInfo =
+        poSrcDS->GetMetadata(GDAL_MDD_GEOLOCATION);
     if (papszGeolocationInfo != nullptr)
-        poDS->GDALPamDataset::SetMetadata(papszGeolocationInfo, "GEOLOCATION");
+        poDS->GDALPamDataset::SetMetadata(papszGeolocationInfo,
+                                          GDAL_MDD_GEOLOCATION);
 
     // Copy geotransform.
     bool bGotGeoTransform = false;

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -2964,8 +2964,9 @@ bool netCDFDataset::SetDefineMode(bool bNewDefineMode)
 
 char **netCDFDataset::GetMetadataDomainList()
 {
-    char **papszDomains = BuildMetadataDomainList(
-        GDALDataset::GetMetadataDomainList(), TRUE, "SUBDATASETS", nullptr);
+    char **papszDomains =
+        BuildMetadataDomainList(GDALDataset::GetMetadataDomainList(), TRUE,
+                                GDAL_MDD_SUBDATASETS, nullptr);
     for (const auto &kv : m_oMapDomainToJSon)
         papszDomains = CSLAddString(papszDomains, ("json:" + kv.first).c_str());
     return papszDomains;
@@ -2976,7 +2977,7 @@ char **netCDFDataset::GetMetadataDomainList()
 /************************************************************************/
 CSLConstList netCDFDataset::GetMetadata(const char *pszDomain)
 {
-    if (pszDomain != nullptr && STARTS_WITH_CI(pszDomain, "SUBDATASETS"))
+    if (pszDomain != nullptr && STARTS_WITH_CI(pszDomain, GDAL_MDD_SUBDATASETS))
         return aosSubDatasets.List();
 
     if (pszDomain != nullptr && STARTS_WITH(pszDomain, "json:"))

--- a/frmts/nitf/ecrgtocdataset.cpp
+++ b/frmts/nitf/ecrgtocdataset.cpp
@@ -614,7 +614,8 @@ GDALDataset *ECRGTOCSubDataset::Build(
         }
     }
 
-    poVirtualDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+    poVirtualDS->SetMetadataItem("INTERLEAVE", "PIXEL",
+                                 GDAL_MDD_IMAGE_STRUCTURE);
 
     return poVirtualDS.release();
 }

--- a/frmts/nitf/ecrgtocdataset.cpp
+++ b/frmts/nitf/ecrgtocdataset.cpp
@@ -614,7 +614,7 @@ GDALDataset *ECRGTOCSubDataset::Build(
         }
     }
 
-    poVirtualDS->SetMetadataItem("INTERLEAVE", "PIXEL",
+    poVirtualDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                  GDAL_MDD_IMAGE_STRUCTURE);
 
     return poVirtualDS.release();

--- a/frmts/nitf/ecrgtocdataset.cpp
+++ b/frmts/nitf/ecrgtocdataset.cpp
@@ -203,7 +203,7 @@ void ECRGTOCDataset::AddSubDataset(const char *pszFilename,
 CSLConstList ECRGTOCDataset::GetMetadata(const char *pszDomain)
 
 {
-    if (pszDomain != nullptr && EQUAL(pszDomain, "SUBDATASETS"))
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_SUBDATASETS))
         return papszSubDatasets;
 
     return GDALPamDataset::GetMetadata(pszDomain);
@@ -931,7 +931,7 @@ GDALDataset *ECRGTOCDataset::Build(const char *pszTOCFilename,
     if (nSubDatasets == 1)
     {
         const char *pszSubDatasetName = CSLFetchNameValue(
-            poDS->GetMetadata("SUBDATASETS"), "SUBDATASET_1_NAME");
+            poDS->GetMetadata(GDAL_MDD_SUBDATASETS), "SUBDATASET_1_NAME");
         GDALOpenInfo oOpenInfo(pszSubDatasetName, GA_ReadOnly);
         poDS.reset();
         GDALDataset *poRetDS = Open(&oOpenInfo);

--- a/frmts/nitf/nitfdataset.cpp
+++ b/frmts/nitf/nitfdataset.cpp
@@ -4183,7 +4183,7 @@ static CPLStringList NITFJP2KAKOptions(const CPLStringList &aosOptionsIn,
         }
     }
 
-    aoJP2KAKOptions.SetNameValue("NBITS", CPLSPrintf("%d", nABPP));
+    aoJP2KAKOptions.SetNameValue(GDALMD_NBITS, CPLSPrintf("%d", nABPP));
 
     return aoJP2KAKOptions;
 }
@@ -4323,7 +4323,7 @@ static CPLStringList NITFJP2OPENJPEGOptions(GDALDriver *poJ2KDriver,
         aoJP2OJPOptions.AddString("PROFILE=UNRESTRICTED");
     }
 
-    aoJP2OJPOptions.SetNameValue("NBITS", CPLSPrintf("%d", nABPP));
+    aoJP2OJPOptions.SetNameValue(GDALMD_NBITS, CPLSPrintf("%d", nABPP));
 
     return aoJP2OJPOptions;
 }
@@ -4496,7 +4496,7 @@ GDALDataset *NITFDataset::NITFDatasetCreate(const char *pszFilename, int nXSize,
         aosOptions.SetNameValue("BLOCKYSIZE", pszBlockSize);
     }
 
-    if (const char *pszNBITS = aosOptions.FetchNameValue("NBITS"))
+    if (const char *pszNBITS = aosOptions.FetchNameValue(GDALMD_NBITS))
     {
         aosOptions.SetNameValue("ABPP", pszNBITS);
     }
@@ -5326,8 +5326,8 @@ NITFDataset::CreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
         nABPP = atoi(pszABPP);
     }
     else if (const char *pszNBITS = aosOptions.FetchNameValueDef(
-                 "NBITS",
-                 poBand1->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE)))
+                 GDALMD_NBITS, poBand1->GetMetadataItem(
+                                   GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE)))
     {
         aosOptions.SetNameValue("ABPP", pszNBITS);
         nABPP = atoi(pszNBITS);

--- a/frmts/nitf/nitfdataset.cpp
+++ b/frmts/nitf/nitfdataset.cpp
@@ -1401,21 +1401,22 @@ NITFDataset *NITFDataset::OpenInternal(GDALOpenInfo *poOpenInfo,
     if (psImage == nullptr)
         /* do nothing */;
     else if (psImage->szIC[1] == '1')
-        poDS->SetMetadataItem("COMPRESSION", "BILEVEL",
+        poDS->SetMetadataItem(GDALMD_COMPRESSION, "BILEVEL",
                               GDAL_MDD_IMAGE_STRUCTURE);
     else if (psImage->szIC[1] == '2')
-        poDS->SetMetadataItem("COMPRESSION", "ARIDPCM",
+        poDS->SetMetadataItem(GDALMD_COMPRESSION, "ARIDPCM",
                               GDAL_MDD_IMAGE_STRUCTURE);
     else if (psImage->szIC[1] == '3')
-        poDS->SetMetadataItem("COMPRESSION", "JPEG", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_COMPRESSION, "JPEG",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     else if (psImage->szIC[1] == '4')
-        poDS->SetMetadataItem("COMPRESSION", "VECTOR QUANTIZATION",
+        poDS->SetMetadataItem(GDALMD_COMPRESSION, "VECTOR QUANTIZATION",
                               GDAL_MDD_IMAGE_STRUCTURE);
     else if (psImage->szIC[1] == '5')
-        poDS->SetMetadataItem("COMPRESSION", "LOSSLESS JPEG",
+        poDS->SetMetadataItem(GDALMD_COMPRESSION, "LOSSLESS JPEG",
                               GDAL_MDD_IMAGE_STRUCTURE);
     else if (psImage->szIC[1] == '8')
-        poDS->SetMetadataItem("COMPRESSION", "JPEG2000",
+        poDS->SetMetadataItem(GDALMD_COMPRESSION, "JPEG2000",
                               GDAL_MDD_IMAGE_STRUCTURE);
 
     /* -------------------------------------------------------------------- */

--- a/frmts/nitf/nitfdataset.cpp
+++ b/frmts/nitf/nitfdataset.cpp
@@ -1164,7 +1164,8 @@ NITFDataset *NITFDataset::OpenInternal(GDALOpenInfo *poOpenInfo,
 
             char *pszAEQD = nullptr;
             oSRS_AEQD.exportToWkt(&(pszAEQD));
-            poDS->SetMetadataItem("GCPPROJECTIONX", pszAEQD, "IMAGE_STRUCTURE");
+            poDS->SetMetadataItem("GCPPROJECTIONX", pszAEQD,
+                                  GDAL_MDD_IMAGE_STRUCTURE);
             CPLFree(pszAEQD);
         }
     }
@@ -1400,19 +1401,22 @@ NITFDataset *NITFDataset::OpenInternal(GDALOpenInfo *poOpenInfo,
     if (psImage == nullptr)
         /* do nothing */;
     else if (psImage->szIC[1] == '1')
-        poDS->SetMetadataItem("COMPRESSION", "BILEVEL", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("COMPRESSION", "BILEVEL",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     else if (psImage->szIC[1] == '2')
-        poDS->SetMetadataItem("COMPRESSION", "ARIDPCM", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("COMPRESSION", "ARIDPCM",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     else if (psImage->szIC[1] == '3')
-        poDS->SetMetadataItem("COMPRESSION", "JPEG", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("COMPRESSION", "JPEG", GDAL_MDD_IMAGE_STRUCTURE);
     else if (psImage->szIC[1] == '4')
         poDS->SetMetadataItem("COMPRESSION", "VECTOR QUANTIZATION",
-                              "IMAGE_STRUCTURE");
+                              GDAL_MDD_IMAGE_STRUCTURE);
     else if (psImage->szIC[1] == '5')
         poDS->SetMetadataItem("COMPRESSION", "LOSSLESS JPEG",
-                              "IMAGE_STRUCTURE");
+                              GDAL_MDD_IMAGE_STRUCTURE);
     else if (psImage->szIC[1] == '8')
-        poDS->SetMetadataItem("COMPRESSION", "JPEG2000", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("COMPRESSION", "JPEG2000",
+                              GDAL_MDD_IMAGE_STRUCTURE);
 
     /* -------------------------------------------------------------------- */
     /*      Do we have RPC info.                                            */
@@ -3263,19 +3267,21 @@ char **NITFDataset::GetMetadataDomainList()
 
 void NITFDataset::InitializeImageStructureMetadata()
 {
-    if (oSpecialMD.GetMetadata("IMAGE_STRUCTURE") != nullptr)
+    if (oSpecialMD.GetMetadata(GDAL_MDD_IMAGE_STRUCTURE) != nullptr)
         return;
 
-    oSpecialMD.SetMetadata(GDALPamDataset::GetMetadata("IMAGE_STRUCTURE"),
-                           "IMAGE_STRUCTURE");
+    oSpecialMD.SetMetadata(
+        GDALPamDataset::GetMetadata(GDAL_MDD_IMAGE_STRUCTURE),
+        GDAL_MDD_IMAGE_STRUCTURE);
     if (poJ2KDataset)
     {
         const char *pszReversibility = poJ2KDataset->GetMetadataItem(
-            "COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE");
+            "COMPRESSION_REVERSIBILITY", GDAL_MDD_IMAGE_STRUCTURE);
         if (pszReversibility)
         {
             oSpecialMD.SetMetadataItem("COMPRESSION_REVERSIBILITY",
-                                       pszReversibility, "IMAGE_STRUCTURE");
+                                       pszReversibility,
+                                       GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
 }
@@ -3361,7 +3367,7 @@ CSLConstList NITFDataset::GetMetadata(const char *pszDomain)
         return oSpecialMD.GetMetadata(pszDomain);
     }
 
-    if (pszDomain != nullptr && EQUAL(pszDomain, "IMAGE_STRUCTURE") &&
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE) &&
         poJ2KDataset)
     {
         InitializeImageStructureMetadata();
@@ -3442,7 +3448,7 @@ const char *NITFDataset::GetMetadataItem(const char *pszName,
         !osRSetVRT.empty())
         return osRSetVRT;
 
-    if (pszDomain != nullptr && EQUAL(pszDomain, "IMAGE_STRUCTURE") &&
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE) &&
         poJ2KDataset && EQUAL(pszName, "COMPRESSION_REVERSIBILITY"))
     {
         InitializeImageStructureMetadata();
@@ -5319,7 +5325,8 @@ NITFDataset::CreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
         nABPP = atoi(pszABPP);
     }
     else if (const char *pszNBITS = aosOptions.FetchNameValueDef(
-                 "NBITS", poBand1->GetMetadataItem("NBITS", "IMAGE_STRUCTURE")))
+                 "NBITS",
+                 poBand1->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE)))
     {
         aosOptions.SetNameValue("ABPP", pszNBITS);
         nABPP = atoi(pszNBITS);

--- a/frmts/nitf/nitfdataset.cpp
+++ b/frmts/nitf/nitfdataset.cpp
@@ -1452,7 +1452,7 @@ NITFDataset *NITFDataset::OpenInternal(GDALOpenInfo *poOpenInfo,
         if (papszMD != nullptr)
         {
             bHasLoadedRPCTXT = true;
-            poDS->SetMetadata(papszMD, "RPC");
+            poDS->SetMetadata(papszMD, GDAL_MDD_RPC);
             CSLDestroy(papszMD);
         }
         else
@@ -1466,84 +1466,84 @@ NITFDataset *NITFDataset::OpenInternal(GDALOpenInfo *poOpenInfo,
         char szValue[1280];
 
         CPLsnprintf(szValue, sizeof(szValue), "%.16g", sRPCInfo.ERR_BIAS);
-        poDS->SetMetadataItem("ERR_BIAS", szValue, "RPC");
+        poDS->SetMetadataItem("ERR_BIAS", szValue, GDAL_MDD_RPC);
 
         CPLsnprintf(szValue, sizeof(szValue), "%.16g", sRPCInfo.ERR_RAND);
-        poDS->SetMetadataItem("ERR_RAND", szValue, "RPC");
+        poDS->SetMetadataItem("ERR_RAND", szValue, GDAL_MDD_RPC);
 
         CPLsnprintf(szValue, sizeof(szValue), "%.16g", sRPCInfo.LINE_OFF);
-        poDS->SetMetadataItem("LINE_OFF", szValue, "RPC");
+        poDS->SetMetadataItem("LINE_OFF", szValue, GDAL_MDD_RPC);
 
         CPLsnprintf(szValue, sizeof(szValue), "%.16g", sRPCInfo.LINE_SCALE);
-        poDS->SetMetadataItem("LINE_SCALE", szValue, "RPC");
+        poDS->SetMetadataItem("LINE_SCALE", szValue, GDAL_MDD_RPC);
 
         CPLsnprintf(szValue, sizeof(szValue), "%.16g", sRPCInfo.SAMP_OFF);
-        poDS->SetMetadataItem("SAMP_OFF", szValue, "RPC");
+        poDS->SetMetadataItem("SAMP_OFF", szValue, GDAL_MDD_RPC);
 
         CPLsnprintf(szValue, sizeof(szValue), "%.16g", sRPCInfo.SAMP_SCALE);
-        poDS->SetMetadataItem("SAMP_SCALE", szValue, "RPC");
+        poDS->SetMetadataItem("SAMP_SCALE", szValue, GDAL_MDD_RPC);
 
         CPLsnprintf(szValue, sizeof(szValue), "%.16g", sRPCInfo.LONG_OFF);
-        poDS->SetMetadataItem("LONG_OFF", szValue, "RPC");
+        poDS->SetMetadataItem("LONG_OFF", szValue, GDAL_MDD_RPC);
 
         CPLsnprintf(szValue, sizeof(szValue), "%.16g", sRPCInfo.LONG_SCALE);
-        poDS->SetMetadataItem("LONG_SCALE", szValue, "RPC");
+        poDS->SetMetadataItem("LONG_SCALE", szValue, GDAL_MDD_RPC);
 
         CPLsnprintf(szValue, sizeof(szValue), "%.16g", sRPCInfo.LAT_OFF);
-        poDS->SetMetadataItem("LAT_OFF", szValue, "RPC");
+        poDS->SetMetadataItem("LAT_OFF", szValue, GDAL_MDD_RPC);
 
         CPLsnprintf(szValue, sizeof(szValue), "%.16g", sRPCInfo.LAT_SCALE);
-        poDS->SetMetadataItem("LAT_SCALE", szValue, "RPC");
+        poDS->SetMetadataItem("LAT_SCALE", szValue, GDAL_MDD_RPC);
 
         CPLsnprintf(szValue, sizeof(szValue), "%.16g", sRPCInfo.HEIGHT_OFF);
-        poDS->SetMetadataItem("HEIGHT_OFF", szValue, "RPC");
+        poDS->SetMetadataItem("HEIGHT_OFF", szValue, GDAL_MDD_RPC);
 
         CPLsnprintf(szValue, sizeof(szValue), "%.16g", sRPCInfo.HEIGHT_SCALE);
-        poDS->SetMetadataItem("HEIGHT_SCALE", szValue, "RPC");
+        poDS->SetMetadataItem("HEIGHT_SCALE", szValue, GDAL_MDD_RPC);
 
         szValue[0] = '\0';
         for (int i = 0; i < 20; i++)
             CPLsnprintf(szValue + strlen(szValue),
                         sizeof(szValue) - strlen(szValue), "%.16g ",
                         sRPCInfo.LINE_NUM_COEFF[i]);
-        poDS->SetMetadataItem("LINE_NUM_COEFF", szValue, "RPC");
+        poDS->SetMetadataItem("LINE_NUM_COEFF", szValue, GDAL_MDD_RPC);
 
         szValue[0] = '\0';
         for (int i = 0; i < 20; i++)
             CPLsnprintf(szValue + strlen(szValue),
                         sizeof(szValue) - strlen(szValue), "%.16g ",
                         sRPCInfo.LINE_DEN_COEFF[i]);
-        poDS->SetMetadataItem("LINE_DEN_COEFF", szValue, "RPC");
+        poDS->SetMetadataItem("LINE_DEN_COEFF", szValue, GDAL_MDD_RPC);
 
         szValue[0] = '\0';
         for (int i = 0; i < 20; i++)
             CPLsnprintf(szValue + strlen(szValue),
                         sizeof(szValue) - strlen(szValue), "%.16g ",
                         sRPCInfo.SAMP_NUM_COEFF[i]);
-        poDS->SetMetadataItem("SAMP_NUM_COEFF", szValue, "RPC");
+        poDS->SetMetadataItem("SAMP_NUM_COEFF", szValue, GDAL_MDD_RPC);
 
         szValue[0] = '\0';
         for (int i = 0; i < 20; i++)
             CPLsnprintf(szValue + strlen(szValue),
                         sizeof(szValue) - strlen(szValue), "%.16g ",
                         sRPCInfo.SAMP_DEN_COEFF[i]);
-        poDS->SetMetadataItem("SAMP_DEN_COEFF", szValue, "RPC");
+        poDS->SetMetadataItem("SAMP_DEN_COEFF", szValue, GDAL_MDD_RPC);
 
         CPLsnprintf(szValue, sizeof(szValue), "%.16g",
                     sRPCInfo.LONG_OFF - sRPCInfo.LONG_SCALE);
-        poDS->SetMetadataItem("MIN_LONG", szValue, "RPC");
+        poDS->SetMetadataItem("MIN_LONG", szValue, GDAL_MDD_RPC);
 
         CPLsnprintf(szValue, sizeof(szValue), "%.16g",
                     sRPCInfo.LONG_OFF + sRPCInfo.LONG_SCALE);
-        poDS->SetMetadataItem("MAX_LONG", szValue, "RPC");
+        poDS->SetMetadataItem("MAX_LONG", szValue, GDAL_MDD_RPC);
 
         CPLsnprintf(szValue, sizeof(szValue), "%.16g",
                     sRPCInfo.LAT_OFF - sRPCInfo.LAT_SCALE);
-        poDS->SetMetadataItem("MIN_LAT", szValue, "RPC");
+        poDS->SetMetadataItem("MIN_LAT", szValue, GDAL_MDD_RPC);
 
         CPLsnprintf(szValue, sizeof(szValue), "%.16g",
                     sRPCInfo.LAT_OFF + sRPCInfo.LAT_SCALE);
-        poDS->SetMetadataItem("MAX_LAT", szValue, "RPC");
+        poDS->SetMetadataItem("MAX_LAT", szValue, GDAL_MDD_RPC);
     }
 
     /* -------------------------------------------------------------------- */
@@ -5254,7 +5254,7 @@ NITFDataset::CreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
     if (!bUseSrcNITFMetadata)
         nGCIFFlags &= ~GCIF_METADATA;
 
-    CSLConstList papszRPC = poSrcDS->GetMetadata("RPC");
+    CSLConstList papszRPC = poSrcDS->GetMetadata(GDAL_MDD_RPC);
     if (papszRPC != nullptr && bUseSrcNITFMetadata &&
         CPLFetchBool(aosOptions.List(), "RPC00B", true))
     {

--- a/frmts/nitf/nitfdataset.cpp
+++ b/frmts/nitf/nitfdataset.cpp
@@ -1668,7 +1668,8 @@ NITFDataset *NITFDataset::OpenInternal(GDALOpenInfo *poOpenInfo,
 
         if (nIMIndex == -1 && nSubDSCount > 1)
         {
-            poDS->GDALMajorObject::SetMetadata(papszSubdatasets, "SUBDATASETS");
+            poDS->GDALMajorObject::SetMetadata(papszSubdatasets,
+                                               GDAL_MDD_SUBDATASETS);
         }
 
         CSLDestroy(papszSubdatasets);

--- a/frmts/nitf/nitfrasterband.cpp
+++ b/frmts/nitf/nitfrasterband.cpp
@@ -442,7 +442,7 @@ NITFRasterBand::NITFRasterBand(NITFDataset *poDSIn, int nBandIn)
     if (psImage->nABPP != 8 && psImage->nABPP != 16 && psImage->nABPP != 32 &&
         psImage->nABPP != 64)
     {
-        SetMetadataItem("NBITS", CPLString().Printf("%d", psImage->nABPP),
+        SetMetadataItem(GDALMD_NBITS, CPLString().Printf("%d", psImage->nABPP),
                         GDAL_MDD_IMAGE_STRUCTURE);
     }
 

--- a/frmts/nitf/nitfrasterband.cpp
+++ b/frmts/nitf/nitfrasterband.cpp
@@ -443,7 +443,7 @@ NITFRasterBand::NITFRasterBand(NITFDataset *poDSIn, int nBandIn)
         psImage->nABPP != 64)
     {
         SetMetadataItem("NBITS", CPLString().Printf("%d", psImage->nABPP),
-                        "IMAGE_STRUCTURE");
+                        GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     if (psImage->nBitsPerSample == 3 || psImage->nBitsPerSample == 5 ||

--- a/frmts/nitf/rpftocdataset.cpp
+++ b/frmts/nitf/rpftocdataset.cpp
@@ -718,7 +718,7 @@ void RPFTOCDataset::AddSubDataset(const char *pszFilename,
 CSLConstList RPFTOCDataset::GetMetadata(const char *pszDomain)
 
 {
-    if (pszDomain != nullptr && EQUAL(pszDomain, "SUBDATASETS"))
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_SUBDATASETS))
         return papszSubDatasets;
 
     return GDALPamDataset::GetMetadata(pszDomain);

--- a/frmts/ogcapi/gdalogcapidataset.cpp
+++ b/frmts/ogcapi/gdalogcapidataset.cpp
@@ -1256,7 +1256,7 @@ bool OGCAPIDataset::InitWithMapAPI(GDALOpenInfo *poOpenInfo,
     {
         SetBand(i, new OGCAPIMapWrapperBand(this, i));
     }
-    SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+    SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
 
     return true;
 }
@@ -1530,7 +1530,7 @@ bool OGCAPIDataset::InitWithCoverageAPI(GDALOpenInfo *poOpenInfo,
     {
         SetBand(i, new OGCAPIMapWrapperBand(this, i));
     }
-    SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+    SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
 
     return true;
 }
@@ -2244,7 +2244,8 @@ bool OGCAPIDataset::InitWithTilesAPI(GDALOpenInfo *poOpenInfo,
             {
                 SetBand(i, new OGCAPITilesWrapperBand(this, i));
             }
-            SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+            SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
+                            GDAL_MDD_IMAGE_STRUCTURE);
 
             bFoundSomething = true;
         }

--- a/frmts/ogcapi/gdalogcapidataset.cpp
+++ b/frmts/ogcapi/gdalogcapidataset.cpp
@@ -1256,7 +1256,7 @@ bool OGCAPIDataset::InitWithMapAPI(GDALOpenInfo *poOpenInfo,
     {
         SetBand(i, new OGCAPIMapWrapperBand(this, i));
     }
-    SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+    SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
 
     return true;
 }
@@ -1530,7 +1530,7 @@ bool OGCAPIDataset::InitWithCoverageAPI(GDALOpenInfo *poOpenInfo,
     {
         SetBand(i, new OGCAPIMapWrapperBand(this, i));
     }
-    SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+    SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
 
     return true;
 }
@@ -2244,7 +2244,7 @@ bool OGCAPIDataset::InitWithTilesAPI(GDALOpenInfo *poOpenInfo,
             {
                 SetBand(i, new OGCAPITilesWrapperBand(this, i));
             }
-            SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+            SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
 
             bFoundSomething = true;
         }

--- a/frmts/ogcapi/gdalogcapidataset.cpp
+++ b/frmts/ogcapi/gdalogcapidataset.cpp
@@ -1068,7 +1068,7 @@ bool OGCAPIDataset::InitFromURL(GDALOpenInfo *poOpenInfo)
             CPLSPrintf("SUBDATASET_%d_DESC", nIdx),
             CPLSPrintf("Collection %s", osTitle.c_str()));
     }
-    SetMetadata(aosSubdatasets.List(), "SUBDATASETS");
+    SetMetadata(aosSubdatasets.List(), GDAL_MDD_SUBDATASETS);
 
     return true;
 }

--- a/frmts/opjlike/jp2opjlikedataset.cpp
+++ b/frmts/opjlike/jp2opjlikedataset.cpp
@@ -1950,7 +1950,7 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     if (poDS->nBands > 1)
     {
-        poDS->GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+        poDS->GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                            GDAL_MDD_IMAGE_STRUCTURE);
     }
 

--- a/frmts/opjlike/jp2opjlikedataset.cpp
+++ b/frmts/opjlike/jp2opjlikedataset.cpp
@@ -48,8 +48,9 @@ JP2OPJLikeRasterBand<CODEC, BASE>::JP2OPJLikeRasterBand(
     poCT = nullptr;
 
     if ((nBits % 8) != 0)
-        GDALRasterBand::SetMetadataItem(
-            "NBITS", CPLString().Printf("%d", nBits), GDAL_MDD_IMAGE_STRUCTURE);
+        GDALRasterBand::SetMetadataItem(GDALMD_NBITS,
+                                        CPLString().Printf("%d", nBits),
+                                        GDAL_MDD_IMAGE_STRUCTURE);
     GDALRasterBand::SetMetadataItem(GDALMD_COMPRESSION, "JPEG2000",
                                     GDAL_MDD_IMAGE_STRUCTURE);
     this->poDS = poDSIn;
@@ -2537,9 +2538,9 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
     int nBits;
     const int nDTBits = GDALGetDataTypeSizeBits(eDataType);
 
-    if (CSLFetchNameValue(papszOptions, "NBITS") != nullptr)
+    if (CSLFetchNameValue(papszOptions, GDALMD_NBITS) != nullptr)
     {
-        nBits = atoi(CSLFetchNameValue(papszOptions, "NBITS"));
+        nBits = atoi(CSLFetchNameValue(papszOptions, GDALMD_NBITS));
         if (bInspireTG &&
             !(nBits == 1 || nBits == 8 || nBits == 16 || nBits == 32))
         {
@@ -2550,10 +2551,10 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
         }
     }
     else if (poSrcDS->GetRasterBand(1)->GetMetadataItem(
-                 "NBITS", GDAL_MDD_IMAGE_STRUCTURE) != nullptr)
+                 GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE) != nullptr)
     {
         nBits = atoi(poSrcDS->GetRasterBand(1)->GetMetadataItem(
-            "NBITS", GDAL_MDD_IMAGE_STRUCTURE));
+            GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE));
         if (bInspireTG &&
             !(nBits == 1 || nBits == 8 || nBits == 16 || nBits == 32))
         {
@@ -2717,7 +2718,7 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
                                             "EPH",
                                             "YCBCR420",
                                             "YCC",
-                                            "NBITS",
+                                            GDALMD_NBITS,
                                             "1BIT_ALPHA",
                                             "PRECINCTS",
                                             "TILEPARTS",
@@ -2859,7 +2860,7 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
 
         const char *pszNBits =
             poSrcDS->GetRasterBand(iBand + 1)->GetMetadataItem(
-                "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+                GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
         /* Recommendation 38 In the case of an opacity channel, the bit depth
          * should be 1-bit. */
         if (iBand == nAlphaBandIndex &&
@@ -3353,7 +3354,7 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
                                             "EPH",
                                             "YCBCR420",
                                             "YCC",
-                                            "NBITS",
+                                            GDALMD_NBITS,
                                             "1BIT_ALPHA",
                                             "PRECINCTS",
                                             "TILEPARTS",

--- a/frmts/opjlike/jp2opjlikedataset.cpp
+++ b/frmts/opjlike/jp2opjlikedataset.cpp
@@ -50,7 +50,7 @@ JP2OPJLikeRasterBand<CODEC, BASE>::JP2OPJLikeRasterBand(
     if ((nBits % 8) != 0)
         GDALRasterBand::SetMetadataItem(
             "NBITS", CPLString().Printf("%d", nBits), GDAL_MDD_IMAGE_STRUCTURE);
-    GDALRasterBand::SetMetadataItem("COMPRESSION", "JPEG2000",
+    GDALRasterBand::SetMetadataItem(GDALMD_COMPRESSION, "JPEG2000",
                                     GDAL_MDD_IMAGE_STRUCTURE);
     this->poDS = poDSIn;
     this->nBand = nBandIn;
@@ -2695,8 +2695,8 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
 
     if (EQUAL(poSrcDS->GetDriverName(), "GEORASTER"))
     {
-        const char *pszGEOR_compress =
-            poSrcDS->GetMetadataItem("COMPRESSION", GDAL_MDD_IMAGE_STRUCTURE);
+        const char *pszGEOR_compress = poSrcDS->GetMetadataItem(
+            GDALMD_COMPRESSION, GDAL_MDD_IMAGE_STRUCTURE);
 
         if (pszGEOR_compress == nullptr)
         {

--- a/frmts/opjlike/jp2opjlikedataset.cpp
+++ b/frmts/opjlike/jp2opjlikedataset.cpp
@@ -49,9 +49,9 @@ JP2OPJLikeRasterBand<CODEC, BASE>::JP2OPJLikeRasterBand(
 
     if ((nBits % 8) != 0)
         GDALRasterBand::SetMetadataItem(
-            "NBITS", CPLString().Printf("%d", nBits), "IMAGE_STRUCTURE");
+            "NBITS", CPLString().Printf("%d", nBits), GDAL_MDD_IMAGE_STRUCTURE);
     GDALRasterBand::SetMetadataItem("COMPRESSION", "JPEG2000",
-                                    "IMAGE_STRUCTURE");
+                                    GDAL_MDD_IMAGE_STRUCTURE);
     this->poDS = poDSIn;
     this->nBand = nBandIn;
 }
@@ -1951,7 +1951,7 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::Open(GDALOpenInfo *poOpenInfo)
     if (poDS->nBands > 1)
     {
         poDS->GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
-                                           "IMAGE_STRUCTURE");
+                                           GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     poOpenInfo->fpL = poDS->fp_;
@@ -2550,10 +2550,10 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
         }
     }
     else if (poSrcDS->GetRasterBand(1)->GetMetadataItem(
-                 "NBITS", "IMAGE_STRUCTURE") != nullptr)
+                 "NBITS", GDAL_MDD_IMAGE_STRUCTURE) != nullptr)
     {
         nBits = atoi(poSrcDS->GetRasterBand(1)->GetMetadataItem(
-            "NBITS", "IMAGE_STRUCTURE"));
+            "NBITS", GDAL_MDD_IMAGE_STRUCTURE));
         if (bInspireTG &&
             !(nBits == 1 || nBits == 8 || nBits == 16 || nBits == 32))
         {
@@ -2696,7 +2696,7 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
     if (EQUAL(poSrcDS->GetDriverName(), "GEORASTER"))
     {
         const char *pszGEOR_compress =
-            poSrcDS->GetMetadataItem("COMPRESSION", "IMAGE_STRUCTURE");
+            poSrcDS->GetMetadataItem("COMPRESSION", GDAL_MDD_IMAGE_STRUCTURE);
 
         if (pszGEOR_compress == nullptr)
         {
@@ -2859,7 +2859,7 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
 
         const char *pszNBits =
             poSrcDS->GetRasterBand(iBand + 1)->GetMetadataItem(
-                "NBITS", "IMAGE_STRUCTURE");
+                "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
         /* Recommendation 38 In the case of an opacity channel, the bit depth
          * should be 1-bit. */
         if (iBand == nAlphaBandIndex &&

--- a/frmts/opjlike/jp2opjlikedataset.cpp
+++ b/frmts/opjlike/jp2opjlikedataset.cpp
@@ -2637,9 +2637,9 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
                 }
             }
         }
-        if (poSrcDS->GetMetadata("RPC") != nullptr)
+        if (poSrcDS->GetMetadata(GDAL_MDD_RPC) != nullptr)
         {
-            oJP2MD.SetRPCMD(poSrcDS->GetMetadata("RPC"));
+            oJP2MD.SetRPCMD(poSrcDS->GetMetadata(GDAL_MDD_RPC));
             bGeoreferencingCompatOfGeoJP2 = TRUE;
         }
 

--- a/frmts/pcidsk/pcidskdataset2.cpp
+++ b/frmts/pcidsk/pcidskdataset2.cpp
@@ -81,7 +81,8 @@ PCIDSK2Band::PCIDSK2Band(PCIDSKChannel *poChannelIn)
 
     if (poChannel->GetType() == CHN_BIT)
     {
-        PCIDSK2Band::SetMetadataItem("NBITS", "1", GDAL_MDD_IMAGE_STRUCTURE);
+        PCIDSK2Band::SetMetadataItem(GDALMD_NBITS, "1",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
 
         if (!STARTS_WITH_CI(poChannel->GetDescription().c_str(),
                             "Contents Not Specified"))

--- a/frmts/pcidsk/pcidskdataset2.cpp
+++ b/frmts/pcidsk/pcidskdataset2.cpp
@@ -2035,7 +2035,7 @@ GDALDataset *PCIDSK2Dataset::Create(const char *pszFilename, int nXSize,
         if (pszValue != nullptr)
             osOptions += pszValue;
 
-        pszValue = CSLFetchNameValue(papszParamList, "COMPRESSION");
+        pszValue = CSLFetchNameValue(papszParamList, GDALMD_COMPRESSION);
         if (pszValue != nullptr)
         {
             osOptions += " ";

--- a/frmts/pcidsk/pcidskdataset2.cpp
+++ b/frmts/pcidsk/pcidskdataset2.cpp
@@ -81,7 +81,7 @@ PCIDSK2Band::PCIDSK2Band(PCIDSKChannel *poChannelIn)
 
     if (poChannel->GetType() == CHN_BIT)
     {
-        PCIDSK2Band::SetMetadataItem("NBITS", "1", "IMAGE_STRUCTURE");
+        PCIDSK2Band::SetMetadataItem("NBITS", "1", GDAL_MDD_IMAGE_STRUCTURE);
 
         if (!STARTS_WITH_CI(poChannel->GetDescription().c_str(),
                             "Contents Not Specified"))
@@ -1863,10 +1863,11 @@ GDALDataset *PCIDSK2Dataset::LLOpen(const char *pszFilename,
         /* --------------------------------------------------------------------
          */
         if (EQUAL(poFile->GetInterleaving().c_str(), "PIXEL"))
-            poDS->SetMetadataItem("IMAGE_STRUCTURE", "PIXEL",
-                                  "IMAGE_STRUCTURE");
+            poDS->SetMetadataItem(GDAL_MDD_IMAGE_STRUCTURE, "PIXEL",
+                                  GDAL_MDD_IMAGE_STRUCTURE);
         else if (EQUAL(poFile->GetInterleaving().c_str(), "BAND"))
-            poDS->SetMetadataItem("IMAGE_STRUCTURE", "BAND", "IMAGE_STRUCTURE");
+            poDS->SetMetadataItem(GDAL_MDD_IMAGE_STRUCTURE, "BAND",
+                                  GDAL_MDD_IMAGE_STRUCTURE);
 
         /* --------------------------------------------------------------------
          */

--- a/frmts/pcidsk/pcidskdataset2.cpp
+++ b/frmts/pcidsk/pcidskdataset2.cpp
@@ -962,41 +962,41 @@ void PCIDSK2Dataset::ProcessRPC()
             dfLineScale);
 
         osValue.Printf("%.16g", dfLineOffset);
-        GDALPamDataset::SetMetadataItem("LINE_OFF", osValue, "RPC");
+        GDALPamDataset::SetMetadataItem("LINE_OFF", osValue, GDAL_MDD_RPC);
 
         osValue.Printf("%.16g", dfLineScale);
-        GDALPamDataset::SetMetadataItem("LINE_SCALE", osValue, "RPC");
+        GDALPamDataset::SetMetadataItem("LINE_SCALE", osValue, GDAL_MDD_RPC);
 
         osValue.Printf("%.16g", dfSampOffset);
-        GDALPamDataset::SetMetadataItem("SAMP_OFF", osValue, "RPC");
+        GDALPamDataset::SetMetadataItem("SAMP_OFF", osValue, GDAL_MDD_RPC);
 
         osValue.Printf("%.16g", dfSampScale);
-        GDALPamDataset::SetMetadataItem("SAMP_SCALE", osValue, "RPC");
+        GDALPamDataset::SetMetadataItem("SAMP_SCALE", osValue, GDAL_MDD_RPC);
 
         osValue.Printf("%.16g", dfLongOffset);
-        GDALPamDataset::SetMetadataItem("LONG_OFF", osValue, "RPC");
+        GDALPamDataset::SetMetadataItem("LONG_OFF", osValue, GDAL_MDD_RPC);
 
         osValue.Printf("%.16g", dfLongScale);
-        GDALPamDataset::SetMetadataItem("LONG_SCALE", osValue, "RPC");
+        GDALPamDataset::SetMetadataItem("LONG_SCALE", osValue, GDAL_MDD_RPC);
 
         osValue.Printf("%.16g", dfLatOffset);
-        GDALPamDataset::SetMetadataItem("LAT_OFF", osValue, "RPC");
+        GDALPamDataset::SetMetadataItem("LAT_OFF", osValue, GDAL_MDD_RPC);
 
         osValue.Printf("%.16g", dfLatScale);
-        GDALPamDataset::SetMetadataItem("LAT_SCALE", osValue, "RPC");
+        GDALPamDataset::SetMetadataItem("LAT_SCALE", osValue, GDAL_MDD_RPC);
 
         osValue.Printf("%.16g", dfHeightOffset);
-        GDALPamDataset::SetMetadataItem("HEIGHT_OFF", osValue, "RPC");
+        GDALPamDataset::SetMetadataItem("HEIGHT_OFF", osValue, GDAL_MDD_RPC);
 
         osValue.Printf("%.16g", dfHeightScale);
-        GDALPamDataset::SetMetadataItem("HEIGHT_SCALE", osValue, "RPC");
+        GDALPamDataset::SetMetadataItem("HEIGHT_SCALE", osValue, GDAL_MDD_RPC);
 
         if (poRPCSeg->GetXNumerator().size() != 20 ||
             poRPCSeg->GetXDenominator().size() != 20 ||
             poRPCSeg->GetYNumerator().size() != 20 ||
             poRPCSeg->GetYDenominator().size() != 20)
         {
-            GDALPamDataset::SetMetadata(nullptr, "RPC");
+            GDALPamDataset::SetMetadata(nullptr, GDAL_MDD_RPC);
             CPLError(CE_Failure, CPLE_AppDefined,
                      "Did not get 20 values in the RPC coefficients lists.");
             return;
@@ -1009,7 +1009,8 @@ void PCIDSK2Dataset::ProcessRPC()
             osValue.Printf("%.16g ", adfCoef[i]);
             osCoefList += osValue;
         }
-        GDALPamDataset::SetMetadataItem("LINE_NUM_COEFF", osCoefList, "RPC");
+        GDALPamDataset::SetMetadataItem("LINE_NUM_COEFF", osCoefList,
+                                        GDAL_MDD_RPC);
 
         adfCoef = poRPCSeg->GetYDenominator();
         osCoefList = "";
@@ -1018,7 +1019,8 @@ void PCIDSK2Dataset::ProcessRPC()
             osValue.Printf("%.16g ", adfCoef[i]);
             osCoefList += osValue;
         }
-        GDALPamDataset::SetMetadataItem("LINE_DEN_COEFF", osCoefList, "RPC");
+        GDALPamDataset::SetMetadataItem("LINE_DEN_COEFF", osCoefList,
+                                        GDAL_MDD_RPC);
 
         adfCoef = poRPCSeg->GetXNumerator();
         osCoefList = "";
@@ -1027,7 +1029,8 @@ void PCIDSK2Dataset::ProcessRPC()
             osValue.Printf("%.16g ", adfCoef[i]);
             osCoefList += osValue;
         }
-        GDALPamDataset::SetMetadataItem("SAMP_NUM_COEFF", osCoefList, "RPC");
+        GDALPamDataset::SetMetadataItem("SAMP_NUM_COEFF", osCoefList,
+                                        GDAL_MDD_RPC);
 
         adfCoef = poRPCSeg->GetXDenominator();
         osCoefList = "";
@@ -1036,11 +1039,12 @@ void PCIDSK2Dataset::ProcessRPC()
             osValue.Printf("%.16g ", adfCoef[i]);
             osCoefList += osValue;
         }
-        GDALPamDataset::SetMetadataItem("SAMP_DEN_COEFF", osCoefList, "RPC");
+        GDALPamDataset::SetMetadataItem("SAMP_DEN_COEFF", osCoefList,
+                                        GDAL_MDD_RPC);
     }
     catch (const PCIDSKException &ex)
     {
-        GDALPamDataset::SetMetadata(nullptr, "RPC");
+        GDALPamDataset::SetMetadata(nullptr, GDAL_MDD_RPC);
         CPLError(CE_Failure, CPLE_AppDefined, "%s", ex.what());
     }
 }

--- a/frmts/pdf/pdfdataset.cpp
+++ b/frmts/pdf/pdfdataset.cpp
@@ -5084,7 +5084,7 @@ PDFDataset *PDFDataset::Open(GDALOpenInfo *poOpenInfo)
             aosList.AddNameValue(szKey, CPLSPrintf("Page %d of %s", i + 1,
                                                    poOpenInfo->pszFilename));
         }
-        poDS->SetMetadata(aosList.List(), "SUBDATASETS");
+        poDS->SetMetadata(aosList.List(), GDAL_MDD_SUBDATASETS);
     }
 
 #ifdef HAVE_POPPLER
@@ -5499,14 +5499,14 @@ PDFDataset *PDFDataset::Open(GDALOpenInfo *poOpenInfo)
                                     CPLSPrintf("PDF_IMAGE:%d:%d:%s", iPage,
                                                poObj->GetRefNum().toInt(),
                                                pszFilename),
-                                    "SUBDATASETS");
+                                    GDAL_MDD_SUBDATASETS);
                                 poDS->SetMetadataItem(
                                     CPLSPrintf("SUBDATASET_%d_DESC",
                                                nSubDataset),
                                     CPLSPrintf("Georeferenced image of size "
                                                "%dx%d of page %d of %s",
                                                nW, nH, iPage, pszFilename),
-                                    "SUBDATASETS");
+                                    GDAL_MDD_SUBDATASETS);
                             }
                             else if (poObj->GetRefNum().toInt() == nImageNum)
                             {
@@ -7479,7 +7479,7 @@ CSLConstList PDFDataset::GetMetadata(const char *pszDomain)
         return m_oMDMD_PDF.GetMetadata(pszDomain);
     }
     if (EQUAL(pszDomain, "LAYERS") || EQUAL(pszDomain, "xml:XMP") ||
-        EQUAL(pszDomain, "SUBDATASETS"))
+        EQUAL(pszDomain, GDAL_MDD_SUBDATASETS))
     {
         return m_oMDMD_PDF.GetMetadata(pszDomain);
     }
@@ -7517,7 +7517,7 @@ CPLErr PDFDataset::SetMetadata(CSLConstList papszMetadata,
         m_bXMPDirty = true;
         return m_oMDMD_PDF.SetMetadata(papszMetadata, pszDomain);
     }
-    else if (EQUAL(pszDomain, "SUBDATASETS"))
+    else if (EQUAL(pszDomain, GDAL_MDD_SUBDATASETS))
     {
         return m_oMDMD_PDF.SetMetadata(papszMetadata, pszDomain);
     }
@@ -7607,7 +7607,7 @@ CPLErr PDFDataset::SetMetadataItem(const char *pszName, const char *pszValue,
         m_bXMPDirty = true;
         return m_oMDMD_PDF.SetMetadataItem(pszName, pszValue, pszDomain);
     }
-    else if (EQUAL(pszDomain, "SUBDATASETS"))
+    else if (EQUAL(pszDomain, GDAL_MDD_SUBDATASETS))
     {
         return m_oMDMD_PDF.SetMetadataItem(pszName, pszValue, pszDomain);
     }

--- a/frmts/pdf/pdfdataset.cpp
+++ b/frmts/pdf/pdfdataset.cpp
@@ -548,13 +548,15 @@ void PDFRasterBand::SetSize(int nXSize, int nYSize)
     {
         nBlockXSize = 256;
         nBlockYSize = 256;
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (poPDFDS->m_nBlockXSize)
     {
         nBlockXSize = poPDFDS->m_nBlockXSize;
         nBlockYSize = poPDFDS->m_nBlockYSize;
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (nRasterXSize < 64 * 1024 * 1024 / nRasterYSize)
     {
@@ -565,7 +567,8 @@ void PDFRasterBand::SetSize(int nXSize, int nYSize)
     {
         nBlockXSize = std::min(1024, nRasterXSize);
         nBlockYSize = std::min(1024, nRasterYSize);
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     }
 }
 
@@ -5333,7 +5336,7 @@ PDFDataset *PDFDataset::Open(GDALOpenInfo *poOpenInfo)
     {
         poDS->CheckTiledRaster();
         if (!poDS->m_aiTiles.empty())
-            poDS->SetMetadataItem("INTERLEAVE", "PIXEL",
+            poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                   GDAL_MDD_IMAGE_STRUCTURE);
     }
 

--- a/frmts/pdf/pdfdataset.cpp
+++ b/frmts/pdf/pdfdataset.cpp
@@ -548,13 +548,13 @@ void PDFRasterBand::SetSize(int nXSize, int nYSize)
     {
         nBlockXSize = 256;
         nBlockYSize = 256;
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (poPDFDS->m_nBlockXSize)
     {
         nBlockXSize = poPDFDS->m_nBlockXSize;
         nBlockYSize = poPDFDS->m_nBlockYSize;
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (nRasterXSize < 64 * 1024 * 1024 / nRasterYSize)
     {
@@ -565,7 +565,7 @@ void PDFRasterBand::SetSize(int nXSize, int nYSize)
     {
         nBlockXSize = std::min(1024, nRasterXSize);
         nBlockYSize = std::min(1024, nRasterYSize);
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
     }
 }
 
@@ -5333,7 +5333,8 @@ PDFDataset *PDFDataset::Open(GDALOpenInfo *poOpenInfo)
     {
         poDS->CheckTiledRaster();
         if (!poDS->m_aiTiles.empty())
-            poDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+            poDS->SetMetadataItem("INTERLEAVE", "PIXEL",
+                                  GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     GDALPDFObject *poLGIDict = nullptr;

--- a/frmts/pds/isis3dataset.cpp
+++ b/frmts/pds/isis3dataset.cpp
@@ -2274,8 +2274,9 @@ GDALDataset *ISIS3Dataset::Open(GDALOpenInfo *poOpenInfo)
                     poTIF_DS->GetRasterCount() != nBands ||
                     poTIF_DS->GetRasterBand(1)->GetRasterDataType() !=
                         eDataType ||
-                    poTIF_DS->GetMetadataItem(
-                        "COMPRESSION", GDAL_MDD_IMAGE_STRUCTURE) != nullptr)
+                    poTIF_DS->GetMetadataItem(GDALMD_COMPRESSION,
+                                              GDAL_MDD_IMAGE_STRUCTURE) !=
+                        nullptr)
                 {
                     bWarned = true;
                     CPLError(

--- a/frmts/pds/isis3dataset.cpp
+++ b/frmts/pds/isis3dataset.cpp
@@ -4275,7 +4275,7 @@ GDALDataset *ISIS3Dataset::Create(const char *pszFilename, int nXSize,
         {
             bGeoTIFFAsRegularExternal = true;
             papszGTiffOptions =
-                CSLSetNameValue(papszGTiffOptions, "INTERLEAVE", "BAND");
+                CSLSetNameValue(papszGTiffOptions, GDALMD_INTERLEAVE, "BAND");
             // Will make sure that our blocks at nodata are not optimized
             // away but indeed well written
             papszGTiffOptions = CSLSetNameValue(

--- a/frmts/pds/isis3dataset.cpp
+++ b/frmts/pds/isis3dataset.cpp
@@ -2274,8 +2274,8 @@ GDALDataset *ISIS3Dataset::Open(GDALOpenInfo *poOpenInfo)
                     poTIF_DS->GetRasterCount() != nBands ||
                     poTIF_DS->GetRasterBand(1)->GetRasterDataType() !=
                         eDataType ||
-                    poTIF_DS->GetMetadataItem("COMPRESSION",
-                                              "IMAGE_STRUCTURE") != nullptr)
+                    poTIF_DS->GetMetadataItem(
+                        "COMPRESSION", GDAL_MDD_IMAGE_STRUCTURE) != nullptr)
                 {
                     bWarned = true;
                     CPLError(

--- a/frmts/pds/pds4dataset.cpp
+++ b/frmts/pds/pds4dataset.cpp
@@ -2434,7 +2434,8 @@ std::unique_ptr<PDS4Dataset> PDS4Dataset::OpenInternal(GDALOpenInfo *poOpenInfo)
 
     if (nFAOIdxLookup < 0 && aosSubdatasets.size() > 2)
     {
-        poDS->GDALDataset::SetMetadata(aosSubdatasets.List(), "SUBDATASETS");
+        poDS->GDALDataset::SetMetadata(aosSubdatasets.List(),
+                                       GDAL_MDD_SUBDATASETS);
     }
     else if (poDS->nBands == 0 &&
              (poOpenInfo->nOpenFlags & GDAL_OF_RASTER) != 0 &&

--- a/frmts/pds/pds4dataset.cpp
+++ b/frmts/pds/pds4dataset.cpp
@@ -2333,13 +2333,13 @@ std::unique_ptr<PDS4Dataset> PDS4Dataset::OpenInternal(GDALOpenInfo *poOpenInfo)
                 dimSemantics[1] == 'L' && dimSemantics[2] == 'S')
             {
                 poDS->GDALDataset::SetMetadataItem("INTERLEAVE", "BAND",
-                                                   "IMAGE_STRUCTURE");
+                                                   GDAL_MDD_IMAGE_STRUCTURE);
             }
             if (l_nBands > 1 && dimSemantics[0] == 'L' &&
                 dimSemantics[1] == 'S' && dimSemantics[2] == 'B')
             {
                 poDS->GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
-                                                   "IMAGE_STRUCTURE");
+                                                   GDAL_MDD_IMAGE_STRUCTURE);
             }
 
             CPLXMLNode *psOS = CPLGetXMLNode(psSubIter, "Object_Statistics");
@@ -5079,12 +5079,12 @@ std::unique_ptr<PDS4Dataset> PDS4Dataset::CreateInternal(
     if (EQUAL(pszInterleave, "BIP"))
     {
         poDS->GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
-                                           "IMAGE_STRUCTURE");
+                                           GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (EQUAL(pszInterleave, "BSQ"))
     {
         poDS->GDALDataset::SetMetadataItem("INTERLEAVE", "BAND",
-                                           "IMAGE_STRUCTURE");
+                                           GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     for (int i = 0; i < nBandsIn; i++)

--- a/frmts/pds/pds4dataset.cpp
+++ b/frmts/pds/pds4dataset.cpp
@@ -2332,13 +2332,13 @@ std::unique_ptr<PDS4Dataset> PDS4Dataset::OpenInternal(GDALOpenInfo *poOpenInfo)
             if (l_nBands > 1 && dimSemantics[0] == 'B' &&
                 dimSemantics[1] == 'L' && dimSemantics[2] == 'S')
             {
-                poDS->GDALDataset::SetMetadataItem("INTERLEAVE", "BAND",
+                poDS->GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "BAND",
                                                    GDAL_MDD_IMAGE_STRUCTURE);
             }
             if (l_nBands > 1 && dimSemantics[0] == 'L' &&
                 dimSemantics[1] == 'S' && dimSemantics[2] == 'B')
             {
-                poDS->GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+                poDS->GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                                    GDAL_MDD_IMAGE_STRUCTURE);
             }
 
@@ -4800,7 +4800,7 @@ std::unique_ptr<PDS4Dataset> PDS4Dataset::CreateInternal(
     vsi_l_offset nBandOffset;
 
     const char *pszInterleave =
-        aosOptions.FetchNameValueDef("INTERLEAVE", "BSQ");
+        aosOptions.FetchNameValueDef(GDALMD_INTERLEAVE, "BSQ");
     if (bIsArray2D)
         pszInterleave = "BIP";
 
@@ -5009,7 +5009,7 @@ std::unique_ptr<PDS4Dataset> PDS4Dataset::CreateInternal(
 #endif
 
         papszGTiffOptions =
-            CSLSetNameValue(papszGTiffOptions, "INTERLEAVE",
+            CSLSetNameValue(papszGTiffOptions, GDALMD_INTERLEAVE,
                             EQUAL(pszInterleave, "BSQ") ? "BAND" : "PIXEL");
         // Will make sure that our blocks at nodata are not optimized
         // away but indeed well written
@@ -5078,12 +5078,12 @@ std::unique_ptr<PDS4Dataset> PDS4Dataset::CreateInternal(
 
     if (EQUAL(pszInterleave, "BIP"))
     {
-        poDS->GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+        poDS->GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                            GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (EQUAL(pszInterleave, "BSQ"))
     {
-        poDS->GDALDataset::SetMetadataItem("INTERLEAVE", "BAND",
+        poDS->GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "BAND",
                                            GDAL_MDD_IMAGE_STRUCTURE);
     }
 

--- a/frmts/pds/vicardataset.cpp
+++ b/frmts/pds/vicardataset.cpp
@@ -2741,7 +2741,7 @@ GDALDataset *VICARDataset::Open(GDALOpenInfo *poOpenInfo)
                      "Update of compressed VICAR file not supported");
             return nullptr;
         }
-        poDS->SetMetadataItem("COMPRESS", osCompress, "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("COMPRESS", osCompress, GDAL_MDD_IMAGE_STRUCTURE);
         poDS->m_eCompress =
             EQUAL(osCompress, "BASIC") ? COMPRESS_BASIC : COMPRESS_BASIC2;
         if (poDS->nRasterYSize > 100 * 1000 * 1000 / nBands)

--- a/frmts/plmosaic/plmosaicdataset.cpp
+++ b/frmts/plmosaic/plmosaicdataset.cpp
@@ -166,7 +166,7 @@ PLMosaicRasterBand::PLMosaicRasterBand(PLMosaicDataset *poDSIn, int nBandIn,
     if (eDataType == GDT_UInt16)
     {
         if (nBand <= 3)
-            SetMetadataItem("NBITS", "12", GDAL_MDD_IMAGE_STRUCTURE);
+            SetMetadataItem(GDALMD_NBITS, "12", GDAL_MDD_IMAGE_STRUCTURE);
     }
 }
 

--- a/frmts/plmosaic/plmosaicdataset.cpp
+++ b/frmts/plmosaic/plmosaicdataset.cpp
@@ -647,7 +647,7 @@ GDALDataset *PLMosaicDataset::Open(GDALOpenInfo *poOpenInfo)
                     CPLSPrintf("SUBDATASET_%d_DESC", nDatasetIdx),
                     CPLSPrintf("Mosaic %s", osName.c_str()));
             }
-            poDS->SetMetadata(aosSubdatasets.List(), "SUBDATASETS");
+            poDS->SetMetadata(aosSubdatasets.List(), GDAL_MDD_SUBDATASETS);
         }
     }
 

--- a/frmts/plmosaic/plmosaicdataset.cpp
+++ b/frmts/plmosaic/plmosaicdataset.cpp
@@ -166,7 +166,7 @@ PLMosaicRasterBand::PLMosaicRasterBand(PLMosaicDataset *poDSIn, int nBandIn,
     if (eDataType == GDT_UInt16)
     {
         if (nBand <= 3)
-            SetMetadataItem("NBITS", "12", "IMAGE_STRUCTURE");
+            SetMetadataItem("NBITS", "12", GDAL_MDD_IMAGE_STRUCTURE);
     }
 }
 
@@ -320,7 +320,7 @@ PLMosaicDataset::PLMosaicDataset()
 {
     m_oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
 
-    SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+    SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
     osCachePathRoot = CPLGetPathSafe(CPLGenerateTempFilenameSafe("").c_str());
 }
 

--- a/frmts/plmosaic/plmosaicdataset.cpp
+++ b/frmts/plmosaic/plmosaicdataset.cpp
@@ -320,7 +320,7 @@ PLMosaicDataset::PLMosaicDataset()
 {
     m_oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
 
-    SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+    SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
     osCachePathRoot = CPLGetPathSafe(CPLGenerateTempFilenameSafe("").c_str());
 }
 

--- a/frmts/png/pngdataset.cpp
+++ b/frmts/png/pngdataset.cpp
@@ -1575,7 +1575,7 @@ void PNGDataset::CollectMetadata()
         {
             GetRasterBand(iBand + 1)->SetMetadataItem(
                 "NBITS", CPLString().Printf("%d", nBitDepth),
-                "IMAGE_STRUCTURE");
+                GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
 
@@ -2044,7 +2044,7 @@ GDALDataset *PNGDataset::OpenStage2(GDALOpenInfo *poOpenInfo, PNGDataset *&poDS)
     // More metadata.
     if (poDS->nBands > 1)
     {
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     // Initialize any PAM information.
@@ -2363,7 +2363,7 @@ GDALDataset *PNGDataset::CreateCopy(const char *pszFilename,
         if (nBands == 1)
         {
             const char *pszNbits = poSrcDS->GetRasterBand(1)->GetMetadataItem(
-                "NBITS", "IMAGE_STRUCTURE");
+                "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
             if (pszNbits != nullptr)
             {
                 nBitDepth = atoi(pszNbits);

--- a/frmts/png/pngdataset.cpp
+++ b/frmts/png/pngdataset.cpp
@@ -2044,7 +2044,8 @@ GDALDataset *PNGDataset::OpenStage2(GDALOpenInfo *poOpenInfo, PNGDataset *&poDS)
     // More metadata.
     if (poDS->nBands > 1)
     {
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     // Initialize any PAM information.

--- a/frmts/png/pngdataset.cpp
+++ b/frmts/png/pngdataset.cpp
@@ -1574,7 +1574,7 @@ void PNGDataset::CollectMetadata()
         for (int iBand = 0; iBand < nBands; iBand++)
         {
             GetRasterBand(iBand + 1)->SetMetadataItem(
-                "NBITS", CPLString().Printf("%d", nBitDepth),
+                GDALMD_NBITS, CPLString().Printf("%d", nBitDepth),
                 GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
@@ -2364,7 +2364,7 @@ GDALDataset *PNGDataset::CreateCopy(const char *pszFilename,
         if (nBands == 1)
         {
             const char *pszNbits = poSrcDS->GetRasterBand(1)->GetMetadataItem(
-                "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+                GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
             if (pszNbits != nullptr)
             {
                 nBitDepth = atoi(pszNbits);
@@ -2379,7 +2379,7 @@ GDALDataset *PNGDataset::CreateCopy(const char *pszFilename,
         nBitDepth = 16;
     }
 
-    const char *pszNbits = CSLFetchNameValue(papszOptions, "NBITS");
+    const char *pszNbits = CSLFetchNameValue(papszOptions, GDALMD_NBITS);
     if (eType == GDT_UInt8 && pszNbits != nullptr)
     {
         nBitDepth = atoi(pszNbits);

--- a/frmts/postgisraster/postgisrasterdataset.cpp
+++ b/frmts/postgisraster/postgisrasterdataset.cpp
@@ -1878,7 +1878,7 @@ void PostGISRasterDataset::BuildBands(BandMetadata *poBandMetaData,
             b->SetMetadataItem(
                 "NBITS",
                 CPLString().Printf("%d", poBandMetaData[iBand].nBitsDepth),
-                "IMAGE_STRUCTURE");
+                GDAL_MDD_IMAGE_STRUCTURE);
         }
 
 #ifdef DEBUG_VERBOSE

--- a/frmts/postgisraster/postgisrasterdataset.cpp
+++ b/frmts/postgisraster/postgisrasterdataset.cpp
@@ -1876,7 +1876,7 @@ void PostGISRasterDataset::BuildBands(BandMetadata *poBandMetaData,
         if (poBandMetaData[iBand].nBitsDepth < 8)
         {
             b->SetMetadataItem(
-                "NBITS",
+                GDALMD_NBITS,
                 CPLString().Printf("%d", poBandMetaData[iBand].nBitsDepth),
                 GDAL_MDD_IMAGE_STRUCTURE);
         }

--- a/frmts/postgisraster/postgisrasterdataset.cpp
+++ b/frmts/postgisraster/postgisrasterdataset.cpp
@@ -3305,7 +3305,7 @@ GDALDataset *PostGISRasterDataset::Open(GDALOpenInfo *poOpenInfo)
 char **PostGISRasterDataset::GetMetadataDomainList()
 {
     return BuildMetadataDomainList(GDALDataset::GetMetadataDomainList(), TRUE,
-                                   "SUBDATASETS", nullptr);
+                                   GDAL_MDD_SUBDATASETS, nullptr);
 }
 
 /*****************************************
@@ -3315,7 +3315,7 @@ char **PostGISRasterDataset::GetMetadataDomainList()
  *****************************************/
 CSLConstList PostGISRasterDataset::GetMetadata(const char *pszDomain)
 {
-    if (pszDomain != nullptr && STARTS_WITH_CI(pszDomain, "SUBDATASETS"))
+    if (pszDomain != nullptr && STARTS_WITH_CI(pszDomain, GDAL_MDD_SUBDATASETS))
         return papszSubdatasets;
     else
         return GDALDataset::GetMetadata(pszDomain);

--- a/frmts/raw/ehdrdataset.cpp
+++ b/frmts/raw/ehdrdataset.cpp
@@ -127,7 +127,7 @@ EHdrRasterBand::EHdrRasterBand(GDALDataset *poDSIn, int nBandIn,
         nBlockYSize = 1;
 
         SetMetadataItem("NBITS", CPLString().Printf("%d", nBits),
-                        "IMAGE_STRUCTURE");
+                        GDAL_MDD_IMAGE_STRUCTURE);
     }
 }
 
@@ -1772,12 +1772,13 @@ GDALDataset *EHdrDataset::CreateCopy(const char *pszFilename,
 
     // Ensure we pass on NBITS and PIXELTYPE structure information.
     auto poSrcBand = poSrcDS->GetRasterBand(1);
-    if (poSrcBand->GetMetadataItem("NBITS", "IMAGE_STRUCTURE") != nullptr &&
+    if (poSrcBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE) !=
+            nullptr &&
         CSLFetchNameValue(papszOptions, "NBITS") == nullptr)
     {
         papszAdjustedOptions = CSLSetNameValue(
             papszAdjustedOptions, "NBITS",
-            poSrcBand->GetMetadataItem("NBITS", "IMAGE_STRUCTURE"));
+            poSrcBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE));
     }
 
     if (poSrcBand->GetRasterDataType() == GDT_UInt8 &&
@@ -1785,7 +1786,7 @@ GDALDataset *EHdrDataset::CreateCopy(const char *pszFilename,
     {
         poSrcBand->EnablePixelTypeSignedByteWarning(false);
         const char *pszPixelType =
-            poSrcBand->GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
+            poSrcBand->GetMetadataItem("PIXELTYPE", GDAL_MDD_IMAGE_STRUCTURE);
         poSrcBand->EnablePixelTypeSignedByteWarning(true);
         if (pszPixelType != nullptr)
         {

--- a/frmts/raw/ehdrdataset.cpp
+++ b/frmts/raw/ehdrdataset.cpp
@@ -126,7 +126,7 @@ EHdrRasterBand::EHdrRasterBand(GDALDataset *poDSIn, int nBandIn,
         nBlockXSize = poDS->GetRasterXSize();
         nBlockYSize = 1;
 
-        SetMetadataItem("NBITS", CPLString().Printf("%d", nBits),
+        SetMetadataItem(GDALMD_NBITS, CPLString().Printf("%d", nBits),
                         GDAL_MDD_IMAGE_STRUCTURE);
     }
 }
@@ -1073,7 +1073,7 @@ GDALDataset *EHdrDataset::Open(GDALOpenInfo *poOpenInfo, bool bFileSizeCheck)
             dfNoData = CPLAtofM(papszTokens[1]);
             bNoDataSet = TRUE;
         }
-        else if (EQUAL(papszTokens[0], "NBITS"))
+        else if (EQUAL(papszTokens[0], GDALMD_NBITS))
         {
             nBits = atoi(papszTokens[1]);
         }
@@ -1693,7 +1693,7 @@ GDALDataset *EHdrDataset::Create(const char *pszFilename, int nXSize,
     }
 
     // Decide how many bits the file should have.
-    const char *pszNBITS = CSLFetchNameValue(papszParamList, "NBITS");
+    const char *pszNBITS = CSLFetchNameValue(papszParamList, GDALMD_NBITS);
     const int nBits =
         pszNBITS ? atoi(pszNBITS) : GDALGetDataTypeSizeBits(eType);
     if (nBits <= 0 || nXSize > (static_cast<int64_t>(INT_MAX) * 8 - 7) / nBits)
@@ -1772,13 +1772,13 @@ GDALDataset *EHdrDataset::CreateCopy(const char *pszFilename,
 
     // Ensure we pass on NBITS and PIXELTYPE structure information.
     auto poSrcBand = poSrcDS->GetRasterBand(1);
-    if (poSrcBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE) !=
+    if (poSrcBand->GetMetadataItem(GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE) !=
             nullptr &&
-        CSLFetchNameValue(papszOptions, "NBITS") == nullptr)
+        CSLFetchNameValue(papszOptions, GDALMD_NBITS) == nullptr)
     {
         papszAdjustedOptions = CSLSetNameValue(
-            papszAdjustedOptions, "NBITS",
-            poSrcBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE));
+            papszAdjustedOptions, GDALMD_NBITS,
+            poSrcBand->GetMetadataItem(GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE));
     }
 
     if (poSrcBand->GetRasterDataType() == GDT_UInt8 &&

--- a/frmts/raw/envidataset.cpp
+++ b/frmts/raw/envidataset.cpp
@@ -2153,7 +2153,8 @@ ENVIDataset *ENVIDataset::Open(GDALOpenInfo *poOpenInfo, bool bFileSizeCheck)
     if (STARTS_WITH_CI(osInterleave, "bil"))
     {
         poDS->eInterleave = Interleave::BIL;
-        poDS->SetMetadataItem("INTERLEAVE", "LINE", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_INTERLEAVE, "LINE",
+                              GDAL_MDD_IMAGE_STRUCTURE);
         if (nSamples > std::numeric_limits<int>::max() / (nDataSize * nBands))
         {
             CPLError(CE_Failure, CPLE_AppDefined, "Int overflow occurred.");
@@ -2166,7 +2167,8 @@ ENVIDataset *ENVIDataset::Open(GDALOpenInfo *poOpenInfo, bool bFileSizeCheck)
     else if (STARTS_WITH_CI(osInterleave, "bip"))
     {
         poDS->eInterleave = Interleave::BIP;
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
+                              GDAL_MDD_IMAGE_STRUCTURE);
         if (nSamples > std::numeric_limits<int>::max() / (nDataSize * nBands))
         {
             CPLError(CE_Failure, CPLE_AppDefined, "Int overflow occurred.");
@@ -2179,7 +2181,8 @@ ENVIDataset *ENVIDataset::Open(GDALOpenInfo *poOpenInfo, bool bFileSizeCheck)
     else
     {
         poDS->eInterleave = Interleave::BSQ;
-        poDS->SetMetadataItem("INTERLEAVE", "BAND", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_INTERLEAVE, "BAND",
+                              GDAL_MDD_IMAGE_STRUCTURE);
         if (nSamples > std::numeric_limits<int>::max() / nDataSize)
         {
             CPLError(CE_Failure, CPLE_AppDefined, "Int overflow occurred.");
@@ -2421,7 +2424,8 @@ GDALDataset *ENVIDataset::Create(const char *pszFilename, int nXSize,
     bRet &=
         VSIFPrintfL(fp, "header offset = 0\nfile type = ENVI Standard\n") > 0;
     bRet &= VSIFPrintfL(fp, "data type = %d\n", iENVIType) > 0;
-    const char *pszInterleaving = CSLFetchNameValue(papszOptions, "INTERLEAVE");
+    const char *pszInterleaving =
+        CSLFetchNameValue(papszOptions, GDALMD_INTERLEAVE);
     if (pszInterleaving)
     {
         if (STARTS_WITH_CI(pszInterleaving, "bip"))

--- a/frmts/raw/envidataset.cpp
+++ b/frmts/raw/envidataset.cpp
@@ -2153,7 +2153,7 @@ ENVIDataset *ENVIDataset::Open(GDALOpenInfo *poOpenInfo, bool bFileSizeCheck)
     if (STARTS_WITH_CI(osInterleave, "bil"))
     {
         poDS->eInterleave = Interleave::BIL;
-        poDS->SetMetadataItem("INTERLEAVE", "LINE", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("INTERLEAVE", "LINE", GDAL_MDD_IMAGE_STRUCTURE);
         if (nSamples > std::numeric_limits<int>::max() / (nDataSize * nBands))
         {
             CPLError(CE_Failure, CPLE_AppDefined, "Int overflow occurred.");
@@ -2166,7 +2166,7 @@ ENVIDataset *ENVIDataset::Open(GDALOpenInfo *poOpenInfo, bool bFileSizeCheck)
     else if (STARTS_WITH_CI(osInterleave, "bip"))
     {
         poDS->eInterleave = Interleave::BIP;
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
         if (nSamples > std::numeric_limits<int>::max() / (nDataSize * nBands))
         {
             CPLError(CE_Failure, CPLE_AppDefined, "Int overflow occurred.");
@@ -2179,7 +2179,7 @@ ENVIDataset *ENVIDataset::Open(GDALOpenInfo *poOpenInfo, bool bFileSizeCheck)
     else
     {
         poDS->eInterleave = Interleave::BSQ;
-        poDS->SetMetadataItem("INTERLEAVE", "BAND", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("INTERLEAVE", "BAND", GDAL_MDD_IMAGE_STRUCTURE);
         if (nSamples > std::numeric_limits<int>::max() / nDataSize)
         {
             CPLError(CE_Failure, CPLE_AppDefined, "Int overflow occurred.");

--- a/frmts/raw/envidataset.cpp
+++ b/frmts/raw/envidataset.cpp
@@ -919,7 +919,7 @@ bool ENVIDataset::ParseRpcCoeffsMetaDataString(const char *psName,
                                                CPLStringList &aosVal)
 {
     // Separate one string with 20 coefficients into an array of 20 strings.
-    const char *psz20Vals = GetMetadataItem(psName, "RPC");
+    const char *psz20Vals = GetMetadataItem(psName, GDAL_MDD_RPC);
     if (!psz20Vals)
         return false;
 
@@ -948,7 +948,7 @@ bool ENVIDataset::WriteRpcInfo()
                                 "HEIGHT_OFF", "LINE_SCALE", "SAMP_SCALE",
                                 "LAT_SCALE", "LONG_SCALE", "HEIGHT_SCALE"})
     {
-        const char *pszValue = GetMetadataItem(pszItem, "RPC");
+        const char *pszValue = GetMetadataItem(pszItem, GDAL_MDD_RPC);
         if (!pszValue)
             return false;
         aosVal.push_back(pszValue);
@@ -965,7 +965,7 @@ bool ENVIDataset::WriteRpcInfo()
     for (const char *pszItem :
          {"TILE_ROW_OFFSET", "TILE_COL_OFFSET", "ENVI_RPC_EMULATION"})
     {
-        const char *pszValue = GetMetadataItem(pszItem, "RPC");
+        const char *pszValue = GetMetadataItem(pszItem, GDAL_MDD_RPC);
         if (!pszValue)
             return false;
         aosVal.push_back(pszValue);
@@ -1111,7 +1111,8 @@ void ENVIDataset::SetDescription(const char *pszDescription)
 CPLErr ENVIDataset::SetMetadata(CSLConstList papszMetadata,
                                 const char *pszDomain)
 {
-    if (pszDomain && (EQUAL(pszDomain, "RPC") || EQUAL(pszDomain, "ENVI")))
+    if (pszDomain &&
+        (EQUAL(pszDomain, GDAL_MDD_RPC) || EQUAL(pszDomain, "ENVI")))
     {
         bHeaderDirty = true;
     }
@@ -1125,7 +1126,8 @@ CPLErr ENVIDataset::SetMetadata(CSLConstList papszMetadata,
 CPLErr ENVIDataset::SetMetadataItem(const char *pszName, const char *pszValue,
                                     const char *pszDomain)
 {
-    if (pszDomain && (EQUAL(pszDomain, "RPC") || EQUAL(pszDomain, "ENVI")))
+    if (pszDomain &&
+        (EQUAL(pszDomain, GDAL_MDD_RPC) || EQUAL(pszDomain, "ENVI")))
     {
         bHeaderDirty = true;
     }
@@ -1522,71 +1524,71 @@ void ENVIDataset::ProcessRPCinfo(const char *pszRPCinfo, int numCols,
 
     char sVal[1280] = {'\0'};
     CPLsnprintf(sVal, sizeof(sVal), "%.16g", CPLAtof(aosFields[0]));
-    SetMetadataItem("LINE_OFF", sVal, "RPC");
+    SetMetadataItem("LINE_OFF", sVal, GDAL_MDD_RPC);
     CPLsnprintf(sVal, sizeof(sVal), "%.16g", CPLAtof(aosFields[5]));
-    SetMetadataItem("LINE_SCALE", sVal, "RPC");
+    SetMetadataItem("LINE_SCALE", sVal, GDAL_MDD_RPC);
     CPLsnprintf(sVal, sizeof(sVal), "%.16g", CPLAtof(aosFields[1]));
-    SetMetadataItem("SAMP_OFF", sVal, "RPC");
+    SetMetadataItem("SAMP_OFF", sVal, GDAL_MDD_RPC);
     CPLsnprintf(sVal, sizeof(sVal), "%.16g", CPLAtof(aosFields[6]));
-    SetMetadataItem("SAMP_SCALE", sVal, "RPC");
+    SetMetadataItem("SAMP_SCALE", sVal, GDAL_MDD_RPC);
     CPLsnprintf(sVal, sizeof(sVal), "%.16g", CPLAtof(aosFields[2]));
-    SetMetadataItem("LAT_OFF", sVal, "RPC");
+    SetMetadataItem("LAT_OFF", sVal, GDAL_MDD_RPC);
     CPLsnprintf(sVal, sizeof(sVal), "%.16g", CPLAtof(aosFields[7]));
-    SetMetadataItem("LAT_SCALE", sVal, "RPC");
+    SetMetadataItem("LAT_SCALE", sVal, GDAL_MDD_RPC);
     CPLsnprintf(sVal, sizeof(sVal), "%.16g", CPLAtof(aosFields[3]));
-    SetMetadataItem("LONG_OFF", sVal, "RPC");
+    SetMetadataItem("LONG_OFF", sVal, GDAL_MDD_RPC);
     CPLsnprintf(sVal, sizeof(sVal), "%.16g", CPLAtof(aosFields[8]));
-    SetMetadataItem("LONG_SCALE", sVal, "RPC");
+    SetMetadataItem("LONG_SCALE", sVal, GDAL_MDD_RPC);
     CPLsnprintf(sVal, sizeof(sVal), "%.16g", CPLAtof(aosFields[4]));
-    SetMetadataItem("HEIGHT_OFF", sVal, "RPC");
+    SetMetadataItem("HEIGHT_OFF", sVal, GDAL_MDD_RPC);
     CPLsnprintf(sVal, sizeof(sVal), "%.16g", CPLAtof(aosFields[9]));
-    SetMetadataItem("HEIGHT_SCALE", sVal, "RPC");
+    SetMetadataItem("HEIGHT_SCALE", sVal, GDAL_MDD_RPC);
 
     sVal[0] = '\0';
     for (int i = 0; i < 20; i++)
         CPLsnprintf(sVal + strlen(sVal), sizeof(sVal) - strlen(sVal), "%.16g ",
                     CPLAtof(aosFields[10 + i]));
-    SetMetadataItem("LINE_NUM_COEFF", sVal, "RPC");
+    SetMetadataItem("LINE_NUM_COEFF", sVal, GDAL_MDD_RPC);
 
     sVal[0] = '\0';
     for (int i = 0; i < 20; i++)
         CPLsnprintf(sVal + strlen(sVal), sizeof(sVal) - strlen(sVal), "%.16g ",
                     CPLAtof(aosFields[30 + i]));
-    SetMetadataItem("LINE_DEN_COEFF", sVal, "RPC");
+    SetMetadataItem("LINE_DEN_COEFF", sVal, GDAL_MDD_RPC);
 
     sVal[0] = '\0';
     for (int i = 0; i < 20; i++)
         CPLsnprintf(sVal + strlen(sVal), sizeof(sVal) - strlen(sVal), "%.16g ",
                     CPLAtof(aosFields[50 + i]));
-    SetMetadataItem("SAMP_NUM_COEFF", sVal, "RPC");
+    SetMetadataItem("SAMP_NUM_COEFF", sVal, GDAL_MDD_RPC);
 
     sVal[0] = '\0';
     for (int i = 0; i < 20; i++)
         CPLsnprintf(sVal + strlen(sVal), sizeof(sVal) - strlen(sVal), "%.16g ",
                     CPLAtof(aosFields[70 + i]));
-    SetMetadataItem("SAMP_DEN_COEFF", sVal, "RPC");
+    SetMetadataItem("SAMP_DEN_COEFF", sVal, GDAL_MDD_RPC);
 
     CPLsnprintf(sVal, sizeof(sVal), "%.16g",
                 CPLAtof(aosFields[3]) - CPLAtof(aosFields[8]));
-    SetMetadataItem("MIN_LONG", sVal, "RPC");
+    SetMetadataItem("MIN_LONG", sVal, GDAL_MDD_RPC);
 
     CPLsnprintf(sVal, sizeof(sVal), "%.16g",
                 CPLAtof(aosFields[3]) + CPLAtof(aosFields[8]));
-    SetMetadataItem("MAX_LONG", sVal, "RPC");
+    SetMetadataItem("MAX_LONG", sVal, GDAL_MDD_RPC);
 
     CPLsnprintf(sVal, sizeof(sVal), "%.16g",
                 CPLAtof(aosFields[2]) - CPLAtof(aosFields[7]));
-    SetMetadataItem("MIN_LAT", sVal, "RPC");
+    SetMetadataItem("MIN_LAT", sVal, GDAL_MDD_RPC);
 
     CPLsnprintf(sVal, sizeof(sVal), "%.16g",
                 CPLAtof(aosFields[2]) + CPLAtof(aosFields[7]));
-    SetMetadataItem("MAX_LAT", sVal, "RPC");
+    SetMetadataItem("MAX_LAT", sVal, GDAL_MDD_RPC);
 
     if (nCount == 93)
     {
-        SetMetadataItem("TILE_ROW_OFFSET", aosFields[90], "RPC");
-        SetMetadataItem("TILE_COL_OFFSET", aosFields[91], "RPC");
-        SetMetadataItem("ENVI_RPC_EMULATION", aosFields[92], "RPC");
+        SetMetadataItem("TILE_ROW_OFFSET", aosFields[90], GDAL_MDD_RPC);
+        SetMetadataItem("TILE_COL_OFFSET", aosFields[91], GDAL_MDD_RPC);
+        SetMetadataItem("ENVI_RPC_EMULATION", aosFields[92], GDAL_MDD_RPC);
     }
 
     // Handle the chipping case where the image is a subset.

--- a/frmts/raw/genbindataset.cpp
+++ b/frmts/raw/genbindataset.cpp
@@ -91,7 +91,7 @@ class GenBinBitRasterBand final : public GDALPamRasterBand
 GenBinBitRasterBand::GenBinBitRasterBand(GenBinDataset *poDSIn, int nBitsIn)
     : nBits(nBitsIn)
 {
-    SetMetadataItem("NBITS", CPLString().Printf("%d", nBitsIn),
+    SetMetadataItem(GDALMD_NBITS, CPLString().Printf("%d", nBitsIn),
                     GDAL_MDD_IMAGE_STRUCTURE);
 
     poDS = poDSIn;

--- a/frmts/raw/genbindataset.cpp
+++ b/frmts/raw/genbindataset.cpp
@@ -92,7 +92,7 @@ GenBinBitRasterBand::GenBinBitRasterBand(GenBinDataset *poDSIn, int nBitsIn)
     : nBits(nBitsIn)
 {
     SetMetadataItem("NBITS", CPLString().Printf("%d", nBitsIn),
-                    "IMAGE_STRUCTURE");
+                    GDAL_MDD_IMAGE_STRUCTURE);
 
     poDS = poDSIn;
     nBand = 1;

--- a/frmts/raw/krodataset.cpp
+++ b/frmts/raw/krodataset.cpp
@@ -214,7 +214,8 @@ GDALDataset *KRODataset::Open(GDALOpenInfo *poOpenInfo)
     }
 
     if (nComp > 1)
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
+                              GDAL_MDD_IMAGE_STRUCTURE);
 
     /* -------------------------------------------------------------------- */
     /*      Initialize any PAM information.                                 */

--- a/frmts/raw/krodataset.cpp
+++ b/frmts/raw/krodataset.cpp
@@ -214,7 +214,7 @@ GDALDataset *KRODataset::Open(GDALOpenInfo *poOpenInfo)
     }
 
     if (nComp > 1)
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
 
     /* -------------------------------------------------------------------- */
     /*      Initialize any PAM information.                                 */

--- a/frmts/raw/ntv2dataset.cpp
+++ b/frmts/raw/ntv2dataset.cpp
@@ -383,11 +383,11 @@ GDALDataset *NTv2Dataset::Open(GDALOpenInfo *poOpenInfo)
             CPLString osValue;
             osKey.Printf("SUBDATASET_%d_NAME", iGrid);
             osValue.Printf("NTv2:%d:%s", iGrid, osFilename.c_str());
-            poDS->SetMetadataItem(osKey, osValue, "SUBDATASETS");
+            poDS->SetMetadataItem(osKey, osValue, GDAL_MDD_SUBDATASETS);
 
             osKey.Printf("SUBDATASET_%d_DESC", iGrid);
             osValue.Printf("%s", osSubName.c_str());
-            poDS->SetMetadataItem(osKey, osValue, "SUBDATASETS");
+            poDS->SetMetadataItem(osKey, osValue, GDAL_MDD_SUBDATASETS);
         }
 
         nGridOffset +=

--- a/frmts/raw/rrasterdataset.cpp
+++ b/frmts/raw/rrasterdataset.cpp
@@ -1429,7 +1429,7 @@ GDALDataset *RRASTERDataset::Create(const char *pszFilename, int nXSize,
     int nLineOffset = 0;
     vsi_l_offset nBandOffset = 0;
     CPLString osBandOrder(
-        CSLFetchNameValueDef(papszOptions, "INTERLEAVE", "BIL"));
+        CSLFetchNameValueDef(papszOptions, GDALMD_INTERLEAVE, "BIL"));
     if (!ComputeSpacings(osBandOrder, nXSize, nYSize, nBandsIn, eType,
                          nPixelOffset, nLineOffset, nBandOffset))
     {

--- a/frmts/rcm/rcmdataset.cpp
+++ b/frmts/rcm/rcmdataset.cpp
@@ -2545,7 +2545,7 @@ CPLErr RCMDataset::GetGeoTransform(GDALGeoTransform &gt) const
 char **RCMDataset::GetMetadataDomainList()
 {
     return BuildMetadataDomainList(GDALDataset::GetMetadataDomainList(), TRUE,
-                                   "SUBDATASETS", nullptr);
+                                   GDAL_MDD_SUBDATASETS, nullptr);
 }
 
 /************************************************************************/
@@ -2555,7 +2555,8 @@ char **RCMDataset::GetMetadataDomainList()
 CSLConstList RCMDataset::GetMetadata(const char *pszDomain)
 
 {
-    if (pszDomain != nullptr && STARTS_WITH_CI(pszDomain, "SUBDATASETS") &&
+    if (pszDomain != nullptr &&
+        STARTS_WITH_CI(pszDomain, GDAL_MDD_SUBDATASETS) &&
         papszSubDatasets != nullptr)
         return papszSubDatasets;
 

--- a/frmts/rcm/rcmdataset.cpp
+++ b/frmts/rcm/rcmdataset.cpp
@@ -2411,7 +2411,7 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
                 papszRPC = CSLSetNameValue(
                     papszRPC, apszXMLToGDALMapping[i + 1], pszValue);
         }
-        poDS->GDALDataset::SetMetadata(papszRPC, "RPC");
+        poDS->GDALDataset::SetMetadata(papszRPC, GDAL_MDD_RPC);
         CSLDestroy(papszRPC);
     }
 

--- a/frmts/rmf/rmfdataset.cpp
+++ b/frmts/rmf/rmfdataset.cpp
@@ -1823,7 +1823,7 @@ RMFDataset *RMFDataset::Open(GDALOpenInfo *poOpenInfo, RMFDataset *poParentDS,
 
     if (poDS->nBands > 1)
     {
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
     }
     /* -------------------------------------------------------------------- */
     /*  Set up projection.                                                  */
@@ -2381,7 +2381,7 @@ GDALDataset *RMFDataset::Create(const char *pszFilename, int nXSize, int nYSize,
 
     if (nBandsIn > 1)
     {
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     poDS->WriteHeader();
@@ -2798,7 +2798,7 @@ int RMFDataset::SetupCompression(GDALDataType eType, const char *pszFilename)
     {
         Decompress = &LZWDecompress;
         Compress = &LZWCompress;
-        SetMetadataItem("COMPRESSION", "LZW", "IMAGE_STRUCTURE");
+        SetMetadataItem("COMPRESSION", "LZW", GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (sHeader.iCompression == RMF_COMPRESSION_JPEG)
     {
@@ -2814,8 +2814,8 @@ int RMFDataset::SetupCompression(GDALDataType eType, const char *pszFilename)
         oBuf.Printf("%d", sHeader.iJpegQuality);
         Decompress = &JPEGDecompress;
         Compress = &JPEGCompress;
-        SetMetadataItem("JPEG_QUALITY", oBuf.c_str(), "IMAGE_STRUCTURE");
-        SetMetadataItem("COMPRESSION", "JPEG", "IMAGE_STRUCTURE");
+        SetMetadataItem("JPEG_QUALITY", oBuf.c_str(), GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem("COMPRESSION", "JPEG", GDAL_MDD_IMAGE_STRUCTURE);
 #else   // HAVE_LIBJPEG
         CPLError(CE_Failure, CPLE_AppDefined,
                  "JPEG codec is needed to open <%s>.\n"
@@ -2829,7 +2829,7 @@ int RMFDataset::SetupCompression(GDALDataType eType, const char *pszFilename)
     {
         Decompress = &DEMDecompress;
         Compress = &DEMCompress;
-        SetMetadataItem("COMPRESSION", "RMF_DEM", "IMAGE_STRUCTURE");
+        SetMetadataItem("COMPRESSION", "RMF_DEM", GDAL_MDD_IMAGE_STRUCTURE);
     }
     else
     {
@@ -3256,7 +3256,7 @@ void RMFDataset::SetupNBits()
         for (int iBand = 1; iBand <= nBands; iBand++)
         {
             GetRasterBand(iBand)->SetMetadataItem("NBITS", szNBits,
-                                                  "IMAGE_STRUCTURE");
+                                                  GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
 }

--- a/frmts/rmf/rmfdataset.cpp
+++ b/frmts/rmf/rmfdataset.cpp
@@ -2800,7 +2800,7 @@ int RMFDataset::SetupCompression(GDALDataType eType, const char *pszFilename)
     {
         Decompress = &LZWDecompress;
         Compress = &LZWCompress;
-        SetMetadataItem("COMPRESSION", "LZW", GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem(GDALMD_COMPRESSION, "LZW", GDAL_MDD_IMAGE_STRUCTURE);
     }
     else if (sHeader.iCompression == RMF_COMPRESSION_JPEG)
     {
@@ -2817,7 +2817,7 @@ int RMFDataset::SetupCompression(GDALDataType eType, const char *pszFilename)
         Decompress = &JPEGDecompress;
         Compress = &JPEGCompress;
         SetMetadataItem("JPEG_QUALITY", oBuf.c_str(), GDAL_MDD_IMAGE_STRUCTURE);
-        SetMetadataItem("COMPRESSION", "JPEG", GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem(GDALMD_COMPRESSION, "JPEG", GDAL_MDD_IMAGE_STRUCTURE);
 #else   // HAVE_LIBJPEG
         CPLError(CE_Failure, CPLE_AppDefined,
                  "JPEG codec is needed to open <%s>.\n"
@@ -2831,7 +2831,8 @@ int RMFDataset::SetupCompression(GDALDataType eType, const char *pszFilename)
     {
         Decompress = &DEMDecompress;
         Compress = &DEMCompress;
-        SetMetadataItem("COMPRESSION", "RMF_DEM", GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem(GDALMD_COMPRESSION, "RMF_DEM",
+                        GDAL_MDD_IMAGE_STRUCTURE);
     }
     else
     {

--- a/frmts/rmf/rmfdataset.cpp
+++ b/frmts/rmf/rmfdataset.cpp
@@ -3258,7 +3258,7 @@ void RMFDataset::SetupNBits()
         snprintf(szNBits, sizeof(szNBits), "%d", nBitDepth);
         for (int iBand = 1; iBand <= nBands; iBand++)
         {
-            GetRasterBand(iBand)->SetMetadataItem("NBITS", szNBits,
+            GetRasterBand(iBand)->SetMetadataItem(GDALMD_NBITS, szNBits,
                                                   GDAL_MDD_IMAGE_STRUCTURE);
         }
     }

--- a/frmts/rmf/rmfdataset.cpp
+++ b/frmts/rmf/rmfdataset.cpp
@@ -1823,7 +1823,8 @@ RMFDataset *RMFDataset::Open(GDALOpenInfo *poOpenInfo, RMFDataset *poParentDS,
 
     if (poDS->nBands > 1)
     {
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     }
     /* -------------------------------------------------------------------- */
     /*  Set up projection.                                                  */
@@ -2381,7 +2382,8 @@ GDALDataset *RMFDataset::Create(const char *pszFilename, int nXSize, int nYSize,
 
     if (nBandsIn > 1)
     {
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
+                              GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     poDS->WriteHeader();

--- a/frmts/rs2/rs2dataset.cpp
+++ b/frmts/rs2/rs2dataset.cpp
@@ -1487,7 +1487,7 @@ GDALDataset *RS2Dataset::Open(GDALOpenInfo *poOpenInfo)
                 papszRPC = CSLSetNameValue(
                     papszRPC, apszXMLToGDALMapping[i + 1], pszValue);
         }
-        poDS->GDALDataset::SetMetadata(papszRPC, "RPC");
+        poDS->GDALDataset::SetMetadata(papszRPC, GDAL_MDD_RPC);
         CSLDestroy(papszRPC);
     }
 

--- a/frmts/rs2/rs2dataset.cpp
+++ b/frmts/rs2/rs2dataset.cpp
@@ -1602,7 +1602,7 @@ CPLErr RS2Dataset::GetGeoTransform(GDALGeoTransform &gt) const
 char **RS2Dataset::GetMetadataDomainList()
 {
     return BuildMetadataDomainList(GDALDataset::GetMetadataDomainList(), TRUE,
-                                   "SUBDATASETS", nullptr);
+                                   GDAL_MDD_SUBDATASETS, nullptr);
 }
 
 /************************************************************************/
@@ -1612,7 +1612,8 @@ char **RS2Dataset::GetMetadataDomainList()
 CSLConstList RS2Dataset::GetMetadata(const char *pszDomain)
 
 {
-    if (pszDomain != nullptr && STARTS_WITH_CI(pszDomain, "SUBDATASETS") &&
+    if (pszDomain != nullptr &&
+        STARTS_WITH_CI(pszDomain, GDAL_MDD_SUBDATASETS) &&
         papszSubDatasets != nullptr)
         return papszSubDatasets;
 

--- a/frmts/safe/safedataset.cpp
+++ b/frmts/safe/safedataset.cpp
@@ -1939,7 +1939,7 @@ const GDAL_GCP *SAFEDataset::GetGCPs()
 char **SAFEDataset::GetMetadataDomainList()
 {
     return BuildMetadataDomainList(GDALDataset::GetMetadataDomainList(), TRUE,
-                                   "SUBDATASETS", nullptr);
+                                   GDAL_MDD_SUBDATASETS, nullptr);
 }
 
 /************************************************************************/
@@ -1948,7 +1948,7 @@ char **SAFEDataset::GetMetadataDomainList()
 
 CSLConstList SAFEDataset::GetMetadata(const char *pszDomain)
 {
-    if (pszDomain != nullptr && STARTS_WITH_CI(pszDomain, "SUBDATASETS"))
+    if (pszDomain != nullptr && STARTS_WITH_CI(pszDomain, GDAL_MDD_SUBDATASETS))
         return papszSubDatasets;
 
     return GDALDataset::GetMetadata(pszDomain);

--- a/frmts/sentinel2/sentinel2dataset.cpp
+++ b/frmts/sentinel2/sentinel2dataset.cpp
@@ -2036,7 +2036,7 @@ static void SENTINEL2SetBandMetadata(GDALRasterBand *poBand,
             CPLSPrintf("%.3f", double(psBandDesc->nWaveLength) / 1000),
             "IMAGERY");
         poBand->SetMetadataItem(
-            "FWHM_UM",
+            GDALMD_FWHM_UM,
             CPLSPrintf("%.3f", double(psBandDesc->nBandWidth) / 1000),
             "IMAGERY");
     }

--- a/frmts/sentinel2/sentinel2dataset.cpp
+++ b/frmts/sentinel2/sentinel2dataset.cpp
@@ -4093,7 +4093,7 @@ SENTINEL2Dataset *SENTINEL2Dataset::CreateL1CL2ADataset(
 
     poDS->SetGeoTransform(GDALGeoTransform(dfMinX, nSubDSPrecision, 0, dfMaxY,
                                            0, -nSubDSPrecision));
-    poDS->GDALDataset::SetMetadataItem("COMPRESSION", "JPEG2000",
+    poDS->GDALDataset::SetMetadataItem(GDALMD_COMPRESSION, "JPEG2000",
                                        GDAL_MDD_IMAGE_STRUCTURE);
     if (bIsPreview || bIsTCI)
         poDS->GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",

--- a/frmts/sentinel2/sentinel2dataset.cpp
+++ b/frmts/sentinel2/sentinel2dataset.cpp
@@ -2729,7 +2729,7 @@ SENTINEL2Dataset::OpenL1BSubdatasetWithGeoloc(GDALOpenInfo *poOpenInfo)
             osMD.SetNameValue("SRS", oSRS.exportToWkt().c_str());
         }
 
-        poDS->SetMetadata(osMD.List(), "GEOLOCATION");
+        poDS->SetMetadata(osMD.List(), GDAL_MDD_GEOLOCATION);
     }
 
     return poDS.release();

--- a/frmts/sentinel2/sentinel2dataset.cpp
+++ b/frmts/sentinel2/sentinel2dataset.cpp
@@ -275,7 +275,8 @@ CPLErr SENTINEL2AlphaBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
         eBufType, nPixelSpace, nLineSpace, psExtraArg);
     if (eErr == CE_None)
     {
-        const char *pszNBITS = GetMetadataItem("NBITS", "IMAGE_STRUCTURE");
+        const char *pszNBITS =
+            GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
         const int nBits = (pszNBITS) ? atoi(pszNBITS) : 16;
         const GUInt16 nMaxVal = (nBits > 8 && nBits <= 16)
                                     ? static_cast<GUInt16>((1 << nBits) - 1)
@@ -2278,7 +2279,7 @@ GDALDataset *SENTINEL2Dataset::OpenL1BSubdataset(GDALOpenInfo *poOpenInfo)
         if ((nBits % 8) != 0)
         {
             poBand->SetMetadataItem("NBITS", CPLSPrintf("%d", nBits),
-                                    "IMAGE_STRUCTURE");
+                                    GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
 
@@ -2674,7 +2675,7 @@ SENTINEL2Dataset::OpenL1BSubdatasetWithGeoloc(GDALOpenInfo *poOpenInfo)
     if ((nBits % 8) != 0)
     {
         poBand->SetMetadataItem("NBITS", CPLSPrintf("%d", nBits),
-                                "IMAGE_STRUCTURE");
+                                GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     // Get metadata from top MTD XML filename
@@ -3491,7 +3492,7 @@ static bool SENTINEL2GetTileInfo(const char *pszFilename, int *pnWidth,
                 {
                     const char *pszNBits =
                         poDS->GetRasterBand(1)->GetMetadataItem(
-                            "NBITS", "IMAGE_STRUCTURE");
+                            "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
                     if (pszNBits == nullptr)
                     {
                         GDALDataType eDT =
@@ -4093,10 +4094,10 @@ SENTINEL2Dataset *SENTINEL2Dataset::CreateL1CL2ADataset(
     poDS->SetGeoTransform(GDALGeoTransform(dfMinX, nSubDSPrecision, 0, dfMaxY,
                                            0, -nSubDSPrecision));
     poDS->GDALDataset::SetMetadataItem("COMPRESSION", "JPEG2000",
-                                       "IMAGE_STRUCTURE");
+                                       GDAL_MDD_IMAGE_STRUCTURE);
     if (bIsPreview || bIsTCI)
         poDS->GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
-                                           "IMAGE_STRUCTURE");
+                                           GDAL_MDD_IMAGE_STRUCTURE);
 
     int nBits = (bIsPreview || bIsTCI) ? 8 : 0 /* 0 = unknown yet*/;
     int nValMax = (bIsPreview || bIsTCI) ? 255 : 0 /* 0 = unknown yet*/;
@@ -4232,7 +4233,7 @@ SENTINEL2Dataset *SENTINEL2Dataset::CreateL1CL2ADataset(
         if ((nBits % 8) != 0)
         {
             poBand->SetMetadataItem("NBITS", CPLSPrintf("%d", nBits),
-                                    "IMAGE_STRUCTURE");
+                                    GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
 

--- a/frmts/sentinel2/sentinel2dataset.cpp
+++ b/frmts/sentinel2/sentinel2dataset.cpp
@@ -2032,7 +2032,7 @@ static void SENTINEL2SetBandMetadata(GDALRasterBand *poBand,
         poBand->SetMetadataItem("WAVELENGTH_UNIT", "nm");
 
         poBand->SetMetadataItem(
-            "CENTRAL_WAVELENGTH_UM",
+            GDALMD_CENTRAL_WAVELENGTH_UM,
             CPLSPrintf("%.3f", double(psBandDesc->nWaveLength) / 1000),
             "IMAGERY");
         poBand->SetMetadataItem(

--- a/frmts/sentinel2/sentinel2dataset.cpp
+++ b/frmts/sentinel2/sentinel2dataset.cpp
@@ -4096,7 +4096,7 @@ SENTINEL2Dataset *SENTINEL2Dataset::CreateL1CL2ADataset(
     poDS->GDALDataset::SetMetadataItem("COMPRESSION", "JPEG2000",
                                        GDAL_MDD_IMAGE_STRUCTURE);
     if (bIsPreview || bIsTCI)
-        poDS->GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+        poDS->GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                            GDAL_MDD_IMAGE_STRUCTURE);
 
     int nBits = (bIsPreview || bIsTCI) ? 8 : 0 /* 0 = unknown yet*/;

--- a/frmts/sentinel2/sentinel2dataset.cpp
+++ b/frmts/sentinel2/sentinel2dataset.cpp
@@ -276,7 +276,7 @@ CPLErr SENTINEL2AlphaBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
     if (eErr == CE_None)
     {
         const char *pszNBITS =
-            GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+            GetMetadataItem(GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
         const int nBits = (pszNBITS) ? atoi(pszNBITS) : 16;
         const GUInt16 nMaxVal = (nBits > 8 && nBits <= 16)
                                     ? static_cast<GUInt16>((1 << nBits) - 1)
@@ -2278,7 +2278,7 @@ GDALDataset *SENTINEL2Dataset::OpenL1BSubdataset(GDALOpenInfo *poOpenInfo)
 
         if ((nBits % 8) != 0)
         {
-            poBand->SetMetadataItem("NBITS", CPLSPrintf("%d", nBits),
+            poBand->SetMetadataItem(GDALMD_NBITS, CPLSPrintf("%d", nBits),
                                     GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
@@ -2674,7 +2674,7 @@ SENTINEL2Dataset::OpenL1BSubdatasetWithGeoloc(GDALOpenInfo *poOpenInfo)
 
     if ((nBits % 8) != 0)
     {
-        poBand->SetMetadataItem("NBITS", CPLSPrintf("%d", nBits),
+        poBand->SetMetadataItem(GDALMD_NBITS, CPLSPrintf("%d", nBits),
                                 GDAL_MDD_IMAGE_STRUCTURE);
     }
 
@@ -3492,7 +3492,7 @@ static bool SENTINEL2GetTileInfo(const char *pszFilename, int *pnWidth,
                 {
                     const char *pszNBits =
                         poDS->GetRasterBand(1)->GetMetadataItem(
-                            "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+                            GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
                     if (pszNBits == nullptr)
                     {
                         GDALDataType eDT =
@@ -4232,7 +4232,7 @@ SENTINEL2Dataset *SENTINEL2Dataset::CreateL1CL2ADataset(
 
         if ((nBits % 8) != 0)
         {
-            poBand->SetMetadataItem("NBITS", CPLSPrintf("%d", nBits),
+            poBand->SetMetadataItem(GDALMD_NBITS, CPLSPrintf("%d", nBits),
                                     GDAL_MDD_IMAGE_STRUCTURE);
         }
     }

--- a/frmts/sentinel2/sentinel2dataset.cpp
+++ b/frmts/sentinel2/sentinel2dataset.cpp
@@ -2034,11 +2034,11 @@ static void SENTINEL2SetBandMetadata(GDALRasterBand *poBand,
         poBand->SetMetadataItem(
             GDALMD_CENTRAL_WAVELENGTH_UM,
             CPLSPrintf("%.3f", double(psBandDesc->nWaveLength) / 1000),
-            "IMAGERY");
+            GDAL_MDD_IMAGERY);
         poBand->SetMetadataItem(
             GDALMD_FWHM_UM,
             CPLSPrintf("%.3f", double(psBandDesc->nBandWidth) / 1000),
-            "IMAGERY");
+            GDAL_MDD_IMAGERY);
     }
     else
     {

--- a/frmts/sentinel2/sentinel2dataset.cpp
+++ b/frmts/sentinel2/sentinel2dataset.cpp
@@ -1519,7 +1519,7 @@ GDALDataset *SENTINEL2Dataset::OpenL1BUserProduct(GDALOpenInfo *poOpenInfo)
                         CPLSPrintf("SENTINEL2_L1B_WITH_GEOLOC:\"%s\":%s",
                                    poOpenInfo->pszFilename,
                                    CPLGetBasenameSafe(osVRT.c_str()).c_str()),
-                        "SUBDATASETS");
+                        GDAL_MDD_SUBDATASETS);
                     ++iSubDSNum;
                 }
             }
@@ -1566,7 +1566,7 @@ GDALDataset *SENTINEL2Dataset::OpenL1BUserProduct(GDALOpenInfo *poOpenInfo)
                 CPLSPrintf("SUBDATASET_%d_NAME", iSubDSNum),
                 CPLSPrintf("SENTINEL2_L1B:%s:%dm", aosGranuleList[i].c_str(),
                            nResolution),
-                "SUBDATASETS");
+                GDAL_MDD_SUBDATASETS);
 
             CPLString osBandNames = SENTINEL2GetBandListForResolution(
                 oMapResolutionsToBands[nResolution]);
@@ -1577,7 +1577,7 @@ GDALDataset *SENTINEL2Dataset::OpenL1BUserProduct(GDALOpenInfo *poOpenInfo)
                            CPLGetFilename(aosGranuleList[i]), nResolution));
             poDS->GDALDataset::SetMetadataItem(
                 CPLSPrintf("SUBDATASET_%d_DESC", iSubDSNum), osDesc.c_str(),
-                "SUBDATASETS");
+                GDAL_MDD_SUBDATASETS);
 
             iSubDSNum++;
         }
@@ -1980,7 +1980,7 @@ GDALDataset *SENTINEL2Dataset::OpenL1BGranule(const char *pszFilename,
         poDS->GDALDataset::SetMetadataItem(
             CPLSPrintf("SUBDATASET_%d_NAME", iSubDSNum),
             CPLSPrintf("SENTINEL2_L1B:%s:%dm", pszFilename, nResolution),
-            "SUBDATASETS");
+            GDAL_MDD_SUBDATASETS);
 
         CPLString osBandNames = SENTINEL2GetBandListForResolution(
             oMapResolutionsToBands[nResolution]);
@@ -1989,7 +1989,7 @@ GDALDataset *SENTINEL2Dataset::OpenL1BGranule(const char *pszFilename,
                                     osBandNames.c_str(), nResolution));
         poDS->GDALDataset::SetMetadataItem(
             CPLSPrintf("SUBDATASET_%d_DESC", iSubDSNum), osDesc.c_str(),
-            "SUBDATASETS");
+            GDAL_MDD_SUBDATASETS);
 
         iSubDSNum++;
     }
@@ -3099,7 +3099,7 @@ GDALDataset *SENTINEL2Dataset::OpenL1C_L2A(const char *pszFilename,
                 CPLSPrintf("SUBDATASET_%d_NAME", iSubDSNum),
                 CPLSPrintf("%s:%s:%dm:EPSG_%d", pszPrefix, pszFilename,
                            nResolution, nEPSGCode),
-                "SUBDATASETS");
+                GDAL_MDD_SUBDATASETS);
 
             CPLString osBandNames = SENTINEL2GetBandListForResolution(
                 oMapResolutionsToBands[nResolution]);
@@ -3114,7 +3114,7 @@ GDALDataset *SENTINEL2Dataset::OpenL1C_L2A(const char *pszFilename,
                 osDesc += CPLSPrintf(", EPSG:%d", nEPSGCode);
             poDS->GDALDataset::SetMetadataItem(
                 CPLSPrintf("SUBDATASET_%d_DESC", iSubDSNum), osDesc.c_str(),
-                "SUBDATASETS");
+                GDAL_MDD_SUBDATASETS);
 
             iSubDSNum++;
         }
@@ -3131,7 +3131,7 @@ GDALDataset *SENTINEL2Dataset::OpenL1C_L2A(const char *pszFilename,
                 CPLSPrintf("SUBDATASET_%d_NAME", iSubDSNum),
                 CPLSPrintf("%s:%s:TCI:EPSG_%d", pszPrefix, pszFilename,
                            nEPSGCode),
-                "SUBDATASETS");
+                GDAL_MDD_SUBDATASETS);
 
             CPLString osDesc("True color image");
             if (nEPSGCode >= 32601 && nEPSGCode <= 32660)
@@ -3142,7 +3142,7 @@ GDALDataset *SENTINEL2Dataset::OpenL1C_L2A(const char *pszFilename,
                 osDesc += CPLSPrintf(", EPSG:%d", nEPSGCode);
             poDS->GDALDataset::SetMetadataItem(
                 CPLSPrintf("SUBDATASET_%d_DESC", iSubDSNum), osDesc.c_str(),
-                "SUBDATASETS");
+                GDAL_MDD_SUBDATASETS);
 
             iSubDSNum++;
         }
@@ -3157,7 +3157,7 @@ GDALDataset *SENTINEL2Dataset::OpenL1C_L2A(const char *pszFilename,
                 CPLSPrintf("SUBDATASET_%d_NAME", iSubDSNum),
                 CPLSPrintf("%s:%s:PREVIEW:EPSG_%d", pszPrefix, pszFilename,
                            nEPSGCode),
-                "SUBDATASETS");
+                GDAL_MDD_SUBDATASETS);
 
             CPLString osDesc("RGB preview");
             if (nEPSGCode >= 32601 && nEPSGCode <= 32660)
@@ -3168,7 +3168,7 @@ GDALDataset *SENTINEL2Dataset::OpenL1C_L2A(const char *pszFilename,
                 osDesc += CPLSPrintf(", EPSG:%d", nEPSGCode);
             poDS->GDALDataset::SetMetadataItem(
                 CPLSPrintf("SUBDATASET_%d_DESC", iSubDSNum), osDesc.c_str(),
-                "SUBDATASETS");
+                GDAL_MDD_SUBDATASETS);
 
             iSubDSNum++;
         }
@@ -3311,7 +3311,7 @@ GDALDataset *SENTINEL2Dataset::OpenL1CTile(const char *pszFilename,
             CPLSPrintf("SUBDATASET_%d_NAME", iSubDSNum),
             CPLSPrintf("%s:%s:%dm", "SENTINEL2_L1C_TILE", pszFilename,
                        nResolution),
-            "SUBDATASETS");
+            GDAL_MDD_SUBDATASETS);
 
         CPLString osBandNames = SENTINEL2GetBandListForResolution(
             oMapResolutionsToBands[nResolution]);
@@ -3320,7 +3320,7 @@ GDALDataset *SENTINEL2Dataset::OpenL1CTile(const char *pszFilename,
                                     osBandNames.c_str(), nResolution));
         poDS->GDALDataset::SetMetadataItem(
             CPLSPrintf("SUBDATASET_%d_DESC", iSubDSNum), osDesc.c_str(),
-            "SUBDATASETS");
+            GDAL_MDD_SUBDATASETS);
 
         iSubDSNum++;
     }
@@ -3329,12 +3329,12 @@ GDALDataset *SENTINEL2Dataset::OpenL1CTile(const char *pszFilename,
     poDS->GDALDataset::SetMetadataItem(
         CPLSPrintf("SUBDATASET_%d_NAME", iSubDSNum),
         CPLSPrintf("%s:%s:PREVIEW", "SENTINEL2_L1C_TILE", pszFilename),
-        "SUBDATASETS");
+        GDAL_MDD_SUBDATASETS);
 
     CPLString osDesc("RGB preview");
     poDS->GDALDataset::SetMetadataItem(
         CPLSPrintf("SUBDATASET_%d_DESC", iSubDSNum), osDesc.c_str(),
-        "SUBDATASETS");
+        GDAL_MDD_SUBDATASETS);
 
     return poDS;
 }

--- a/frmts/snap_tiff/snaptiffdriver.cpp
+++ b/frmts/snap_tiff/snaptiffdriver.cpp
@@ -395,8 +395,8 @@ GDALDataset *SNAPTIFFDataset::Open(GDALOpenInfo *poOpenInfo)
 char **SNAPTIFFDataset::GetMetadataDomainList()
 {
     return BuildMetadataDomainList(GDALPamDataset::GetMetadataDomainList(),
-                                   TRUE, GDAL_MDD_GEOLOCATION, "SUBDATASETS",
-                                   "xml:DIMAP", nullptr);
+                                   TRUE, GDAL_MDD_GEOLOCATION,
+                                   GDAL_MDD_SUBDATASETS, "xml:DIMAP", nullptr);
 }
 
 /************************************************************************/
@@ -666,7 +666,7 @@ CSLConstList SNAPTIFFDataset::GetMetadata(const char *pszDomain)
         {
             return m_aosGEOLOCATION.List();
         }
-        else if (pszDomain && EQUAL(pszDomain, "SUBDATASETS"))
+        else if (pszDomain && EQUAL(pszDomain, GDAL_MDD_SUBDATASETS))
         {
             if (m_aosSUBDATASETS.empty() && GetGeolocationMetadata())
             {
@@ -703,7 +703,7 @@ const char *SNAPTIFFDataset::GetMetadataItem(const char *pszName,
 {
     if (!m_bIsGeolocArray && pszDomain &&
         (EQUAL(pszDomain, GDAL_MDD_GEOLOCATION) ||
-         EQUAL(pszDomain, "SUBDATASETS")))
+         EQUAL(pszDomain, GDAL_MDD_SUBDATASETS)))
     {
         return CSLFetchNameValue(GetMetadata(pszDomain), pszName);
     }

--- a/frmts/snap_tiff/snaptiffdriver.cpp
+++ b/frmts/snap_tiff/snaptiffdriver.cpp
@@ -180,7 +180,7 @@ GDALDataset *SNAPTIFFDataset::Open(GDALOpenInfo *poOpenInfo)
             poOpenInfo->pszFilename, ":", CSLT_HONOURSTRINGS));
         if (aosTokens.size() != 3)
             return nullptr;
-        bIsGeolocation = EQUAL(aosTokens[2], "GEOLOCATION");
+        bIsGeolocation = EQUAL(aosTokens[2], GDAL_MDD_GEOLOCATION);
         if (!bIsGeolocation && !EQUAL(aosTokens[2], "MAIN"))
             return nullptr;
         GDALOpenInfo oOpenInfo(aosTokens[1], GA_ReadOnly);
@@ -395,7 +395,7 @@ GDALDataset *SNAPTIFFDataset::Open(GDALOpenInfo *poOpenInfo)
 char **SNAPTIFFDataset::GetMetadataDomainList()
 {
     return BuildMetadataDomainList(GDALPamDataset::GetMetadataDomainList(),
-                                   TRUE, "GEOLOCATION", "SUBDATASETS",
+                                   TRUE, GDAL_MDD_GEOLOCATION, "SUBDATASETS",
                                    "xml:DIMAP", nullptr);
 }
 
@@ -662,7 +662,7 @@ CSLConstList SNAPTIFFDataset::GetMetadata(const char *pszDomain)
             }
             return m_aosDIMAPMetadata.List();
         }
-        else if (pszDomain && EQUAL(pszDomain, "GEOLOCATION"))
+        else if (pszDomain && EQUAL(pszDomain, GDAL_MDD_GEOLOCATION))
         {
             return m_aosGEOLOCATION.List();
         }
@@ -702,7 +702,8 @@ const char *SNAPTIFFDataset::GetMetadataItem(const char *pszName,
                                              const char *pszDomain)
 {
     if (!m_bIsGeolocArray && pszDomain &&
-        (EQUAL(pszDomain, "GEOLOCATION") || EQUAL(pszDomain, "SUBDATASETS")))
+        (EQUAL(pszDomain, GDAL_MDD_GEOLOCATION) ||
+         EQUAL(pszDomain, "SUBDATASETS")))
     {
         return CSLFetchNameValue(GetMetadata(pszDomain), pszName);
     }

--- a/frmts/stacit/stacitdataset.cpp
+++ b/frmts/stacit/stacitdataset.cpp
@@ -728,7 +728,7 @@ void STACITDataset::SetSubdatasets(
             }
         }
     }
-    GDALDataset::SetMetadata(aosSubdatasets.List(), "SUBDATASETS");
+    GDALDataset::SetMetadata(aosSubdatasets.List(), GDAL_MDD_SUBDATASETS);
 }
 
 /************************************************************************/

--- a/frmts/stacta/stactadataset.cpp
+++ b/frmts/stacta/stactadataset.cpp
@@ -1414,7 +1414,7 @@ bool STACTADataset::Open(GDALOpenInfo *poOpenInfo)
                  poBand->GetRasterDataType() == GDT_UInt16))
             {
                 poBand->GDALRasterBand::SetMetadataItem(
-                    "NBITS", CPLSPrintf("%d", nBitsPerSample),
+                    GDALMD_NBITS, CPLSPrintf("%d", nBitsPerSample),
                     GDAL_MDD_IMAGE_STRUCTURE);
             }
         }

--- a/frmts/stacta/stactadataset.cpp
+++ b/frmts/stacta/stactadataset.cpp
@@ -1436,9 +1436,9 @@ bool STACTADataset::Open(GDALOpenInfo *poOpenInfo)
 
     if (poProtoDS)
     {
-        const char *pszInterleave =
-            poProtoDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
-        GDALDataset::SetMetadataItem("INTERLEAVE",
+        const char *pszInterleave = poProtoDS->GetMetadataItem(
+            GDALMD_INTERLEAVE, GDAL_MDD_IMAGE_STRUCTURE);
+        GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE,
                                      pszInterleave ? pszInterleave : "PIXEL",
                                      GDAL_MDD_IMAGE_STRUCTURE);
     }
@@ -1446,7 +1446,7 @@ bool STACTADataset::Open(GDALOpenInfo *poOpenInfo)
     {
         // A bit bold to assume that, but that should be a reasonable
         // setting
-        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+        GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                      GDAL_MDD_IMAGE_STRUCTURE);
     }
 
@@ -1538,7 +1538,7 @@ bool STACTARawDataset::InitRaster(GDALDataset *poProtoDS,
     m_gt.yorig =
         oTM.mTopLeftY - m_nMinMetaTileRow * m_nMetaTileHeight * oTM.mResY;
     m_gt.yscale = -oTM.mResY;
-    SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+    SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
 
     return true;
 }

--- a/frmts/stacta/stactadataset.cpp
+++ b/frmts/stacta/stactadataset.cpp
@@ -902,12 +902,12 @@ bool STACTADataset::Open(GDALOpenInfo *poOpenInfo)
                         CPLSPrintf("SUBDATASET_%d_NAME", nSDSCount + 1),
                         CPLSPrintf("STACTA:\"%s\":%s:%s", osFilename.c_str(),
                                    pszAssetNameSubDS, pszTMSSubDS),
-                        "SUBDATASETS");
+                        GDAL_MDD_SUBDATASETS);
                     GDALDataset::SetMetadataItem(
                         CPLSPrintf("SUBDATASET_%d_DESC", nSDSCount + 1),
                         CPLSPrintf("Asset %s, tile matrix set %s",
                                    pszAssetNameSubDS, pszTMSSubDS),
-                        "SUBDATASETS");
+                        GDAL_MDD_SUBDATASETS);
                     nSDSCount++;
                 }
             }
@@ -917,10 +917,11 @@ bool STACTADataset::Open(GDALOpenInfo *poOpenInfo)
                     CPLSPrintf("SUBDATASET_%d_NAME", nSDSCount + 1),
                     CPLSPrintf("STACTA:\"%s\":%s", osFilename.c_str(),
                                pszAssetNameSubDS),
-                    "SUBDATASETS");
+                    GDAL_MDD_SUBDATASETS);
                 GDALDataset::SetMetadataItem(
                     CPLSPrintf("SUBDATASET_%d_DESC", nSDSCount + 1),
-                    CPLSPrintf("Asset %s", pszAssetNameSubDS), "SUBDATASETS");
+                    CPLSPrintf("Asset %s", pszAssetNameSubDS),
+                    GDAL_MDD_SUBDATASETS);
                 nSDSCount++;
             }
         }

--- a/frmts/stacta/stactadataset.cpp
+++ b/frmts/stacta/stactadataset.cpp
@@ -1415,7 +1415,7 @@ bool STACTADataset::Open(GDALOpenInfo *poOpenInfo)
             {
                 poBand->GDALRasterBand::SetMetadataItem(
                     "NBITS", CPLSPrintf("%d", nBitsPerSample),
-                    "IMAGE_STRUCTURE");
+                    GDAL_MDD_IMAGE_STRUCTURE);
             }
         }
         SetBand(i + 1, poBand);
@@ -1437,16 +1437,17 @@ bool STACTADataset::Open(GDALOpenInfo *poOpenInfo)
     if (poProtoDS)
     {
         const char *pszInterleave =
-            poProtoDS->GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE");
+            poProtoDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
         GDALDataset::SetMetadataItem("INTERLEAVE",
                                      pszInterleave ? pszInterleave : "PIXEL",
-                                     "IMAGE_STRUCTURE");
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
     else
     {
         // A bit bold to assume that, but that should be a reasonable
         // setting
-        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     m_bDownloadWholeMetaTile = CPLTestBool(CSLFetchNameValueDef(
@@ -1537,7 +1538,7 @@ bool STACTARawDataset::InitRaster(GDALDataset *poProtoDS,
     m_gt.yorig =
         oTM.mTopLeftY - m_nMinMetaTileRow * m_nMetaTileHeight * oTM.mResY;
     m_gt.yscale = -oTM.mResY;
-    SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+    SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
 
     return true;
 }

--- a/frmts/til/tildataset.cpp
+++ b/frmts/til/tildataset.cpp
@@ -214,7 +214,7 @@ GDALDataset *TILDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Try to find the corresponding .IMD file.                        */
     /* -------------------------------------------------------------------- */
-    char **papszIMD = mdreader->GetMetadataDomain(MD_DOMAIN_IMD);
+    char **papszIMD = mdreader->GetMetadataDomain(GDAL_MDD_IMD);
 
     if (papszIMD == nullptr)
     {

--- a/frmts/tiledb/tiledbcommon.cpp
+++ b/frmts/tiledb/tiledbcommon.cpp
@@ -383,7 +383,7 @@ GDALDataset *TileDBDataset::CreateCopy(const char *pszFilename,
     try
     {
         if (poSrcDS->GetRasterCount() > 0 ||
-            poSrcDS->GetMetadata("SUBDATASETS"))
+            poSrcDS->GetMetadata(GDAL_MDD_SUBDATASETS))
         {
             return TileDBRasterDataset::CreateCopy(pszFilename, poSrcDS,
                                                    bStrict, papszOptions,

--- a/frmts/tiledb/tiledbdense.cpp
+++ b/frmts/tiledb/tiledbdense.cpp
@@ -1459,7 +1459,7 @@ GDALDataset *TileDBRasterDataset::OpenInternal(GDALOpenInfo *poOpenInfo,
 
     tiledb::ArraySchema schema = poDS->m_array->schema();
 
-    CSLConstList papszStructMeta = poDS->GetMetadata("IMAGE_STRUCTURE");
+    CSLConstList papszStructMeta = poDS->GetMetadata(GDAL_MDD_IMAGE_STRUCTURE);
     const char *pszXSize = CSLFetchNameValue(papszStructMeta, "X_SIZE");
     if (pszXSize)
     {
@@ -1577,7 +1577,7 @@ GDALDataset *TileDBRasterDataset::OpenInternal(GDALOpenInfo *poOpenInfo,
         else
         {
             const char *pszBands =
-                poDS->GetMetadataItem("NUM_BANDS", "IMAGE_STRUCTURE");
+                poDS->GetMetadataItem("NUM_BANDS", GDAL_MDD_IMAGE_STRUCTURE);
             if (pszBands)
             {
                 poDS->nBands = atoi(pszBands);
@@ -1995,7 +1995,7 @@ CPLErr TileDBRasterDataset::CreateAttribute(GDALDataType eType,
                     CPLCreateXMLNode(psSubNode, CXT_Element, "PAMDataset"),
                     CXT_Element, "Metadata");
                 CPLAddXMLAttributeAndValue(psMetaNode, "domain",
-                                           "IMAGE_STRUCTURE");
+                                           GDAL_MDD_IMAGE_STRUCTURE);
 
                 CPLAddXMLAttributeAndValue(
                     CPLCreateXMLElementAndValue(
@@ -2186,7 +2186,7 @@ TileDBRasterDataset *TileDBRasterDataset::CreateLL(const char *pszFilename,
                                          pszCompression, nLevel) == CE_None)
             {
                 poDS->SetMetadataItem("COMPRESSION", pszCompression,
-                                      "IMAGE_STRUCTURE");
+                                      GDAL_MDD_IMAGE_STRUCTURE);
                 poDS->m_schema->set_coords_filter_list(*poDS->m_filterList);
             }
         }
@@ -2640,7 +2640,7 @@ TileDBRasterDataset *TileDBRasterDataset::Create(const char *pszFilename,
                     CPLGetBasenameSafe(poAttrDS->GetDescription()).c_str());
             }
         }
-        poDS->SetMetadata(aosImageStruct.List(), "IMAGE_STRUCTURE");
+        poDS->SetMetadata(aosImageStruct.List(), GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     return poDS.release();

--- a/frmts/tiledb/tiledbdense.cpp
+++ b/frmts/tiledb/tiledbdense.cpp
@@ -2153,7 +2153,7 @@ TileDBRasterDataset *TileDBRasterDataset::CreateLL(const char *pszFilename,
         }
 
         const char *pszCompression =
-            CSLFetchNameValue(papszOptions, "COMPRESSION");
+            CSLFetchNameValue(papszOptions, GDALMD_COMPRESSION);
         const char *pszCompressionLevel =
             CSLFetchNameValue(papszOptions, "COMPRESSION_LEVEL");
 
@@ -2186,7 +2186,7 @@ TileDBRasterDataset *TileDBRasterDataset::CreateLL(const char *pszFilename,
                                          *(poDS->m_filterList.get()),
                                          pszCompression, nLevel) == CE_None)
             {
-                poDS->SetMetadataItem("COMPRESSION", pszCompression,
+                poDS->SetMetadataItem(GDALMD_COMPRESSION, pszCompression,
                                       GDAL_MDD_IMAGE_STRUCTURE);
                 poDS->m_schema->set_coords_filter_list(*poDS->m_filterList);
             }

--- a/frmts/tiledb/tiledbdense.cpp
+++ b/frmts/tiledb/tiledbdense.cpp
@@ -1527,7 +1527,8 @@ GDALDataset *TileDBRasterDataset::OpenInternal(GDALOpenInfo *poOpenInfo,
         }
     }
 
-    const char *pszIndexMode = CSLFetchNameValue(papszStructMeta, "INTERLEAVE");
+    const char *pszIndexMode =
+        CSLFetchNameValue(papszStructMeta, GDALMD_INTERLEAVE);
 
     if (pszIndexMode)
         option_to_index_type(pszIndexMode, poDS->eIndexMode);
@@ -2106,7 +2107,7 @@ TileDBRasterDataset *TileDBRasterDataset::CreateLL(const char *pszFilename,
         else
         {
             const char *pszIndexMode =
-                CSLFetchNameValue(papszOptions, "INTERLEAVE");
+                CSLFetchNameValue(papszOptions, GDALMD_INTERLEAVE);
 
             if (option_to_index_type(pszIndexMode, poDS->eIndexMode))
                 return nullptr;
@@ -2626,7 +2627,7 @@ TileDBRasterDataset *TileDBRasterDataset::Create(const char *pszFilename,
             "X_SIZE", CPLString().Printf("%d", poDS->nRasterXSize));
         aosImageStruct.SetNameValue(
             "Y_SIZE", CPLString().Printf("%d", poDS->nRasterYSize));
-        aosImageStruct.SetNameValue("INTERLEAVE",
+        aosImageStruct.SetNameValue(GDALMD_INTERLEAVE,
                                     index_type_name(poDS->eIndexMode));
         aosImageStruct.SetNameValue("DATASET_TYPE", RASTER_DATASET_TYPE);
 
@@ -3030,7 +3031,7 @@ CPLErr TileDBRasterDataset::IBuildOverviews(
             aosCreationOptions.SetNameValue("CREATE_GROUP", "NO");
             aosCreationOptions.SetNameValue(
                 "NBITS", CPLString().Printf("%d", nBitsPerSample));
-            aosCreationOptions.SetNameValue("INTERLEAVE",
+            aosCreationOptions.SetNameValue(GDALMD_INTERLEAVE,
                                             index_type_name(eIndexMode));
             if (nTimestamp)
             {

--- a/frmts/tiledb/tiledbdense.cpp
+++ b/frmts/tiledb/tiledbdense.cpp
@@ -1283,7 +1283,7 @@ CPLErr TileDBRasterDataset::TryLoadCachedXML(CSLConstList /*papszSiblingFiles*/,
 CSLConstList TileDBRasterDataset::GetMetadata(const char *pszDomain)
 
 {
-    if (pszDomain != nullptr && EQUAL(pszDomain, "SUBDATASETS"))
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_SUBDATASETS))
     {
         if (m_aosSubdatasetMD.empty())
         {
@@ -1677,7 +1677,7 @@ GDALDataset *TileDBRasterDataset::OpenInternal(GDALOpenInfo *poOpenInfo,
     else  // subdatasets or only attributes
     {
         if ((poOpenInfo->eAccess == GA_Update) &&
-            (poDS->GetMetadata("SUBDATASETS") != nullptr))
+            (poDS->GetMetadata(GDAL_MDD_SUBDATASETS) != nullptr))
         {
             CPLError(CE_Failure, CPLE_NotSupported,
                      "The TileDB driver does not support update access "
@@ -1717,7 +1717,7 @@ GDALDataset *TileDBRasterDataset::OpenInternal(GDALOpenInfo *poOpenInfo,
         }
         else
         {
-            CSLConstList papszMeta = poDS->GetMetadata("SUBDATASETS");
+            CSLConstList papszMeta = poDS->GetMetadata(GDAL_MDD_SUBDATASETS);
             if (papszMeta != nullptr)
             {
                 if ((CSLCount(papszMeta) / 2) == 1)
@@ -2383,7 +2383,8 @@ CPLErr TileDBRasterDataset::CopySubDatasets(GDALDataset *poSrcDS,
     {
         std::vector<std::unique_ptr<GDALDataset>> apoDatasets;
         poDstDS->m_bHasSubDatasets = true;
-        CSLConstList papszSrcSubDatasets = poSrcDS->GetMetadata("SUBDATASETS");
+        CSLConstList papszSrcSubDatasets =
+            poSrcDS->GetMetadata(GDAL_MDD_SUBDATASETS);
         if (!papszSrcSubDatasets)
             return CE_Failure;
         const char *pszSubDSName =
@@ -2485,7 +2486,8 @@ CPLErr TileDBRasterDataset::CopySubDatasets(GDALDataset *poSrcDS,
             }
         }
 
-        poDstDS->SetMetadata(poDstDS->m_aosSubdatasetMD.List(), "SUBDATASETS");
+        poDstDS->SetMetadata(poDstDS->m_aosSubdatasetMD.List(),
+                             GDAL_MDD_SUBDATASETS);
 
         poDstDS->CreateArray();
 
@@ -2672,7 +2674,8 @@ GDALDataset *TileDBRasterDataset::CreateCopy(const char *pszFilename,
         return nullptr;
     }
 
-    CSLConstList papszSrcSubDatasets = poSrcDS->GetMetadata("SUBDATASETS");
+    CSLConstList papszSrcSubDatasets =
+        poSrcDS->GetMetadata(GDAL_MDD_SUBDATASETS);
 
     if (papszSrcSubDatasets == nullptr)
     {

--- a/frmts/tiledb/tiledbdense.cpp
+++ b/frmts/tiledb/tiledbdense.cpp
@@ -1486,7 +1486,7 @@ GDALDataset *TileDBRasterDataset::OpenInternal(GDALOpenInfo *poOpenInfo,
         }
     }
 
-    const char *pszNBits = CSLFetchNameValue(papszStructMeta, "NBITS");
+    const char *pszNBits = CSLFetchNameValue(papszStructMeta, GDALMD_NBITS);
     if (pszNBits)
     {
         poDS->nBitsPerSample = atoi(pszNBits);
@@ -2037,7 +2037,7 @@ CPLErr TileDBRasterDataset::CreateAttribute(GDALDataType eType,
                     CPLCreateXMLElementAndValue(
                         psMetaNode, "MDI",
                         CPLString().Printf("%d", nBitsPerSample)),
-                    "KEY", "NBITS");
+                    "KEY", GDALMD_NBITS);
             }
         }
         return CE_None;
@@ -2619,7 +2619,7 @@ TileDBRasterDataset *TileDBRasterDataset::Create(const char *pszFilename,
     {
         CPLStringList aosImageStruct;
         aosImageStruct.SetNameValue(
-            "NBITS", CPLString().Printf("%d", poDS->nBitsPerSample));
+            GDALMD_NBITS, CPLString().Printf("%d", poDS->nBitsPerSample));
         aosImageStruct.SetNameValue(
             "DATA_TYPE",
             CPLString().Printf("%s", GDALGetDataTypeName(poDS->eDataType)));
@@ -3030,7 +3030,7 @@ CPLErr TileDBRasterDataset::IBuildOverviews(
             CPLStringList aosCreationOptions;
             aosCreationOptions.SetNameValue("CREATE_GROUP", "NO");
             aosCreationOptions.SetNameValue(
-                "NBITS", CPLString().Printf("%d", nBitsPerSample));
+                GDALMD_NBITS, CPLString().Printf("%d", nBitsPerSample));
             aosCreationOptions.SetNameValue(GDALMD_INTERLEAVE,
                                             index_type_name(eIndexMode));
             if (nTimestamp)

--- a/frmts/tiledb/tiledbmultidimarray.cpp
+++ b/frmts/tiledb/tiledbmultidimarray.cpp
@@ -410,7 +410,7 @@ std::shared_ptr<TileDBArray> TileDBArray::OpenFromDisk(
                             if (psIter->eType == CXT_Element &&
                                 strcmp(psIter->pszValue, "Metadata") == 0 &&
                                 strcmp(CPLGetXMLValue(psIter, "domain", ""),
-                                       "IMAGE_STRUCTURE") == 0)
+                                       GDAL_MDD_IMAGE_STRUCTURE) == 0)
                             {
                                 for (const CPLXMLNode *psIter2 =
                                          psIter->psChild;

--- a/frmts/tiledb/tiledbmultidimarray.cpp
+++ b/frmts/tiledb/tiledbmultidimarray.cpp
@@ -1427,7 +1427,7 @@ std::shared_ptr<TileDBArray> TileDBArray::CreateOnDisk(
 
         tiledb::FilterList filterList(ctx);
         const char *pszCompression =
-            CSLFetchNameValue(papszOptions, "COMPRESSION");
+            CSLFetchNameValue(papszOptions, GDALMD_COMPRESSION);
         const char *pszCompressionLevel =
             CSLFetchNameValue(papszOptions, "COMPRESSION_LEVEL");
 

--- a/frmts/tiledb/tiledbsparse.cpp
+++ b/frmts/tiledb/tiledbsparse.cpp
@@ -472,7 +472,8 @@ OGRTileDBDataset::ICreateLayer(const char *pszName,
         CSLFetchNameValueDef(papszOptions, "TILEDB_TIMESTAMP", "0");
     poLayer->m_nTimestamp = std::strtoull(pszTimestamp, nullptr, 10);
 
-    const char *pszCompression = CSLFetchNameValue(papszOptions, "COMPRESSION");
+    const char *pszCompression =
+        CSLFetchNameValue(papszOptions, GDALMD_COMPRESSION);
     const char *pszCompressionLevel =
         CSLFetchNameValue(papszOptions, "COMPRESSION_LEVEL");
 

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1173,7 +1173,8 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
                          "'sd'");
                 return nullptr;
             }
-            CSLConstList papszSubdatasets = poSrcDS->GetMetadata("SUBDATASETS");
+            CSLConstList papszSubdatasets =
+                poSrcDS->GetMetadata(GDAL_MDD_SUBDATASETS);
             int nSubdatasets = CSLCount(papszSubdatasets);
 
             if (nSubdatasets > 0)
@@ -1242,7 +1243,8 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
                          "'sd_name'");
                 return nullptr;
             }
-            CSLConstList papszSubdatasets = poSrcDS->GetMetadata("SUBDATASETS");
+            CSLConstList papszSubdatasets =
+                poSrcDS->GetMetadata(GDAL_MDD_SUBDATASETS);
             int nSubdatasets = CSLCount(papszSubdatasets);
 
             if (nSubdatasets > 0)

--- a/frmts/vrt/vrtdriver.cpp
+++ b/frmts/vrt/vrtdriver.cpp
@@ -316,8 +316,8 @@ static GDALDataset *VRTCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
         /* -------------------------------------------------------------------- */
         /*      Copy any special domains that should be transportable.          */
         /* -------------------------------------------------------------------- */
-        constexpr const char *apszDefaultDomains[] = {GDAL_MDD_RPC, "IMD",
-                                                      "GEOLOCATION"};
+        constexpr const char *apszDefaultDomains[] = {
+            GDAL_MDD_RPC, GDAL_MDD_IMD, "GEOLOCATION"};
         for (const char *pszDomain : apszDefaultDomains)
         {
             if (!papszSrcMDD || CSLFindString(papszSrcMDD, pszDomain) >= 0)

--- a/frmts/vrt/vrtdriver.cpp
+++ b/frmts/vrt/vrtdriver.cpp
@@ -316,7 +316,7 @@ static GDALDataset *VRTCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
         /* -------------------------------------------------------------------- */
         /*      Copy any special domains that should be transportable.          */
         /* -------------------------------------------------------------------- */
-        constexpr const char *apszDefaultDomains[] = {"RPC", "IMD",
+        constexpr const char *apszDefaultDomains[] = {GDAL_MDD_RPC, "IMD",
                                                       "GEOLOCATION"};
         for (const char *pszDomain : apszDefaultDomains)
         {

--- a/frmts/vrt/vrtdriver.cpp
+++ b/frmts/vrt/vrtdriver.cpp
@@ -333,7 +333,7 @@ static GDALDataset *VRTCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
         {
             char **papszDomainList = poSrcDS->GetMetadataDomainList();
             constexpr const char *apszReservedDomains[] = {
-                "IMAGE_STRUCTURE", "DERIVED_SUBDATASETS"};
+                GDAL_MDD_IMAGE_STRUCTURE, "DERIVED_SUBDATASETS"};
             for (char **papszIter = papszDomainList; papszIter && *papszIter;
                  ++papszIter)
             {
@@ -376,20 +376,20 @@ static GDALDataset *VRTCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
 
     {
         const char *pszInterleave =
-            poSrcDS->GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE");
+            poSrcDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
         if (pszInterleave)
         {
             poVRTDS->SetMetadataItem("INTERLEAVE", pszInterleave,
-                                     "IMAGE_STRUCTURE");
+                                     GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
     {
         const char *pszCompression =
-            poSrcDS->GetMetadataItem("COMPRESSION", "IMAGE_STRUCTURE");
+            poSrcDS->GetMetadataItem("COMPRESSION", GDAL_MDD_IMAGE_STRUCTURE);
         if (pszCompression)
         {
             poVRTDS->SetMetadataItem("COMPRESSION", pszCompression,
-                                     "IMAGE_STRUCTURE");
+                                     GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
 
@@ -445,11 +445,11 @@ static GDALDataset *VRTCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
         poVRTBand->CopyCommonInfoFrom(poSrcBand);
 
         const char *pszCompression =
-            poSrcBand->GetMetadataItem("COMPRESSION", "IMAGE_STRUCTURE");
+            poSrcBand->GetMetadataItem("COMPRESSION", GDAL_MDD_IMAGE_STRUCTURE);
         if (pszCompression)
         {
             poVRTBand->SetMetadataItem("COMPRESSION", pszCompression,
-                                       "IMAGE_STRUCTURE");
+                                       GDAL_MDD_IMAGE_STRUCTURE);
         }
 
         /* --------------------------------------------------------------------

--- a/frmts/vrt/vrtdriver.cpp
+++ b/frmts/vrt/vrtdriver.cpp
@@ -375,11 +375,11 @@ static GDALDataset *VRTCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
     CSLDestroy(papszSrcMDD);
 
     {
-        const char *pszInterleave =
-            poSrcDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
+        const char *pszInterleave = poSrcDS->GetMetadataItem(
+            GDALMD_INTERLEAVE, GDAL_MDD_IMAGE_STRUCTURE);
         if (pszInterleave)
         {
-            poVRTDS->SetMetadataItem("INTERLEAVE", pszInterleave,
+            poVRTDS->SetMetadataItem(GDALMD_INTERLEAVE, pszInterleave,
                                      GDAL_MDD_IMAGE_STRUCTURE);
         }
     }

--- a/frmts/vrt/vrtdriver.cpp
+++ b/frmts/vrt/vrtdriver.cpp
@@ -317,7 +317,7 @@ static GDALDataset *VRTCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
         /*      Copy any special domains that should be transportable.          */
         /* -------------------------------------------------------------------- */
         constexpr const char *apszDefaultDomains[] = {
-            GDAL_MDD_RPC, GDAL_MDD_IMD, "GEOLOCATION"};
+            GDAL_MDD_RPC, GDAL_MDD_IMD, GDAL_MDD_GEOLOCATION};
         for (const char *pszDomain : apszDefaultDomains)
         {
             if (!papszSrcMDD || CSLFindString(papszSrcMDD, pszDomain) >= 0)

--- a/frmts/vrt/vrtdriver.cpp
+++ b/frmts/vrt/vrtdriver.cpp
@@ -384,11 +384,11 @@ static GDALDataset *VRTCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
         }
     }
     {
-        const char *pszCompression =
-            poSrcDS->GetMetadataItem("COMPRESSION", GDAL_MDD_IMAGE_STRUCTURE);
+        const char *pszCompression = poSrcDS->GetMetadataItem(
+            GDALMD_COMPRESSION, GDAL_MDD_IMAGE_STRUCTURE);
         if (pszCompression)
         {
-            poVRTDS->SetMetadataItem("COMPRESSION", pszCompression,
+            poVRTDS->SetMetadataItem(GDALMD_COMPRESSION, pszCompression,
                                      GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
@@ -444,11 +444,11 @@ static GDALDataset *VRTCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
          */
         poVRTBand->CopyCommonInfoFrom(poSrcBand);
 
-        const char *pszCompression =
-            poSrcBand->GetMetadataItem("COMPRESSION", GDAL_MDD_IMAGE_STRUCTURE);
+        const char *pszCompression = poSrcBand->GetMetadataItem(
+            GDALMD_COMPRESSION, GDAL_MDD_IMAGE_STRUCTURE);
         if (pszCompression)
         {
-            poVRTBand->SetMetadataItem("COMPRESSION", pszCompression,
+            poVRTBand->SetMetadataItem(GDALMD_COMPRESSION, pszCompression,
                                        GDAL_MDD_IMAGE_STRUCTURE);
         }
 

--- a/frmts/vrt/vrtpansharpened.cpp
+++ b/frmts/vrt/vrtpansharpened.cpp
@@ -1147,7 +1147,7 @@ CPLErr VRTPansharpenedDataset::XMLInit(const CPLXMLNode *psTree,
     psPanOptions->nThreads = nThreads;
 
     if (nBands == psPanOptions->nOutPansharpenedBands)
-        SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
 
     m_poPansharpener = std::make_unique<GDALPansharpenOperation>();
     eErr = m_poPansharpener->Initialize(psPanOptions.get());
@@ -1879,7 +1879,7 @@ int VRTPansharpenedRasterBand::GetOverviewCount()
                 }
 
                 poOvrDS->m_poMainDataset = poGDS;
-                poOvrDS->SetMetadataItem("INTERLEAVE", "PIXEL",
+                poOvrDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                          GDAL_MDD_IMAGE_STRUCTURE);
 
                 poGDS->m_apoOverviewDatasets.push_back(std::move(poOvrDS));

--- a/frmts/vrt/vrtpansharpened.cpp
+++ b/frmts/vrt/vrtpansharpened.cpp
@@ -783,11 +783,11 @@ CPLErr VRTPansharpenedDataset::XMLInit(const CPLXMLNode *psTree,
                     static_cast<VRTSourcedRasterBand *>(
                         poVDS->GetRasterBand(i + 1));
 
-                const char *pszNBITS =
-                    poSrcBand->GetMetadataItem("NBITS", "IMAGE_STRUCTURE");
+                const char *pszNBITS = poSrcBand->GetMetadataItem(
+                    "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
                 if (pszNBITS)
                     poVRTBand->SetMetadataItem("NBITS", pszNBITS,
-                                               "IMAGE_STRUCTURE");
+                                               GDAL_MDD_IMAGE_STRUCTURE);
 
                 VRTSimpleSource *poSimpleSource = new VRTSimpleSource();
                 poVRTBand->ConfigureSource(
@@ -1034,8 +1034,9 @@ CPLErr VRTPansharpenedDataset::XMLInit(const CPLXMLNode *psTree,
         const char *pszBitDepth =
             CPLGetXMLValue(psOptions, "BitDepth", nullptr);
         if (pszBitDepth == nullptr)
-            pszBitDepth = GDALRasterBand::FromHandle(ahSpectralBands[0])
-                              ->GetMetadataItem("NBITS", "IMAGE_STRUCTURE");
+            pszBitDepth =
+                GDALRasterBand::FromHandle(ahSpectralBands[0])
+                    ->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
         if (pszBitDepth)
             nBitDepth = atoi(pszBitDepth);
         if (nBitDepth)
@@ -1046,19 +1047,19 @@ CPLErr VRTPansharpenedDataset::XMLInit(const CPLXMLNode *psTree,
                          ->IsPansharpenRasterBand())
                     continue;
                 if (GetRasterBand(i + 1)->GetMetadataItem(
-                        "NBITS", "IMAGE_STRUCTURE") == nullptr)
+                        "NBITS", GDAL_MDD_IMAGE_STRUCTURE) == nullptr)
                 {
                     if (nBitDepth != 8 && nBitDepth != 16 && nBitDepth != 32)
                     {
                         GetRasterBand(i + 1)->SetMetadataItem(
                             "NBITS", CPLSPrintf("%d", nBitDepth),
-                            "IMAGE_STRUCTURE");
+                            GDAL_MDD_IMAGE_STRUCTURE);
                     }
                 }
                 else if (nBitDepth == 8 || nBitDepth == 16 || nBitDepth == 32)
                 {
-                    GetRasterBand(i + 1)->SetMetadataItem("NBITS", nullptr,
-                                                          "IMAGE_STRUCTURE");
+                    GetRasterBand(i + 1)->SetMetadataItem(
+                        "NBITS", nullptr, GDAL_MDD_IMAGE_STRUCTURE);
                 }
             }
         }
@@ -1146,7 +1147,7 @@ CPLErr VRTPansharpenedDataset::XMLInit(const CPLXMLNode *psTree,
     psPanOptions->nThreads = nThreads;
 
     if (nBands == psPanOptions->nOutPansharpenedBands)
-        SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
 
     m_poPansharpener = std::make_unique<GDALPansharpenOperation>();
     eErr = m_poPansharpener->Initialize(psPanOptions.get());
@@ -1826,11 +1827,11 @@ int VRTPansharpenedRasterBand::GetOverviewCount()
                     GDALRasterBand *poSrcBand = poGDS->GetRasterBand(i + 1);
                     auto poBand = std::make_unique<VRTPansharpenedRasterBand>(
                         poOvrDS.get(), i + 1, poSrcBand->GetRasterDataType());
-                    const char *pszNBITS =
-                        poSrcBand->GetMetadataItem("NBITS", "IMAGE_STRUCTURE");
+                    const char *pszNBITS = poSrcBand->GetMetadataItem(
+                        "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
                     if (pszNBITS)
                         poBand->SetMetadataItem("NBITS", pszNBITS,
-                                                "IMAGE_STRUCTURE");
+                                                GDAL_MDD_IMAGE_STRUCTURE);
                     int bHasNoData = FALSE;
                     const double dfNoData =
                         poSrcBand->GetNoDataValue(&bHasNoData);
@@ -1879,7 +1880,7 @@ int VRTPansharpenedRasterBand::GetOverviewCount()
 
                 poOvrDS->m_poMainDataset = poGDS;
                 poOvrDS->SetMetadataItem("INTERLEAVE", "PIXEL",
-                                         "IMAGE_STRUCTURE");
+                                         GDAL_MDD_IMAGE_STRUCTURE);
 
                 poGDS->m_apoOverviewDatasets.push_back(std::move(poOvrDS));
             }

--- a/frmts/vrt/vrtpansharpened.cpp
+++ b/frmts/vrt/vrtpansharpened.cpp
@@ -784,9 +784,9 @@ CPLErr VRTPansharpenedDataset::XMLInit(const CPLXMLNode *psTree,
                         poVDS->GetRasterBand(i + 1));
 
                 const char *pszNBITS = poSrcBand->GetMetadataItem(
-                    "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+                    GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
                 if (pszNBITS)
-                    poVRTBand->SetMetadataItem("NBITS", pszNBITS,
+                    poVRTBand->SetMetadataItem(GDALMD_NBITS, pszNBITS,
                                                GDAL_MDD_IMAGE_STRUCTURE);
 
                 VRTSimpleSource *poSimpleSource = new VRTSimpleSource();
@@ -1036,7 +1036,7 @@ CPLErr VRTPansharpenedDataset::XMLInit(const CPLXMLNode *psTree,
         if (pszBitDepth == nullptr)
             pszBitDepth =
                 GDALRasterBand::FromHandle(ahSpectralBands[0])
-                    ->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+                    ->GetMetadataItem(GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
         if (pszBitDepth)
             nBitDepth = atoi(pszBitDepth);
         if (nBitDepth)
@@ -1047,19 +1047,19 @@ CPLErr VRTPansharpenedDataset::XMLInit(const CPLXMLNode *psTree,
                          ->IsPansharpenRasterBand())
                     continue;
                 if (GetRasterBand(i + 1)->GetMetadataItem(
-                        "NBITS", GDAL_MDD_IMAGE_STRUCTURE) == nullptr)
+                        GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE) == nullptr)
                 {
                     if (nBitDepth != 8 && nBitDepth != 16 && nBitDepth != 32)
                     {
                         GetRasterBand(i + 1)->SetMetadataItem(
-                            "NBITS", CPLSPrintf("%d", nBitDepth),
+                            GDALMD_NBITS, CPLSPrintf("%d", nBitDepth),
                             GDAL_MDD_IMAGE_STRUCTURE);
                     }
                 }
                 else if (nBitDepth == 8 || nBitDepth == 16 || nBitDepth == 32)
                 {
                     GetRasterBand(i + 1)->SetMetadataItem(
-                        "NBITS", nullptr, GDAL_MDD_IMAGE_STRUCTURE);
+                        GDALMD_NBITS, nullptr, GDAL_MDD_IMAGE_STRUCTURE);
                 }
             }
         }
@@ -1828,9 +1828,9 @@ int VRTPansharpenedRasterBand::GetOverviewCount()
                     auto poBand = std::make_unique<VRTPansharpenedRasterBand>(
                         poOvrDS.get(), i + 1, poSrcBand->GetRasterDataType());
                     const char *pszNBITS = poSrcBand->GetMetadataItem(
-                        "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+                        GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
                     if (pszNBITS)
-                        poBand->SetMetadataItem("NBITS", pszNBITS,
+                        poBand->SetMetadataItem(GDALMD_NBITS, pszNBITS,
                                                 GDAL_MDD_IMAGE_STRUCTURE);
                     int bHasNoData = FALSE;
                     const double dfNoData =

--- a/frmts/vrt/vrtprocesseddataset.cpp
+++ b/frmts/vrt/vrtprocesseddataset.cpp
@@ -761,7 +761,7 @@ CPLErr VRTProcessedDataset::Init(const CPLXMLNode *psTree,
     }
 
     if (nBands > 1)
-        SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
 
     m_oXMLTree.reset(CPLCloneXMLTree(psTree));
 
@@ -1224,7 +1224,7 @@ bool VRTProcessedDataset::ProcessRegion(int nXOff, int nYOff, int nBufXSize,
     auto &abyOutput = m_abyOutput;
 
     const char *pszInterleave =
-        m_poSrcDS->GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE");
+        m_poSrcDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
     if (nFirstBandCount > 1 && (!pszInterleave || EQUAL(pszInterleave, "BAND")))
     {
         // If there are several bands and the source dataset organization

--- a/frmts/vrt/vrtprocesseddataset.cpp
+++ b/frmts/vrt/vrtprocesseddataset.cpp
@@ -761,7 +761,7 @@ CPLErr VRTProcessedDataset::Init(const CPLXMLNode *psTree,
     }
 
     if (nBands > 1)
-        SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
 
     m_oXMLTree.reset(CPLCloneXMLTree(psTree));
 
@@ -1224,7 +1224,7 @@ bool VRTProcessedDataset::ProcessRegion(int nXOff, int nYOff, int nBufXSize,
     auto &abyOutput = m_abyOutput;
 
     const char *pszInterleave =
-        m_poSrcDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
+        m_poSrcDS->GetMetadataItem(GDALMD_INTERLEAVE, GDAL_MDD_IMAGE_STRUCTURE);
     if (nFirstBandCount > 1 && (!pszInterleave || EQUAL(pszInterleave, "BAND")))
     {
         // If there are several bands and the source dataset organization

--- a/frmts/vrt/vrtrasterband.cpp
+++ b/frmts/vrt/vrtrasterband.cpp
@@ -90,15 +90,15 @@ CPLErr VRTRasterBand::CopyCommonInfoFrom(const GDALRasterBand *poSrcBand)
     auto poSrcBandNonConst = const_cast<GDALRasterBand *>(poSrcBand);
     SetMetadata(poSrcBandNonConst->GetMetadata());
     const char *pszNBits =
-        poSrcBandNonConst->GetMetadataItem("NBITS", "IMAGE_STRUCTURE");
-    SetMetadataItem("NBITS", pszNBits, "IMAGE_STRUCTURE");
+        poSrcBandNonConst->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+    SetMetadataItem("NBITS", pszNBits, GDAL_MDD_IMAGE_STRUCTURE);
     if (poSrcBand->GetRasterDataType() == GDT_UInt8)
     {
         poSrcBandNonConst->EnablePixelTypeSignedByteWarning(false);
-        const char *pszPixelType =
-            poSrcBandNonConst->GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
+        const char *pszPixelType = poSrcBandNonConst->GetMetadataItem(
+            "PIXELTYPE", GDAL_MDD_IMAGE_STRUCTURE);
         poSrcBandNonConst->EnablePixelTypeSignedByteWarning(true);
-        SetMetadataItem("PIXELTYPE", pszPixelType, "IMAGE_STRUCTURE");
+        SetMetadataItem("PIXELTYPE", pszPixelType, GDAL_MDD_IMAGE_STRUCTURE);
     }
     SetColorTable(poSrcBandNonConst->GetColorTable());
     SetColorInterpretation(poSrcBandNonConst->GetColorInterpretation());

--- a/frmts/vrt/vrtrasterband.cpp
+++ b/frmts/vrt/vrtrasterband.cpp
@@ -89,9 +89,9 @@ CPLErr VRTRasterBand::CopyCommonInfoFrom(const GDALRasterBand *poSrcBand)
 {
     auto poSrcBandNonConst = const_cast<GDALRasterBand *>(poSrcBand);
     SetMetadata(poSrcBandNonConst->GetMetadata());
-    const char *pszNBits =
-        poSrcBandNonConst->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
-    SetMetadataItem("NBITS", pszNBits, GDAL_MDD_IMAGE_STRUCTURE);
+    const char *pszNBits = poSrcBandNonConst->GetMetadataItem(
+        GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
+    SetMetadataItem(GDALMD_NBITS, pszNBits, GDAL_MDD_IMAGE_STRUCTURE);
     if (poSrcBand->GetRasterDataType() == GDT_UInt8)
     {
         poSrcBandNonConst->EnablePixelTypeSignedByteWarning(false);

--- a/frmts/vrt/vrtsourcedrasterband.cpp
+++ b/frmts/vrt/vrtsourcedrasterband.cpp
@@ -2296,10 +2296,10 @@ CPLErr VRTSourcedRasterBand::AddSource(std::unique_ptr<VRTSource> poNewSource)
     {
         VRTSimpleSource *poSS =
             static_cast<VRTSimpleSource *>(poNewSource.get());
-        if (GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE) != nullptr)
+        if (GetMetadataItem(GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE) != nullptr)
         {
             int nBits =
-                atoi(GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE));
+                atoi(GetMetadataItem(GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE));
             if (nBits >= 1 && nBits <= 31)
             {
                 poSS->SetMaxValue(static_cast<int>((1U << nBits) - 1));

--- a/frmts/vrt/vrtsourcedrasterband.cpp
+++ b/frmts/vrt/vrtsourcedrasterband.cpp
@@ -1530,7 +1530,7 @@ CPLErr VRTSourcedRasterBand::ComputeRasterMinMax(int bApproxOK,
         {
             EnablePixelTypeSignedByteWarning(false);
             const char *pszPixelType =
-                GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
+                GetMetadataItem("PIXELTYPE", GDAL_MDD_IMAGE_STRUCTURE);
             EnablePixelTypeSignedByteWarning(true);
             bSignedByte =
                 pszPixelType != nullptr && EQUAL(pszPixelType, "SIGNEDBYTE");
@@ -2296,9 +2296,10 @@ CPLErr VRTSourcedRasterBand::AddSource(std::unique_ptr<VRTSource> poNewSource)
     {
         VRTSimpleSource *poSS =
             static_cast<VRTSimpleSource *>(poNewSource.get());
-        if (GetMetadataItem("NBITS", "IMAGE_STRUCTURE") != nullptr)
+        if (GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE) != nullptr)
         {
-            int nBits = atoi(GetMetadataItem("NBITS", "IMAGE_STRUCTURE"));
+            int nBits =
+                atoi(GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE));
             if (nBits >= 1 && nBits <= 31)
             {
                 poSS->SetMaxValue(static_cast<int>((1U << nBits) - 1));

--- a/frmts/vrt/vrtsources.cpp
+++ b/frmts/vrt/vrtsources.cpp
@@ -1369,7 +1369,8 @@ int VRTSimpleSource::NeedMaxValAdjustment() const
     auto l_band = GetRasterBand();
     if (!l_band)
         return FALSE;
-    const char *pszNBITS = l_band->GetMetadataItem("NBITS", "IMAGE_STRUCTURE");
+    const char *pszNBITS =
+        l_band->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
     const int nBits = (pszNBITS) ? atoi(pszNBITS) : 0;
     if (nBits >= 1 && nBits <= 31)
     {

--- a/frmts/vrt/vrtsources.cpp
+++ b/frmts/vrt/vrtsources.cpp
@@ -1370,7 +1370,7 @@ int VRTSimpleSource::NeedMaxValAdjustment() const
     if (!l_band)
         return FALSE;
     const char *pszNBITS =
-        l_band->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+        l_band->GetMetadataItem(GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
     const int nBits = (pszNBITS) ? atoi(pszNBITS) : 0;
     if (nBits >= 1 && nBits <= 31)
     {

--- a/frmts/vrt/vrtwarped.cpp
+++ b/frmts/vrt/vrtwarped.cpp
@@ -619,7 +619,8 @@ CPLErr VRTWarpedDataset::Initialize(void *psWO)
 
     if (nBands > 1)
     {
-        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     return eErr;
@@ -1395,7 +1396,8 @@ CPLErr VRTWarpedDataset::XMLInit(const CPLXMLNode *psTree,
 
     if (nBands > 1)
     {
-        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     /* -------------------------------------------------------------------- */

--- a/frmts/vrt/vrtwarped.cpp
+++ b/frmts/vrt/vrtwarped.cpp
@@ -619,7 +619,7 @@ CPLErr VRTWarpedDataset::Initialize(void *psWO)
 
     if (nBands > 1)
     {
-        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+        GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                      GDAL_MDD_IMAGE_STRUCTURE);
     }
 
@@ -1396,7 +1396,7 @@ CPLErr VRTWarpedDataset::XMLInit(const CPLXMLNode *psTree,
 
     if (nBands > 1)
     {
-        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+        GDALDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                      GDAL_MDD_IMAGE_STRUCTURE);
     }
 

--- a/frmts/wcs/wcsdataset.cpp
+++ b/frmts/wcs/wcsdataset.cpp
@@ -207,7 +207,7 @@ CPLErr WCSDataset::DirectRasterIO(CPL_UNUSED GDALRWFlag eRWFlag, int nXOff,
     // todo: in 2.0.1 the band list in this dataset may be user-defined
 
     int band_count = nBandCount;
-    if (EQUAL(CPLGetXMLValue(psService, "INTERLEAVE", ""), "PIXEL"))
+    if (EQUAL(CPLGetXMLValue(psService, GDALMD_INTERLEAVE, ""), "PIXEL"))
     {
         band_count = 0;
     }
@@ -1043,7 +1043,7 @@ static CPLXMLNode *CreateService(const std::string &base_url,
 #define WCS_TWEAK_OPTIONS                                                      \
     "OriginAtBoundary", "OuterExtents", "BufSizeAdjust", "OffsetsPositive",    \
         "NrOffsets", "GridCRSOptional", "NoGridAxisSwap", "GridAxisLabelSwap", \
-        "SubsetAxisSwap", "UseScaleFactor", "INTERLEAVE"
+        "SubsetAxisSwap", "UseScaleFactor", GDALMD_INTERLEAVE
 
 static bool UpdateService(CPLXMLNode *service, GDALOpenInfo *poOpenInfo)
 {

--- a/frmts/wcs/wcsdataset.cpp
+++ b/frmts/wcs/wcsdataset.cpp
@@ -1102,7 +1102,7 @@ static WCSDataset *CreateFromCache(const std::string &cache)
         metadata = CSLSetNameValue(metadata, name.c_str(), value.c_str());
         index += 1;
     }
-    ds->SetMetadata(metadata, "SUBDATASETS");
+    ds->SetMetadata(metadata, GDAL_MDD_SUBDATASETS);
     CSLDestroy(metadata);
     return ds;
 }
@@ -1285,7 +1285,7 @@ GDALDataset *WCSDataset::Open(GDALOpenInfo *poOpenInfo)
             CPLXMLTreeCloser doc(CPLParseXMLFile(global_meta.c_str()));
             CPLXMLNode *metadata = doc.getDocumentElement();
             CPLXMLNode *domain =
-                SearchChildWithValue(metadata, "domain", "SUBDATASETS");
+                SearchChildWithValue(metadata, "domain", GDAL_MDD_SUBDATASETS);
             if (domain != nullptr)
             {
                 CPLRemoveXMLChild(metadata, domain);
@@ -1586,7 +1586,8 @@ GDALDataset *WCSDataset::Open(GDALOpenInfo *poOpenInfo)
                                                osValue.c_str());
         }
 
-        poDS->GDALMajorObject::SetMetadata(papszSubdatasets, "SUBDATASETS");
+        poDS->GDALMajorObject::SetMetadata(papszSubdatasets,
+                                           GDAL_MDD_SUBDATASETS);
 
         CSLDestroy(papszSubdatasets);
     }

--- a/frmts/wcs/wcsdataset.cpp
+++ b/frmts/wcs/wcsdataset.cpp
@@ -550,8 +550,8 @@ int WCSDataset::EstablishRasterDetails()
     {
         nMaxCols = atoi(pszCols);
         nMaxRows = atoi(pszRows);
-        SetMetadataItem("MAXNCOLS", pszCols, "IMAGE_STRUCTURE");
-        SetMetadataItem("MAXNROWS", pszRows, "IMAGE_STRUCTURE");
+        SetMetadataItem("MAXNCOLS", pszCols, GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem("MAXNROWS", pszRows, GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     /* -------------------------------------------------------------------- */

--- a/frmts/wcs/wcsdataset100.cpp
+++ b/frmts/wcs/wcsdataset100.cpp
@@ -670,7 +670,7 @@ CPLErr WCSDataset100::ParseCapabilities(CPLXMLNode *Capabilities,
             // ParseCoverageCapabilities
         }
     }
-    this->SetMetadata(metadata, "SUBDATASETS");
+    this->SetMetadata(metadata, GDAL_MDD_SUBDATASETS);
     CSLDestroy(metadata);
     return CE_None;
 }

--- a/frmts/wcs/wcsdataset110.cpp
+++ b/frmts/wcs/wcsdataset110.cpp
@@ -896,7 +896,7 @@ CPLErr WCSDataset110::ParseCapabilities(CPLXMLNode *Capabilities,
             // ParseCoverageCapabilities
         }
     }
-    this->SetMetadata(metadata, "SUBDATASETS");
+    this->SetMetadata(metadata, GDAL_MDD_SUBDATASETS);
     CSLDestroy(metadata);
     return CE_None;
 }

--- a/frmts/wcs/wcsdataset201.cpp
+++ b/frmts/wcs/wcsdataset201.cpp
@@ -514,7 +514,7 @@ bool WCSDataset201::GridOffsets(CPLXMLNode *grid, const std::string &subtype,
 
 std::string WCSDataset201::GetSubdataset(const std::string &coverage)
 {
-    CSLConstList metadata = GDALPamDataset::GetMetadata("SUBDATASETS");
+    CSLConstList metadata = GDALPamDataset::GetMetadata(GDAL_MDD_SUBDATASETS);
     std::string subdataset;
     if (metadata != nullptr)
     {

--- a/frmts/wcs/wcsrasterband.cpp
+++ b/frmts/wcs/wcsrasterband.cpp
@@ -129,7 +129,7 @@ CPLErr WCSRasterBand::IReadBlock(int nBlockXOff, int nBlockYOff, void *pImage)
     // todo: in 2.0.1 the band list in this dataset may be user-defined
 
     int band_count = 1;
-    if (EQUAL(CPLGetXMLValue(poODS->psService, "INTERLEAVE", ""), "PIXEL"))
+    if (EQUAL(CPLGetXMLValue(poODS->psService, GDALMD_INTERLEAVE, ""), "PIXEL"))
     {
         band_count = 0;
     }

--- a/frmts/webp/webpdataset.cpp
+++ b/frmts/webp/webpdataset.cpp
@@ -608,9 +608,10 @@ GDALPamDataset *WEBPDataset::OpenPAM(GDALOpenInfo *poOpenInfo)
     // Cf commit https://github.com/webmproject/libwebp/commit/86c0031eb2c24f78d4dcfc5dab752ebc9f511607#diff-859d219dccb3163cc11cd538effed461ff0145135070abfe70bd263f16408023
     // Added in webp 0.4.0
 #if WEBP_DECODER_ABI_VERSION >= 0x0202
-    poDS->GDALDataset::SetMetadataItem(
-        "COMPRESSION_REVERSIBILITY",
-        config.input.format == 2 ? "LOSSLESS" : "LOSSY", "IMAGE_STRUCTURE");
+    poDS->GDALDataset::SetMetadataItem("COMPRESSION_REVERSIBILITY",
+                                       config.input.format == 2 ? "LOSSLESS"
+                                                                : "LOSSY",
+                                       GDAL_MDD_IMAGE_STRUCTURE);
 #endif
 
     if (config.input.has_alpha ||

--- a/frmts/wms/wmsdriver.cpp
+++ b/frmts/wms/wmsdriver.cpp
@@ -1020,7 +1020,8 @@ GDALDataset *GDALWMSDataset::Open(GDALOpenInfo *poOpenInfo)
         }
         else
         {
-            ds->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+            ds->SetMetadataItem("INTERLEAVE", "PIXEL",
+                                GDAL_MDD_IMAGE_STRUCTURE);
             ds->SetDescription(poOpenInfo->pszFilename);
             ds->TryLoadXML();
         }

--- a/frmts/wms/wmsdriver.cpp
+++ b/frmts/wms/wmsdriver.cpp
@@ -1020,7 +1020,7 @@ GDALDataset *GDALWMSDataset::Open(GDALOpenInfo *poOpenInfo)
         }
         else
         {
-            ds->SetMetadataItem("INTERLEAVE", "PIXEL",
+            ds->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                 GDAL_MDD_IMAGE_STRUCTURE);
             ds->SetDescription(poOpenInfo->pszFilename);
             ds->TryLoadXML();

--- a/frmts/wms/wmsmetadataset.cpp
+++ b/frmts/wms/wmsmetadataset.cpp
@@ -197,7 +197,7 @@ GDALWMSMetaDataset::DownloadGetTileService(GDALOpenInfo *poOpenInfo)
 char **GDALWMSMetaDataset::GetMetadataDomainList()
 {
     return BuildMetadataDomainList(GDALPamDataset::GetMetadataDomainList(),
-                                   TRUE, "SUBDATASETS", nullptr);
+                                   TRUE, GDAL_MDD_SUBDATASETS, nullptr);
 }
 
 /************************************************************************/
@@ -207,7 +207,7 @@ char **GDALWMSMetaDataset::GetMetadataDomainList()
 CSLConstList GDALWMSMetaDataset::GetMetadata(const char *pszDomain)
 
 {
-    if (pszDomain != nullptr && EQUAL(pszDomain, "SUBDATASETS"))
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_SUBDATASETS))
         return papszSubDatasets;
 
     return GDALPamDataset::GetMetadata(pszDomain);

--- a/frmts/wmts/wmtsdataset.cpp
+++ b/frmts/wmts/wmtsdataset.cpp
@@ -2421,7 +2421,8 @@ GDALDataset *WMTSDataset::Open(GDALOpenInfo *poOpenInfo)
             return nullptr;
         }
 
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
+        poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
+                              GDAL_MDD_IMAGE_STRUCTURE);
         for (int i = 0; i < nBands; i++)
             poDS->SetBand(i + 1, new WMTSBand(poDS, i + 1, eDataType));
 

--- a/frmts/wmts/wmtsdataset.cpp
+++ b/frmts/wmts/wmtsdataset.cpp
@@ -2421,7 +2421,7 @@ GDALDataset *WMTSDataset::Open(GDALOpenInfo *poOpenInfo)
             return nullptr;
         }
 
-        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        poDS->SetMetadataItem("INTERLEAVE", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
         for (int i = 0; i < nBands; i++)
             poDS->SetBand(i + 1, new WMTSBand(poDS, i + 1, eDataType));
 

--- a/frmts/wmts/wmtsdataset.cpp
+++ b/frmts/wmts/wmtsdataset.cpp
@@ -1572,7 +1572,7 @@ GDALDataset *WMTSDataset::Open(GDALOpenInfo *poOpenInfo)
     WMTSDataset *poDS = new WMTSDataset();
 
     if (aosSubDatasets.size() > 2)
-        poDS->SetMetadata(aosSubDatasets.List(), "SUBDATASETS");
+        poDS->SetMetadata(aosSubDatasets.List(), GDAL_MDD_SUBDATASETS);
 
     if (nLayerCount == 1)
     {

--- a/frmts/zarr/zarrdriver.cpp
+++ b/frmts/zarr/zarrdriver.cpp
@@ -122,7 +122,7 @@ const char *ZarrDataset::GetMetadataItem(const char *pszName,
 {
     if (pszDomain != nullptr && EQUAL(pszDomain, "SUBDATASETS"))
         return m_aosSubdatasets.FetchNameValue(pszName);
-    if (pszDomain != nullptr && EQUAL(pszDomain, "IMAGE_STRUCTURE"))
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE))
         return GDALDataset::GetMetadataItem(pszName, pszDomain);
     return nullptr;
 }
@@ -135,7 +135,7 @@ CSLConstList ZarrDataset::GetMetadata(const char *pszDomain)
 {
     if (pszDomain != nullptr && EQUAL(pszDomain, "SUBDATASETS"))
         return m_aosSubdatasets.List();
-    if (pszDomain != nullptr && EQUAL(pszDomain, "IMAGE_STRUCTURE"))
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE))
         return GDALDataset::GetMetadata(pszDomain);
     return nullptr;
 }
@@ -1445,7 +1445,7 @@ GDALDataset *ZarrDataset::Create(const char *pszName, int nXSize, int nYSize,
             return nullptr;
         }
         poDS->SetMetadataItem("INTERLEAVE", bBandInterleave ? "BAND" : "PIXEL",
-                              "IMAGE_STRUCTURE");
+                              GDAL_MDD_IMAGE_STRUCTURE);
         if (bBandInterleave)
         {
             const char *pszBlockSize =
@@ -1458,7 +1458,7 @@ GDALDataset *ZarrDataset::Create(const char *pszName, int nXSize, int nYSize,
                 {
                     // Actually expose as pixel interleaved
                     poDS->SetMetadataItem("INTERLEAVE", "PIXEL",
-                                          "IMAGE_STRUCTURE");
+                                          GDAL_MDD_IMAGE_STRUCTURE);
                 }
             }
         }

--- a/frmts/zarr/zarrdriver.cpp
+++ b/frmts/zarr/zarrdriver.cpp
@@ -120,7 +120,7 @@ static bool ExploreGroup(const std::shared_ptr<GDALGroup> &poGroup,
 const char *ZarrDataset::GetMetadataItem(const char *pszName,
                                          const char *pszDomain)
 {
-    if (pszDomain != nullptr && EQUAL(pszDomain, "SUBDATASETS"))
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_SUBDATASETS))
         return m_aosSubdatasets.FetchNameValue(pszName);
     if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE))
         return GDALDataset::GetMetadataItem(pszName, pszDomain);
@@ -133,7 +133,7 @@ const char *ZarrDataset::GetMetadataItem(const char *pszName,
 
 CSLConstList ZarrDataset::GetMetadata(const char *pszDomain)
 {
-    if (pszDomain != nullptr && EQUAL(pszDomain, "SUBDATASETS"))
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_SUBDATASETS))
         return m_aosSubdatasets.List();
     if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE))
         return GDALDataset::GetMetadata(pszDomain);
@@ -716,7 +716,8 @@ GDALDataset *ZarrDataset::Open(GDALOpenInfo *poOpenInfo)
         }
         if (!poDS->m_aosSubdatasets.empty())
         {
-            poNewDS->SetMetadata(poDS->m_aosSubdatasets.List(), "SUBDATASETS");
+            poNewDS->SetMetadata(poDS->m_aosSubdatasets.List(),
+                                 GDAL_MDD_SUBDATASETS);
         }
         return poNewDS.release();
     }

--- a/frmts/zarr/zarrdriver.cpp
+++ b/frmts/zarr/zarrdriver.cpp
@@ -1139,7 +1139,8 @@ void ZarrDriver::InitMetadata()
 
             auto psInterleaveNode =
                 CPLCreateXMLNode(oTree.get(), CXT_Element, "Option");
-            CPLAddXMLAttributeAndValue(psInterleaveNode, "name", "INTERLEAVE");
+            CPLAddXMLAttributeAndValue(psInterleaveNode, "name",
+                                       GDALMD_INTERLEAVE);
             CPLAddXMLAttributeAndValue(psInterleaveNode, "type",
                                        "string-select");
             CPLAddXMLAttributeAndValue(psInterleaveNode, "default", "BAND");
@@ -1411,8 +1412,8 @@ GDALDataset *ZarrDataset::Create(const char *pszName, int nXSize, int nYSize,
 
     const bool bSingleArray =
         CPLTestBool(CSLFetchNameValueDef(papszOptions, "SINGLE_ARRAY", "YES"));
-    const bool bBandInterleave =
-        EQUAL(CSLFetchNameValueDef(papszOptions, "INTERLEAVE", "BAND"), "BAND");
+    const bool bBandInterleave = EQUAL(
+        CSLFetchNameValueDef(papszOptions, GDALMD_INTERLEAVE, "BAND"), "BAND");
     std::shared_ptr<GDALDimension> poBandDim(
         (bSingleArray && nBandsIn > 1)
             ? poRG->CreateDimension("Band", std::string(), std::string(),
@@ -1444,7 +1445,8 @@ GDALDataset *ZarrDataset::Create(const char *pszName, int nXSize, int nYSize,
             CleanupCreatedFiles();
             return nullptr;
         }
-        poDS->SetMetadataItem("INTERLEAVE", bBandInterleave ? "BAND" : "PIXEL",
+        poDS->SetMetadataItem(GDALMD_INTERLEAVE,
+                              bBandInterleave ? "BAND" : "PIXEL",
                               GDAL_MDD_IMAGE_STRUCTURE);
         if (bBandInterleave)
         {
@@ -1457,7 +1459,7 @@ GDALDataset *ZarrDataset::Create(const char *pszName, int nXSize, int nYSize,
                 if (aosTokens.size() == 3 && atoi(aosTokens[0]) == nBandsIn)
                 {
                     // Actually expose as pixel interleaved
-                    poDS->SetMetadataItem("INTERLEAVE", "PIXEL",
+                    poDS->SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                           GDAL_MDD_IMAGE_STRUCTURE);
                 }
             }

--- a/gcore/enviutils.cpp
+++ b/gcore/enviutils.cpp
@@ -277,7 +277,7 @@ void GDALApplyENVIHeaders(GDALDataset *poDS, const CPLStringList &aosHeaders,
                             ConvertWaveLength(CPLAtof(aosWL[i])))
                     {
                         poDS->GetRasterBand(i + 1)->SetMetadataItem(
-                            "CENTRAL_WAVELENGTH_UM", pszVal, "IMAGERY");
+                            GDALMD_CENTRAL_WAVELENGTH_UM, pszVal, "IMAGERY");
                     }
                 }
             }

--- a/gcore/enviutils.cpp
+++ b/gcore/enviutils.cpp
@@ -287,7 +287,7 @@ void GDALApplyENVIHeaders(GDALDataset *poDS, const CPLStringList &aosHeaders,
                 if (const char *pszVal = ConvertWaveLength(CPLAtof(aosFWHM[i])))
                 {
                     poDS->GetRasterBand(i + 1)->SetMetadataItem(
-                        "FWHM_UM", pszVal, "IMAGERY");
+                        GDALMD_FWHM_UM, pszVal, "IMAGERY");
                 }
             }
         }

--- a/gcore/enviutils.cpp
+++ b/gcore/enviutils.cpp
@@ -277,7 +277,8 @@ void GDALApplyENVIHeaders(GDALDataset *poDS, const CPLStringList &aosHeaders,
                             ConvertWaveLength(CPLAtof(aosWL[i])))
                     {
                         poDS->GetRasterBand(i + 1)->SetMetadataItem(
-                            GDALMD_CENTRAL_WAVELENGTH_UM, pszVal, "IMAGERY");
+                            GDALMD_CENTRAL_WAVELENGTH_UM, pszVal,
+                            GDAL_MDD_IMAGERY);
                     }
                 }
             }
@@ -287,7 +288,7 @@ void GDALApplyENVIHeaders(GDALDataset *poDS, const CPLStringList &aosHeaders,
                 if (const char *pszVal = ConvertWaveLength(CPLAtof(aosFWHM[i])))
                 {
                     poDS->GetRasterBand(i + 1)->SetMetadataItem(
-                        GDALMD_FWHM_UM, pszVal, "IMAGERY");
+                        GDALMD_FWHM_UM, pszVal, GDAL_MDD_IMAGERY);
                 }
             }
         }

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -383,6 +383,51 @@ typedef enum
 
 const char CPL_DLL *GDALGetPaletteInterpretationName(GDALPaletteInterp);
 
+/* "well known" metadata domains. */
+
+/** Name of the default metadata domain.
+ * @since 3.14
+ */
+#define GDAL_MDD_DEFAULT ""
+
+/** Name of the metadata domain that holds structural information about image
+ * organization that would not normally be carried with an image when
+ * translated into another format.
+ * @since 3.14
+ */
+#define GDAL_MDD_IMAGE_STRUCTURE "IMAGE_STRUCTURE"
+
+/** Name of the metadata domain that holds Rational Polynomial Coefficients
+ * (RPC)
+ * @since 3.14
+ */
+#define GDAL_MDD_RPC "RPC"
+
+/** Name of the metadata domain that holds the definition of a geolocation
+ * array.
+ * @since 3.14
+ */
+#define GDAL_MDD_GEOLOCATION "GEOLOCATION"
+
+/** Name of the metadata domain that holds the name and description of
+ * subdatasets.
+ * @since 3.14
+ */
+#define GDAL_MDD_SUBDATASETS "SUBDATASETS"
+
+/** Name of the metadata domain that holds information from IMD side-car files.
+ * @since 3.14
+ */
+#define GDAL_MDD_IMD "IMD"
+
+/** Name of the metadata domain that holds GDAL-standardized metadata items
+ * for satellite or aerial imagery, in particular GDALMD_SATELLITEID,
+ * GDALMD_CLOUDCOVER, GDALMD_ACQUISITIONDATETIME, GDALMD_CENTRAL_WAVELENGTH_UM,
+ * GDALMD_FWHM_UM
+ * @since 3.14
+ */
+#define GDAL_MDD_IMAGERY "IMAGERY"
+
 /* "well known" metadata items. */
 
 /** Metadata item for dataset that indicates the spatial interpretation of a
@@ -394,6 +439,56 @@ const char CPL_DLL *GDALGetPaletteInterpretationName(GDALPaletteInterp);
 /** Value for GDALMD_AREA_OR_POINT that indicates that a pixel represents a
  * point */
 #define GDALMD_AOP_POINT "Point"
+
+/** Metadata item for compression method, in the GDAL_MDD_IMAGE_STRUCTURE
+ * domain.
+ * @since 3.14
+ */
+#define GDALMD_COMPRESSION "COMPRESSION"
+
+/** Metadata item for interleave pattern, in the GDAL_MDD_IMAGE_STRUCTURE
+ * domain.
+ * Typical values are PIXEL, LINE or BAND.
+ * @since 3.14
+ */
+#define GDALMD_INTERLEAVE "INTERLEAVE"
+
+/** Metadata item for actual number of bits used for this band, or the bands of
+ * this dataset, in the GDAL_MDD_IMAGE_STRUCTURE domain.
+ * Normally only present when the number of bits is non-standard for th
+ * datatype, such as when a 1 bit TIFF is represented through GDAL as GDT_UInt8.
+ * @since 3.14
+ */
+#define GDALMD_NBITS "NBITS"
+
+/** Metadata item for satellite/scanner ID, in the GDAL_MDD_IMAGERY domain.
+ * @since 3.14
+ */
+#define GDALMD_SATELLITEID "SATELLITEID"
+
+/** Metadata item for cloud cover, in the GDAL_MDD_IMAGERY domain.
+ * The value is between 0 and 100, or 999 if not available
+ * @since 3.14
+ */
+#define GDALMD_CLOUDCOVER "CLOUDCOVER"
+
+/** Metadata item for image acquisition date time in UTC, in the
+ * GDAL_MDD_IMAGERY domain.
+ * @since 3.14
+ */
+#define GDALMD_ACQUISITIONDATETIME "ACQUISITIONDATETIME"
+
+/** Metadata item for the central Wavelength in micrometers,
+ * in the GDAL_MDD_IMAGERY domain.
+ * @since 3.14
+ */
+#define GDALMD_CENTRAL_WAVELENGTH_UM "CENTRAL_WAVELENGTH_UM"
+
+/** Metadata item for full-width half-maximum (FWHM) in micrometers,
+ * in the GDAL_MDD_IMAGERY domain.
+ * @since 3.14
+ */
+#define GDALMD_FWHM_UM "FWHM_UM"
 
 /* -------------------------------------------------------------------- */
 /*      GDAL Specific error codes.                                      */

--- a/gcore/gdal_mdreader.cpp
+++ b/gcore/gdal_mdreader.cpp
@@ -183,7 +183,7 @@ char **GDALMDReaderBase::GetMetadataDomain(const char *pszDomain)
     LoadMetadata();
     if (EQUAL(pszDomain, MD_DOMAIN_DEFAULT))
         return m_papszDEFAULTMD;
-    else if (EQUAL(pszDomain, MD_DOMAIN_IMD))
+    else if (EQUAL(pszDomain, GDAL_MDD_IMD))
         return m_papszIMDMD;
     else if (EQUAL(pszDomain, MD_DOMAIN_RPC))
         return m_papszRPCMD;
@@ -255,7 +255,7 @@ bool GDALMDReaderBase::FillMetadata(GDALMultiDomainMetadata *poMDMD)
 
     LoadMetadata();
 
-    SETMETADATA(poMDMD, m_papszIMDMD, MD_DOMAIN_IMD);
+    SETMETADATA(poMDMD, m_papszIMDMD, GDAL_MDD_IMD);
     SETMETADATA(poMDMD, m_papszRPCMD, MD_DOMAIN_RPC);
     SETMETADATA(poMDMD, m_papszIMAGERYMD, MD_DOMAIN_IMAGERY);
     SETMETADATA(poMDMD, m_papszDEFAULTMD, MD_DOMAIN_DEFAULT);

--- a/gcore/gdal_mdreader.cpp
+++ b/gcore/gdal_mdreader.cpp
@@ -187,7 +187,7 @@ char **GDALMDReaderBase::GetMetadataDomain(const char *pszDomain)
         return m_papszIMDMD;
     else if (EQUAL(pszDomain, GDAL_MDD_RPC))
         return m_papszRPCMD;
-    else if (EQUAL(pszDomain, MD_DOMAIN_IMAGERY))
+    else if (EQUAL(pszDomain, GDAL_MDD_IMAGERY))
         return m_papszIMAGERYMD;
     return nullptr;
 }
@@ -257,7 +257,7 @@ bool GDALMDReaderBase::FillMetadata(GDALMultiDomainMetadata *poMDMD)
 
     SETMETADATA(poMDMD, m_papszIMDMD, GDAL_MDD_IMD);
     SETMETADATA(poMDMD, m_papszRPCMD, GDAL_MDD_RPC);
-    SETMETADATA(poMDMD, m_papszIMAGERYMD, MD_DOMAIN_IMAGERY);
+    SETMETADATA(poMDMD, m_papszIMAGERYMD, GDAL_MDD_IMAGERY);
     SETMETADATA(poMDMD, m_papszDEFAULTMD, MD_DOMAIN_DEFAULT);
 
     return true;

--- a/gcore/gdal_mdreader.cpp
+++ b/gcore/gdal_mdreader.cpp
@@ -185,7 +185,7 @@ char **GDALMDReaderBase::GetMetadataDomain(const char *pszDomain)
         return m_papszDEFAULTMD;
     else if (EQUAL(pszDomain, GDAL_MDD_IMD))
         return m_papszIMDMD;
-    else if (EQUAL(pszDomain, MD_DOMAIN_RPC))
+    else if (EQUAL(pszDomain, GDAL_MDD_RPC))
         return m_papszRPCMD;
     else if (EQUAL(pszDomain, MD_DOMAIN_IMAGERY))
         return m_papszIMAGERYMD;
@@ -256,7 +256,7 @@ bool GDALMDReaderBase::FillMetadata(GDALMultiDomainMetadata *poMDMD)
     LoadMetadata();
 
     SETMETADATA(poMDMD, m_papszIMDMD, GDAL_MDD_IMD);
-    SETMETADATA(poMDMD, m_papszRPCMD, MD_DOMAIN_RPC);
+    SETMETADATA(poMDMD, m_papszRPCMD, GDAL_MDD_RPC);
     SETMETADATA(poMDMD, m_papszIMAGERYMD, MD_DOMAIN_IMAGERY);
     SETMETADATA(poMDMD, m_papszDEFAULTMD, MD_DOMAIN_DEFAULT);
 

--- a/gcore/gdal_mdreader.cpp
+++ b/gcore/gdal_mdreader.cpp
@@ -181,7 +181,7 @@ GDALMDReaderBase::~GDALMDReaderBase()
 char **GDALMDReaderBase::GetMetadataDomain(const char *pszDomain)
 {
     LoadMetadata();
-    if (EQUAL(pszDomain, MD_DOMAIN_DEFAULT))
+    if (EQUAL(pszDomain, GDAL_MDD_DEFAULT))
         return m_papszDEFAULTMD;
     else if (EQUAL(pszDomain, GDAL_MDD_IMD))
         return m_papszIMDMD;
@@ -258,7 +258,7 @@ bool GDALMDReaderBase::FillMetadata(GDALMultiDomainMetadata *poMDMD)
     SETMETADATA(poMDMD, m_papszIMDMD, GDAL_MDD_IMD);
     SETMETADATA(poMDMD, m_papszRPCMD, GDAL_MDD_RPC);
     SETMETADATA(poMDMD, m_papszIMAGERYMD, GDAL_MDD_IMAGERY);
-    SETMETADATA(poMDMD, m_papszDEFAULTMD, MD_DOMAIN_DEFAULT);
+    SETMETADATA(poMDMD, m_papszDEFAULTMD, GDAL_MDD_DEFAULT);
 
     return true;
 }

--- a/gcore/gdal_mdreader.h
+++ b/gcore/gdal_mdreader.h
@@ -19,19 +19,45 @@
 
 #include <map>
 
-#define MD_DOMAIN_IMD "IMD"         /**< image metadata section */
-#define MD_DOMAIN_RPC "RPC"         /**< rpc metadata section */
-#define MD_DOMAIN_IMAGERY "IMAGERY" /**< imagery metadata section */
-#define MD_DOMAIN_DEFAULT ""        /**< default metadata section */
+/** Name of the metadata domain that holds information from IMD side-car files.
+ * @deprecated Use GDAL_MDD_IMD
+ */
+#define MD_DOMAIN_IMD GDAL_MDD_IMD /**< image metadata section */
 
-#define MD_NAME_ACQDATETIME                                                    \
-    "ACQUISITIONDATETIME" /**< Acquisition Date Time property name. The time   \
-                             should be in UTC */
-#define MD_NAME_SATELLITE                                                      \
-    "SATELLITEID" /**< Satellite identificator property name */
-#define MD_NAME_CLOUDCOVER                                                     \
-    "CLOUDCOVER" /**< Cloud coverage property name. The value between 0 - 100  \
-                    or 999 if n/a */
+/** Name of the metadata domain that holds Rational Polynomial Coefficients
+ * (RPC)
+ * @deprecated Use GDAL_MDD_RPC
+ */
+#define MD_DOMAIN_RPC GDAL_MDD_RPC /**< rpc metadata section */
+
+/** Name of the metadata domain that holds GDAL-standardized metadata items
+ * for satellite or aerial imagery.
+ * @deprecated Use GDAL_MDD_IMAGERY
+ */
+#define MD_DOMAIN_IMAGERY GDAL_MDD_IMAGERY /**< imagery metadata section */
+
+/** Name of the default metadata domain.
+ * @deprecated Use GDAL_MDD_DEFAULT
+ */
+#define MD_DOMAIN_DEFAULT GDAL_MDD_DEFAULT
+
+/** Metadata item for image acquisition date time in UTC, in the
+ * GDAL_MDD_IMAGERY domain.
+ * @deprecated GDALMD_ACQUISITIONDATETIME
+ */
+#define MD_NAME_ACQDATETIME GDALMD_ACQUISITIONDATETIME
+
+/** Metadata item for satellite/scanner ID, in the GDAL_MDD_IMAGERY domain.
+ * @deprecated GDALMD_SATELLITEID
+ */
+#define MD_NAME_SATELLITE GDALMD_SATELLITEID
+
+/** Metadata item for cloud cover, in the GDAL_MDD_IMAGERY domain.
+ * The value is between 0 and 100, or 999 if not available
+ * @deprecated GDALMD_CLOUDCOVER
+ */
+#define MD_NAME_CLOUDCOVER GDALMD_CLOUDCOVER
+
 #define MD_NAME_MDTYPE                                                         \
     "METADATATYPE" /**< Metadata reader type property name. The reader         \
                       processed this metadata */

--- a/gcore/gdaldataset.cpp
+++ b/gcore/gdaldataset.cpp
@@ -2720,7 +2720,7 @@ CPLErr GDALDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
     if (!bHasSubpixelShift && nXSize == nBufXSize && nYSize == nBufYSize &&
         nBandCount > 1 &&
         (pszInterleave = GetMetadataItem(
-             "INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE)) != nullptr &&
+             GDALMD_INTERLEAVE, GDAL_MDD_IMAGE_STRUCTURE)) != nullptr &&
         EQUAL(pszInterleave, "PIXEL"))
     {
         return BlockBasedRasterIO(eRWFlag, nXOff, nYOff, nXSize, nYSize, pData,
@@ -11974,7 +11974,7 @@ class GDALMDArrayFromDataset final : public GDALMDArray
             if (EQUAL(pszDimOrder, "AUTO"))
             {
                 const char *pszInterleave = poDS->GetMetadataItem(
-                    "INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
+                    GDALMD_INTERLEAVE, GDAL_MDD_IMAGE_STRUCTURE);
                 return nBandCount == 1 || !pszInterleave ||
                        !EQUAL(pszInterleave, "PIXEL");
             }

--- a/gcore/gdaldataset.cpp
+++ b/gcore/gdaldataset.cpp
@@ -2719,8 +2719,8 @@ CPLErr GDALDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
 
     if (!bHasSubpixelShift && nXSize == nBufXSize && nYSize == nBufYSize &&
         nBandCount > 1 &&
-        (pszInterleave = GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE")) !=
-            nullptr &&
+        (pszInterleave = GetMetadataItem(
+             "INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE)) != nullptr &&
         EQUAL(pszInterleave, "PIXEL"))
     {
         return BlockBasedRasterIO(eRWFlag, nXOff, nYOff, nXSize, nYSize, pData,
@@ -11973,8 +11973,8 @@ class GDALMDArrayFromDataset final : public GDALMDArray
                 CSLFetchNameValueDef(papszOptions, "DIM_ORDER", "AUTO");
             if (EQUAL(pszDimOrder, "AUTO"))
             {
-                const char *pszInterleave =
-                    poDS->GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE");
+                const char *pszInterleave = poDS->GetMetadataItem(
+                    "INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
                 return nBandCount == 1 || !pszInterleave ||
                        !EQUAL(pszInterleave, "PIXEL");
             }

--- a/gcore/gdaldefaultoverviews.cpp
+++ b/gcore/gdaldefaultoverviews.cpp
@@ -1425,7 +1425,7 @@ CPLErr GDALDefaultOverviews::CreateMaskBand(int nFlags, int nBand)
             (nFlags & GMF_PER_DATASET) ? 1 : poDS->GetRasterCount();
 
         char **papszOpt = CSLSetNameValue(nullptr, "COMPRESS", "DEFLATE");
-        papszOpt = CSLSetNameValue(papszOpt, "INTERLEAVE", "BAND");
+        papszOpt = CSLSetNameValue(papszOpt, GDALMD_INTERLEAVE, "BAND");
 
         int nBX = 0;
         int nBY = 0;

--- a/gcore/gdaldriver.cpp
+++ b/gcore/gdaldriver.cpp
@@ -935,7 +935,7 @@ void GDALDriver::DefaultCopyMetadata(GDALDataset *poSrcDS, GDALDataset *poDstDS,
         /*      It would be nice to copy geolocation, but it is pretty fragile. */
         /* -------------------------------------------------------------------- */
         constexpr const char *apszDefaultDomains[] = {
-            "RPC", "xml:XMP", "json:ISIS3", "json:VICAR"};
+            GDAL_MDD_RPC, "xml:XMP", "json:ISIS3", "json:VICAR"};
         for (const char *pszDomain : apszDefaultDomains)
         {
             if ((!papszSrcMDD || CSLFindString(papszSrcMDD, pszDomain) >= 0) &&

--- a/gcore/gdaldriver.cpp
+++ b/gcore/gdaldriver.cpp
@@ -663,7 +663,7 @@ GDALDataset *GDALDriver::DefaultCreateCopy(const char *pszFilename,
     /*      didn't provide values.                                          */
     /* -------------------------------------------------------------------- */
     char **papszCreateOptions = CSLDuplicate(papszOptions);
-    const char *const apszOptItems[] = {"NBITS", GDAL_MDD_IMAGE_STRUCTURE,
+    const char *const apszOptItems[] = {GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE,
                                         "PIXELTYPE", GDAL_MDD_IMAGE_STRUCTURE,
                                         nullptr};
 

--- a/gcore/gdaldriver.cpp
+++ b/gcore/gdaldriver.cpp
@@ -663,8 +663,9 @@ GDALDataset *GDALDriver::DefaultCreateCopy(const char *pszFilename,
     /*      didn't provide values.                                          */
     /* -------------------------------------------------------------------- */
     char **papszCreateOptions = CSLDuplicate(papszOptions);
-    const char *const apszOptItems[] = {"NBITS", "IMAGE_STRUCTURE", "PIXELTYPE",
-                                        "IMAGE_STRUCTURE", nullptr};
+    const char *const apszOptItems[] = {"NBITS", GDAL_MDD_IMAGE_STRUCTURE,
+                                        "PIXELTYPE", GDAL_MDD_IMAGE_STRUCTURE,
+                                        nullptr};
 
     for (int iOptItem = 0; nBands > 0 && apszOptItems[iOptItem] != nullptr;
          iOptItem += 2)
@@ -974,7 +975,8 @@ void GDALDriver::DefaultCopyMetadata(GDALDataset *poSrcDS, GDALDataset *poDstDS,
                         if (!papszSrcMDD)
                         {
                             constexpr const char *const apszReservedDomains[] =
-                                {"IMAGE_STRUCTURE", "DERIVED_SUBDATASETS"};
+                                {GDAL_MDD_IMAGE_STRUCTURE,
+                                 "DERIVED_SUBDATASETS"};
                             for (const char *pszOtherDomain :
                                  apszReservedDomains)
                             {
@@ -1203,7 +1205,7 @@ GDALDataset *GDALDriver::CreateCopy(const char *pszFilename,
     /* -------------------------------------------------------------------- */
     char **papszOptionsToDelete = nullptr;
     const char *srcInterleave =
-        poSrcDS->GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE");
+        poSrcDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
     if (nBandCount > 1 && srcInterleave != nullptr &&
         CSLFetchNameValue(papszOptions, "INTERLEAVE") == nullptr &&
         EQUAL(CSLFetchNameValueDef(papszOptions, "COMPRESS", "NONE"), "NONE"))

--- a/gcore/gdaldriver.cpp
+++ b/gcore/gdaldriver.cpp
@@ -1205,9 +1205,9 @@ GDALDataset *GDALDriver::CreateCopy(const char *pszFilename,
     /* -------------------------------------------------------------------- */
     char **papszOptionsToDelete = nullptr;
     const char *srcInterleave =
-        poSrcDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
+        poSrcDS->GetMetadataItem(GDALMD_INTERLEAVE, GDAL_MDD_IMAGE_STRUCTURE);
     if (nBandCount > 1 && srcInterleave != nullptr &&
-        CSLFetchNameValue(papszOptions, "INTERLEAVE") == nullptr &&
+        CSLFetchNameValue(papszOptions, GDALMD_INTERLEAVE) == nullptr &&
         EQUAL(CSLFetchNameValueDef(papszOptions, "COMPRESS", "NONE"), "NONE"))
     {
 
@@ -1226,7 +1226,7 @@ GDALDataset *GDALDriver::CreateCopy(const char *pszFilename,
                 const char *nameAttribute =
                     CPLGetXMLValue(child, "name", nullptr);
                 const bool isInterleaveAttribute =
-                    nameAttribute && EQUAL(nameAttribute, "INTERLEAVE");
+                    nameAttribute && EQUAL(nameAttribute, GDALMD_INTERLEAVE);
                 if (isInterleaveAttribute)
                 {
                     for (CPLXMLNode *optionChild = child->psChild;
@@ -1272,8 +1272,8 @@ GDALDataset *GDALDriver::CreateCopy(const char *pszFilename,
         if (dstInterleave != nullptr)
         {
             papszOptionsToDelete = CSLDuplicate(papszOptions);
-            papszOptionsToDelete = CSLSetNameValue(papszOptionsToDelete,
-                                                   "INTERLEAVE", dstInterleave);
+            papszOptionsToDelete = CSLSetNameValue(
+                papszOptionsToDelete, GDALMD_INTERLEAVE, dstInterleave);
             papszOptionsToDelete = CSLSetNameValue(
                 papszOptionsToDelete, "@INTERLEAVE_ADDED_AUTOMATICALLY", "YES");
             papszOptions = papszOptionsToDelete;

--- a/gcore/gdalgeorefpamdataset.cpp
+++ b/gcore/gdalgeorefpamdataset.cpp
@@ -55,7 +55,7 @@ GDALGeorefPamDataset::~GDALGeorefPamDataset()
 
 CSLConstList GDALGeorefPamDataset::GetMetadata(const char *pszDomain)
 {
-    if (pszDomain != nullptr && EQUAL(pszDomain, "RPC"))
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_RPC))
     {
         const int nPAMIndex = GetPAMGeorefSrcIndex();
         if (nPAMIndex >= 0 &&
@@ -106,7 +106,8 @@ CSLConstList GDALGeorefPamDataset::GetMetadata(const char *pszDomain)
 const char *GDALGeorefPamDataset::GetMetadataItem(const char *pszName,
                                                   const char *pszDomain)
 {
-    if (pszDomain == nullptr || EQUAL(pszDomain, "") || EQUAL(pszDomain, "RPC"))
+    if (pszDomain == nullptr || EQUAL(pszDomain, "") ||
+        EQUAL(pszDomain, GDAL_MDD_RPC))
     {
         return CSLFetchNameValue(GetMetadata(pszDomain), pszName);
     }

--- a/gcore/gdaljp2abstractdataset.cpp
+++ b/gcore/gdaljp2abstractdataset.cpp
@@ -212,7 +212,7 @@ void GDALJP2AbstractDataset::LoadJP2Metadata(GDALOpenInfo *poOpenInfo,
                      static_cast<CSLConstList>(oLocalMDMD.GetDomainList())))
             {
                 if (!EQUAL(pszDomain, "") &&
-                    !EQUAL(pszDomain, "IMAGE_STRUCTURE"))
+                    !EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE))
                 {
                     if (GDALDataset::GetMetadata(pszDomain) != nullptr)
                     {
@@ -631,7 +631,7 @@ OGRLayer *GDALJP2AbstractDataset::GetLayer(int i) const
 
 CSLConstList GDALJP2AbstractDataset::GetMetadata(const char *pszDomain)
 {
-    if (pszDomain && EQUAL(pszDomain, "IMAGE_STRUCTURE"))
+    if (pszDomain && EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE))
     {
         if (m_aosImageStructureMetadata.empty())
         {
@@ -658,7 +658,7 @@ CSLConstList GDALJP2AbstractDataset::GetMetadata(const char *pszDomain)
 const char *GDALJP2AbstractDataset::GetMetadataItem(const char *pszName,
                                                     const char *pszDomain)
 {
-    if (pszDomain && EQUAL(pszDomain, "IMAGE_STRUCTURE") &&
+    if (pszDomain && EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE) &&
         EQUAL(pszName, "COMPRESSION_REVERSIBILITY"))
     {
         CSLConstList papszMD = GetMetadata(pszDomain);

--- a/gcore/gdaljp2metadata.cpp
+++ b/gcore/gdaljp2metadata.cpp
@@ -3290,7 +3290,7 @@ GDALJP2Metadata::CreateGDALMultiDomainMetadataXML(GDALDataset *poSrcDS,
              papszMDListIter && *papszMDListIter; ++papszMDListIter)
         {
             if (!EQUAL(*papszMDListIter, "") &&
-                !EQUAL(*papszMDListIter, "IMAGE_STRUCTURE") &&
+                !EQUAL(*papszMDListIter, GDAL_MDD_IMAGE_STRUCTURE) &&
                 !EQUAL(*papszMDListIter, "DERIVED_SUBDATASETS") &&
                 !EQUAL(*papszMDListIter, "JPEG2000") &&
                 !STARTS_WITH_CI(*papszMDListIter, "xml:BOX_") &&

--- a/gcore/gdalmultidomainmetadata.cpp
+++ b/gcore/gdalmultidomainmetadata.cpp
@@ -95,7 +95,7 @@ CPLErr GDALMultiDomainMetadata::SetMetadata(CSLConstList papszMetadata,
     // access.
     if (!STARTS_WITH_CI(pszDomain, "xml:") &&
         !STARTS_WITH_CI(pszDomain, "json:") &&
-        !EQUAL(pszDomain, "SUBDATASETS")
+        !EQUAL(pszDomain, GDAL_MDD_SUBDATASETS)
         // The IMD metadata domain should not be sorted, as order matters
         // when writing it back. Cf https://github.com/OSGeo/gdal/issues/11470
         && !EQUAL(pszDomain, "IMD"))

--- a/gcore/gdaloverviewdataset.cpp
+++ b/gcore/gdaloverviewdataset.cpp
@@ -533,7 +533,7 @@ const char *GDALOverviewDataset::GetMetadataItem(const char *pszName,
     }
 
     if (pszDomain != nullptr &&
-        (EQUAL(pszDomain, "RPC") || EQUAL(pszDomain, "GEOLOCATION")))
+        (EQUAL(pszDomain, GDAL_MDD_RPC) || EQUAL(pszDomain, "GEOLOCATION")))
     {
         CSLConstList papszMD = GetMetadata(pszDomain);
         return CSLFetchNameValue(papszMD, pszName);

--- a/gcore/gdaloverviewdataset.cpp
+++ b/gcore/gdaloverviewdataset.cpp
@@ -465,7 +465,7 @@ CSLConstList GDALOverviewDataset::GetMetadata(const char *pszDomain)
     CSLConstList papszMD = poMainDS->GetMetadata(pszDomain);
 
     // We may need to rescale some values from the RPC metadata domain.
-    if (pszDomain != nullptr && EQUAL(pszDomain, MD_DOMAIN_RPC) &&
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_RPC) &&
         papszMD != nullptr)
     {
         if (papszMD_RPC)

--- a/gcore/gdaloverviewdataset.cpp
+++ b/gcore/gdaloverviewdataset.cpp
@@ -491,7 +491,7 @@ CSLConstList GDALOverviewDataset::GetMetadata(const char *pszDomain)
     }
 
     // We may need to rescale some values from the GEOLOCATION metadata domain.
-    if (pszDomain != nullptr && EQUAL(pszDomain, "GEOLOCATION") &&
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_GEOLOCATION) &&
         papszMD != nullptr)
     {
         if (papszMD_GEOLOCATION)
@@ -532,8 +532,8 @@ const char *GDALOverviewDataset::GetMetadataItem(const char *pszName,
             return pszValue;
     }
 
-    if (pszDomain != nullptr &&
-        (EQUAL(pszDomain, GDAL_MDD_RPC) || EQUAL(pszDomain, "GEOLOCATION")))
+    if (pszDomain != nullptr && (EQUAL(pszDomain, GDAL_MDD_RPC) ||
+                                 EQUAL(pszDomain, GDAL_MDD_GEOLOCATION)))
     {
         CSLConstList papszMD = GetMetadata(pszDomain);
         return CSLFetchNameValue(papszMD, pszName);

--- a/gcore/gdalpamdataset.cpp
+++ b/gcore/gdalpamdataset.cpp
@@ -1204,7 +1204,8 @@ CPLErr GDALPamDataset::CloneInfo(GDALDataset *poSrcDS, int nCloneFlags)
     /* -------------------------------------------------------------------- */
     if (nCloneFlags & GCIF_METADATA)
     {
-        for (const char *pszMDD : {"", "RPC", "json:ISIS3", "json:VICAR"})
+        for (const char *pszMDD :
+             {"", GDAL_MDD_RPC, "json:ISIS3", "json:VICAR"})
         {
             auto papszSrcMD = poSrcDS->GetMetadata(pszMDD);
             if (papszSrcMD != nullptr)

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -2926,7 +2926,7 @@ double GDALRasterBand::GetMaximum(int *pbSuccess)
         {
             EnablePixelTypeSignedByteWarning(false);
             const char *pszPixelType =
-                GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
+                GetMetadataItem("PIXELTYPE", GDAL_MDD_IMAGE_STRUCTURE);
             EnablePixelTypeSignedByteWarning(true);
             if (pszPixelType != nullptr && EQUAL(pszPixelType, "SIGNEDBYTE"))
                 return 127;
@@ -3035,7 +3035,7 @@ double GDALRasterBand::GetMinimum(int *pbSuccess)
         {
             EnablePixelTypeSignedByteWarning(false);
             const char *pszPixelType =
-                GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
+                GetMetadataItem("PIXELTYPE", GDAL_MDD_IMAGE_STRUCTURE);
             EnablePixelTypeSignedByteWarning(true);
             if (pszPixelType != nullptr && EQUAL(pszPixelType, "SIGNEDBYTE"))
                 return -128;
@@ -4298,7 +4298,7 @@ CPLErr GDALRasterBand::GetHistogram(double dfMin, double dfMax, int nBuckets,
     {
         EnablePixelTypeSignedByteWarning(false);
         const char *pszPixelType =
-            GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
+            GetMetadataItem("PIXELTYPE", GDAL_MDD_IMAGE_STRUCTURE);
         EnablePixelTypeSignedByteWarning(true);
         bSignedByte =
             pszPixelType != nullptr && EQUAL(pszPixelType, "SIGNEDBYTE");
@@ -4955,7 +4955,7 @@ CPLErr GDALRasterBand::GetDefaultHistogram(double *pdfMin, double *pdfMax,
     {
         EnablePixelTypeSignedByteWarning(false);
         const char *pszPixelType =
-            GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
+            GetMetadataItem("PIXELTYPE", GDAL_MDD_IMAGE_STRUCTURE);
         EnablePixelTypeSignedByteWarning(true);
         bSignedByte =
             pszPixelType != nullptr && EQUAL(pszPixelType, "SIGNEDBYTE");
@@ -7208,7 +7208,7 @@ CPLErr GDALRasterBand::ComputeStatistics(int bApproxOK, double *pdfMin,
     {
         EnablePixelTypeSignedByteWarning(false);
         const char *pszPixelType =
-            GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
+            GetMetadataItem("PIXELTYPE", GDAL_MDD_IMAGE_STRUCTURE);
         EnablePixelTypeSignedByteWarning(true);
         bSignedByte =
             pszPixelType != nullptr && EQUAL(pszPixelType, "SIGNEDBYTE");
@@ -8611,7 +8611,7 @@ CPLErr GDALRasterBand::ComputeRasterMinMax(int bApproxOK, double *adfMinMax)
     {
         EnablePixelTypeSignedByteWarning(false);
         const char *pszPixelType =
-            GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
+            GetMetadataItem("PIXELTYPE", GDAL_MDD_IMAGE_STRUCTURE);
         EnablePixelTypeSignedByteWarning(true);
         bSignedByte =
             pszPixelType != nullptr && EQUAL(pszPixelType, "SIGNEDBYTE");
@@ -8977,7 +8977,7 @@ CPLErr GDALRasterBand::ComputeRasterMinMaxLocation(double *pdfMin,
     {
         EnablePixelTypeSignedByteWarning(false);
         const char *pszPixelType =
-            GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE");
+            GetMetadataItem("PIXELTYPE", GDAL_MDD_IMAGE_STRUCTURE);
         EnablePixelTypeSignedByteWarning(true);
         bSignedByte =
             pszPixelType != nullptr && EQUAL(pszPixelType, "SIGNEDBYTE");
@@ -10782,7 +10782,7 @@ const char *GDALRasterBand::GetMetadataItem(const char *pszName,
 {
     // TODO (GDAL 4.0?): remove this when GDAL 3.7 has been widely adopted.
     if (m_bEnablePixelTypeSignedByteWarning && eDataType == GDT_UInt8 &&
-        pszDomain != nullptr && EQUAL(pszDomain, "IMAGE_STRUCTURE") &&
+        pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_IMAGE_STRUCTURE) &&
         EQUAL(pszName, "PIXELTYPE"))
     {
         CPLError(CE_Warning, CPLE_AppDefined,

--- a/gcore/mdreader/reader_alos.cpp
+++ b/gcore/mdreader/reader_alos.cpp
@@ -98,7 +98,8 @@ GDALMDReaderALOS::GDALMDReaderALOS(const char *pszPath,
     if (osBaseName.size() >= 6)
     {
         CPLString osRPCFileName = CPLFormFilenameSafe(
-            osDirName, (std::string("RPC") + (osBaseName.c_str() + 6)).c_str(),
+            osDirName,
+            (std::string(GDAL_MDD_RPC) + (osBaseName.c_str() + 6)).c_str(),
             "txt");
         if (CPLCheckForFile(&osRPCFileName[0], papszSiblingFiles))
         {
@@ -108,7 +109,8 @@ GDALMDReaderALOS::GDALMDReaderALOS(const char *pszPath,
         {
             osRPCFileName = CPLFormFilenameSafe(
                 osDirName,
-                (std::string("RPC") + (osBaseName.c_str() + 6)).c_str(), "TXT");
+                (std::string(GDAL_MDD_RPC) + (osBaseName.c_str() + 6)).c_str(),
+                "TXT");
             if (CPLCheckForFile(&osRPCFileName[0], papszSiblingFiles))
             {
                 m_osRPBSourceFilename = std::move(osRPCFileName);
@@ -120,7 +122,8 @@ GDALMDReaderALOS::GDALMDReaderALOS(const char *pszPath,
     if (osBaseName.size() >= 3 && m_osRPBSourceFilename.empty())
     {
         CPLString osRPCFileName = CPLFormFilenameSafe(
-            osDirName, (std::string("RPC") + (osBaseName.c_str() + 3)).c_str(),
+            osDirName,
+            (std::string(GDAL_MDD_RPC) + (osBaseName.c_str() + 3)).c_str(),
             "txt");
         if (CPLCheckForFile(&osRPCFileName[0], papszSiblingFiles))
         {
@@ -130,7 +133,8 @@ GDALMDReaderALOS::GDALMDReaderALOS(const char *pszPath,
         {
             osRPCFileName = CPLFormFilenameSafe(
                 osDirName,
-                (std::string("RPC") + (osBaseName.c_str() + 3)).c_str(), "TXT");
+                (std::string(GDAL_MDD_RPC) + (osBaseName.c_str() + 3)).c_str(),
+                "TXT");
             if (CPLCheckForFile(&osRPCFileName[0], papszSiblingFiles))
             {
                 m_osRPBSourceFilename = std::move(osRPCFileName);

--- a/gcore/mdreader/reader_alos.cpp
+++ b/gcore/mdreader/reader_alos.cpp
@@ -225,18 +225,18 @@ void GDALMDReaderALOS::LoadMetadata()
     if (nullptr != pszSatId1 && nullptr != pszSatId2)
     {
         m_papszIMAGERYMD = CSLAddNameValue(
-            m_papszIMAGERYMD, MD_NAME_SATELLITE,
+            m_papszIMAGERYMD, GDALMD_SATELLITEID,
             CPLSPrintf("%s %s", CPLStripQuotes(pszSatId1).c_str(),
                        CPLStripQuotes(pszSatId2).c_str()));
     }
     else if (nullptr != pszSatId1 && nullptr == pszSatId2)
     {
-        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_SATELLITE,
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, GDALMD_SATELLITEID,
                                            CPLStripQuotes(pszSatId1));
     }
     else if (nullptr == pszSatId1 && nullptr != pszSatId2)
     {
-        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_SATELLITE,
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, GDALMD_SATELLITEID,
                                            CPLStripQuotes(pszSatId2));
     }
 

--- a/gcore/mdreader/reader_alos.cpp
+++ b/gcore/mdreader/reader_alos.cpp
@@ -248,12 +248,12 @@ void GDALMDReaderALOS::LoadMetadata()
         if (nCC >= 99)
         {
             m_papszIMAGERYMD = CSLAddNameValue(
-                m_papszIMAGERYMD, MD_NAME_CLOUDCOVER, MD_CLOUDCOVER_NA);
+                m_papszIMAGERYMD, GDALMD_CLOUDCOVER, MD_CLOUDCOVER_NA);
         }
         else
         {
             m_papszIMAGERYMD =
-                CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_CLOUDCOVER,
+                CSLAddNameValue(m_papszIMAGERYMD, GDALMD_CLOUDCOVER,
                                 CPLSPrintf("%d", nCC * 10));
         }
     }

--- a/gcore/mdreader/reader_alos.cpp
+++ b/gcore/mdreader/reader_alos.cpp
@@ -268,8 +268,8 @@ void GDALMDReaderALOS::LoadMetadata()
         struct tm tmBuf;
         strftime(buffer, 80, MD_DATETIMEFORMAT,
                  CPLUnixTimeToYMDHMS(timeMid, &tmBuf));
-        m_papszIMAGERYMD =
-            CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_ACQDATETIME, buffer);
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD,
+                                           GDALMD_ACQUISITIONDATETIME, buffer);
     }
     else
     {
@@ -285,8 +285,8 @@ void GDALMDReaderALOS::LoadMetadata()
             struct tm tmBuf;
             strftime(buffer, 80, MD_DATETIMEFORMAT,
                      CPLUnixTimeToYMDHMS(timeMid, &tmBuf));
-            m_papszIMAGERYMD =
-                CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_ACQDATETIME, buffer);
+            m_papszIMAGERYMD = CSLAddNameValue(
+                m_papszIMAGERYMD, GDALMD_ACQUISITIONDATETIME, buffer);
         }
     }
 }

--- a/gcore/mdreader/reader_digital_globe.cpp
+++ b/gcore/mdreader/reader_digital_globe.cpp
@@ -184,8 +184,8 @@ void GDALMDReaderDigitalGlobe::LoadMetadata()
         strftime(szMidDateTime, 80, MD_DATETIMEFORMAT,
                  CPLUnixTimeToYMDHMS(timeStart, &tmBuf));
 
-        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD,
-                                           MD_NAME_ACQDATETIME, szMidDateTime);
+        m_papszIMAGERYMD = CSLAddNameValue(
+            m_papszIMAGERYMD, GDALMD_ACQUISITIONDATETIME, szMidDateTime);
     }
     else
     {
@@ -199,7 +199,7 @@ void GDALMDReaderDigitalGlobe::LoadMetadata()
                      CPLUnixTimeToYMDHMS(timeStart, &tmBuf));
 
             m_papszIMAGERYMD = CSLAddNameValue(
-                m_papszIMAGERYMD, MD_NAME_ACQDATETIME, szMidDateTime);
+                m_papszIMAGERYMD, GDALMD_ACQUISITIONDATETIME, szMidDateTime);
         }
     }
 }

--- a/gcore/mdreader/reader_digital_globe.cpp
+++ b/gcore/mdreader/reader_digital_globe.cpp
@@ -145,12 +145,12 @@ void GDALMDReaderDigitalGlobe::LoadMetadata()
         if (fCC < 0)
         {
             m_papszIMAGERYMD = CSLAddNameValue(
-                m_papszIMAGERYMD, MD_NAME_CLOUDCOVER, MD_CLOUDCOVER_NA);
+                m_papszIMAGERYMD, GDALMD_CLOUDCOVER, MD_CLOUDCOVER_NA);
         }
         else
         {
             m_papszIMAGERYMD =
-                CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_CLOUDCOVER,
+                CSLAddNameValue(m_papszIMAGERYMD, GDALMD_CLOUDCOVER,
                                 CPLSPrintf("%d", int(fCC * 100)));
         }
     }
@@ -163,12 +163,12 @@ void GDALMDReaderDigitalGlobe::LoadMetadata()
             if (fCC < 0)
             {
                 m_papszIMAGERYMD = CSLAddNameValue(
-                    m_papszIMAGERYMD, MD_NAME_CLOUDCOVER, MD_CLOUDCOVER_NA);
+                    m_papszIMAGERYMD, GDALMD_CLOUDCOVER, MD_CLOUDCOVER_NA);
             }
             else
             {
                 m_papszIMAGERYMD =
-                    CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_CLOUDCOVER,
+                    CSLAddNameValue(m_papszIMAGERYMD, GDALMD_CLOUDCOVER,
                                     CPLSPrintf("%d", int(fCC * 100)));
             }
         }

--- a/gcore/mdreader/reader_digital_globe.cpp
+++ b/gcore/mdreader/reader_digital_globe.cpp
@@ -124,7 +124,7 @@ void GDALMDReaderDigitalGlobe::LoadMetadata()
     const char *pszSatId = CSLFetchNameValue(m_papszIMDMD, "IMAGE.SATID");
     if (nullptr != pszSatId)
     {
-        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_SATELLITE,
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, GDALMD_SATELLITEID,
                                            CPLStripQuotes(pszSatId));
     }
     else
@@ -133,7 +133,7 @@ void GDALMDReaderDigitalGlobe::LoadMetadata()
         if (nullptr != pszSatId)
         {
             m_papszIMAGERYMD = CSLAddNameValue(
-                m_papszIMAGERYMD, MD_NAME_SATELLITE, CPLStripQuotes(pszSatId));
+                m_papszIMAGERYMD, GDALMD_SATELLITEID, CPLStripQuotes(pszSatId));
         }
     }
 

--- a/gcore/mdreader/reader_eros.cpp
+++ b/gcore/mdreader/reader_eros.cpp
@@ -93,7 +93,8 @@ GDALMDReaderEROS::GDALMDReaderEROS(const char *pszPath,
     }
     else
     {
-        osRPCFileName = CPLFormFilenameSafe(osDirName, szMetadataName, "RPC");
+        osRPCFileName =
+            CPLFormFilenameSafe(osDirName, szMetadataName, GDAL_MDD_RPC);
         if (CPLCheckForFile(&osRPCFileName[0], papszSiblingFiles))
         {
             m_osRPBSourceFilename = std::move(osRPCFileName);

--- a/gcore/mdreader/reader_eros.cpp
+++ b/gcore/mdreader/reader_eros.cpp
@@ -169,18 +169,18 @@ void GDALMDReaderEROS::LoadMetadata()
     if (nullptr != pszSatId1 && nullptr != pszSatId2)
     {
         m_papszIMAGERYMD = CSLAddNameValue(
-            m_papszIMAGERYMD, MD_NAME_SATELLITE,
+            m_papszIMAGERYMD, GDALMD_SATELLITEID,
             CPLSPrintf("%s %s", CPLStripQuotes(pszSatId1).c_str(),
                        CPLStripQuotes(pszSatId2).c_str()));
     }
     else if (nullptr != pszSatId1 && nullptr == pszSatId2)
     {
-        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_SATELLITE,
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, GDALMD_SATELLITEID,
                                            CPLStripQuotes(pszSatId1));
     }
     else if (nullptr == pszSatId1 && nullptr != pszSatId2)
     {
-        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_SATELLITE,
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, GDALMD_SATELLITEID,
                                            CPLStripQuotes(pszSatId2));
     }
 

--- a/gcore/mdreader/reader_eros.cpp
+++ b/gcore/mdreader/reader_eros.cpp
@@ -191,12 +191,12 @@ void GDALMDReaderEROS::LoadMetadata()
         if (nCC > 100 || nCC < 0)
         {
             m_papszIMAGERYMD = CSLAddNameValue(
-                m_papszIMAGERYMD, MD_NAME_CLOUDCOVER, MD_CLOUDCOVER_NA);
+                m_papszIMAGERYMD, GDALMD_CLOUDCOVER, MD_CLOUDCOVER_NA);
         }
         else
         {
             m_papszIMAGERYMD = CSLAddNameValue(
-                m_papszIMAGERYMD, MD_NAME_CLOUDCOVER, CPLSPrintf("%d", nCC));
+                m_papszIMAGERYMD, GDALMD_CLOUDCOVER, CPLSPrintf("%d", nCC));
         }
     }
 

--- a/gcore/mdreader/reader_eros.cpp
+++ b/gcore/mdreader/reader_eros.cpp
@@ -208,8 +208,8 @@ void GDALMDReaderEROS::LoadMetadata()
         struct tm tmBuf;
         strftime(buffer, 80, MD_DATETIMEFORMAT,
                  CPLUnixTimeToYMDHMS(timeMid, &tmBuf));
-        m_papszIMAGERYMD =
-            CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_ACQDATETIME, buffer);
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD,
+                                           GDALMD_ACQUISITIONDATETIME, buffer);
     }
 }
 

--- a/gcore/mdreader/reader_geo_eye.cpp
+++ b/gcore/mdreader/reader_geo_eye.cpp
@@ -157,7 +157,7 @@ void GDALMDReaderGeoEye::LoadMetadata()
         CSLFetchNameValue(m_papszIMDMD, "Source Image Metadata.Sensor");
     if (nullptr != pszSatId)
     {
-        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_SATELLITE,
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, GDALMD_SATELLITEID,
                                            CPLStripQuotes(pszSatId));
     }
 

--- a/gcore/mdreader/reader_geo_eye.cpp
+++ b/gcore/mdreader/reader_geo_eye.cpp
@@ -165,8 +165,8 @@ void GDALMDReaderGeoEye::LoadMetadata()
         m_papszIMDMD, "Source Image Metadata.Percent Cloud Cover");
     if (nullptr != pszCloudCover)
     {
-        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_CLOUDCOVER,
-                                           pszCloudCover);
+        m_papszIMAGERYMD =
+            CSLAddNameValue(m_papszIMAGERYMD, GDALMD_CLOUDCOVER, pszCloudCover);
     }
 
     const char *pszDateTime = CSLFetchNameValue(

--- a/gcore/mdreader/reader_geo_eye.cpp
+++ b/gcore/mdreader/reader_geo_eye.cpp
@@ -180,8 +180,8 @@ void GDALMDReaderGeoEye::LoadMetadata()
         struct tm tmBuf;
         strftime(buffer, 80, MD_DATETIMEFORMAT,
                  CPLUnixTimeToYMDHMS(timeMid, &tmBuf));
-        m_papszIMAGERYMD =
-            CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_ACQDATETIME, buffer);
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD,
+                                           GDALMD_ACQUISITIONDATETIME, buffer);
     }
 }
 

--- a/gcore/mdreader/reader_kompsat.cpp
+++ b/gcore/mdreader/reader_kompsat.cpp
@@ -34,7 +34,7 @@ GDALMDReaderKompsat::GDALMDReaderKompsat(const char *pszPath,
       m_osIMDSourceFilename(
           GDALFindAssociatedFile(pszPath, "TXT", papszSiblingFiles, 0)),
       m_osRPBSourceFilename(
-          GDALFindAssociatedFile(pszPath, "RPC", papszSiblingFiles, 0))
+          GDALFindAssociatedFile(pszPath, GDAL_MDD_RPC, papszSiblingFiles, 0))
 {
     if (!m_osIMDSourceFilename.empty())
         CPLDebug("MDReaderDigitalGlobe", "IMD Filename: %s",

--- a/gcore/mdreader/reader_kompsat.cpp
+++ b/gcore/mdreader/reader_kompsat.cpp
@@ -106,18 +106,18 @@ void GDALMDReaderKompsat::LoadMetadata()
     if (nullptr != pszSatId1 && nullptr != pszSatId2)
     {
         m_papszIMAGERYMD = CSLAddNameValue(
-            m_papszIMAGERYMD, MD_NAME_SATELLITE,
+            m_papszIMAGERYMD, GDALMD_SATELLITEID,
             CPLSPrintf("%s %s", CPLStripQuotes(pszSatId1).c_str(),
                        CPLStripQuotes(pszSatId2).c_str()));
     }
     else if (nullptr != pszSatId1 && nullptr == pszSatId2)
     {
-        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_SATELLITE,
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, GDALMD_SATELLITEID,
                                            CPLStripQuotes(pszSatId1));
     }
     else if (nullptr == pszSatId1 && nullptr != pszSatId2)
     {
-        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_SATELLITE,
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, GDALMD_SATELLITEID,
                                            CPLStripQuotes(pszSatId2));
     }
 

--- a/gcore/mdreader/reader_kompsat.cpp
+++ b/gcore/mdreader/reader_kompsat.cpp
@@ -154,8 +154,8 @@ void GDALMDReaderKompsat::LoadMetadata()
         struct tm tmBuf;
         strftime(buffer, 80, MD_DATETIMEFORMAT,
                  CPLUnixTimeToYMDHMS(timeMid, &tmBuf));
-        m_papszIMAGERYMD =
-            CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_ACQDATETIME, buffer);
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD,
+                                           GDALMD_ACQUISITIONDATETIME, buffer);
     }
 }
 

--- a/gcore/mdreader/reader_kompsat.cpp
+++ b/gcore/mdreader/reader_kompsat.cpp
@@ -129,12 +129,12 @@ void GDALMDReaderKompsat::LoadMetadata()
         if (nCC > 100 || nCC < 0)
         {
             m_papszIMAGERYMD = CSLAddNameValue(
-                m_papszIMAGERYMD, MD_NAME_CLOUDCOVER, MD_CLOUDCOVER_NA);
+                m_papszIMAGERYMD, GDALMD_CLOUDCOVER, MD_CLOUDCOVER_NA);
         }
         else
         {
             m_papszIMAGERYMD = CSLAddNameValue(
-                m_papszIMAGERYMD, MD_NAME_CLOUDCOVER, CPLSPrintf("%d", nCC));
+                m_papszIMAGERYMD, GDALMD_CLOUDCOVER, CPLSPrintf("%d", nCC));
         }
     }
 

--- a/gcore/mdreader/reader_landsat.cpp
+++ b/gcore/mdreader/reader_landsat.cpp
@@ -142,12 +142,12 @@ void GDALMDReaderLandsat::LoadMetadata()
         if (fCC < 0)
         {
             m_papszIMAGERYMD = CSLAddNameValue(
-                m_papszIMAGERYMD, MD_NAME_CLOUDCOVER, MD_CLOUDCOVER_NA);
+                m_papszIMAGERYMD, GDALMD_CLOUDCOVER, MD_CLOUDCOVER_NA);
         }
         else
         {
             m_papszIMAGERYMD =
-                CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_CLOUDCOVER,
+                CSLAddNameValue(m_papszIMAGERYMD, GDALMD_CLOUDCOVER,
                                 CPLSPrintf("%d", int(fCC)));
         }
     }

--- a/gcore/mdreader/reader_landsat.cpp
+++ b/gcore/mdreader/reader_landsat.cpp
@@ -129,7 +129,7 @@ void GDALMDReaderLandsat::LoadMetadata()
         m_papszIMDMD, "L1_METADATA_FILE.PRODUCT_METADATA.SPACECRAFT_ID");
     if (nullptr != pszSatId)
     {
-        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_SATELLITE,
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, GDALMD_SATELLITEID,
                                            CPLStripQuotes(pszSatId));
     }
 

--- a/gcore/mdreader/reader_landsat.cpp
+++ b/gcore/mdreader/reader_landsat.cpp
@@ -186,7 +186,7 @@ void GDALMDReaderLandsat::LoadMetadata()
         struct tm tmBuf;
         strftime(buffer, 80, MD_DATETIMEFORMAT,
                  CPLUnixTimeToYMDHMS(timeMid, &tmBuf));
-        m_papszIMAGERYMD =
-            CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_ACQDATETIME, buffer);
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD,
+                                           GDALMD_ACQUISITIONDATETIME, buffer);
     }
 }

--- a/gcore/mdreader/reader_orb_view.cpp
+++ b/gcore/mdreader/reader_orb_view.cpp
@@ -132,8 +132,8 @@ void GDALMDReaderOrbView::LoadMetadata()
         m_papszIMDMD, "productInfo.productCloudCoverPercentage");
     if (nullptr != pszCloudCover)
     {
-        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_CLOUDCOVER,
-                                           pszCloudCover);
+        m_papszIMAGERYMD =
+            CSLAddNameValue(m_papszIMAGERYMD, GDALMD_CLOUDCOVER, pszCloudCover);
     }
 
     const char *pszDateTime = CSLFetchNameValue(

--- a/gcore/mdreader/reader_orb_view.cpp
+++ b/gcore/mdreader/reader_orb_view.cpp
@@ -124,7 +124,7 @@ void GDALMDReaderOrbView::LoadMetadata()
         CSLFetchNameValue(m_papszIMDMD, "sensorInfo.satelliteName");
     if (nullptr != pszSatId)
     {
-        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_SATELLITE,
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, GDALMD_SATELLITEID,
                                            CPLStripQuotes(pszSatId));
     }
 

--- a/gcore/mdreader/reader_orb_view.cpp
+++ b/gcore/mdreader/reader_orb_view.cpp
@@ -146,7 +146,7 @@ void GDALMDReaderOrbView::LoadMetadata()
         struct tm tmBuf;
         strftime(buffer, 80, MD_DATETIMEFORMAT,
                  CPLUnixTimeToYMDHMS(timeMid, &tmBuf));
-        m_papszIMAGERYMD =
-            CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_ACQDATETIME, buffer);
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD,
+                                           GDALMD_ACQUISITIONDATETIME, buffer);
     }
 }

--- a/gcore/mdreader/reader_pleiades.cpp
+++ b/gcore/mdreader/reader_pleiades.cpp
@@ -291,7 +291,7 @@ void GDALMDReaderPleiades::LoadMetadata()
     }
 
     m_papszIMAGERYMD =
-        CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_CLOUDCOVER, MD_CLOUDCOVER_NA);
+        CSLAddNameValue(m_papszIMAGERYMD, GDALMD_CLOUDCOVER, MD_CLOUDCOVER_NA);
 }
 
 /**

--- a/gcore/mdreader/reader_pleiades.cpp
+++ b/gcore/mdreader/reader_pleiades.cpp
@@ -286,8 +286,8 @@ void GDALMDReaderPleiades::LoadMetadata()
         struct tm tmBuf;
         strftime(buffer, 80, MD_DATETIMEFORMAT,
                  CPLUnixTimeToYMDHMS(timeMid, &tmBuf));
-        m_papszIMAGERYMD =
-            CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_ACQDATETIME, buffer);
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD,
+                                           GDALMD_ACQUISITIONDATETIME, buffer);
     }
 
     m_papszIMAGERYMD =

--- a/gcore/mdreader/reader_pleiades.cpp
+++ b/gcore/mdreader/reader_pleiades.cpp
@@ -237,18 +237,18 @@ void GDALMDReaderPleiades::LoadMetadata()
     if (nullptr != pszSatId1 && nullptr != pszSatId2)
     {
         m_papszIMAGERYMD = CSLAddNameValue(
-            m_papszIMAGERYMD, MD_NAME_SATELLITE,
+            m_papszIMAGERYMD, GDALMD_SATELLITEID,
             CPLSPrintf("%s %s", CPLStripQuotes(pszSatId1).c_str(),
                        CPLStripQuotes(pszSatId2).c_str()));
     }
     else if (nullptr != pszSatId1 && nullptr == pszSatId2)
     {
-        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_SATELLITE,
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, GDALMD_SATELLITEID,
                                            CPLStripQuotes(pszSatId1));
     }
     else if (nullptr == pszSatId1 && nullptr != pszSatId2)
     {
-        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_SATELLITE,
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, GDALMD_SATELLITEID,
                                            CPLStripQuotes(pszSatId2));
     }
 

--- a/gcore/mdreader/reader_rapid_eye.cpp
+++ b/gcore/mdreader/reader_rapid_eye.cpp
@@ -121,7 +121,7 @@ void GDALMDReaderRapidEye::LoadMetadata()
                       "eop:Platform.eop:serialIdentifier");
     if (nullptr != pszSatId)
     {
-        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_SATELLITE,
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, GDALMD_SATELLITEID,
                                            CPLStripQuotes(pszSatId));
     }
 

--- a/gcore/mdreader/reader_rapid_eye.cpp
+++ b/gcore/mdreader/reader_rapid_eye.cpp
@@ -136,8 +136,8 @@ void GDALMDReaderRapidEye::LoadMetadata()
         struct tm tmBuf;
         strftime(buffer, 80, MD_DATETIMEFORMAT,
                  CPLUnixTimeToYMDHMS(timeMid, &tmBuf));
-        m_papszIMAGERYMD =
-            CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_ACQDATETIME, buffer);
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD,
+                                           GDALMD_ACQUISITIONDATETIME, buffer);
     }
 
     const char *pszCC = CSLFetchNameValue(

--- a/gcore/mdreader/reader_rapid_eye.cpp
+++ b/gcore/mdreader/reader_rapid_eye.cpp
@@ -146,6 +146,6 @@ void GDALMDReaderRapidEye::LoadMetadata()
     if (nullptr != pszSatId)
     {
         m_papszIMAGERYMD =
-            CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_CLOUDCOVER, pszCC);
+            CSLAddNameValue(m_papszIMAGERYMD, GDALMD_CLOUDCOVER, pszCC);
     }
 }

--- a/gcore/mdreader/reader_rdk1.cpp
+++ b/gcore/mdreader/reader_rdk1.cpp
@@ -107,7 +107,7 @@ void GDALMDReaderResursDK1::LoadMetadata()
     const char *pszSatId = CSLFetchNameValue(m_papszIMDMD, "MSP_ROOT.cCodeKA");
     if (nullptr != pszSatId)
     {
-        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_SATELLITE,
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, GDALMD_SATELLITEID,
                                            CPLStripQuotes(pszSatId));
     }
 

--- a/gcore/mdreader/reader_rdk1.cpp
+++ b/gcore/mdreader/reader_rdk1.cpp
@@ -132,7 +132,7 @@ void GDALMDReaderResursDK1::LoadMetadata()
     }
 
     m_papszIMAGERYMD =
-        CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_CLOUDCOVER, MD_CLOUDCOVER_NA);
+        CSLAddNameValue(m_papszIMAGERYMD, GDALMD_CLOUDCOVER, MD_CLOUDCOVER_NA);
 }
 
 /**

--- a/gcore/mdreader/reader_rdk1.cpp
+++ b/gcore/mdreader/reader_rdk1.cpp
@@ -127,8 +127,8 @@ void GDALMDReaderResursDK1::LoadMetadata()
         struct tm tmBuf;
         strftime(buffer, 80, MD_DATETIMEFORMAT,
                  CPLUnixTimeToYMDHMS(timeMid, &tmBuf));
-        m_papszIMAGERYMD =
-            CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_ACQDATETIME, buffer);
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD,
+                                           GDALMD_ACQUISITIONDATETIME, buffer);
     }
 
     m_papszIMAGERYMD =

--- a/gcore/mdreader/reader_spot.cpp
+++ b/gcore/mdreader/reader_spot.cpp
@@ -212,7 +212,7 @@ void GDALMDReaderSpot::LoadMetadata()
     }
 
     m_papszIMAGERYMD =
-        CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_CLOUDCOVER, MD_CLOUDCOVER_NA);
+        CSLAddNameValue(m_papszIMAGERYMD, GDALMD_CLOUDCOVER, MD_CLOUDCOVER_NA);
 }
 
 /**

--- a/gcore/mdreader/reader_spot.cpp
+++ b/gcore/mdreader/reader_spot.cpp
@@ -207,8 +207,8 @@ void GDALMDReaderSpot::LoadMetadata()
         struct tm tmBuf;
         strftime(buffer, 80, MD_DATETIMEFORMAT,
                  CPLUnixTimeToYMDHMS(timeMid, &tmBuf));
-        m_papszIMAGERYMD =
-            CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_ACQDATETIME, buffer);
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD,
+                                           GDALMD_ACQUISITIONDATETIME, buffer);
     }
 
     m_papszIMAGERYMD =

--- a/gcore/mdreader/reader_spot.cpp
+++ b/gcore/mdreader/reader_spot.cpp
@@ -159,18 +159,18 @@ void GDALMDReaderSpot::LoadMetadata()
     if (nullptr != pszSatId1 && nullptr != pszSatId2)
     {
         m_papszIMAGERYMD = CSLAddNameValue(
-            m_papszIMAGERYMD, MD_NAME_SATELLITE,
+            m_papszIMAGERYMD, GDALMD_SATELLITEID,
             CPLSPrintf("%s %s", CPLStripQuotes(pszSatId1).c_str(),
                        CPLStripQuotes(pszSatId2).c_str()));
     }
     else if (nullptr != pszSatId1 && nullptr == pszSatId2)
     {
-        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_SATELLITE,
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, GDALMD_SATELLITEID,
                                            CPLStripQuotes(pszSatId1));
     }
     else if (nullptr == pszSatId1 && nullptr != pszSatId2)
     {
-        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, MD_NAME_SATELLITE,
+        m_papszIMAGERYMD = CSLAddNameValue(m_papszIMAGERYMD, GDALMD_SATELLITEID,
                                            CPLStripQuotes(pszSatId2));
     }
 

--- a/gcore/multidim/gdalmultidim_array_bridge_classic.cpp
+++ b/gcore/multidim/gdalmultidim_array_bridge_classic.cpp
@@ -1755,7 +1755,7 @@ lbl_next_depth:
         poDS->GetRasterCount() > 1)
     {
         poDS->m_bPixelInterleaved = true;
-        poDS->m_oMDD.SetMetadataItem("INTERLEAVE", "PIXEL",
+        poDS->m_oMDD.SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                      GDAL_MDD_IMAGE_STRUCTURE);
     }
 

--- a/gcore/multidim/gdalmultidim_array_bridge_classic.cpp
+++ b/gcore/multidim/gdalmultidim_array_bridge_classic.cpp
@@ -585,7 +585,7 @@ GDALRasterBandFromArray::GDALRasterBandFromArray(
                         GDALExtendedDataType::Create(GDT_Float64));
                     dt.FreeDynamicMemory(abyTmp.data());
                     SetMetadataItem(
-                        "FWHM_UM",
+                        GDALMD_FWHM_UM,
                         CPLSPrintf("%g", dfVal * aoBandImageryMetadata[j]
                                                      .dfFWHMToMicrometer),
                         "IMAGERY");
@@ -1409,7 +1409,7 @@ std::unique_ptr<GDALDatasetFromArray> GDALDatasetFromArray::Create(
         for (const auto &oJsonItem : oRoot.GetChildren())
         {
             if (oJsonItem.GetName() == GDALMD_CENTRAL_WAVELENGTH_UM ||
-                oJsonItem.GetName() == "FWHM_UM")
+                oJsonItem.GetName() == GDALMD_FWHM_UM)
             {
                 const auto osBandArrayFullname = oJsonItem.GetString("array");
                 const auto osBandAttributeName =
@@ -1873,7 +1873,7 @@ lbl_next_depth:
  *                         The object currently accepts 2 members:
  *                         - GDALMD_CENTRAL_WAVELENGTH_UM: Central Wavelength in
  *                           micrometers.
- *                         - "FWHM_UM": Full-width half-maximum
+ *                         - GDALMD_FWHM_UM: Full-width half-maximum
  *                           in micrometers.
  *                         The value of each member should be an object with the
  *                         following members:
@@ -1907,7 +1907,7 @@ lbl_next_depth:
  *                                "array": "/sensor_band_parameters/wavelengths",
  *                                "unit": "${units}"
  *                            },
- *                            "FWHM_UM": {
+ *                            GDALMD_FWHM_UM: {
  *                                "array": "/sensor_band_parameters/fwhm",
  *                                "unit": "${units}"
  *                            }
@@ -1919,7 +1919,7 @@ lbl_next_depth:
  *                              "attribute": "center_wavelengths",
  *                              "unit": "${center_wavelengths_units}"
  *                            },
- *                            "FWHM_UM": {
+ *                            GDALMD_FWHM_UM: {
  *                              "attribute": "fwhm",
  *                              "unit": "${fwhm_units}"
  *                            }

--- a/gcore/multidim/gdalmultidim_array_bridge_classic.cpp
+++ b/gcore/multidim/gdalmultidim_array_bridge_classic.cpp
@@ -562,7 +562,7 @@ GDALRasterBandFromArray::GDALRasterBandFromArray(
                         GDALExtendedDataType::Create(GDT_Float64));
                     dt.FreeDynamicMemory(abyTmp.data());
                     SetMetadataItem(
-                        "CENTRAL_WAVELENGTH_UM",
+                        GDALMD_CENTRAL_WAVELENGTH_UM,
                         CPLSPrintf(
                             "%g", dfVal * aoBandImageryMetadata[j]
                                               .dfCentralWavelengthToMicrometer),
@@ -1408,7 +1408,7 @@ std::unique_ptr<GDALDatasetFromArray> GDALDatasetFromArray::Create(
         }
         for (const auto &oJsonItem : oRoot.GetChildren())
         {
-            if (oJsonItem.GetName() == "CENTRAL_WAVELENGTH_UM" ||
+            if (oJsonItem.GetName() == GDALMD_CENTRAL_WAVELENGTH_UM ||
                 oJsonItem.GetName() == "FWHM_UM")
             {
                 const auto osBandArrayFullname = oJsonItem.GetString("array");
@@ -1611,7 +1611,7 @@ std::unique_ptr<GDALDatasetFromArray> GDALDatasetFromArray::Create(
                     abstractArray = std::move(poArray);
                 else
                     abstractArray = std::move(poAttribute);
-                if (oJsonItem.GetName() == "CENTRAL_WAVELENGTH_UM")
+                if (oJsonItem.GetName() == GDALMD_CENTRAL_WAVELENGTH_UM)
                 {
                     item.poCentralWavelengthArray = std::move(abstractArray);
                     item.dfCentralWavelengthToMicrometer = dfConvToUM;
@@ -1871,7 +1871,7 @@ lbl_next_depth:
  *                         should be mapped as band metadata items in the
  *                         band IMAGERY domain.
  *                         The object currently accepts 2 members:
- *                         - "CENTRAL_WAVELENGTH_UM": Central Wavelength in
+ *                         - GDALMD_CENTRAL_WAVELENGTH_UM: Central Wavelength in
  *                           micrometers.
  *                         - "FWHM_UM": Full-width half-maximum
  *                           in micrometers.
@@ -1903,7 +1903,7 @@ lbl_next_depth:
  *
  *                         Example for EMIT datasets:
  *                         {
- *                            "CENTRAL_WAVELENGTH_UM": {
+ *                            GDALMD_CENTRAL_WAVELENGTH_UM: {
  *                                "array": "/sensor_band_parameters/wavelengths",
  *                                "unit": "${units}"
  *                            },
@@ -1915,7 +1915,7 @@ lbl_next_depth:
  *
  *                         Example for Planet Labs Tanager radiance products:
  *                         {
- *                            "CENTRAL_WAVELENGTH_UM": {
+ *                            GDALMD_CENTRAL_WAVELENGTH_UM: {
  *                              "attribute": "center_wavelengths",
  *                              "unit": "${center_wavelengths_units}"
  *                            },

--- a/gcore/multidim/gdalmultidim_array_bridge_classic.cpp
+++ b/gcore/multidim/gdalmultidim_array_bridge_classic.cpp
@@ -566,7 +566,7 @@ GDALRasterBandFromArray::GDALRasterBandFromArray(
                         CPLSPrintf(
                             "%g", dfVal * aoBandImageryMetadata[j]
                                               .dfCentralWavelengthToMicrometer),
-                        "IMAGERY");
+                        GDAL_MDD_IMAGERY);
                 }
             }
 
@@ -588,7 +588,7 @@ GDALRasterBandFromArray::GDALRasterBandFromArray(
                         GDALMD_FWHM_UM,
                         CPLSPrintf("%g", dfVal * aoBandImageryMetadata[j]
                                                      .dfFWHMToMicrometer),
-                        "IMAGERY");
+                        GDAL_MDD_IMAGERY);
                 }
             }
 

--- a/gcore/multidim/gdalmultidim_array_bridge_classic.cpp
+++ b/gcore/multidim/gdalmultidim_array_bridge_classic.cpp
@@ -1755,7 +1755,8 @@ lbl_next_depth:
         poDS->GetRasterCount() > 1)
     {
         poDS->m_bPixelInterleaved = true;
-        poDS->m_oMDD.SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+        poDS->m_oMDD.SetMetadataItem("INTERLEAVE", "PIXEL",
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     if (!array->GetFilename().empty() &&

--- a/gcore/multidim/gdalmultidim_array_bridge_classic.cpp
+++ b/gcore/multidim/gdalmultidim_array_bridge_classic.cpp
@@ -1871,9 +1871,9 @@ lbl_next_depth:
  *                         should be mapped as band metadata items in the
  *                         band IMAGERY domain.
  *                         The object currently accepts 2 members:
- *                         - GDALMD_CENTRAL_WAVELENGTH_UM: Central Wavelength in
+ *                         - "CENTRAL_WAVELENGTH_UM": Central Wavelength in
  *                           micrometers.
- *                         - GDALMD_FWHM_UM: Full-width half-maximum
+ *                         - "FWHM_UM": Full-width half-maximum
  *                           in micrometers.
  *                         The value of each member should be an object with the
  *                         following members:
@@ -1903,11 +1903,11 @@ lbl_next_depth:
  *
  *                         Example for EMIT datasets:
  *                         {
- *                            GDALMD_CENTRAL_WAVELENGTH_UM: {
+ *                            "CENTRAL_WAVELENGTH_UM": {
  *                                "array": "/sensor_band_parameters/wavelengths",
  *                                "unit": "${units}"
  *                            },
- *                            GDALMD_FWHM_UM: {
+ *                            "FWHM_UM": {
  *                                "array": "/sensor_band_parameters/fwhm",
  *                                "unit": "${units}"
  *                            }
@@ -1915,11 +1915,11 @@ lbl_next_depth:
  *
  *                         Example for Planet Labs Tanager radiance products:
  *                         {
- *                            GDALMD_CENTRAL_WAVELENGTH_UM: {
+ *                            "CENTRAL_WAVELENGTH_UM": {
  *                              "attribute": "center_wavelengths",
  *                              "unit": "${center_wavelengths_units}"
  *                            },
- *                            GDALMD_FWHM_UM: {
+ *                            "FWHM_UM": {
  *                              "attribute": "fwhm",
  *                              "unit": "${fwhm_units}"
  *                            }

--- a/gcore/multidim/gdalmultidim_array_resampled.cpp
+++ b/gcore/multidim/gdalmultidim_array_resampled.cpp
@@ -126,7 +126,7 @@ class GDALMDArrayResampledDataset final : public GDALPamDataset
         aosGeoLoc.SetNameValue("Y_BAND", "1");
         aosGeoLoc.SetNameValue("Y_DATASET", m_osFilenameLat.c_str());
         aosGeoLoc.SetNameValue("GEOREFERENCING_CONVENTION", "PIXEL_CENTER");
-        SetMetadata(aosGeoLoc.List(), "GEOLOCATION");
+        SetMetadata(aosGeoLoc.List(), GDAL_MDD_GEOLOCATION);
     }
 };
 

--- a/gcore/multidim/gdalmultidim_c_api_array.cpp
+++ b/gcore/multidim/gdalmultidim_c_api_array.cpp
@@ -1396,7 +1396,7 @@ GDALDatasetH GDALMDArrayAsClassicDatasetEx(GDALMDArrayH hArray, size_t iXDim,
  * For multi-byte data types, drivers should return a "ENDIANNESS" key whose
  * value is "LITTLE" or "BIG".
  *
- * For HDF5 and netCDF 4, the potential keys are "COMPRESSION" (possible values
+ * For HDF5 and netCDF 4, the potential keys are GDALMD_COMPRESSION (possible values
  * "DEFLATE" or "SZIP") and "FILTER" (if several filters, names are
  * comma-separated)
  *
@@ -1449,7 +1449,7 @@ bool GDALMDArray::GetRawBlockInfo(const uint64_t *panBlockCoordinates,
  * For multi-byte data types, drivers should return a "ENDIANNESS" key whose
  * value is "LITTLE" or "BIG".
  *
- * For HDF5 and netCDF 4, the potential keys are "COMPRESSION" (possible values
+ * For HDF5 and netCDF 4, the potential keys are GDALMD_COMPRESSION (possible values
  * "DEFLATE" or "SZIP") and "FILTER" (if several filters, names are
  * comma-separated)
  *

--- a/gcore/overview.cpp
+++ b/gcore/overview.cpp
@@ -5553,8 +5553,8 @@ CPLErr GDALRegenerateOverviewsEx(GDALRasterBandH hSrcBand, int nOverviewCount,
             poJob->args.eOvrDataType = poDstBand->GetRasterDataType();
             poJob->args.nOvrXSize = poDstBand->GetXSize();
             poJob->args.nOvrYSize = poDstBand->GetYSize();
-            const char *pszNBITS =
-                poDstBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+            const char *pszNBITS = poDstBand->GetMetadataItem(
+                GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
             poJob->args.nOvrNBITS = pszNBITS ? atoi(pszNBITS) : 0;
             poJob->args.dfXRatioDstToSrc = dfXRatioDstToSrc;
             poJob->args.dfYRatioDstToSrc = dfYRatioDstToSrc;
@@ -6646,7 +6646,7 @@ CPLErr GDALRegenerateOverviewsMultiBand(
                     poJob->args.nOvrXSize = poJob->poDstBand->GetXSize();
                     poJob->args.nOvrYSize = poJob->poDstBand->GetYSize();
                     const char *pszNBITS = poJob->poDstBand->GetMetadataItem(
-                        "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+                        GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
                     poJob->args.nOvrNBITS = pszNBITS ? atoi(pszNBITS) : 0;
                     poJob->args.dfXRatioDstToSrc = dfXRatioDstToSrc;
                     poJob->args.dfYRatioDstToSrc = dfYRatioDstToSrc;

--- a/gcore/overview.cpp
+++ b/gcore/overview.cpp
@@ -5554,7 +5554,7 @@ CPLErr GDALRegenerateOverviewsEx(GDALRasterBandH hSrcBand, int nOverviewCount,
             poJob->args.nOvrXSize = poDstBand->GetXSize();
             poJob->args.nOvrYSize = poDstBand->GetYSize();
             const char *pszNBITS =
-                poDstBand->GetMetadataItem("NBITS", "IMAGE_STRUCTURE");
+                poDstBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
             poJob->args.nOvrNBITS = pszNBITS ? atoi(pszNBITS) : 0;
             poJob->args.dfXRatioDstToSrc = dfXRatioDstToSrc;
             poJob->args.dfYRatioDstToSrc = dfYRatioDstToSrc;
@@ -6646,7 +6646,7 @@ CPLErr GDALRegenerateOverviewsMultiBand(
                     poJob->args.nOvrXSize = poJob->poDstBand->GetXSize();
                     poJob->args.nOvrYSize = poJob->poDstBand->GetYSize();
                     const char *pszNBITS = poJob->poDstBand->GetMetadataItem(
-                        "NBITS", "IMAGE_STRUCTURE");
+                        "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
                     poJob->args.nOvrNBITS = pszNBITS ? atoi(pszNBITS) : 0;
                     poJob->args.dfXRatioDstToSrc = dfXRatioDstToSrc;
                     poJob->args.dfYRatioDstToSrc = dfYRatioDstToSrc;

--- a/gcore/rasterio.cpp
+++ b/gcore/rasterio.cpp
@@ -5658,18 +5658,18 @@ CPLErr CPL_STDCALL GDALDatasetCopyWholeRaster(GDALDatasetH hSrcDS,
     /* -------------------------------------------------------------------- */
     bool bInterleave = false;
     const char *pszInterleave =
-        poSrcDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
+        poSrcDS->GetMetadataItem(GDALMD_INTERLEAVE, GDAL_MDD_IMAGE_STRUCTURE);
     if (pszInterleave != nullptr &&
         (EQUAL(pszInterleave, "PIXEL") || EQUAL(pszInterleave, "LINE")))
         bInterleave = true;
 
     pszInterleave =
-        poDstDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
+        poDstDS->GetMetadataItem(GDALMD_INTERLEAVE, GDAL_MDD_IMAGE_STRUCTURE);
     if (pszInterleave != nullptr &&
         (EQUAL(pszInterleave, "PIXEL") || EQUAL(pszInterleave, "LINE")))
         bInterleave = true;
 
-    pszInterleave = CSLFetchNameValue(papszOptions, "INTERLEAVE");
+    pszInterleave = CSLFetchNameValue(papszOptions, GDALMD_INTERLEAVE);
     if (pszInterleave != nullptr && EQUAL(pszInterleave, "PIXEL"))
         bInterleave = true;
     else if (pszInterleave != nullptr && EQUAL(pszInterleave, "BAND"))

--- a/gcore/rasterio.cpp
+++ b/gcore/rasterio.cpp
@@ -5348,13 +5348,13 @@ static void GDALCopyWholeRasterGetSwathSize(GDALRasterBand *poSrcPrototypeBand,
     int nSwathLines = nMaxBlockYSize;
 
     const char *pszSrcCompression = poSrcPrototypeBand->GetMetadataItem(
-        "COMPRESSION", GDAL_MDD_IMAGE_STRUCTURE);
+        GDALMD_COMPRESSION, GDAL_MDD_IMAGE_STRUCTURE);
     if (pszSrcCompression == nullptr)
     {
         auto poSrcDS = poSrcPrototypeBand->GetDataset();
         if (poSrcDS)
             pszSrcCompression = poSrcDS->GetMetadataItem(
-                "COMPRESSION", GDAL_MDD_IMAGE_STRUCTURE);
+                GDALMD_COMPRESSION, GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     /* -------------------------------------------------------------------- */

--- a/gcore/rasterio.cpp
+++ b/gcore/rasterio.cpp
@@ -1111,11 +1111,11 @@ CPLErr GDALRasterBand::RasterIOResampled(
         poMEMDS, 1, pabyData, eDTMem, nPSMem, nLSMem, false);
     poMEMDS->SetBand(1, GDALRasterBand::FromHandle(hMEMBand));
 
-    const char *pszNBITS = GetMetadataItem("NBITS", "IMAGE_STRUCTURE");
+    const char *pszNBITS = GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
     const int nNBITS = pszNBITS ? atoi(pszNBITS) : 0;
     if (pszNBITS)
         GDALRasterBand::FromHandle(hMEMBand)->SetMetadataItem(
-            "NBITS", pszNBITS, "IMAGE_STRUCTURE");
+            "NBITS", pszNBITS, GDAL_MDD_IMAGE_STRUCTURE);
 
     CPLErr eErr = CE_None;
 
@@ -1610,12 +1610,12 @@ CPLErr GDALDataset::RasterIOResampled(
         apoDstBands[i] = poMEMBand;
 #endif
         const char *pszNBITS =
-            poSrcBand->GetMetadataItem("NBITS", "IMAGE_STRUCTURE");
+            poSrcBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
         if (pszNBITS)
         {
             nNBITS = atoi(pszNBITS);
-            poMEMDS->GetRasterBand(i + 1)->SetMetadataItem("NBITS", pszNBITS,
-                                                           "IMAGE_STRUCTURE");
+            poMEMDS->GetRasterBand(i + 1)->SetMetadataItem(
+                "NBITS", pszNBITS, GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
 
@@ -5347,14 +5347,14 @@ static void GDALCopyWholeRasterGetSwathSize(GDALRasterBand *poSrcPrototypeBand,
     int nSwathCols = nXSize;
     int nSwathLines = nMaxBlockYSize;
 
-    const char *pszSrcCompression =
-        poSrcPrototypeBand->GetMetadataItem("COMPRESSION", "IMAGE_STRUCTURE");
+    const char *pszSrcCompression = poSrcPrototypeBand->GetMetadataItem(
+        "COMPRESSION", GDAL_MDD_IMAGE_STRUCTURE);
     if (pszSrcCompression == nullptr)
     {
         auto poSrcDS = poSrcPrototypeBand->GetDataset();
         if (poSrcDS)
-            pszSrcCompression =
-                poSrcDS->GetMetadataItem("COMPRESSION", "IMAGE_STRUCTURE");
+            pszSrcCompression = poSrcDS->GetMetadataItem(
+                "COMPRESSION", GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     /* -------------------------------------------------------------------- */
@@ -5658,12 +5658,13 @@ CPLErr CPL_STDCALL GDALDatasetCopyWholeRaster(GDALDatasetH hSrcDS,
     /* -------------------------------------------------------------------- */
     bool bInterleave = false;
     const char *pszInterleave =
-        poSrcDS->GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE");
+        poSrcDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
     if (pszInterleave != nullptr &&
         (EQUAL(pszInterleave, "PIXEL") || EQUAL(pszInterleave, "LINE")))
         bInterleave = true;
 
-    pszInterleave = poDstDS->GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE");
+    pszInterleave =
+        poDstDS->GetMetadataItem("INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE);
     if (pszInterleave != nullptr &&
         (EQUAL(pszInterleave, "PIXEL") || EQUAL(pszInterleave, "LINE")))
         bInterleave = true;

--- a/gcore/rasterio.cpp
+++ b/gcore/rasterio.cpp
@@ -1111,11 +1111,12 @@ CPLErr GDALRasterBand::RasterIOResampled(
         poMEMDS, 1, pabyData, eDTMem, nPSMem, nLSMem, false);
     poMEMDS->SetBand(1, GDALRasterBand::FromHandle(hMEMBand));
 
-    const char *pszNBITS = GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+    const char *pszNBITS =
+        GetMetadataItem(GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
     const int nNBITS = pszNBITS ? atoi(pszNBITS) : 0;
     if (pszNBITS)
         GDALRasterBand::FromHandle(hMEMBand)->SetMetadataItem(
-            "NBITS", pszNBITS, GDAL_MDD_IMAGE_STRUCTURE);
+            GDALMD_NBITS, pszNBITS, GDAL_MDD_IMAGE_STRUCTURE);
 
     CPLErr eErr = CE_None;
 
@@ -1610,12 +1611,12 @@ CPLErr GDALDataset::RasterIOResampled(
         apoDstBands[i] = poMEMBand;
 #endif
         const char *pszNBITS =
-            poSrcBand->GetMetadataItem("NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+            poSrcBand->GetMetadataItem(GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
         if (pszNBITS)
         {
             nNBITS = atoi(pszNBITS);
             poMEMDS->GetRasterBand(i + 1)->SetMetadataItem(
-                "NBITS", pszNBITS, GDAL_MDD_IMAGE_STRUCTURE);
+                GDALMD_NBITS, pszNBITS, GDAL_MDD_IMAGE_STRUCTURE);
         }
     }
 

--- a/gcore/rawdataset.cpp
+++ b/gcore/rawdataset.cpp
@@ -1607,8 +1607,8 @@ CPLErr RawDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
     // BlockBasedRasterIO, but rather used our optimized path in
     // RawRasterBand::IRasterIO().
     if (nXSize == nBufXSize && nYSize == nBufYSize && nBandCount > 1 &&
-        (pszInterleave = GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE")) !=
-            nullptr &&
+        (pszInterleave = GetMetadataItem(
+             "INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE)) != nullptr &&
         EQUAL(pszInterleave, "PIXEL"))
     {
         RawRasterBand *poFirstBand = nullptr;

--- a/gcore/rawdataset.cpp
+++ b/gcore/rawdataset.cpp
@@ -1608,7 +1608,7 @@ CPLErr RawDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
     // RawRasterBand::IRasterIO().
     if (nXSize == nBufXSize && nYSize == nBufYSize && nBandCount > 1 &&
         (pszInterleave = GetMetadataItem(
-             "INTERLEAVE", GDAL_MDD_IMAGE_STRUCTURE)) != nullptr &&
+             GDALMD_INTERLEAVE, GDAL_MDD_IMAGE_STRUCTURE)) != nullptr &&
         EQUAL(pszInterleave, "PIXEL"))
     {
         RawRasterBand *poFirstBand = nullptr;

--- a/ogr/ogrsf_frmts/arrow/ogrfeatherdriver.cpp
+++ b/ogr/ogrsf_frmts/arrow/ogrfeatherdriver.cpp
@@ -387,7 +387,7 @@ void OGRFeatherDriver::InitMetadata()
 
     {
         auto psOption = CPLCreateXMLNode(oTree.get(), CXT_Element, "Option");
-        CPLAddXMLAttributeAndValue(psOption, "name", "COMPRESSION");
+        CPLAddXMLAttributeAndValue(psOption, "name", GDALMD_COMPRESSION);
         CPLAddXMLAttributeAndValue(psOption, "type", "string-select");
         CPLAddXMLAttributeAndValue(psOption, "description",
                                    "Compression method");

--- a/ogr/ogrsf_frmts/arrow/ogrfeatherwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/arrow/ogrfeatherwriterlayer.cpp
@@ -144,7 +144,8 @@ bool OGRFeatherWriterLayer::SetOptions(const std::string &osFilename,
 
     m_osFIDColumn = CSLFetchNameValueDef(papszOptions, "FID", "");
 
-    const char *pszCompression = CSLFetchNameValue(papszOptions, "COMPRESSION");
+    const char *pszCompression =
+        CSLFetchNameValue(papszOptions, GDALMD_COMPRESSION);
     if (pszCompression == nullptr)
     {
         auto oResult = arrow::util::Codec::GetCompressionType("lz4");

--- a/ogr/ogrsf_frmts/cad/gdalcaddataset.cpp
+++ b/ogr/ogrsf_frmts/cad/gdalcaddataset.cpp
@@ -196,12 +196,12 @@ int GDALCADDataset::Open(GDALOpenInfo *poOpenInfo, CADFileIO *pFileIO,
                         CPLSPrintf("SUBDATASET_%d_NAME", nRasters),
                         CPLSPrintf("CAD:%s:%ld:%ld", osCADFilename.c_str(),
                                    nSubRasterLayer, nSubRasterFID),
-                        "SUBDATASETS");
+                        GDAL_MDD_SUBDATASETS);
                     GDALDataset::SetMetadataItem(
                         CPLSPrintf("SUBDATASET_%d_DESC", nRasters),
                         CPLSPrintf("%s - %ld", oLayer.getName().c_str(),
                                    nSubRasterFID),
-                        "SUBDATASETS");
+                        GDAL_MDD_SUBDATASETS);
                     nRasters++;
                 }
             }

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -3809,7 +3809,7 @@ char **GDALGeoPackageDataset::GetMetadataDomainList()
     if (!m_osRasterTable.empty())
         GetMetadata("GEOPACKAGE");
     return BuildMetadataDomainList(GDALPamDataset::GetMetadataDomainList(),
-                                   TRUE, "SUBDATASETS", nullptr);
+                                   TRUE, GDAL_MDD_SUBDATASETS, nullptr);
 }
 
 /************************************************************************/
@@ -4077,7 +4077,7 @@ CSLConstList GDALGeoPackageDataset::GetMetadata(const char *pszDomain)
 
 {
     pszDomain = CheckMetadataDomain(pszDomain);
-    if (pszDomain != nullptr && EQUAL(pszDomain, "SUBDATASETS"))
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_SUBDATASETS))
         return m_aosSubDatasets.List();
 
     if (m_bHasReadMetadataFromStorage)

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -2551,7 +2551,7 @@ bool GDALGeoPackageDataset::InitRaster(
         return false;
     }
 
-    GDALPamDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+    GDALPamDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                     GDAL_MDD_IMAGE_STRUCTURE);
     GDALPamDataset::SetMetadataItem("ZOOM_LEVEL",
                                     CPLSPrintf("%d", m_nZoomLevel));
@@ -5554,7 +5554,7 @@ int GDALGeoPackageDataset::Create(const char *pszFilename, int nXSize,
                            this, nTileWidth, nTileHeight));
         }
 
-        GDALPamDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+        GDALPamDataset::SetMetadataItem(GDALMD_INTERLEAVE, "PIXEL",
                                         GDAL_MDD_IMAGE_STRUCTURE);
         GDALPamDataset::SetMetadataItem("IDENTIFIER", m_osIdentifier);
         if (!m_osDescription.empty())

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -2368,11 +2368,11 @@ bool GDALGeoPackageDataset::InitRaster(
         {
             nBandCount = atoi(pszBAND_COUNT);
             if (nBandCount == 1)
-                GetMetadata("IMAGE_STRUCTURE");
+                GetMetadata(GDAL_MDD_IMAGE_STRUCTURE);
         }
         else
         {
-            GetMetadata("IMAGE_STRUCTURE");
+            GetMetadata(GDAL_MDD_IMAGE_STRUCTURE);
             nBandCount = m_nBandCountFromMetadata;
             if (nBandCount == 1)
                 m_eTF = GPKG_TF_PNG;
@@ -2551,7 +2551,8 @@ bool GDALGeoPackageDataset::InitRaster(
         return false;
     }
 
-    GDALPamDataset::SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+    GDALPamDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
+                                    GDAL_MDD_IMAGE_STRUCTURE);
     GDALPamDataset::SetMetadataItem("ZOOM_LEVEL",
                                     CPLSPrintf("%d", m_nZoomLevel));
 
@@ -3427,7 +3428,7 @@ CPLErr GDALGeoPackageDataset::IFlushCacheWithErrCode(bool bAtClosing)
             CPLFree(pszKey);
         }
         oMDMD.SetMetadata(aosMD.List());
-        oMDMD.SetMetadata(nullptr, "IMAGE_STRUCTURE");
+        oMDMD.SetMetadata(nullptr, GDAL_MDD_IMAGE_STRUCTURE);
 
         GDALPamDataset::FlushCache(bAtClosing);
     }
@@ -4153,7 +4154,7 @@ CSLConstList GDALGeoPackageDataset::GetMetadata(const char *pszDomain)
                     CSLConstList papszIter = papszDomainList;
                     while (papszIter && *papszIter)
                     {
-                        if (EQUAL(*papszIter, "IMAGE_STRUCTURE"))
+                        if (EQUAL(*papszIter, GDAL_MDD_IMAGE_STRUCTURE))
                         {
                             CSLConstList papszMD =
                                 oLocalMDMD.GetMetadata(*papszIter);
@@ -4199,7 +4200,7 @@ CSLConstList GDALGeoPackageDataset::GetMetadata(const char *pszDomain)
                                 m_osTFFromMetadata = pszTILE_FORMAT;
                                 oMDMD.SetMetadataItem("TILE_FORMAT",
                                                       pszTILE_FORMAT,
-                                                      "IMAGE_STRUCTURE");
+                                                      GDAL_MDD_IMAGE_STRUCTURE);
                             }
 
                             const char *pszNodataValue =
@@ -4707,7 +4708,7 @@ void GDALGeoPackageDataset::FlushMetadata()
         while (papszIter && *papszIter)
         {
             if (!EQUAL(*papszIter, "") &&
-                !EQUAL(*papszIter, "IMAGE_STRUCTURE") &&
+                !EQUAL(*papszIter, GDAL_MDD_IMAGE_STRUCTURE) &&
                 !EQUAL(*papszIter, "GEOPACKAGE"))
             {
                 oLocalMDMD.SetMetadata(oMDMD.GetMetadata(*papszIter),
@@ -4719,7 +4720,7 @@ void GDALGeoPackageDataset::FlushMetadata()
         {
             oLocalMDMD.SetMetadataItem(
                 "BAND_COUNT", CPLSPrintf("%d", m_nBandCountFromMetadata),
-                "IMAGE_STRUCTURE");
+                GDAL_MDD_IMAGE_STRUCTURE);
             if (nBands == 1)
             {
                 const auto poCT = GetRasterBand(1)->GetColorTable();
@@ -4738,7 +4739,7 @@ void GDALGeoPackageDataset::FlushMetadata()
                     }
                     osVal += '}';
                     oLocalMDMD.SetMetadataItem("COLOR_TABLE", osVal.c_str(),
-                                               "IMAGE_STRUCTURE");
+                                               GDAL_MDD_IMAGE_STRUCTURE);
                 }
             }
             if (nBands == 1)
@@ -4767,7 +4768,7 @@ void GDALGeoPackageDataset::FlushMetadata()
                 }
                 if (pszTILE_FORMAT)
                     oLocalMDMD.SetMetadataItem("TILE_FORMAT", pszTILE_FORMAT,
-                                               "IMAGE_STRUCTURE");
+                                               GDAL_MDD_IMAGE_STRUCTURE);
             }
         }
         if (GetRasterCount() > 0 &&
@@ -4780,7 +4781,7 @@ void GDALGeoPackageDataset::FlushMetadata()
             {
                 oLocalMDMD.SetMetadataItem("NODATA_VALUE",
                                            CPLSPrintf("%.17g", dfNoDataValue),
-                                           "IMAGE_STRUCTURE");
+                                           GDAL_MDD_IMAGE_STRUCTURE);
             }
         }
         for (int i = 1; i <= GetRasterCount(); ++i)
@@ -5554,7 +5555,7 @@ int GDALGeoPackageDataset::Create(const char *pszFilename, int nXSize,
         }
 
         GDALPamDataset::SetMetadataItem("INTERLEAVE", "PIXEL",
-                                        "IMAGE_STRUCTURE");
+                                        GDAL_MDD_IMAGE_STRUCTURE);
         GDALPamDataset::SetMetadataItem("IDENTIFIER", m_osIdentifier);
         if (!m_osDescription.empty())
             GDALPamDataset::SetMetadataItem("DESCRIPTION", m_osDescription);

--- a/ogr/ogrsf_frmts/ngw/gdalngwdataset.cpp
+++ b/ogr/ogrsf_frmts/ngw/gdalngwdataset.cpp
@@ -738,12 +738,12 @@ void OGRNGWDataset::AddRaster(const CPLJSONObject &oRasterJsonObj)
     GDALDataset::SetMetadataItem(CPLSPrintf("SUBDATASET_%d_NAME", nRasters + 1),
                                  CPLSPrintf("NGW:%s/resource/%s", osUrl.c_str(),
                                             osOutResourceId.c_str()),
-                                 "SUBDATASETS");
+                                 GDAL_MDD_SUBDATASETS);
     GDALDataset::SetMetadataItem(CPLSPrintf("SUBDATASET_%d_DESC", nRasters + 1),
                                  CPLSPrintf("%s (%s)",
                                             osOutResourceName.c_str(),
                                             osResourceType.c_str()),
-                                 "SUBDATASETS");
+                                 GDAL_MDD_SUBDATASETS);
     nRasters++;
 }
 

--- a/ogr/ogrsf_frmts/openfilegdb/gdalopenfilegdbrasterband.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/gdalopenfilegdbrasterband.cpp
@@ -1104,7 +1104,7 @@ GDALOpenFileGDBRasterBand::GDALOpenFileGDBRasterBand(
     nBlockYSize = nBlockHeight;
     if (nBitWidth < 8)
     {
-        SetMetadataItem("NBITS", CPLSPrintf("%d", nBitWidth),
+        SetMetadataItem(GDALMD_NBITS, CPLSPrintf("%d", nBitWidth),
                         GDAL_MDD_IMAGE_STRUCTURE);
     }
 }

--- a/ogr/ogrsf_frmts/openfilegdb/gdalopenfilegdbrasterband.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/gdalopenfilegdbrasterband.cpp
@@ -339,15 +339,17 @@ bool OGROpenFileGDBDataSource::OpenRaster(const GDALOpenInfo *poOpenInfo,
             break;
         case 4:
             m_eRasterCompression = Compression::LZ77;
-            SetMetadataItem("COMPRESSION", "DEFLATE", GDAL_MDD_IMAGE_STRUCTURE);
+            SetMetadataItem(GDALMD_COMPRESSION, "DEFLATE",
+                            GDAL_MDD_IMAGE_STRUCTURE);
             break;
         case 8:
             m_eRasterCompression = Compression::JPEG;
-            SetMetadataItem("COMPRESSION", "JPEG", GDAL_MDD_IMAGE_STRUCTURE);
+            SetMetadataItem(GDALMD_COMPRESSION, "JPEG",
+                            GDAL_MDD_IMAGE_STRUCTURE);
             break;
         case 12:
             m_eRasterCompression = Compression::JPEG2000;
-            SetMetadataItem("COMPRESSION", "JPEG2000",
+            SetMetadataItem(GDALMD_COMPRESSION, "JPEG2000",
                             GDAL_MDD_IMAGE_STRUCTURE);
             break;
         default:

--- a/ogr/ogrsf_frmts/openfilegdb/gdalopenfilegdbrasterband.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/gdalopenfilegdbrasterband.cpp
@@ -339,15 +339,16 @@ bool OGROpenFileGDBDataSource::OpenRaster(const GDALOpenInfo *poOpenInfo,
             break;
         case 4:
             m_eRasterCompression = Compression::LZ77;
-            SetMetadataItem("COMPRESSION", "DEFLATE", "IMAGE_STRUCTURE");
+            SetMetadataItem("COMPRESSION", "DEFLATE", GDAL_MDD_IMAGE_STRUCTURE);
             break;
         case 8:
             m_eRasterCompression = Compression::JPEG;
-            SetMetadataItem("COMPRESSION", "JPEG", "IMAGE_STRUCTURE");
+            SetMetadataItem("COMPRESSION", "JPEG", GDAL_MDD_IMAGE_STRUCTURE);
             break;
         case 12:
             m_eRasterCompression = Compression::JPEG2000;
-            SetMetadataItem("COMPRESSION", "JPEG2000", "IMAGE_STRUCTURE");
+            SetMetadataItem("COMPRESSION", "JPEG2000",
+                            GDAL_MDD_IMAGE_STRUCTURE);
             break;
         default:
         {
@@ -593,7 +594,7 @@ bool OGROpenFileGDBDataSource::OpenRaster(const GDALOpenInfo *poOpenInfo,
 
     if (m_oMapGDALBandToGDBBandId.size() > 1)
     {
-        SetMetadataItem("INTERLEAVE", "BAND", "IMAGE_STRUCTURE");
+        SetMetadataItem("INTERLEAVE", "BAND", GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     // Figure out number of overviews by looking at the biggest block_key
@@ -900,11 +901,11 @@ void OGROpenFileGDBDataSource::GuessJPEGQuality(int nOverviewCount)
                     if (poJPEGDS)
                     {
                         const char *pszQuality = poJPEGDS->GetMetadataItem(
-                            "JPEG_QUALITY", "IMAGE_STRUCTURE");
+                            "JPEG_QUALITY", GDAL_MDD_IMAGE_STRUCTURE);
                         if (pszQuality)
                         {
                             SetMetadataItem("JPEG_QUALITY", pszQuality,
-                                            "IMAGE_STRUCTURE");
+                                            GDAL_MDD_IMAGE_STRUCTURE);
                         }
                     }
                     VSIUnlink(osTmpFilename);
@@ -1102,7 +1103,7 @@ GDALOpenFileGDBRasterBand::GDALOpenFileGDBRasterBand(
     if (nBitWidth < 8)
     {
         SetMetadataItem("NBITS", CPLSPrintf("%d", nBitWidth),
-                        "IMAGE_STRUCTURE");
+                        GDAL_MDD_IMAGE_STRUCTURE);
     }
 }
 

--- a/ogr/ogrsf_frmts/openfilegdb/gdalopenfilegdbrasterband.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/gdalopenfilegdbrasterband.cpp
@@ -594,7 +594,7 @@ bool OGROpenFileGDBDataSource::OpenRaster(const GDALOpenInfo *poOpenInfo,
 
     if (m_oMapGDALBandToGDBBandId.size() > 1)
     {
-        SetMetadataItem("INTERLEAVE", "BAND", GDAL_MDD_IMAGE_STRUCTURE);
+        SetMetadataItem(GDALMD_INTERLEAVE, "BAND", GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     // Figure out number of overviews by looking at the biggest block_key

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdatasource.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdatasource.cpp
@@ -1290,7 +1290,7 @@ bool OGROpenFileGDBDataSource::IsLayerPrivate(int iLayer) const
 
 CSLConstList OGROpenFileGDBDataSource::GetMetadata(const char *pszDomain)
 {
-    if (pszDomain && EQUAL(pszDomain, "SUBDATASETS"))
+    if (pszDomain && EQUAL(pszDomain, GDAL_MDD_SUBDATASETS))
         return m_aosSubdatasets.List();
     return GDALDataset::GetMetadata(pszDomain);
 }

--- a/ogr/ogrsf_frmts/parquet/ogrparquetdriver.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetdriver.cpp
@@ -826,7 +826,7 @@ void OGRParquetDriver::InitMetadata()
 
     {
         auto psOption = CPLCreateXMLNode(oTree.get(), CXT_Element, "Option");
-        CPLAddXMLAttributeAndValue(psOption, "name", "COMPRESSION");
+        CPLAddXMLAttributeAndValue(psOption, "name", GDALMD_COMPRESSION);
         CPLAddXMLAttributeAndValue(psOption, "type", "string-select");
         CPLAddXMLAttributeAndValue(psOption, "description",
                                    "Compression method");

--- a/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
@@ -439,7 +439,8 @@ bool OGRParquetWriterLayer::SetOptions(
 
     m_osFIDColumn = CSLFetchNameValueDef(papszOptions, "FID", "");
 
-    const char *pszCompression = CSLFetchNameValue(papszOptions, "COMPRESSION");
+    const char *pszCompression =
+        CSLFetchNameValue(papszOptions, GDALMD_COMPRESSION);
     if (pszCompression == nullptr)
     {
         auto oResult = arrow::util::Codec::GetCompressionType("snappy");

--- a/ogr/ogrsf_frmts/plscenes/ogrplscenesdatav1dataset.cpp
+++ b/ogr/ogrsf_frmts/plscenes/ogrplscenesdatav1dataset.cpp
@@ -475,7 +475,7 @@ retry:
             if (nSubDataset != 0)
             {
                 GDALDataset *poDS = new OGRPLScenesDataV1Dataset();
-                poDS->SetMetadata(papszSubdatasets, "SUBDATASETS");
+                poDS->SetMetadata(papszSubdatasets, GDAL_MDD_SUBDATASETS);
                 CSLDestroy(papszSubdatasets);
                 return poDS;
             }

--- a/ogr/ogrsf_frmts/pmtiles/ogrpmtilesdataset.cpp
+++ b/ogr/ogrsf_frmts/pmtiles/ogrpmtilesdataset.cpp
@@ -523,7 +523,7 @@ bool OGRPMTilesDataset::OpenRaster(int nZoomLevel)
     m_osTmpGPKGFilename = VSIMemGenerateHiddenFilename("pmtiles.gti.gpkg");
 
     if (nTargetBands > 1)
-        SetMetadataItem("INTERLEAVING", "PIXEL", "IMAGE_STRUCTURE");
+        SetMetadataItem("INTERLEAVING", "PIXEL", GDAL_MDD_IMAGE_STRUCTURE);
 
     // Create overview datasets
     for (int iOvr = 0; iOvr < m_nZoomLevel - m_nMinZoomLevel; ++iOvr)
@@ -556,7 +556,7 @@ bool OGRPMTilesDataset::OpenRaster(int nZoomLevel)
 
         if (nTargetBands > 1)
             poOvrDS->SetMetadataItem("INTERLEAVING", "PIXEL",
-                                     "IMAGE_STRUCTURE");
+                                     GDAL_MDD_IMAGE_STRUCTURE);
 
         m_apoOverviews.push_back(std::move(poOvrDS));
     }

--- a/ogr/ogrsf_frmts/sqlite/rasterlite2.cpp
+++ b/ogr/ogrsf_frmts/sqlite/rasterlite2.cpp
@@ -475,7 +475,7 @@ bool OGRSQLiteDataSource::OpenRasterSubDataset(
     if (pszCompression != nullptr)
     {
         GDALDataset::SetMetadataItem("COMPRESSION", pszCompression,
-                                     "IMAGE_STRUCTURE");
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     if (nQuality != 0 && (nCompression == RL2_COMPRESSION_JPEG ||
@@ -483,7 +483,7 @@ bool OGRSQLiteDataSource::OpenRasterSubDataset(
                           nCompression == RL2_COMPRESSION_LOSSY_JP2))
     {
         GDALDataset::SetMetadataItem("QUALITY", CPLSPrintf("%d", nQuality),
-                                     "IMAGE_STRUCTURE");
+                                     GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     // Get tile dimensions
@@ -899,7 +899,7 @@ RL2RasterBand::RL2RasterBand(int nBandIn, int nPixelType, GDALDataType eDT,
     {
         GDALRasterBand::SetMetadataItem(
             (nBits == 1 && bPromote1BitAs8Bit) ? "SOURCE_NBITS" : "NBITS",
-            CPLSPrintf("%d", nBits), "IMAGE_STRUCTURE");
+            CPLSPrintf("%d", nBits), GDAL_MDD_IMAGE_STRUCTURE);
     }
 
     if (nPixelType == RL2_PIXEL_MONOCHROME || nPixelType == RL2_PIXEL_GRAYSCALE)
@@ -929,8 +929,8 @@ RL2RasterBand::RL2RasterBand(const RL2RasterBand *poOther)
     GDALRasterBand::SetMetadataItem(
         "NBITS",
         const_cast<RL2RasterBand *>(poOther)->GetMetadataItem(
-            "NBITS", "IMAGE_STRUCTURE"),
-        "IMAGE_STRUCTURE");
+            "NBITS", GDAL_MDD_IMAGE_STRUCTURE),
+        GDAL_MDD_IMAGE_STRUCTURE);
     m_eColorInterp = poOther->m_eColorInterp;
     m_bHasNoData = poOther->m_bHasNoData;
     m_dfNoDataValue = poOther->m_dfNoDataValue;
@@ -1554,7 +1554,7 @@ GDALDataset *OGRSQLiteDriverCreateCopy(const char *pszName,
     else
     {
         pszNBITS = poSrcDS->GetRasterBand(1)->GetMetadataItem(
-            "NBITS", "IMAGE_STRUCTURE");
+            "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
         if (pszNBITS != nullptr)
         {
             nBITS = atoi(pszNBITS);

--- a/ogr/ogrsf_frmts/sqlite/rasterlite2.cpp
+++ b/ogr/ogrsf_frmts/sqlite/rasterlite2.cpp
@@ -2248,7 +2248,7 @@ CPLErr OGRSQLiteDataSource::IBuildOverviews(
 
 CSLConstList OGRSQLiteDataSource::GetMetadata(const char *pszDomain)
 {
-    if (pszDomain != nullptr && EQUAL(pszDomain, "SUBDATASETS") &&
+    if (pszDomain != nullptr && EQUAL(pszDomain, GDAL_MDD_SUBDATASETS) &&
         m_aosSubDatasets.size() > 2)
     {
         return m_aosSubDatasets.List();

--- a/ogr/ogrsf_frmts/sqlite/rasterlite2.cpp
+++ b/ogr/ogrsf_frmts/sqlite/rasterlite2.cpp
@@ -898,7 +898,7 @@ RL2RasterBand::RL2RasterBand(int nBandIn, int nPixelType, GDALDataType eDT,
     if ((nBits % 8) != 0)
     {
         GDALRasterBand::SetMetadataItem(
-            (nBits == 1 && bPromote1BitAs8Bit) ? "SOURCE_NBITS" : "NBITS",
+            (nBits == 1 && bPromote1BitAs8Bit) ? "SOURCE_NBITS" : GDALMD_NBITS,
             CPLSPrintf("%d", nBits), GDAL_MDD_IMAGE_STRUCTURE);
     }
 
@@ -927,9 +927,9 @@ RL2RasterBand::RL2RasterBand(const RL2RasterBand *poOther)
     nBlockXSize = poOther->nBlockXSize;
     nBlockYSize = poOther->nBlockYSize;
     GDALRasterBand::SetMetadataItem(
-        "NBITS",
+        GDALMD_NBITS,
         const_cast<RL2RasterBand *>(poOther)->GetMetadataItem(
-            "NBITS", GDAL_MDD_IMAGE_STRUCTURE),
+            GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE),
         GDAL_MDD_IMAGE_STRUCTURE);
     m_eColorInterp = poOther->m_eColorInterp;
     m_bHasNoData = poOther->m_bHasNoData;
@@ -1540,7 +1540,7 @@ GDALDataset *OGRSQLiteDriverCreateCopy(const char *pszName,
     }
 
     // Deal with NBITS
-    const char *pszNBITS = CSLFetchNameValue(papszOptions, "NBITS");
+    const char *pszNBITS = CSLFetchNameValue(papszOptions, GDALMD_NBITS);
     int nBITS = 0;
     if (pszNBITS != nullptr)
     {
@@ -1554,7 +1554,7 @@ GDALDataset *OGRSQLiteDriverCreateCopy(const char *pszName,
     else
     {
         pszNBITS = poSrcDS->GetRasterBand(1)->GetMetadataItem(
-            "NBITS", GDAL_MDD_IMAGE_STRUCTURE);
+            GDALMD_NBITS, GDAL_MDD_IMAGE_STRUCTURE);
         if (pszNBITS != nullptr)
         {
             nBITS = atoi(pszNBITS);

--- a/ogr/ogrsf_frmts/sqlite/rasterlite2.cpp
+++ b/ogr/ogrsf_frmts/sqlite/rasterlite2.cpp
@@ -474,7 +474,7 @@ bool OGRSQLiteDataSource::OpenRasterSubDataset(
 
     if (pszCompression != nullptr)
     {
-        GDALDataset::SetMetadataItem("COMPRESSION", pszCompression,
+        GDALDataset::SetMetadataItem(GDALMD_COMPRESSION, pszCompression,
                                      GDAL_MDD_IMAGE_STRUCTURE);
     }
 

--- a/scripts/collect_config_options.py
+++ b/scripts/collect_config_options.py
@@ -29,7 +29,9 @@ def collect_config_options(filename):
             if pos >= 0:
                 pos_start = pos + len(func_name + "(")
                 option = None
-                if pos_start < len(l) and l[pos_start] == '"':
+                if l[pos_start:].startswith("GDALMD_INTERLEAVE,"):
+                    option = "INTERLEAVE"
+                elif pos_start < len(l) and l[pos_start] == '"':
                     pos_end = l.find('"', pos_start + 1)
                     if pos_end + 1 < len(l) and l[pos_end + 1] == ",":
                         option = l[pos_start + 1 : pos_end]


### PR DESCRIPTION
This should make them more discoverable for users, and limit the risk of typos in our code base (or users' ones)