### PR TITLE
autotest: avoid use of tempfile module

### DIFF
--- a/autotest/gcore/vsis3.py
+++ b/autotest/gcore/vsis3.py
@@ -17,7 +17,6 @@ import os
 import os.path
 import stat
 import sys
-import tempfile
 import urllib
 
 import gdaltest
@@ -5356,11 +5355,10 @@ aws_secret_access_key = bar
 # Read credentials from sts AssumeRoleWithWebIdentity
 @pytest.mark.skipif(sys.platform not in ("linux", "win32"), reason="Incorrect platform")
 def test_vsis3_read_credentials_sts_assume_role_with_web_identity(
-    aws_test_config, webserver_port
+    aws_test_config, webserver_port, tmp_path
 ):
-    fp = tempfile.NamedTemporaryFile(delete=False)
-    fp.write(b"token")
-    fp.close()
+    with open(tmp_path / "token.txt", "wb") as fp:
+        fp.write(b"token")
 
     aws_role_arn = "arn:aws:iam:role/test"
     aws_role_arn_encoded = urllib.parse.quote_plus(aws_role_arn)
@@ -7167,12 +7165,12 @@ region = us-east-1
 # Test credential_process with invalid JSON
 
 
-def test_vsis3_credential_process_invalid_json(tmp_vsimem, aws_test_config):
+def test_vsis3_credential_process_invalid_json(tmp_vsimem, aws_test_config, tmp_path):
     script_content = """#!/usr/bin/env python3
 print('invalid json response')
 """
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+    with open(tmp_path / "script.py", "w") as f:
         f.write(script_content)
         script_path = f.name
 
@@ -7211,7 +7209,7 @@ region = us-east-1
 # Test credential_process with missing required fields
 
 
-def test_vsis3_credential_process_missing_fields(tmp_vsimem, aws_test_config):
+def test_vsis3_credential_process_missing_fields(tmp_vsimem, aws_test_config, tmp_path):
 
     script_content = """#!/usr/bin/env python3
 import json
@@ -7219,7 +7217,7 @@ credentials = {"AccessKeyId": "test_key"}
 print(json.dumps(credentials))
 """
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+    with open(tmp_path / "script.py", "w") as f:
         f.write(script_content)
         script_path = f.name
 

--- a/autotest/gdrivers/sentinel2.py
+++ b/autotest/gdrivers/sentinel2.py
@@ -14,8 +14,6 @@
 
 import os
 import sys
-import tempfile
-import uuid
 import zipfile
 
 import gdaltest
@@ -2656,56 +2654,30 @@ def test_sentinel2_l1c_safe_compact_3():
 # Test opening zipped versions of S2 datasets
 
 
-def test_sentinel2_zipped():
-    # S2 L1C
-    zipname = str(uuid.uuid4()) + ".zip"
-    with tempfile.TemporaryDirectory() as tmpdir:
-        zipwpath = os.path.join(tmpdir, zipname)
-        _zip_a_dir(zipwpath, "data/sentinel2/fake_l1c/S2A_OPER_PRD_MSIL1C.SAFE/")
-        assert os.path.exists(zipwpath)
-        ds = gdal.Open(zipwpath)
-        assert ds is not None
-
-    # S2 L1B
-    zipname = str(uuid.uuid4()) + ".zip"
-    with tempfile.TemporaryDirectory() as tmpdir:
-        zipwpath = os.path.join(tmpdir, zipname)
-        _zip_a_dir(zipwpath, "data/sentinel2/fake_l1b/S2B_OPER_PRD_MSIL1B.SAFE/")
-        assert os.path.exists(zipwpath)
-        ds = gdal.Open(zipwpath)
-        assert ds is not None
-
-    # S2 L1A
-    zipname = str(uuid.uuid4()) + ".zip"
-    with tempfile.TemporaryDirectory() as tmpdir:
-        zipwpath = os.path.join(tmpdir, zipname)
-        _zip_a_dir(zipwpath, "data/sentinel2/fake_l2a/S2A_USER_PRD_MSIL2A.SAFE/")
-        assert os.path.exists(zipwpath)
-        ds = gdal.Open(zipwpath)
-        assert ds is not None
-
-    # S2 L2A
-    zipname = str(uuid.uuid4()) + ".zip"
-    with tempfile.TemporaryDirectory() as tmpdir:
-        zipwpath = os.path.join(tmpdir, zipname)
-        _zip_a_dir(
-            zipwpath,
+@pytest.mark.parametrize(
+    "src_dir",
+    (
+        pytest.param("data/sentinel2/fake_l1c/S2A_OPER_PRD_MSIL1C.SAFE/", id="S2 L1C"),
+        pytest.param("data/sentinel2/fake_l1b/S2B_OPER_PRD_MSIL1B.SAFE/", id="S2 L1B"),
+        pytest.param("data/sentinel2/fake_l2a/S2A_USER_PRD_MSIL2A.SAFE/", id="S2 L1A"),
+        pytest.param(
             "data/sentinel2/fake_l2a_MSIL2A/S2A_MSIL2A_20180818T094031_N0208_R036_T34VFJ_20180818T120345.SAFE/",
-        )
-        assert os.path.exists(zipwpath)
-        ds = gdal.Open(zipwpath)
-        assert ds is not None
+            id="S2 L2A",
+        ),
+        pytest.param(
+            "data/sentinel2/fake_l1c_safecompact/S2A_MSIL1C_test.SAFE/",
+            id="S2 L1c SAFE compact",
+        ),
+    ),
+)
+def test_sentinel2_zipped(src_dir, tmp_path):
 
-    # S2 L1c SAFE compact
-    zipname = str(uuid.uuid4()) + ".zip"
-    with tempfile.TemporaryDirectory() as tmpdir:
-        zipwpath = os.path.join(tmpdir, zipname)
-        _zip_a_dir(
-            zipwpath, "data/sentinel2/fake_l1c_safecompact/S2A_MSIL1C_test.SAFE/"
-        )
-        assert os.path.exists(zipwpath)
-        ds = gdal.Open(zipwpath)
-        assert ds is not None
+    zipwpath = tmp_path / "S2.zip"
+    _zip_a_dir(zipwpath, src_dir)
+    assert os.path.exists(zipwpath)
+
+    ds = gdal.Open(zipwpath)
+    assert ds is not None
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_miramon_vector.py
+++ b/autotest/ogr/ogr_miramon_vector.py
@@ -1571,15 +1571,11 @@ def test_ogr_miramon_write_launder_layer_name(tmp_path):
 ###############################################################################
 
 
-def test_ogr_miramon_vector_sql_select_preserve_reserved_fields():
+def test_ogr_miramon_vector_sql_select_preserve_reserved_fields(tmp_path):
 
     src_filename = "data/miramon/Polygons/SimplePolygons/SimplePolFile.pol"
 
-    import os
-    import tempfile
-
-    tmp_dir = tempfile.mkdtemp()
-    out_filename = os.path.join(tmp_dir, "selected.pol")
+    out_filename = str(tmp_path / "selected.pol")
 
     ds = ogr.Open(src_filename)
     assert ds is not None

--- a/autotest/pyscripts/gdal2tiles/test_option_parser.py
+++ b/autotest/pyscripts/gdal2tiles/test_option_parser.py
@@ -14,7 +14,6 @@
 ###############################################################################
 
 import os
-import tempfile
 from unittest import TestCase, mock
 
 import pytest
@@ -29,44 +28,51 @@ class AttrDict(dict):
         self.__dict__ = self
 
 
-class OptionParserInputOutputTest(TestCase):
-    def test_vanilla_input_output(self):
-        input_file = "../../gcore/data/byte.tif"
-        output_folder = tempfile.mkdtemp()
-        parsed_input, parsed_output, options, tmsMap = gdal2tiles.process_args(
-            [input_file, output_folder]
-        )
+def test_vanilla_input_output(tmp_path):
+    input_file = "../../gcore/data/byte.tif"
+    output_folder = str(tmp_path)
+    parsed_input, parsed_output, options, tmsMap = gdal2tiles.process_args(
+        [input_file, output_folder]
+    )
 
-        self.assertEqual(parsed_input, input_file)
-        self.assertEqual(parsed_output, output_folder)
-        self.assertNotEqual(options, {})
-        self.assertNotEqual(tmsMap, {})
+    assert parsed_input == input_file
+    assert parsed_output == output_folder
+    assert options != {}
+    assert tmsMap != {}
 
-    def test_output_folder_is_the_input_file_folder_when_none_passed(self):
-        input_file = "../../gcore/data/byte.tif"
-        _, parsed_output, _, _ = gdal2tiles.process_args([input_file])
 
-        self.assertEqual(parsed_output, "byte")
+def test_output_folder_is_the_input_file_folder_when_none_passed():
+    input_file = "../../gcore/data/byte.tif"
+    _, parsed_output, _, _ = gdal2tiles.process_args([input_file])
 
-    def _asserts_exits_with_code_2(self, params):
-        with self.assertRaises(SystemExit) as cm:
-            gdal2tiles.process_args(params)
+    assert parsed_output == "byte"
 
-        e = cm.exception
-        self.assertEqual(str(e), "2")
 
-    def test_exits_when_0_args_passed(self):
-        self._asserts_exits_with_code_2([])
+@pytest.mark.parametrize(
+    "params",
+    (
+        pytest.param([], id="0 args passed"),
+        pytest.param(
+            ["input1.tiff", "input2.tiff", "output_folder"],
+            id="more than 2 free parameters",
+        ),
+        pytest.param(["foobar.tiff"], id="input file does not exist"),
+    ),
+)
+def test_exits_invalid_input_output(params):
 
-    def test_exits_when_more_than_2_free_parameters(self):
-        self._asserts_exits_with_code_2(["input1.tiff", "input2.tiff", "output_folder"])
+    with pytest.raises(SystemExit) as cm:
+        gdal2tiles.process_args(params)
 
-    def test_exits_when_input_file_does_not_exist(self):
-        self._asserts_exits_with_code_2(["foobar.tiff"])
+    assert str(cm.value) == "2"
 
-    def test_exits_when_first_param_is_not_a_file(self):
-        folder = tempfile.gettempdir()
-        self._asserts_exits_with_code_2([folder])
+
+def test_exits_first_param_is_not_a_file(tmp_path):
+
+    with pytest.raises(SystemExit) as cm:
+        gdal2tiles.process_args([str(tmp_path)])
+
+    assert str(cm.value) == "2"
 
 
 def mock_GetDriverByName_wo_webp(name, orig_GetDriverByName=gdal.GetDriverByName):

--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -15,7 +15,6 @@
 import collections
 import json
 import pathlib
-import tempfile
 
 import gdaltest
 import ogrtest
@@ -1907,6 +1906,7 @@ def test_width_precision_flags(
     expected_dest_precision,
     exp_src_decimal_flag,
     exp_src_minus_flag,
+    tmp_path,
 ):
     """Test precision/width (scale) conversions for numeric type"""
 
@@ -1923,11 +1923,11 @@ def test_width_precision_flags(
     # but it writes the full precision value in the GML without warning
     PRECISION_UNRELIABLE_DRIVERS = ("GML", "CSV")
 
-    src_file_base_name = "ogr_precision_flags_test"
-    src_file_name = tempfile.mktemp(src_ext, src_file_base_name)
+    src_file_base_name = "ogr_precision_flags_test_src"
+    src_file_name = tmp_path / f"{src_file_base_name}.{src_ext}"
 
-    dest_file_base_name = "ogr_precision_flags_test"
-    dest_file_name = tempfile.mktemp(dest_ext, dest_file_base_name)
+    dest_file_base_name = "ogr_precision_flags_test_dst"
+    dest_file_name = tmp_path / f"{dest_file_base_name}.{dest_ext}"
 
     dr = ogr.GetDriverByName(src_driver)
     src_width_includes_sign = (


### PR DESCRIPTION
Prevents pollution of `/tmp` directory by files that are not removed at the end of a test run.