### PR TITLE
Add string_view utility functions, strict string->numeric parser

### DIFF
--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -3283,7 +3283,17 @@ CPLErr GDALWarpOperation::ComputeSourceWindow(
     if (const char *pszSourceExtra =
             CSLFetchNameValue(psOptions->papszWarpOptions, "SOURCE_EXTRA"))
     {
-        const int nSrcExtra = atoi(pszSourceExtra);
+        int nSrcExtra = cpl::strict_parse<int>(pszSourceExtra).value_or(-1);
+
+        if (nSrcExtra < 0)
+        {
+            // no point raising CE_Failure because it will get converted into
+            // a warning at an outer scope
+            CPLError(CE_Warning, CPLE_IllegalArg,
+                     "SOURCE_EXTRA must be a positive integer or zero.");
+            nSrcExtra = 0;
+        }
+
         nXRadius += nSrcExtra;
         nYRadius += nSrcExtra;
     }

--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -723,18 +723,33 @@ GDALWarpOperation::Initialize(const GDALWarpOptions *psNewOptions,
         }
     }
 
-    if (eErr == CE_None && psOptions->hDstDS &&
-        CPLTestBool(CSLFetchNameValueDef(psOptions->papszWarpOptions,
-                                         "RESET_DEST_PIXELS", "NO")))
+    if (eErr == CE_None && psOptions->hDstDS)
     {
-        for (int i = 0; eErr == CE_None && i < psOptions->nBandCount; ++i)
+        const auto oResetDestPixels =
+            cpl::strict_parse<bool>(CSLFetchNameValueDef(
+                psOptions->papszWarpOptions, "RESET_DEST_PIXELS", "NO"));
+
+        if (!oResetDestPixels.has_value())
         {
-            eErr = GDALFillRaster(
-                GDALGetRasterBand(psOptions->hDstDS, psOptions->panDstBands[i]),
-                psOptions->padfDstNoDataReal ? psOptions->padfDstNoDataReal[i]
-                                             : 0.0,
-                psOptions->padfDstNoDataImag ? psOptions->padfDstNoDataImag[i]
-                                             : 0.0);
+            CPLError(CE_Failure, CPLE_IllegalArg,
+                     "Invalid value of RESET_DEST_PIXELS");
+            return CE_Failure;
+        }
+
+        if (oResetDestPixels.value())
+        {
+            for (int i = 0; eErr == CE_None && i < psOptions->nBandCount; ++i)
+            {
+                eErr =
+                    GDALFillRaster(GDALGetRasterBand(psOptions->hDstDS,
+                                                     psOptions->panDstBands[i]),
+                                   psOptions->padfDstNoDataReal
+                                       ? psOptions->padfDstNoDataReal[i]
+                                       : 0.0,
+                                   psOptions->padfDstNoDataImag
+                                       ? psOptions->padfDstNoDataImag[i]
+                                       : 0.0);
+            }
         }
     }
 

--- a/apps/gdal_rasterize_lib.cpp
+++ b/apps/gdal_rasterize_lib.cpp
@@ -678,16 +678,16 @@ static CPLErr ProcessLayer(OGRLayerH hSrcLayer, bool bSRSIsSet,
                     {
                         const char *pszAttribute =
                             OGR_F_GetFieldAsString(hFeat, iBurnField);
-                        char *end;
-                        dfBurnValue = CPLStrtod(pszAttribute, &end);
 
-                        while (isspace(*end) && *end != '\0')
+                        if (auto parsed =
+                                cpl::strict_parse<double>(pszAttribute);
+                            parsed.has_value())
                         {
-                            end++;
+                            dfBurnValue = parsed.value();
                         }
-
-                        if (*end != '\0')
+                        else
                         {
+                            dfBurnValue = 0;
                             CPLErrorOnce(
                                 CE_Warning, CPLE_AppDefined,
                                 "Failed to parse attribute value %s of feature "

--- a/apps/gdalalg_raster_calc.cpp
+++ b/apps/gdalalg_raster_calc.cpp
@@ -396,9 +396,12 @@ CreateDerivedBandXML(const char *pszVRTFilename, CPLXMLNode *root, int nXOut,
         }
         else if (noDataText != "none")
         {
-            char *end;
-            dstNoData = CPLStrtod(noDataText.c_str(), &end);
-            if (end != noDataText.c_str() + noDataText.size())
+            if (auto parsed = cpl::strict_parse<double>(noDataText);
+                parsed.has_value())
+            {
+                dstNoData = parsed.value();
+            }
+            else
             {
                 CPLError(CE_Failure, CPLE_AppDefined,
                          "Invalid NoData value: %s", noDataText.c_str());

--- a/apps/gdalalg_raster_resize.cpp
+++ b/apps/gdalalg_raster_resize.cpp
@@ -56,28 +56,13 @@ GDALRasterResizeAlgorithm::GDALRasterResizeAlgorithm(bool standaloneStep)
             {
                 for (const auto &s : m_size)
                 {
-                    char *endptr = nullptr;
-                    const double val = CPLStrtod(s.c_str(), &endptr);
-                    bool ok = false;
-                    if (endptr == s.c_str() + s.size())
+                    auto trimmed = cpl::trim(s);
+                    if (!trimmed.empty() && trimmed.back() == '%')
                     {
-                        if (val >= 0 && val <= INT_MAX &&
-                            static_cast<int>(val) == val)
-                        {
-                            ok = true;
-                        }
+                        trimmed = trimmed.substr(0, trimmed.size() - 1);
                     }
-                    else if (endptr && ((endptr[0] == ' ' && endptr[1] == '%' &&
-                                         endptr + 2 == s.c_str() + s.size()) ||
-                                        (endptr[0] == '%' &&
-                                         endptr + 1 == s.c_str() + s.size())))
-                    {
-                        if (val >= 0)
-                        {
-                            ok = true;
-                        }
-                    }
-                    if (!ok)
+
+                    if (cpl::strict_parse<int>(trimmed).value_or(-1) < 0)
                     {
                         ReportError(CE_Failure, CPLE_IllegalArg,
                                     "Invalid size value: %s'", s.c_str());

--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -8590,10 +8590,23 @@ GDALVectorTranslateOptions *GDALVectorTranslateOptionsNew(
             psOptions->asGCPs.resize(psOptions->asGCPs.size() + 1);
             auto &sGCP = psOptions->asGCPs.back();
 
-            sGCP.Pixel() = CPLAtof(papszArgv[++i]);
-            sGCP.Line() = CPLAtof(papszArgv[++i]);
-            sGCP.X() = CPLAtof(papszArgv[++i]);
-            sGCP.Y() = CPLAtof(papszArgv[++i]);
+            const auto oPixel = cpl::strict_parse<double>(papszArgv[++i]);
+            const auto oLine = cpl::strict_parse<double>(papszArgv[++i]);
+            const auto oX = cpl::strict_parse<double>(papszArgv[++i]);
+            const auto oY = cpl::strict_parse<double>(papszArgv[++i]);
+
+            if (!oPixel.has_value() || !oLine.has_value() || !oX.has_value() ||
+                !oY.has_value())
+            {
+                CPLError(CE_Failure, CPLE_IllegalArg, "Invalid -gcp value");
+                return nullptr;
+            }
+
+            sGCP.Pixel() = oPixel.value();
+            sGCP.Line() = oLine.value();
+            sGCP.X() = oX.value();
+            sGCP.Y() = oY.value();
+
             if (papszArgv[i + 1] != nullptr &&
                 (CPLStrtod(papszArgv[i + 1], &endptr) != 0.0 ||
                  papszArgv[i + 1][0] == '0'))

--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -47,6 +47,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <charconv>
 #include <cmath>
 #include <limits>
 #include <fstream>
@@ -286,7 +287,7 @@ TEST_F(test_cpl, CSLTokenizeString2)
     }
     {
         CPLStringList aosStringList(
-            CSLTokenizeString2("one two, three;four,five; six", " ;,", 0));
+            CSLTokenizeString2(",one two, three;four,five; six,", " ;,", 0));
         ASSERT_EQ(aosStringList.size(), 6);
         EXPECT_STREQ(aosStringList[0], "one");
         EXPECT_STREQ(aosStringList[1], "two");
@@ -298,14 +299,16 @@ TEST_F(test_cpl, CSLTokenizeString2)
 
     {
         CPLStringList aosStringList(CSLTokenizeString2(
-            "one two,,,five,six", " ,", CSLT_ALLOWEMPTYTOKENS));
-        ASSERT_EQ(aosStringList.size(), 6);
-        EXPECT_STREQ(aosStringList[0], "one");
-        EXPECT_STREQ(aosStringList[1], "two");
-        EXPECT_STREQ(aosStringList[2], "");
+            ",one two,,,five,six,", " ,", CSLT_ALLOWEMPTYTOKENS));
+        ASSERT_EQ(aosStringList.size(), 8);
+        EXPECT_STREQ(aosStringList[0], "");
+        EXPECT_STREQ(aosStringList[1], "one");
+        EXPECT_STREQ(aosStringList[2], "two");
         EXPECT_STREQ(aosStringList[3], "");
-        EXPECT_STREQ(aosStringList[4], "five");
-        EXPECT_STREQ(aosStringList[5], "six");
+        EXPECT_STREQ(aosStringList[4], "");
+        EXPECT_STREQ(aosStringList[5], "five");
+        EXPECT_STREQ(aosStringList[6], "six");
+        EXPECT_STREQ(aosStringList[7], "");
     }
 
     {
@@ -4964,10 +4967,37 @@ TEST_F(test_cpl, CPLStrtod)
     }
 
     {
-        const char *pszVal = "5 foo";
+        const char *pszVal = "-5 foo";
         char *pszEnd = nullptr;
-        EXPECT_EQ(CPLStrtod(pszVal, &pszEnd), 5.0);
-        EXPECT_EQ(pszEnd, pszVal + 1);
+        EXPECT_EQ(CPLStrtod(pszVal, &pszEnd), -5.0);
+        EXPECT_EQ(pszEnd, pszVal + 2);
+    }
+
+    {
+        const char *pszVal = "3.1415";
+        char *pszEnd = nullptr;
+        EXPECT_EQ(CPLStrtod(pszVal, &pszEnd), 3.1415);
+        EXPECT_EQ(pszEnd, pszVal + strlen(pszVal));
+    }
+
+    {
+        const char *pszVal = "6.022e23";
+        char *pszEnd = nullptr;
+        EXPECT_EQ(CPLStrtod(pszVal, &pszEnd), 6.022e23);
+        EXPECT_EQ(pszEnd, pszVal + strlen(pszVal));
+    }
+
+    {
+        const char *pszVal = "  +6.022E+23";
+        char *pszEnd = nullptr;
+        EXPECT_EQ(CPLStrtod(pszVal, &pszEnd), 6.022e23);
+        EXPECT_EQ(pszEnd, pszVal + strlen(pszVal));
+    }
+    {
+        const char *pszVal = "1.e-23";
+        char *pszEnd = nullptr;
+        EXPECT_EQ(CPLStrtod(pszVal, &pszEnd), 1.0e-23);
+        EXPECT_EQ(pszEnd, pszVal + strlen(pszVal));
     }
 
     {
@@ -5935,6 +5965,233 @@ TEST_F(test_cpl, CPLLaunderForFilenameSafe)
     EXPECT_STREQ(CPLLaunderForFilenameSafe("CON", '\0', nullptr).c_str(),
                  "CON_");
     EXPECT_STREQ(CPLLaunderForFilenameSafe("CON", ';').c_str(), "CON;");
+}
+
+TEST_F(test_cpl, cpl_starts_with)
+{
+    std::string str = "abc";
+    const char *cstr = "abc";
+    std::string_view sv = std::string_view(str).substr(0, 2);
+
+    EXPECT_TRUE(cpl::starts_with(str, "ab"));
+    EXPECT_TRUE(cpl::starts_with(cstr, "ab"));
+    EXPECT_TRUE(cpl::starts_with(sv, "ab"));
+    EXPECT_TRUE(cpl::starts_with(sv, ""));
+
+    EXPECT_TRUE(cpl::starts_with_ci(str, "ab"));
+    EXPECT_TRUE(cpl::starts_with_ci(str, "aB"));
+    EXPECT_TRUE(cpl::starts_with_ci(str, ""));
+
+    EXPECT_FALSE(cpl::starts_with(str, "ac"));
+    EXPECT_FALSE(cpl::starts_with(str, "abcd"));
+    EXPECT_FALSE(cpl::starts_with(str, "aB"));
+    EXPECT_FALSE(cpl::starts_with(std::string_view(str).substr(0, 1), "ab"));
+}
+
+TEST_F(test_cpl, cpl_ends_with)
+{
+    std::string str = "abc";
+    const char *cstr = "abc";
+    std::string_view sv = std::string_view(str).substr(0, 3);
+
+    EXPECT_TRUE(cpl::ends_with(str, "bc"));
+    EXPECT_TRUE(cpl::ends_with(cstr, "bc"));
+    EXPECT_TRUE(cpl::ends_with(sv, "bc"));
+    EXPECT_TRUE(cpl::ends_with(sv, ""));
+
+    EXPECT_TRUE(cpl::ends_with_ci(str, "bc"));
+    EXPECT_TRUE(cpl::ends_with_ci(str, "bC"));
+    EXPECT_TRUE(cpl::ends_with_ci(str, ""));
+
+    EXPECT_FALSE(cpl::ends_with(str, "ac"));
+    EXPECT_FALSE(cpl::ends_with(str, "abcd"));
+    EXPECT_FALSE(cpl::ends_with(str, "Bc"));
+    EXPECT_FALSE(cpl::ends_with(std::string_view(str).substr(0, 2), "bc"));
+}
+
+TEST_F(test_cpl, cpl_equals)
+{
+    std::string str = "abc";
+    const char *cstr = "abc";
+    std::string_view sv = str;
+
+    EXPECT_TRUE(cpl::equals(str, cstr));
+    EXPECT_TRUE(cpl::equals(cstr, sv));
+    EXPECT_TRUE(cpl::equals(sv, str));
+
+    EXPECT_FALSE(cpl::equals(str, ""));
+    EXPECT_FALSE(cpl::equals(str, std::string_view(str).substr(0, 2)));
+
+    EXPECT_FALSE(cpl::equals(str, "abC"));
+    EXPECT_TRUE(cpl::equals_ci(str, "abC"));
+    EXPECT_FALSE(cpl::equals_ci(str, ""));
+}
+
+TEST_F(test_cpl, trim)
+{
+    // input type: const char*
+    {
+        const char *str = "";
+        const auto trimmed = cpl::trim(str);
+        EXPECT_EQ(trimmed, "");
+        EXPECT_EQ(trimmed.data(), str);  // trimmed points within str
+
+        const auto ltrimmed = cpl::ltrim(str);
+        EXPECT_EQ(ltrimmed, "");
+        EXPECT_EQ(ltrimmed.data(), str);
+
+        const auto rtrimmed = cpl::rtrim(str);
+        EXPECT_EQ(rtrimmed, "");
+        EXPECT_EQ(rtrimmed.data(), str);
+    }
+
+    // input type: std::string
+    {
+        const std::string str = "\r\n\t    \r\n\t";
+        const auto trimmed = cpl::trim(str);
+
+        EXPECT_EQ(trimmed, "");
+        EXPECT_EQ(trimmed.data(), str.data() + str.size());
+
+        const auto ltrimmed = cpl::ltrim(str);
+
+        EXPECT_EQ(ltrimmed, "");
+        EXPECT_EQ(ltrimmed.data(), str.data() + str.size());
+
+        const auto rtrimmed = cpl::rtrim(str);
+
+        EXPECT_EQ(rtrimmed, "");
+        EXPECT_EQ(rtrimmed.data(), str.data());
+    }
+
+    // input type: std::string_view
+    {
+        const std::string_view str = "  abc\t  ";
+        const auto trimmed = cpl::trim(str);
+
+        EXPECT_EQ(trimmed, "abc");
+        EXPECT_EQ(trimmed.data(), str.data() + 2);  // trimmed points within str
+
+        const auto ltrimmed = cpl::ltrim(str);
+
+        EXPECT_EQ(ltrimmed, "abc\t  ");
+        EXPECT_EQ(ltrimmed.data(), str.data() + 2);
+
+        const auto rtrimmed = cpl::rtrim(str);
+
+        EXPECT_EQ(rtrimmed, "  abc");
+        EXPECT_EQ(rtrimmed.data(), str.data());
+    }
+
+    // input_type: std::string_view&&
+    {
+        // line below should not compile
+        //auto trimmed = cpl::trim(std::string("abc"));
+    }
+}
+
+TEST_F(test_cpl, parse_name_value)
+{
+    {
+        std::string input = "OPT_NAME=VALUE";
+        auto [name, value] = cpl::parse_name_value(input);
+
+        EXPECT_EQ(name, "OPT_NAME");
+        EXPECT_EQ(value, "VALUE");
+    }
+
+    {
+        const char *input = "  OPT_NAME =   VALUE WITH SPACE ";
+        auto [name, value] = cpl::parse_name_value(input);
+
+        EXPECT_EQ(name, "OPT_NAME");
+        EXPECT_EQ(value, "VALUE WITH SPACE");
+    }
+
+    {
+        std::string input = "OPT_NAME=";
+        auto [name, value] = cpl::parse_name_value(input);
+
+        EXPECT_EQ(name, "OPT_NAME");
+        EXPECT_EQ(value, "");
+    }
+
+    {
+        std::string input = "=VALUE";
+        auto [name, value] = cpl::parse_name_value(input);
+
+        EXPECT_EQ(name, "");
+        EXPECT_EQ(value, "");
+    }
+
+    {
+        std::string input = "INVALID";
+        auto [name, value] = cpl::parse_name_value(input);
+
+        EXPECT_EQ(name, "");
+        EXPECT_EQ(value, "");
+    }
+
+    {
+        const char *input = "";
+        auto [name, value] = cpl::parse_name_value(input);
+
+        EXPECT_EQ(name, "");
+        EXPECT_EQ(value, "");
+    }
+}
+
+TEST_F(test_cpl, strict_parse)
+{
+    EXPECT_EQ(cpl::strict_parse<bool>("YES"), true);
+    EXPECT_EQ(cpl::strict_parse<bool>("1 "), true);
+    EXPECT_EQ(cpl::strict_parse<bool>(" ON "), true);
+    EXPECT_EQ(cpl::strict_parse<bool>("\tyes "), true);
+    EXPECT_EQ(cpl::strict_parse<bool>("TRUEE"), std::nullopt);
+    EXPECT_EQ(cpl::strict_parse<bool>(""), std::nullopt);
+
+    EXPECT_EQ(cpl::strict_parse<bool>("NO"), false);
+    EXPECT_EQ(cpl::strict_parse<bool>("0 "), false);
+    EXPECT_EQ(cpl::strict_parse<bool>(" OFF "), false);
+    EXPECT_EQ(cpl::strict_parse<bool>("\tno "), false);
+    EXPECT_EQ(cpl::strict_parse<bool>("NON"), std::nullopt);
+
+    EXPECT_EQ(cpl::strict_parse<int>("123"), 123);
+    EXPECT_EQ(cpl::strict_parse<int>("0123"), 123);
+    EXPECT_EQ(cpl::strict_parse<int>(" -456"), -456);
+    EXPECT_EQ(cpl::strict_parse<int>(" - 456"), std::nullopt);
+    EXPECT_EQ(cpl::strict_parse<int>("789."), 789);
+    EXPECT_EQ(cpl::strict_parse<int>("789.0"), 789);
+    EXPECT_EQ(cpl::strict_parse<int>("789.0.0"), std::nullopt);
+    EXPECT_EQ(cpl::strict_parse<int>("789.1"), std::nullopt);
+    EXPECT_EQ(cpl::strict_parse<int>("50000000000000000"), std::nullopt);
+    EXPECT_EQ(cpl::strict_parse<int>(""), std::nullopt);
+
+    EXPECT_EQ(cpl::strict_parse<double>("3.141569"), 3.141569);
+    EXPECT_EQ(cpl::strict_parse<double>("3,141569"), std::nullopt);
+    EXPECT_EQ(cpl::strict_parse<double>("-8.33e-2"), -8.33e-2);
+    EXPECT_EQ(cpl::strict_parse<double>("06.022e23"), 6.022e23);
+    EXPECT_EQ(cpl::strict_parse<double>("6.022E23"), 6.022e23);
+    EXPECT_EQ(cpl::strict_parse<double>("6.022e+23"), 6.022e23);
+    EXPECT_EQ(cpl::strict_parse<double>("6.022e+23"), 6.022e23);
+    EXPECT_EQ(cpl::strict_parse<double>(""), std::nullopt);
+    EXPECT_EQ(cpl::strict_parse<double>("  "), std::nullopt);
+    EXPECT_EQ(cpl::strict_parse<double>(" -"), std::nullopt);
+
+    EXPECT_EQ(cpl::strict_parse<double>("inf"),
+              std::numeric_limits<double>::infinity());
+    EXPECT_EQ(cpl::strict_parse<double>("-inf"),
+              -std::numeric_limits<double>::infinity());
+
+    EXPECT_EQ(std::isnan(cpl::strict_parse<double>("nan").value()), true);
+    EXPECT_EQ(std::isnan(cpl::strict_parse<double>("NaN").value()), true);
+    EXPECT_EQ(std::isnan(cpl::strict_parse<double>("NAN").value()), true);
+    EXPECT_EQ(cpl::strict_parse<double>("NANA"), std::nullopt);
+
+    EXPECT_EQ(cpl::strict_parse<float>("3.4e39"), std::nullopt);
+    EXPECT_EQ(cpl::strict_parse<float>("-3.4e39"), std::nullopt);
+    EXPECT_EQ(cpl::strict_parse<float>("1e-39"), std::nullopt);
+    EXPECT_EQ(cpl::strict_parse<float>("-1e-39"), std::nullopt);
 }
 
 }  // namespace

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -214,6 +214,35 @@ def test_vrt_read_5(tmp_vsimem):
     ds = None
 
 
+@gdaltest.enable_exceptions()
+@pytest.mark.parametrize("bad_value", ("6.4", "10000000000000", "32f"))
+def test_vrt_read_invalid_color_table(bad_value):
+
+    ct_xml = """<VRTDataset rasterXSize="50" rasterYSize="50">
+  <VRTRasterBand dataType="Byte" band="1">
+    <ColorTable>
+       <Entry c1="{bad_value}" c2="0" c3="0" c4="255"/>
+    </ColorTable>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">data/rgbsmall.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">data/rgbsmall.tif</SourceFilename>
+      <SourceBand>2</SourceBand>
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">data/rgbsmall.tif</SourceFilename>
+      <SourceBand>3</SourceBand>
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>
+"""
+
+    with pytest.raises(Exception, match="Invalid VRT color table entry"):
+        gdal.Open(ct_xml)
+
+
 ###############################################################################
 # Test GetMinimum() and GetMaximum()
 

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -4945,3 +4945,15 @@ def test_gdalwarp_lib_invalid_source_extra(tmp_vsimem):
             "../gcore/data/byte.tif",
             warpOptions={"SOURCE_EXTRA": "5.1"},
         )
+
+
+@gdaltest.enable_exceptions()
+def test_gdalwarp_lib_invalid_reset_dest_pixels(tmp_vsimem):
+
+    with pytest.raises(Exception, match="Invalid value of RESET_DEST_PIXELS"):
+        # code path does not allow raising an exception
+        gdal.Warp(
+            tmp_vsimem / "out.tif",
+            "../gcore/data/byte.tif",
+            warpOptions={"RESET_DEST_PIXELS": "POSSIBLY"},
+        )

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -4927,3 +4927,21 @@ def test_gdalwarp_lib_detect_border_geoloc_array(tmp_vsimem):
     assert out_ds.GetGeoTransform() == pytest.approx(
         (-7.071067810058594, 0.1414, 0.0, 14.14213752746582, 0.0, -0.1414)
     )
+
+
+###############################################################################
+# Test parameter parsing error cases
+
+
+@gdaltest.enable_exceptions()
+def test_gdalwarp_lib_invalid_source_extra(tmp_vsimem):
+
+    with gdaltest.error_raised(
+        gdal.CE_Warning, "SOURCE_EXTRA must be a positive integer"
+    ):
+        # code path does not allow raising an exception
+        gdal.Warp(
+            tmp_vsimem / "out.tif",
+            "../gcore/data/byte.tif",
+            warpOptions={"SOURCE_EXTRA": "5.1"},
+        )

--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -2891,6 +2891,24 @@ def test_ogr2ogr_lib_two_gcps():
 
 
 ###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_ogr2ogr_lib_invalid_gcp():
+
+    src_ds = gdal.GetDriverByName("MEM").CreateVector("")
+    src_lyr = src_ds.CreateLayer("test")
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (2 3)"))
+    src_lyr.CreateFeature(f)
+
+    with pytest.raises(Exception, match="Invalid -gcp value"):
+        gdal.VectorTranslate(
+            "", src_ds, options="-f MEM -gcp 1 2 200 300k -gcp 3 4 300 400"
+        )
+
+
+###############################################################################
 # Test -skipInvalid
 
 

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1301,12 +1301,8 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
                 return nullptr;
             }
 
-            // Convert using CPLStrtod to handle scientific notation (e.g., 1e0)
-            // and detect non-numeric values via endPtr
-            char *pszEnd = nullptr;
-            const double dfBlockXOff = CPLStrtod(aosBlockParams[0], &pszEnd);
-            if (pszEnd == aosBlockParams[0] || *pszEnd != '\0' ||
-                dfBlockXOff < 0 || dfBlockXOff != static_cast<int>(dfBlockXOff))
+            nBlockXOff = cpl::strict_parse<int>(aosBlockParams[0]).value_or(-1);
+            if (nBlockXOff < 0)
             {
                 CPLError(CE_Failure, CPLE_IllegalArg,
                          "Invalid block option: nXBlockOff '%s' is not a valid "
@@ -1315,10 +1311,8 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
                 return nullptr;
             }
 
-            pszEnd = nullptr;
-            const double dfBlockYOff = CPLStrtod(aosBlockParams[1], &pszEnd);
-            if (pszEnd == aosBlockParams[1] || *pszEnd != '\0' ||
-                dfBlockYOff < 0 || dfBlockYOff != static_cast<int>(dfBlockYOff))
+            nBlockYOff = cpl::strict_parse<int>(aosBlockParams[1]).value_or(-1);
+            if (nBlockYOff < 0)
             {
                 CPLError(CE_Failure, CPLE_IllegalArg,
                          "Invalid block option: nYBlockOff '%s' is not a valid "
@@ -1327,8 +1321,6 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
                 return nullptr;
             }
 
-            nBlockXOff = static_cast<int>(dfBlockXOff);
-            nBlockYOff = static_cast<int>(dfBlockYOff);
             bFoundBlock = true;
         }
     }

--- a/frmts/vrt/vrtrasterband.cpp
+++ b/frmts/vrt/vrtrasterband.cpp
@@ -297,11 +297,21 @@ VRTParseColorTable(const CPLXMLNode *psColorTable)
             continue;
         }
 
-        const GDALColorEntry sCEntry = {
-            static_cast<short>(atoi(CPLGetXMLValue(psEntry, "c1", "0"))),
-            static_cast<short>(atoi(CPLGetXMLValue(psEntry, "c2", "0"))),
-            static_cast<short>(atoi(CPLGetXMLValue(psEntry, "c3", "0"))),
-            static_cast<short>(atoi(CPLGetXMLValue(psEntry, "c4", "255")))};
+        auto c1 = cpl::strict_parse<short>(CPLGetXMLValue(psEntry, "c1", "0"));
+        auto c2 = cpl::strict_parse<short>(CPLGetXMLValue(psEntry, "c2", "0"));
+        auto c3 = cpl::strict_parse<short>(CPLGetXMLValue(psEntry, "c3", "0"));
+        auto c4 = cpl::strict_parse<short>(CPLGetXMLValue(psEntry, "c4", "0"));
+
+        if (!c1.has_value() || !c2.has_value() || !c3.has_value() ||
+            !c4.has_value())
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Invalid VRT color table entry");
+            return nullptr;
+        }
+
+        const GDALColorEntry sCEntry = {c1.value(), c2.value(), c3.value(),
+                                        c4.value()};
 
         poColorTable->SetColorEntry(iEntry++, &sCEntry);
     }
@@ -436,6 +446,8 @@ CPLErr VRTRasterBand::XMLInit(const CPLXMLNode *psTree, const char *pszVRTPath,
         auto poColorTable = VRTParseColorTable(psColorTable);
         if (poColorTable)
             SetColorTable(poColorTable.get());
+        else
+            return CE_Failure;
     }
 
     /* -------------------------------------------------------------------- */

--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -49,12 +49,14 @@
 #include <atomic>
 #include <cctype>
 #include <cerrno>
+#include <charconv>
 #include <climits>
 #include <clocale>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <limits>
 #include <mutex>
 #include <set>
 
@@ -4107,5 +4109,142 @@ int CPLGetRemainingFileDescriptorCount()
     return -1;
 #endif
 }
+
+namespace cpl
+{
+
+/** Attempt to parse a number of the designated type from a string. The string
+ *  must contain no characters other than a single number and surrounding
+ *  whitespace, and the parsed number must fit into the designated type.
+ *  If these conditions are not met, std::nullopt will be returned.
+ *
+ * @param str the string to parse
+ * @return a std::optional<T> containing the parsed value, or std::nullopt
+ *         in case of failure.
+ */
+template <typename T>
+std::optional<T> CPL_DLL strict_parse(std::string_view str)
+{
+    str = trim(str);
+
+    T result;
+    const auto begin = str.data();
+    const auto end = str.data() + str.size();
+
+    auto [ptr, ec] = std::from_chars(begin, end, result);
+
+    if (ec != std::errc())
+        return std::nullopt;
+
+    if (ptr != end)
+    {
+        // For integer types, allow decimal and trailing zeros
+        if constexpr (std::is_integral_v<T>)
+        {
+            constexpr char DIGIT_ZERO = '0';
+
+            if (*ptr++ == '.')
+            {
+                while (ptr != end)
+                {
+                    if (*ptr++ != DIGIT_ZERO)
+                    {
+                        return std::nullopt;
+                    }
+                }
+            }
+        }
+        else
+        {
+            return std::nullopt;
+        }
+    }
+
+    return result;
+}
+
+template std::optional<std::int8_t>
+    CPL_DLL strict_parse<std::int8_t>(std::string_view str);
+template std::optional<std::uint8_t>
+    CPL_DLL strict_parse<std::uint8_t>(std::string_view str);
+template std::optional<std::int16_t>
+    CPL_DLL strict_parse<std::int16_t>(std::string_view str);
+template std::optional<std::uint16_t>
+    CPL_DLL strict_parse<std::uint16_t>(std::string_view str);
+template std::optional<std::int32_t>
+    CPL_DLL strict_parse<std::int32_t>(std::string_view str);
+template std::optional<std::uint32_t>
+    CPL_DLL strict_parse<std::uint32_t>(std::string_view str);
+template std::optional<std::int64_t>
+    CPL_DLL strict_parse<std::int64_t>(std::string_view str);
+template std::optional<std::uint64_t>
+    CPL_DLL strict_parse<std::uint64_t>(std::string_view str);
+
+template <>
+std::optional<double> CPL_DLL strict_parse<double>(std::string_view str)
+{
+    str = trim(str);
+
+    if (str.empty())
+    {
+        return std::nullopt;
+    }
+
+    char *end = nullptr;
+    double d = CPLStrtod(str.data(), &end);
+
+    auto i = static_cast<decltype(str.size())>(end - str.data());
+    while (i < str.size() && std::isspace(str[i]))
+    {
+        i++;
+    }
+    if (i < str.size())
+    {
+        return std::nullopt;
+    }
+
+    return d;
+}
+
+template <>
+std::optional<float> CPL_DLL strict_parse<float>(std::string_view str)
+{
+    auto d = strict_parse<double>(str);
+    if (!d)
+    {
+        return std::nullopt;
+    }
+    if (d.value() > static_cast<double>(std::numeric_limits<float>::max()) ||
+        d.value() < static_cast<double>(std::numeric_limits<float>::lowest()))
+    {
+        return std::nullopt;
+    }
+    if (std::abs(d.value()) <
+        static_cast<double>(std::numeric_limits<float>::min()))
+    {
+        return std::nullopt;
+    }
+    return static_cast<float>(d.value());
+}
+
+template <> std::optional<bool> CPL_DLL strict_parse<bool>(std::string_view str)
+{
+    str = trim(str);
+
+    if (str == "YES" || str == "ON" || str == "TRUE" || str == "1")
+        return true;
+
+    if (str == "NO" || str == "OFF" || str == "FALSE" || str == "0")
+        return false;
+
+    if (str == "yes" || str == "on" || str == "true")
+        return true;
+
+    if (str == "no" || str == "off" || str == "false")
+        return false;
+
+    return std::nullopt;
+}
+}  // namespace cpl
 
 #endif

--- a/port/cpl_conv.h
+++ b/port/cpl_conv.h
@@ -20,7 +20,14 @@
 #include "cpl_error.h"
 
 #if defined(__cplusplus) && !defined(CPL_SUPRESS_CPLUSPLUS)
+#include <charconv>
 #include <cstdint>
+#include <limits>
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#include <optional>
+#define HAVE_STRING_VIEW
+#include <string_view>
+#endif
 #endif
 
 /**
@@ -116,6 +123,18 @@ double CPL_DLL CPLStrtodM(const char *, char **);
 double CPL_DLL CPLStrtodDelim(const char *, char **, char);
 float CPL_DLL CPLStrtof(const char *, char **);
 float CPL_DLL CPLStrtofDelim(const char *, char **, char);
+
+#if defined(__cplusplus) && !defined(CPL_SUPRESS_CPLUSPLUS)
+extern "C++"
+{
+    namespace cpl
+    {
+#if defined(DOXYGEN_SKIP) || defined(HAVE_STRING_VIEW)
+    double CPL_DLL strtod_delim(std::string_view, char **, char);
+#endif
+    }  // namespace cpl
+}
+#endif
 
 /* -------------------------------------------------------------------- */
 /*      Convert number to string.  This function is locale agnostic     */
@@ -250,7 +269,7 @@ extern "C++"
         const char *pszExtraReservedCharacters = nullptr)
         CPL_WARN_UNUSED_RESULT;
 
-#if defined(GDAL_COMPILATION) || __cplusplus >= 201703L
+#ifdef HAVE_STRING_VIEW
     std::string
         CPL_DLL CPLLexicallyNormalize(std::string_view svPath, char sep1,
                                       char sep2 = 0) CPL_WARN_UNUSED_RESULT;
@@ -520,8 +539,17 @@ extern "C++"
         return a / b + (((a % b) == 0) ? 0 : 1);
     }
 
+#ifdef HAVE_STRING_VIEW
+    template <typename T>
+    std::optional<T> CPL_DLL strict_parse(std::string_view str);
+#endif
+
     }  // namespace cpl
 }  // extern "C++"
+
+#ifdef HAVE_STRING_VIEW
+#undef HAVE_STRING_VIEW
+#endif
 
 #endif /* def __cplusplus */
 

--- a/port/cpl_string.cpp
+++ b/port/cpl_string.cpp
@@ -34,6 +34,7 @@
 #include "cpl_port.h"
 #include "cpl_string.h"
 
+#include <algorithm>
 #include <cctype>
 #include <climits>
 #include <cmath>
@@ -768,7 +769,7 @@ char **CSLTokenizeStringComplex(const char *pszString,
 /**
  * Tokenize a string.
  *
- * This function will split a string into tokens based on specified'
+ * This function will split a string into tokens based on specified
  * delimiter(s) with a variety of options.  The returned result is a
  * string list that should be freed with CSLDestroy() when no longer
  * needed.
@@ -822,6 +823,15 @@ char **CSLTokenizeString2(const char *pszString, const char *pszDelimiters,
     if (pszString == nullptr)
         return static_cast<char **>(CPLCalloc(sizeof(char *), 1));
 
+    return cpl::tokenize_string(pszString, pszDelimiters, nCSLTFlags)
+        .StealList();
+}
+
+namespace cpl
+{
+CPLStringList tokenize_string(std::string_view str, std::string_view delimiters,
+                              int nCSLTFlags)
+{
     CPLStringList oRetList;
     const bool bHonourStrings = (nCSLTFlags & CSLT_HONOURSTRINGS) != 0;
     const bool bHonourStringsSingleQuotes =
@@ -830,70 +840,49 @@ char **CSLTokenizeString2(const char *pszString, const char *pszDelimiters,
     const bool bStripLeadSpaces = (nCSLTFlags & CSLT_STRIPLEADSPACES) != 0;
     const bool bStripEndSpaces = (nCSLTFlags & CSLT_STRIPENDSPACES) != 0;
 
-    char *pszToken = static_cast<char *>(CPLCalloc(10, 1));
-    size_t nTokenMax = 10;
-
-    while (*pszString != '\0')
+    size_t pos = 0;
+    std::string token;
+    while (pos < str.size())
     {
+        token.clear();
         bool bInString = false;
         bool bInStringSingleQuote = false;
-        bool bStartString = true;
-        size_t nTokenLen = 0;
 
         // Try to find the next delimiter, marking end of token.
-        for (; *pszString != '\0'; ++pszString)
+        while (pos < str.size())
         {
-            // Extend token buffer if we are running close to its end.
-            if (nTokenLen >= nTokenMax - 3)
-            {
-                if (nTokenMax > std::numeric_limits<size_t>::max() / 2)
-                {
-                    CPLFree(pszToken);
-                    return static_cast<char **>(CPLCalloc(sizeof(char *), 1));
-                }
-                nTokenMax = nTokenMax * 2;
-                char *pszNewToken = static_cast<char *>(
-                    VSI_REALLOC_VERBOSE(pszToken, nTokenMax));
-                if (pszNewToken == nullptr)
-                {
-                    CPLFree(pszToken);
-                    return static_cast<char **>(CPLCalloc(sizeof(char *), 1));
-                }
-                pszToken = pszNewToken;
-            }
-
             // End if this is a delimiter skip it and break.
             if (!bInString && !bInStringSingleQuote &&
-                strchr(pszDelimiters, *pszString) != nullptr)
+                delimiters.find(str[pos]) != std::string_view::npos)
             {
-                ++pszString;
+                pos++;
                 break;
             }
 
             // If this is a quote, and we are honouring constant
             // strings, then process the constant strings, with out delim
             // but don't copy over the quotes.
-            if (bHonourStrings && !bInStringSingleQuote && *pszString == '"')
+            if (bHonourStrings && !bInStringSingleQuote && str[pos] == '"')
             {
                 if (nCSLTFlags & CSLT_PRESERVEQUOTES)
                 {
-                    pszToken[nTokenLen] = *pszString;
-                    ++nTokenLen;
+                    token.push_back(str[pos]);
                 }
 
                 bInString = !bInString;
+                pos++;
                 continue;
             }
             else if (bHonourStringsSingleQuotes && !bHonourStrings &&
-                     *pszString == '\'')
+                     str[pos] == '\'')
             {
                 if (nCSLTFlags & CSLT_PRESERVEQUOTES)
                 {
-                    pszToken[nTokenLen] = *pszString;
-                    ++nTokenLen;
+                    token.push_back(str[pos]);
                 }
 
                 bInStringSingleQuote = !bInStringSingleQuote;
+                pos++;
                 continue;
             }
 
@@ -902,70 +891,62 @@ char **CSLTokenizeString2(const char *pszString, const char *pszDelimiters,
              * processing them we will unescape the quotes and \\ sequence
              * reduces to \
              */
-            if (bInString && pszString[0] == '\\')
+            if (bInString && str[pos] == '\\')
             {
-                if (pszString[1] == '"' || pszString[1] == '\\')
+                if (pos + 1 < str.size() &&
+                    (str[pos + 1] == '"' || str[pos + 1] == '\\'))
                 {
                     if (nCSLTFlags & CSLT_PRESERVEESCAPES)
                     {
-                        pszToken[nTokenLen] = *pszString;
-                        ++nTokenLen;
+                        token.push_back(str[pos]);
                     }
 
-                    ++pszString;
+                    ++pos;
                 }
             }
-            else if (bInStringSingleQuote && pszString[0] == '\\')
+            else if (bInStringSingleQuote && str[pos] == '\\')
             {
-                if (pszString[1] == '\'' || pszString[1] == '\\')
+                if (pos + 1 < str.size() &&
+                    (str[pos + 1] == '\'' || str[pos + 1] == '\\'))
                 {
                     if (nCSLTFlags & CSLT_PRESERVEESCAPES)
                     {
-                        pszToken[nTokenLen] = *pszString;
-                        ++nTokenLen;
+                        token.push_back(str[pos]);
                     }
 
-                    ++pszString;
+                    ++pos;
                 }
             }
 
-            // Strip spaces at the token start if requested.
-            if (!bInString && !bInStringSingleQuote && bStripLeadSpaces &&
-                bStartString && isspace(static_cast<unsigned char>(*pszString)))
-                continue;
-
-            bStartString = false;
-
-            pszToken[nTokenLen] = *pszString;
-            ++nTokenLen;
+            token.push_back(str[pos]);
+            pos++;
         }
-
-        // Strip spaces at the token end if requested.
-        if (!bInString && !bInStringSingleQuote && bStripEndSpaces)
-        {
-            while (nTokenLen &&
-                   isspace(static_cast<unsigned char>(pszToken[nTokenLen - 1])))
-                nTokenLen--;
-        }
-
-        pszToken[nTokenLen] = '\0';
 
         // Add the token.
-        if (pszToken[0] != '\0' || bAllowEmptyTokens)
-            oRetList.AddString(pszToken);
+        std::string_view token_view(token);
+        if (bStripLeadSpaces)
+        {
+            token_view = ltrim(token_view);
+        }
+        if (bStripEndSpaces)
+        {
+            token_view = rtrim(token_view);
+        }
+
+        if (!token_view.empty() || bAllowEmptyTokens)
+            oRetList.AddString(token_view);
     }
 
     /*
      * If the last token was empty, then we need to capture
      * it now, as the loop would skip it.
      */
-    if (*pszString == '\0' && bAllowEmptyTokens && oRetList.Count() > 0 &&
-        strchr(pszDelimiters, *(pszString - 1)) != nullptr)
+    if (!str.empty() && pos == str.size() && bAllowEmptyTokens &&
+        oRetList.Count() > 0 &&
+        delimiters.find(str[pos - 1]) != std::string_view::npos)
     {
         oRetList.AddString("");
     }
-
-    CPLFree(pszToken);
 
     if (oRetList.List() == nullptr)
     {
@@ -974,8 +955,10 @@ char **CSLTokenizeString2(const char *pszString, const char *pszDelimiters,
         oRetList.Assign(static_cast<char **>(CPLCalloc(sizeof(char *), 1)));
     }
 
-    return oRetList.StealList();
+    return CPLStringList(oRetList.StealList());
 }
+
+}  // namespace cpl
 
 /**********************************************************************
  *                       CPLSPrintf()
@@ -1897,11 +1880,11 @@ CPLErr CPLParseMemorySize(const char *pszValue, GIntBig *pnValue,
  * Parse NAME=VALUE string into name and value components.
  *
  * Note that if ppszKey is non-NULL, the key (or name) portion will be
- * allocated using CPLMalloc(), and returned in that pointer.  It is the
- * applications responsibility to free this string, but the application should
+ * allocated using CPLMalloc() and returned in that pointer.  It is the
+ * application's responsibility to free this string, but the application should
  * not modify or free the returned value portion.
  *
- * This function also support "NAME:VALUE" strings and will strip white
+ * This function also supports "NAME:VALUE" strings and will strip white
  * space from around the delimiter when forming name and value strings.
  *
  * Eventually CSLFetchNameValue() and friends may be modified to use
@@ -1911,7 +1894,7 @@ CPLErr CPLParseMemorySize(const char *pszValue, GIntBig *pnValue,
  * @param ppszKey optional pointer though which to return the name
  * portion.
  *
- * @return the value portion (pointing into original string).
+ * @return the value portion (pointing into the original string).
  */
 
 const char *CPLParseNameValue(const char *pszNameValue, char **ppszKey)
@@ -1943,6 +1926,40 @@ const char *CPLParseNameValue(const char *pszNameValue, char **ppszKey)
 
     return nullptr;
 }
+
+namespace cpl
+{
+std::pair<std::string_view, std::string_view>
+parse_name_value(std::string_view svNameValue)
+{
+    for (size_t i = 0; i < svNameValue.size(); ++i)
+    {
+        if (svNameValue[i] == '=' || svNameValue[i] == ':')
+        {
+            auto parsed = std::make_pair(trim(svNameValue.substr(0, i)),
+                                         trim(svNameValue.substr(i + 1)));
+
+            if (!parsed.first.empty())
+            {
+                return parsed;
+            }
+            else
+            {
+                return std::make_pair(std::string_view(), std::string_view());
+            }
+        }
+    }
+
+    return std::make_pair(std::string_view(), std::string_view());
+}
+
+std::pair<std::string_view, std::string_view>
+parse_name_value(const char *pszNameValue)
+{
+    return parse_name_value(std::string_view(pszNameValue));
+}
+
+}  // namespace cpl
 
 /**********************************************************************
  *                       CPLParseNameValueSep()
@@ -3254,3 +3271,205 @@ std::string CPLRemoveSQLComments(const std::string &osInput)
     }
     return osSQL;
 }
+
+namespace cpl
+{
+
+static bool CaseInsensitiveCompare(unsigned char c1, unsigned char c2)
+{
+    return toupper(c1) == toupper(c2);
+}
+
+/** Check whether the start of one string is equivalent to another string,
+ *  considering case.
+ *
+ * @param str string to test
+ * @param prefix expected prefix
+ * @return true if the string starts with the prefix
+ *
+ * @since GDAL 3.11
+ */
+bool starts_with(std::string_view str, std::string_view prefix)
+{
+    return str.size() >= prefix.size() &&
+           str.compare(0, prefix.size(), prefix) == 0;
+}
+
+/** Check whether the start of one string is equivalent to another string,
+ *  not considering case.
+ *
+ * @param str string to test
+ * @param prefix expected prefix
+ * @return true if the string starts with the prefix
+ *
+ * @since GDAL 3.14
+ */
+bool starts_with_ci(std::string_view str, std::string_view prefix)
+{
+    return str.size() >= prefix.size() &&
+           std::search(str.begin(), str.end(), prefix.begin(), prefix.end(),
+                       CaseInsensitiveCompare) != str.end();
+}
+
+/** Check whether the end of one string is equivalent to another string,
+ *  considering case.
+ *
+ * @param str string to test
+ * @param suffix expected suffix
+ * @return true if the string ends with the suffix
+ *
+ * @since GDAL 3.11
+ */
+bool ends_with(std::string_view str, std::string_view suffix)
+{
+    return str.size() >= suffix.size() &&
+           (suffix.empty() || str.compare(str.size() - suffix.size(),
+                                          suffix.size(), suffix) == 0);
+}
+
+/** Check whether the end of one string is equivalent to another string,
+ *  not considering case.
+ *
+ * @param str string to test
+ * @param suffix expected suffix
+ * @return true if the string ends with the suffix
+ *
+ * @since GDAL 3.14
+ */
+bool ends_with_ci(std::string_view str, std::string_view suffix)
+{
+    return str.size() >= suffix.size() &&
+           (suffix.empty() ||
+            std::search(str.end() - suffix.size(), str.end(), suffix.begin(),
+                        suffix.end(), CaseInsensitiveCompare) != str.end());
+}
+
+/** Check whether two strings are equal, considering case.
+ *
+ * @param str1 first string to test
+ * @param str2 second string to test
+ * @return true if the strings are considered equal
+ *
+ * @since GDAL 3.14
+ */
+bool equals(std::string_view str1, std::string_view str2)
+{
+    return str1 == str2;
+}
+
+/** Check whether two strings are equal, not considering case.
+ *
+ * @param str1 first string to test
+ * @param str2 second string to test
+ * @return true if the strings are considered equal
+ *
+ * @since GDAL 3.14
+ */
+bool equals_ci(std::string_view str1, std::string_view str2)
+{
+    return str1.size() == str2.size() &&
+           std::equal(str1.begin(), str1.end(), str2.begin(),
+                      CaseInsensitiveCompare);
+}
+
+/** Remove leading and trailing whitespace from a string.
+ *  The returned string view will be a reference into the input.
+ *
+ * @param str string to trim
+ * @return trimmed string
+ *
+ * @since GDAL 3.14
+ */
+std::string_view trim(std::string_view str)
+{
+    if (str.empty())
+    {
+        return str;
+    }
+
+    size_t start = 0;
+    while (start < str.size() &&
+           isspace(static_cast<unsigned char>(str[start])))
+    {
+        start++;
+    }
+
+    if (start == str.size())
+    {
+        return str.substr(start, 0);
+    }
+
+    size_t stop = str.size();
+    while (stop > start && isspace(static_cast<unsigned char>(str[stop - 1])))
+    {
+        stop--;
+    }
+
+    return str.substr(start, stop - start);
+}
+
+std::string_view trim(const char *pszStr)
+{
+    return trim(std::string_view(pszStr));
+}
+
+/** Remove leading whitespace from a string.
+ *  The returned string view will be a reference into the input.
+ *
+ * @param str string to trim
+ * @return trimmed string
+ *
+ * @since GDAL 3.14
+ */
+std::string_view ltrim(std::string_view str)
+{
+    if (str.empty())
+    {
+        return str;
+    }
+
+    size_t start = 0;
+    while (start < str.size() &&
+           isspace(static_cast<unsigned char>(str[start])))
+    {
+        start++;
+    }
+
+    return str.substr(start);
+}
+
+std::string_view ltrim(const char *pszStr)
+{
+    return ltrim(std::string_view(pszStr));
+}
+
+/** Remove trailing whitespace from a string.
+ *  The returned string view will be a reference into the input.
+ *
+ * @param str string to trim
+ * @return trimmed string
+ *
+ * @since GDAL 3.14
+ */
+std::string_view rtrim(std::string_view str)
+{
+    if (str.empty())
+    {
+        return str;
+    }
+
+    size_t stop = str.size();
+    while (stop > 0 && isspace(static_cast<unsigned char>(str[stop - 1])))
+    {
+        stop--;
+    }
+
+    return str.substr(0, stop);
+}
+
+std::string_view rtrim(const char *pszStr)
+{
+    return rtrim(std::string_view(pszStr));
+}
+
+}  // namespace cpl

--- a/port/cpl_string.h
+++ b/port/cpl_string.h
@@ -312,6 +312,7 @@ extern "C++"
 #include <string>
 #include <vector>
 #if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#define HAVE_STRING_VIEW
 #include <string_view>
 #endif
 #endif
@@ -522,6 +523,9 @@ extern "C++"
 
         CPLStringList &AddString(const char *pszNewString);
         CPLStringList &AddString(const std::string &newString);
+#if defined(DOXYGEN_SKIP) || defined(HAVE_STRING_VIEW)
+        CPLStringList &AddString(std::string_view newString);
+#endif
         CPLStringList &AddStringDirectly(char *pszNewString);
 
         /** Add a string to the list */
@@ -536,8 +540,7 @@ extern "C++"
             AddString(osStr.c_str());
         }
 
-#if defined(DOXYGEN_SKIP) || __cplusplus >= 201703L ||                         \
-    (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#if defined(DOXYGEN_SKIP) || defined(HAVE_STRING_VIEW)
         void push_back(std::string_view svStr);
 #endif
 
@@ -719,58 +722,40 @@ extern "C++"
 
     /*! @cond Doxygen_Suppress */
 
-    /** Equivalent of C++20 std::string::starts_with(const char*) */
-    template <class StringType>
-    inline bool starts_with(const StringType &str, const char *prefix)
-    {
-        const size_t prefixLen = strlen(prefix);
-        return str.size() >= prefixLen &&
-               str.compare(0, prefixLen, prefix, prefixLen) == 0;
-    }
+#if defined(DOXYGEN_SKIP) || defined(HAVE_STRING_VIEW)
+    bool CPL_DLL starts_with(std::string_view str, std::string_view prefix);
+    bool CPL_DLL starts_with_ci(std::string_view str, std::string_view prefix);
 
-    /** Equivalent of C++20 std::string::starts_with(const std::string &) */
-    template <class StringType>
-    inline bool starts_with(const StringType &str, const std::string &prefix)
-    {
-        return str.size() >= prefix.size() &&
-               str.compare(0, prefix.size(), prefix) == 0;
-    }
+    bool CPL_DLL ends_with(std::string_view str, std::string_view suffix);
+    bool CPL_DLL ends_with_ci(std::string_view str, std::string_view suffix);
 
-    /** Equivalent of C++20 std::string::starts_with(std::string_view) */
-    template <class StringType>
-    inline bool starts_with(const StringType &str, std::string_view prefix)
-    {
-        return str.size() >= prefix.size() &&
-               str.compare(0, prefix.size(), prefix) == 0;
-    }
+    bool CPL_DLL equals(std::string_view str1, std::string_view str2);
+    bool CPL_DLL equals_ci(std::string_view str1, std::string_view str2);
 
-    /** Equivalent of C++20 std::string::ends_with(const char*) */
-    template <class StringType>
-    inline bool ends_with(const StringType &str, const char *suffix)
-    {
-        const size_t suffixLen = strlen(suffix);
-        return str.size() >= suffixLen &&
-               str.compare(str.size() - suffixLen, suffixLen, suffix,
-                           suffixLen) == 0;
-    }
+    std::string_view CPL_DLL trim(std::string_view str);
+    std::string_view CPL_DLL rtrim(std::string_view str);
+    std::string_view CPL_DLL ltrim(std::string_view str);
 
-    /** Equivalent of C++20 std::string::ends_with(const std::string &) */
-    template <class StringType>
-    inline bool ends_with(const StringType &str, const std::string &suffix)
-    {
-        return str.size() >= suffix.size() &&
-               str.compare(str.size() - suffix.size(), suffix.size(), suffix) ==
-                   0;
-    }
+    std::string_view CPL_DLL trim(const char *str);
+    std::string_view CPL_DLL rtrim(const char *str);
+    std::string_view CPL_DLL ltrim(const char *str);
 
-    /** Equivalent of C++20 std::string::ends_with(std::string_view) */
-    template <class StringType>
-    inline bool ends_with(const StringType &str, std::string_view suffix)
-    {
-        return str.size() >= suffix.size() &&
-               str.compare(str.size() - suffix.size(), suffix.size(), suffix) ==
-                   0;
-    }
+    std::string_view trim(std::string &&) = delete;
+    std::string_view rtrim(std::string &&) = delete;
+    std::string_view ltrim(std::string &&) = delete;
+
+    std::pair<std::string_view, std::string_view>
+        CPL_DLL parse_name_value(std::string_view svNameValue);
+
+    std::pair<std::string_view, std::string_view>
+        CPL_DLL parse_name_value(const char *svNameValue);
+
+    std::pair<std::string_view, std::string_view>
+    parse_name_value(std::string &&) = delete;
+
+    CPLStringList tokenize_string(std::string_view str,
+                                  std::string_view delimiters, int nCSLTFlags);
+#endif
 
     /** Iterator for a CSLConstList */
     struct CPL_DLL CSLIterator
@@ -981,6 +966,10 @@ extern "C++"
 #endif
 
 }  // extern "C++"
+
+#ifdef HAVE_STRING_VIEW
+#undef HAVE_STRING_VIEW
+#endif
 
 #endif /* def __cplusplus && !CPL_SUPRESS_CPLUSPLUS */
 

--- a/port/cpl_strtod.cpp
+++ b/port/cpl_strtod.cpp
@@ -13,12 +13,14 @@
 
 #include "cpl_port.h"
 #include "cpl_conv.h"
+#include "cpl_string.h"
 
 #include <cerrno>
 #include <clocale>
 #include <cstring>
 #include <cstdlib>
 #include <limits>
+#include <optional>
 
 // Coverity complains about CPLAtof(CPLGetConfigOption(...)) causing
 // a "untrusted loop bound" in the loop "Find a reasonable position for the end
@@ -203,8 +205,8 @@ static char *CPLReplacePointByLocalePoint(const char *pszNumber, char point)
  *
  * This function converts the initial portion of the string pointed to
  * by nptr to double floating point representation. This function does the
- * same as standard strtod(3), but does not take locale in account. Instead of
- * locale defined decimal delimiter you can specify your own one. Also see
+ * same as standard strtod(3), but does not take locale into account. Instead of
+ * the locale-defined decimal delimiter you can specify your own one. Also see
  * notes for CPLAtof() function.
  *
  * @param nptr Pointer to string to convert.
@@ -217,152 +219,137 @@ static char *CPLReplacePointByLocalePoint(const char *pszNumber, char point)
  */
 double CPLStrtodDelim(const char *nptr, char **endptr, char point)
 {
-    while (*nptr == ' '
-#ifdef USE_FAST_FLOAT
-           // The GSAG driver provides leading end-of-line character
-           || *nptr == '\r' || *nptr == '\n' || *nptr == '\t'
-#endif
-    )
+    return cpl::strtod_delim(nptr, endptr, point);
+}
+
+namespace cpl
+{
+/**
+ * Converts ASCII string to floating point number using specified delimiter.
+ *
+ * This function converts the initial portion of the string pointed to
+ * by nptr to double floating point representation. This function does the
+ * same as standard strtod(3), but does not take locale into account. Instead of
+ * the locale-defined decimal delimiter you can specify your own one. Also see
+ * notes for CPLAtof() function.
+ *
+ * @param str String view to convert.
+ * @param endptr If is not NULL, a pointer to the character after the last
+ * character used in the conversion is stored in the location referenced
+ * by endptr.
+ * @param point Decimal delimiter.
+ *
+ * @return Converted value, if any.
+ */
+double strtod_delim(std::string_view str, char **endptr, char point)
+{
+    str = trim(str);
+
+    if (str.empty())
     {
-        nptr++;
+        if (endptr)
+            *endptr = const_cast<char *>(str.data());
+        return 0;
     }
 
-    if (nptr[0] == '-')
+    if (str[0] == '-')
     {
-        if (STARTS_WITH(nptr, "-1.#QNAN") || STARTS_WITH(nptr, "-1.#IND"))
+        if (starts_with(str, "-1.#QNAN") || starts_with(str, "-1.#IND"))
         {
             if (endptr)
-                *endptr = const_cast<char *>(nptr) + strlen(nptr);
+                *endptr = const_cast<char *>(str.data()) + str.size();
             // While it is possible on some platforms to flip the sign
             // of NAN to negative, this function will always return a positive
             // quiet (non-signalling) NaN.
             return std::numeric_limits<double>::quiet_NaN();
         }
-        if (
-#ifndef USE_FAST_FLOAT
-            strcmp(nptr, "-inf") == 0 ||
-#endif
-            STARTS_WITH_CI(nptr, "-1.#INF"))
+        if (starts_with_ci(str, "-1.#INF"))
         {
             if (endptr)
-                *endptr = const_cast<char *>(nptr) + strlen(nptr);
+                *endptr = const_cast<char *>(str.data()) + str.size();
             return -std::numeric_limits<double>::infinity();
         }
     }
-    else if (nptr[0] == '1')
+    else if (str[0] == '1')
     {
-        if (STARTS_WITH(nptr, "1.#QNAN") || STARTS_WITH(nptr, "1.#SNAN"))
+        if (starts_with(str, "1.#QNAN") || starts_with(str, "1.#SNAN"))
         {
             if (endptr)
-                *endptr = const_cast<char *>(nptr) + strlen(nptr);
+                *endptr = const_cast<char *>(str.data()) + str.size();
             return std::numeric_limits<double>::quiet_NaN();
         }
-        if (STARTS_WITH_CI(nptr, "1.#INF"))
+        if (starts_with_ci(str, "1.#INF"))
         {
             if (endptr)
-                *endptr = const_cast<char *>(nptr) + strlen(nptr);
+                *endptr = const_cast<char *>(str.data()) + str.size();
             return std::numeric_limits<double>::infinity();
         }
     }
-#ifndef USE_FAST_FLOAT
-    else if (nptr[0] == 'i' && strcmp(nptr, "inf") == 0)
-    {
-        if (endptr)
-            *endptr = const_cast<char *>(nptr) + strlen(nptr);
-        return std::numeric_limits<double>::infinity();
-    }
-    else if (nptr[0] == 'n' && strcmp(nptr, "nan") == 0)
-    {
-        if (endptr)
-            *endptr = const_cast<char *>(nptr) + strlen(nptr);
-        return std::numeric_limits<double>::quiet_NaN();
-    }
-#endif
 
-#ifdef USE_FAST_FLOAT
     // Skip leading '+' as non-handled by fast_float
-    if (*nptr == '+')
-        nptr++;
+    if (str[0] == '+')
+        str = str.substr(1);
 
     // Find a reasonable position for the end of the string to provide to
     // fast_float
-    const char *endptrIn = nptr;
-    while ((*endptrIn >= '0' && *endptrIn <= '9') || *endptrIn == point ||
-           *endptrIn == '+' || *endptrIn == '-' || *endptrIn == 'e' ||
-           *endptrIn == 'E')
+    std::ptrdiff_t endPos = 0;
+    while (endPos < static_cast<std::ptrdiff_t>(str.size()) &&
+           ((str[endPos] >= '0' && str[endPos] <= '9') ||
+            str[endPos] == point || str[endPos] == '+' || str[endPos] == '-' ||
+            str[endPos] == 'e' || str[endPos] == 'E'))
     {
-        ++endptrIn;
+        ++endPos;
     }
 
     double dfValue = 0;
     const fast_float::parse_options options{fast_float::chars_format::general,
                                             point};
-    auto answer =
-        fast_float::from_chars_advanced(nptr, endptrIn, dfValue, options);
+    auto answer = fast_float::from_chars_advanced(
+        str.data(), str.data() + endPos, dfValue, options);
     if (answer.ec != std::errc())
     {
         if (
             // Triggered by ogr_pg tests
-            STARTS_WITH_CI(nptr, "-Infinity"))
+            starts_with_ci(str, "-Infinity"))
         {
             dfValue = -std::numeric_limits<double>::infinity();
-            answer.ptr = nptr + strlen("-Infinity");
+            answer.ptr = str.data() + strlen("-Infinity");
         }
-        else if (STARTS_WITH_CI(nptr, "-inf"))
+        else if (starts_with_ci(str, "-inf"))
         {
             dfValue = -std::numeric_limits<double>::infinity();
-            answer.ptr = nptr + strlen("-inf");
+            answer.ptr = str.data() + strlen("-inf");
         }
         else if (
             // Triggered by ogr_pg tests
-            STARTS_WITH_CI(nptr, "Infinity"))
+            starts_with_ci(str, "Infinity"))
         {
             dfValue = std::numeric_limits<double>::infinity();
-            answer.ptr = nptr + strlen("Infinity");
+            answer.ptr = str.data() + strlen("Infinity");
         }
-        else if (STARTS_WITH_CI(nptr, "inf"))
+        else if (cpl::starts_with_ci(str, "inf"))
         {
             dfValue = std::numeric_limits<double>::infinity();
-            answer.ptr = nptr + strlen("inf");
+            answer.ptr = str.data() + strlen("inf");
         }
-        else if (STARTS_WITH_CI(nptr, "nan"))
+        else if (cpl::starts_with_ci(str, "nan"))
         {
             dfValue = std::numeric_limits<double>::quiet_NaN();
-            answer.ptr = nptr + strlen("nan");
+            answer.ptr = str.data() + strlen("nan");
         }
         else
         {
-            errno = answer.ptr == nptr ? 0 : ERANGE;
+            errno = answer.ptr == str.data() ? 0 : ERANGE;
         }
     }
     if (endptr)
     {
         *endptr = const_cast<char *>(answer.ptr);
     }
-#else
-    /* -------------------------------------------------------------------- */
-    /*  We are implementing a simple method here: copy the input string     */
-    /*  into the temporary buffer, replace the specified decimal delimiter  */
-    /*  with the one, taken from locale settings and use standard strtod()  */
-    /*  on that buffer.                                                     */
-    /* -------------------------------------------------------------------- */
-    char *pszNewNumberOrNull = CPLReplacePointByLocalePoint(nptr, point);
-    const char *pszNumber = pszNewNumberOrNull ? pszNewNumberOrNull : nptr;
-
-    const double dfValue = strtod(pszNumber, endptr);
-    const int nError = errno;
-
-    if (endptr)
-        *endptr = const_cast<char *>(nptr) + (*endptr - pszNumber);
-
-    if (pszNewNumberOrNull)
-        CPLFree(pszNewNumberOrNull);
-
-    errno = nError;
-#endif
 
     return dfValue;
 }
+}  // namespace cpl
 
 /************************************************************************/
 /*                             CPLStrtod()                              */

--- a/port/cplstringlist.cpp
+++ b/port/cplstringlist.cpp
@@ -471,6 +471,32 @@ CPLStringList &CPLStringList::AddString(const std::string &newString)
 }
 
 /************************************************************************/
+/*                             AddString()                              */
+/************************************************************************/
+/**
+ * Add a string to the list.
+ *
+ * A copy of the passed in string_view is made and inserted in the list.
+ *
+ * @param newString the string to add to the list.
+ * @return a reference to the CPLStringList on which it was invoked.
+ */
+
+CPLStringList &CPLStringList::AddString(std::string_view newString)
+{
+    char *pszDupString =
+        static_cast<char *>(VSI_MALLOC_VERBOSE(newString.size() + 1));
+    if (pszDupString == nullptr)
+    {
+        return *this;
+    }
+    std::memcpy(pszDupString, newString.data(), newString.size());
+    pszDupString[newString.size()] = '\0';
+
+    return AddStringDirectly(pszDupString);
+}
+
+/************************************************************************/
 /*                             push_back()                              */
 /************************************************************************/
 


### PR DESCRIPTION
References #10130, #9953

Primary new feature is `cpl::strict_parse<T>`, which intends to make it easier to check string arguments for invalid values instead of silently converting to zero. The final commits show some example applications of this.