### PR TITLE
clean-up: Remove VSICurlFilesystemHandlerBase::oCacheFileProp

### DIFF
--- a/autotest/gcore/vsiaz.py
+++ b/autotest/gcore/vsiaz.py
@@ -2397,29 +2397,25 @@ def test_vsiaz_imds_authentication_expiration():
     ):
 
         handler = webserver.SequentialHandler()
-        handler.add(
-            "GET",
-            "/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fstorage.azure.com%2F",
-            200,
-            {},
-            """{
-                    "access_token": "my_bearer",
-                    "expires_on": "1000",
-                    }""",
-            expected_headers={"Metadata": "true"},
-        )
+
+        def add_get_token():
+            handler.add(
+                "GET",
+                "/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fstorage.azure.com%2F",
+                200,
+                {},
+                """{
+                        "access_token": "my_bearer",
+                        "expires_on": "1000",
+                        }""",
+                expected_headers={"Metadata": "true"},
+            )
+
+        add_get_token()
         # Credentials requested again since they are expired
-        handler.add(
-            "GET",
-            "/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fstorage.azure.com%2F",
-            200,
-            {},
-            """{
-                    "access_token": "my_bearer",
-                    "expires_on": "1000",
-                    }""",
-            expected_headers={"Metadata": "true"},
-        )
+        add_get_token()
+        add_get_token()
+        add_get_token()
         handler.add(
             "GET",
             "/azure/blob/myaccount/az_fake_bucket/resource",
@@ -2714,6 +2710,24 @@ def test_vsiaz_workload_identity_managed_authentication_expiration():
 
         # We have a security margin of 60 seconds over the expires_in delay
         # so we will need to fetch the token again
+        handler.add(
+            "POST",
+            "/tenant_id/oauth2/v2.0/token",
+            200,
+            {},
+            """{"access_token": "my_bearer2", "expires_in": "10"}""",
+            expected_headers={"Content-Type": "application/x-www-form-urlencoded"},
+            expected_body=b"client_assertion=content_of_AZURE_FEDERATED_TOKEN_FILE&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer&client_id=client_id_value&grant_type=client_credentials&scope=https://storage.azure.com/.default",
+        )
+        handler.add(
+            "POST",
+            "/tenant_id/oauth2/v2.0/token",
+            200,
+            {},
+            """{"access_token": "my_bearer2", "expires_in": "10"}""",
+            expected_headers={"Content-Type": "application/x-www-form-urlencoded"},
+            expected_body=b"client_assertion=content_of_AZURE_FEDERATED_TOKEN_FILE&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer&client_id=client_id_value&grant_type=client_credentials&scope=https://storage.azure.com/.default",
+        )
         handler.add(
             "POST",
             "/tenant_id/oauth2/v2.0/token",

--- a/autotest/gcore/vsigs.py
+++ b/autotest/gcore/vsigs.py
@@ -1786,30 +1786,27 @@ def test_vsigs_read_credentials_gce_expiration(gs_test_config, webserver_port):
             request.wfile.write("""foo""".encode("ascii"))
 
         handler = webserver.SequentialHandler()
+
+        def add_get_token():
+            handler.add(
+                "GET",
+                "/computeMetadata/v1/instance/service-accounts/default/token",
+                200,
+                {},
+                """{
+                        "access_token" : "ACCESS_TOKEN",
+                        "token_type" : "Bearer",
+                        "expires_in" : 0,
+                        }""",
+            )
+
         # First time is used when trying to establish if GCE authentication is available
-        handler.add(
-            "GET",
-            "/computeMetadata/v1/instance/service-accounts/default/token",
-            200,
-            {},
-            """{
-                    "access_token" : "ACCESS_TOKEN",
-                    "token_type" : "Bearer",
-                    "expires_in" : 0,
-                    }""",
-        )
-        # Second time is needed because f the access to th file
-        handler.add(
-            "GET",
-            "/computeMetadata/v1/instance/service-accounts/default/token",
-            200,
-            {},
-            """{
-                    "access_token" : "ACCESS_TOKEN",
-                    "token_type" : "Bearer",
-                    "expires_in" : 0,
-                    }""",
-        )
+        add_get_token()
+        # Second time is needed because of the access to the file
+        add_get_token()
+        # A couple more because VSICurlFilesystemHandlerBase::Open() use GetURLFromFilename()
+        add_get_token()
+        add_get_token()
         handler.add("GET", "/gs_fake_bucket/resource", custom_method=method)
         with webserver.install_http_handler(handler):
             f = open_for_read("/vsigs/gs_fake_bucket/resource")

--- a/autotest/gcore/vsis3.py
+++ b/autotest/gcore/vsis3.py
@@ -989,6 +989,7 @@ def test_vsis3_2(aws_test_config_as_config_options_or_credentials, webserver_por
 
 @gdaltest.enable_exceptions()
 def test_vsis3_permanent_redirect_and_region_change(aws_test_config, webserver_port):
+    gdal.VSICurlClearCache()
 
     handler = webserver.SequentialHandler()
     handler.add(
@@ -1019,6 +1020,48 @@ def test_vsis3_permanent_redirect_and_region_change(aws_test_config, webserver_p
             "/vsis3/test_vsis3_permanent_redirect_and_region_change/test.bin", "rb"
         ):
             pass
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_vsis3_permanent_redirect_and_region_change_open_a_dir(
+    aws_test_config, webserver_port
+):
+    gdal.VSICurlClearCache()
+
+    handler = webserver.SequentialHandler()
+    handler.add(
+        "GET",
+        "/test_vsis3_permanent_redirect_and_region_change_open_a_dir/?delimiter=%2F&list-type=2",
+        301,
+        {"Content-type": "application/xml"},
+        f"""<?xml version="1.0" encoding="UTF-8"?>
+            <Error><Code>PermanentRedirect</Code><Message>The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.</Message><Endpoint>localhost:{webserver_port}</Endpoint><Bucket>test_vsis3_permanent_redirect_and_region_change_open_a_dir</Bucket></Error>""",
+    )
+    handler.add(
+        "GET",
+        "/test_vsis3_permanent_redirect_and_region_change_open_a_dir/?delimiter=%2F&list-type=2",
+        200,
+        {"Content-type": "application/xml"},
+        """<?xml version="1.0" encoding="UTF-8"?>
+            <ListBucketResult>
+                <Prefix></Prefix>
+                <Contents/>
+                <CommonPrefixes>
+                    <Prefix>a_dir.ext</Prefix>
+                </CommonPrefixes>
+            </ListBucketResult>""",
+    )
+    with webserver.install_http_handler(handler):
+        assert (
+            gdal.VSIFOpenL(
+                "/vsis3/test_vsis3_permanent_redirect_and_region_change_open_a_dir/a_dir.ext",
+                "rb",
+            )
+            is None
+        )
 
 
 ###############################################################################
@@ -3799,22 +3842,6 @@ def test_vsis3_sync_failed(tmp_vsimem, aws_test_config, webserver_port):
         },
         "x" * 16384,
     )
-    handler.add(
-        "GET",
-        "/out/?delimiter=%2F&list-type=2",
-        200,
-        {"Content-type": "application/xml"},
-        """<?xml version="1.0" encoding="UTF-8"?>
-        <ListBucketResult>
-            <Prefix></Prefix>
-            <Contents>
-                <Key>testsync.txt</Key>
-                <LastModified>1970-01-01T00:00:01.000Z</LastModified>
-                <Size>30000</Size>
-            </Contents>
-        </ListBucketResult>
-        """,
-    )
     handler.add("GET", "/out/testsync.txt", 400)
     # Do not use /vsicurl_streaming/ as source, otherwise errors may be
     # emitted in worker thread, which isn't properly handled (should ideally
@@ -5753,54 +5780,42 @@ def test_vsis3_read_credentials_ec2_expiration(aws_test_config, webserver_port):
     gdal.VSICurlClearCache()
 
     handler = webserver.SequentialHandler()
-    handler.add(
-        "PUT",
-        "/latest/api/token",
-        200,
-        {},
-        "mytoken",
-        expected_headers={"X-aws-ec2-metadata-token-ttl-seconds": "10"},
-    )
-    handler.add(
-        "GET",
-        "/latest/meta-data/iam/security-credentials/",
-        200,
-        {},
-        "myprofile",
-        expected_headers={"X-aws-ec2-metadata-token": "mytoken"},
-    )
-    handler.add(
-        "GET",
-        "/latest/meta-data/iam/security-credentials/myprofile",
-        200,
-        {},
-        """{
-        "AccessKeyId": "AWS_ACCESS_KEY_ID",
-        "SecretAccessKey": "AWS_SECRET_ACCESS_KEY",
-        "Expiration": "1970-01-01T00:00:00Z"
-        }""",
-        expected_headers={"X-aws-ec2-metadata-token": "mytoken"},
-    )
-    handler.add(
-        "PUT",
-        "/latest/api/token",
-        200,
-        {},
-        "mytoken2",
-        expected_headers={"X-aws-ec2-metadata-token-ttl-seconds": "10"},
-    )
-    handler.add(
-        "GET",
-        "/latest/meta-data/iam/security-credentials/myprofile",
-        200,
-        {},
-        """{
-        "AccessKeyId": "AWS_ACCESS_KEY_ID",
-        "SecretAccessKey": "AWS_SECRET_ACCESS_KEY",
-        "Expiration": "1970-01-01T00:00:00Z"
-        }""",
-        expected_headers={"X-aws-ec2-metadata-token": "mytoken2"},
-    )
+
+    def refresh_credentials(with_get_profile=False):
+        handler.add(
+            "PUT",
+            "/latest/api/token",
+            200,
+            {},
+            "mytoken",
+            expected_headers={"X-aws-ec2-metadata-token-ttl-seconds": "10"},
+        )
+        if with_get_profile:
+            handler.add(
+                "GET",
+                "/latest/meta-data/iam/security-credentials/",
+                200,
+                {},
+                "myprofile",
+                expected_headers={"X-aws-ec2-metadata-token": "mytoken"},
+            )
+        handler.add(
+            "GET",
+            "/latest/meta-data/iam/security-credentials/myprofile",
+            200,
+            {},
+            """{
+            "AccessKeyId": "AWS_ACCESS_KEY_ID",
+            "SecretAccessKey": "AWS_SECRET_ACCESS_KEY",
+            "Expiration": "1970-01-01T00:00:00Z"
+            }""",
+            expected_headers={"X-aws-ec2-metadata-token": "mytoken"},
+        )
+
+    refresh_credentials(with_get_profile=True)
+    refresh_credentials()
+    refresh_credentials()
+    refresh_credentials()
     handler.add(
         "GET",
         "/s3_fake_bucket/resource",
@@ -5821,6 +5836,14 @@ def test_vsis3_read_credentials_ec2_expiration(aws_test_config, webserver_port):
     assert data == "foo"
 
     handler = webserver.SequentialHandler()
+    handler.add("PUT", "/invalid/latest/api/token", 404)
+    handler.add(
+        "GET", "/invalid/latest/meta-data/iam/security-credentials/myprofile", 404
+    )
+    handler.add("PUT", "/invalid/latest/api/token", 404)
+    handler.add(
+        "GET", "/invalid/latest/meta-data/iam/security-credentials/myprofile", 404
+    )
     handler.add("PUT", "/invalid/latest/api/token", 404)
     handler.add(
         "GET", "/invalid/latest/meta-data/iam/security-credentials/myprofile", 404
@@ -6115,28 +6138,24 @@ role_session_name = my_role_session_name
         </Credentials></AssumeRoleResult></AssumeRoleResponse>"""
 
     handler = webserver.SequentialHandler()
-    handler.add(
-        "GET",
-        "/?Action=AssumeRole&ExternalId=my_external_id&RoleArn=arn%3Aaws%3Aiam%3A%3A557268267719%3Arole%2Frole&RoleSessionName=my_role_session_name&SerialNumber=my_mfa_serial&Version=2011-06-15",
-        200,
-        {},
-        expired_xml_response,
-        expected_headers={
-            "Authorization": f"AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20150101/us-east-1/sts/aws4_request,SignedHeaders=host,Signature={expected_signature1}",
-            "X-Amz-Date": "20150101T000000Z",
-        },
-    )
-    handler.add(
-        "GET",
-        "/?Action=AssumeRole&ExternalId=my_external_id&RoleArn=arn%3Aaws%3Aiam%3A%3A557268267719%3Arole%2Frole&RoleSessionName=my_role_session_name&SerialNumber=my_mfa_serial&Version=2011-06-15",
-        200,
-        {},
-        expired_xml_response,
-        expected_headers={
-            "Authorization": f"AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20150101/us-east-1/sts/aws4_request,SignedHeaders=host,Signature={expected_signature1}",
-            "X-Amz-Date": "20150101T000000Z",
-        },
-    )
+
+    def add_request_AssumeRole():
+        handler.add(
+            "GET",
+            "/?Action=AssumeRole&ExternalId=my_external_id&RoleArn=arn%3Aaws%3Aiam%3A%3A557268267719%3Arole%2Frole&RoleSessionName=my_role_session_name&SerialNumber=my_mfa_serial&Version=2011-06-15",
+            200,
+            {},
+            expired_xml_response,
+            expected_headers={
+                "Authorization": f"AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/20150101/us-east-1/sts/aws4_request,SignedHeaders=host,Signature={expected_signature1}",
+                "X-Amz-Date": "20150101T000000Z",
+            },
+        )
+
+    add_request_AssumeRole()
+    add_request_AssumeRole()
+    add_request_AssumeRole()
+    add_request_AssumeRole()
     handler.add(
         "GET",
         "/s3_fake_bucket/resource",
@@ -6306,28 +6325,33 @@ source_profile = foo
         </AssumeRoleWithWebIdentityResponse>"""
 
     handler = webserver.SequentialHandler()
-    handler.add(
-        "GET",
-        "/?Action=AssumeRoleWithWebIdentity&RoleSessionName=gdal&Version=2011-06-15&RoleArn=foo_role_arn&WebIdentityToken=token",
-        200,
-        {},
-        assumeRoleWithWebIdentityResponseXML,
-    )
 
     # Note that the Expiration is in the past, so for a next request we will
     # have to renew
-    handler.add(
-        "GET",
-        "/?Action=AssumeRole&RoleArn=my_profile_role_arn&RoleSessionName=GDAL-session&Version=2011-06-15",
-        200,
-        {},
-        """<AssumeRoleResponse><AssumeRoleResult><Credentials>
-            <AccessKeyId>TEMP_ACCESS_KEY_ID</AccessKeyId>
-            <SecretAccessKey>TEMP_SECRET_ACCESS_KEY</SecretAccessKey>
-            <SessionToken>TEMP_SESSION_TOKEN</SessionToken>
-            <Expiration>1970-01-01T01:00:00Z</Expiration>
-        </Credentials></AssumeRoleResult></AssumeRoleResponse>""",
-    )
+    def add_request_AssumeRole():
+        handler.add(
+            "GET",
+            "/?Action=AssumeRoleWithWebIdentity&RoleSessionName=gdal&Version=2011-06-15&RoleArn=foo_role_arn&WebIdentityToken=token",
+            200,
+            {},
+            assumeRoleWithWebIdentityResponseXML,
+        )
+        handler.add(
+            "GET",
+            "/?Action=AssumeRole&RoleArn=my_profile_role_arn&RoleSessionName=GDAL-session&Version=2011-06-15",
+            200,
+            {},
+            """<AssumeRoleResponse><AssumeRoleResult><Credentials>
+                <AccessKeyId>TEMP_ACCESS_KEY_ID</AccessKeyId>
+                <SecretAccessKey>TEMP_SECRET_ACCESS_KEY</SecretAccessKey>
+                <SessionToken>TEMP_SESSION_TOKEN</SessionToken>
+                <Expiration>1970-01-01T01:00:00Z</Expiration>
+            </Credentials></AssumeRoleResult></AssumeRoleResponse>""",
+        )
+
+    add_request_AssumeRole()
+    add_request_AssumeRole()
+    add_request_AssumeRole()
 
     handler.add(
         "GET",
@@ -6340,6 +6364,14 @@ source_profile = foo
             "X-Amz-Security-Token": "TEMP_SESSION_TOKEN",
         },
     )
+
+    with webserver.install_http_handler(handler):
+        with gdaltest.config_options(options, thread_local=False):
+            f = open_for_read("/vsis3/s3_fake_bucket/resource")
+        assert f is not None
+        data = gdal.VSIFReadL(1, 4, f).decode("ascii")
+        gdal.VSIFCloseL(f)
+    assert data == "foo"
 
     handler2 = webserver.SequentialHandler()
     handler2.add(
@@ -6386,14 +6418,6 @@ source_profile = foo
             "X-Amz-Security-Token": "TEMP_SESSION_TOKEN",
         },
     )
-
-    with webserver.install_http_handler(handler):
-        with gdaltest.config_options(options, thread_local=False):
-            f = open_for_read("/vsis3/s3_fake_bucket/resource")
-        assert f is not None
-        data = gdal.VSIFReadL(1, 4, f).decode("ascii")
-        gdal.VSIFCloseL(f)
-    assert data == "foo"
 
     with webserver.install_http_handler(handler2):
         with gdaltest.config_options(options, thread_local=False):

--- a/port/cpl_vsil_curl.cpp
+++ b/port/cpl_vsil_curl.cpp
@@ -315,16 +315,12 @@ static int VSICurlIsFileInList(CSLConstList papszList, const char *pszTarget)
 /*                      StartsWithVSICurlPrefix()                       */
 /************************************************************************/
 
-static bool
-StartsWithVSICurlPrefix(const char *pszFilename,
-                        std::string *posFilenameAfterPrefix = nullptr)
+static bool StartsWithVSICurlPrefix(const char *pszFilename)
 {
     for (const char *pszPrefix : VSICURL_PREFIXES)
     {
         if (STARTS_WITH(pszFilename, pszPrefix))
         {
-            if (posFilenameAfterPrefix)
-                *posFilenameAfterPrefix = pszFilename + strlen(pszPrefix);
             return true;
         }
     }
@@ -4589,12 +4585,9 @@ VSICurlFilesystemHandlerBase::Open(const char *pszFilename,
                                    const char *pszAccess, bool bSetError,
                                    CSLConstList papszOptions)
 {
-    std::string osFilenameAfterPrefix;
-    if (cpl::starts_with(std::string_view(pszFilename), GetFSPrefix()))
-    {
-        osFilenameAfterPrefix = pszFilename + GetFSPrefix().size();
-    }
-    else if (!StartsWithVSICurlPrefix(pszFilename, &osFilenameAfterPrefix))
+    const bool bStartsWithVSICurlPrefix = StartsWithVSICurlPrefix(pszFilename);
+    if (!bStartsWithVSICurlPrefix &&
+        !cpl::starts_with(std::string_view(pszFilename), GetFSPrefix()))
     {
         return nullptr;
     }
@@ -4618,9 +4611,12 @@ VSICurlFilesystemHandlerBase::Open(const char *pszFilename,
 
     bool bListDir = true;
     bool bEmptyDir = false;
-    CPL_IGNORE_RET_VAL(VSICurlGetURLFromFilename(pszFilename, nullptr, nullptr,
-                                                 nullptr, &bListDir, &bEmptyDir,
-                                                 nullptr, nullptr, nullptr));
+    std::string osURL =
+        bStartsWithVSICurlPrefix
+            ? VSICurlGetURLFromFilename(pszFilename, nullptr, nullptr, nullptr,
+                                        &bListDir, &bEmptyDir, nullptr, nullptr,
+                                        nullptr)
+            : GetURLFromFilename(pszFilename);
 
     const char *pszOptionVal = CSLFetchNameValueDef(
         papszOptions, "DISABLE_READDIR_ON_OPEN",
@@ -4637,7 +4633,7 @@ VSICurlFilesystemHandlerBase::Open(const char *pszFilename,
     bool bForceExistsCheck = false;
     FileProp cachedFileProp;
     if (!bSkipReadDir &&
-        !(GetCachedFileProp(osFilenameAfterPrefix.c_str(), cachedFileProp) &&
+        !(GetCachedFileProp(osURL.c_str(), cachedFileProp) &&
           cachedFileProp.eExists == EXIST_YES) &&
         strchr(CPLGetFilename(osFilename.c_str()), '.') != nullptr &&
         !STARTS_WITH(CPLGetExtensionSafe(osFilename.c_str()).c_str(), "zip") &&
@@ -4671,6 +4667,13 @@ VSICurlFilesystemHandlerBase::Open(const char *pszFilename,
                 return nullptr;
             }
         }
+    }
+    if (!bStartsWithVSICurlPrefix)
+        osURL = GetURLFromFilename(pszFilename);
+    if (GetCachedFileProp(osURL.c_str(), cachedFileProp) &&
+        cachedFileProp.eExists == EXIST_YES && cachedFileProp.bIsDirectory)
+    {
+        return nullptr;
     }
 
     auto poHandle =

--- a/port/cpl_vsil_curl.cpp
+++ b/port/cpl_vsil_curl.cpp
@@ -4005,7 +4005,7 @@ int VSICurlHandle::Close()
 /************************************************************************/
 
 VSICurlFilesystemHandlerBase::VSICurlFilesystemHandlerBase()
-    : oCacheFileProp{100 * 1024}, oCacheDirList{1024, 0}
+    : oCacheDirList{1024, 0}
 {
 }
 
@@ -4202,17 +4202,7 @@ void VSICurlFilesystemHandlerBase::AddRegion(const char *pszURL,
 bool VSICurlFilesystemHandlerBase::GetCachedFileProp(const char *pszURL,
                                                      FileProp &oFileProp)
 {
-    CPLMutexHolder oHolder(&hMutex);
-    bool inCache;
-    if (oCacheFileProp.tryGet(std::string(pszURL), inCache))
-    {
-        if (VSICURLGetCachedFileProp(pszURL, oFileProp))
-        {
-            return true;
-        }
-        oCacheFileProp.remove(std::string(pszURL));
-    }
-    return false;
+    return VSICURLGetCachedFileProp(pszURL, oFileProp);
 }
 
 /************************************************************************/
@@ -4222,8 +4212,6 @@ bool VSICurlFilesystemHandlerBase::GetCachedFileProp(const char *pszURL,
 void VSICurlFilesystemHandlerBase::SetCachedFileProp(const char *pszURL,
                                                      FileProp &oFileProp)
 {
-    CPLMutexHolder oHolder(&hMutex);
-    oCacheFileProp.insert(std::string(pszURL), true);
     VSICURLSetCachedFileProp(pszURL, oFileProp);
 }
 
@@ -4305,7 +4293,7 @@ void VSICurlFilesystemHandlerBase::InvalidateCachedData(const char *pszURL)
 {
     CPLMutexHolder oHolder(&hMutex);
 
-    oCacheFileProp.remove(std::string(pszURL));
+    VSICURLInvalidateCachedFileProp(pszURL);
 
     // Invalidate all cached regions for this URL
     std::list<FilenameOffsetPair> keysToRemove;
@@ -4334,12 +4322,7 @@ void VSICurlFilesystemHandlerBase::ClearCache()
 
     GetRegionCache()->clear();
 
-    {
-        const auto lambda = [](const lru11::KeyValuePair<std::string, bool> &kv)
-        { VSICURLInvalidateCachedFileProp(kv.key.c_str()); };
-        oCacheFileProp.cwalk(lambda);
-        oCacheFileProp.clear();
-    }
+    VSICURLDestroyCacheFileProp();
 
     oCacheDirList.clear();
     nCachedFilesInDirList = 0;
@@ -4374,18 +4357,6 @@ void VSICurlFilesystemHandlerBase::PartialClearCache(
             poRegionCache->remove(key);
     }
 
-    {
-        std::list<std::string> keysToRemove;
-        auto lambda = [&keysToRemove,
-                       &osURL](const lru11::KeyValuePair<std::string, bool> &kv)
-        {
-            if (strncmp(kv.key.c_str(), osURL.c_str(), osURL.size()) == 0)
-                keysToRemove.push_back(kv.key);
-        };
-        oCacheFileProp.cwalk(lambda);
-        for (const auto &key : keysToRemove)
-            oCacheFileProp.remove(key);
-    }
     VSICURLInvalidateCachedFilePropPrefix(osURL.c_str());
 
     {

--- a/port/cpl_vsil_curl_class.h
+++ b/port/cpl_vsil_curl_class.h
@@ -183,13 +183,6 @@ class VSICurlFilesystemHandlerBase : public VSIFilesystemHandler
                                             // GetRegionCache();
     RegionCacheType *GetRegionCache();
 
-    // LRU cache that just keeps in memory if this file system handler is
-    // spposed to know the file properties of a file. The actual cache is a
-    // shared one among all network file systems.
-    // The aim of that design is that invalidating /vsis3/foo results in
-    // /vsis3_streaming/foo to be invalidated as well.
-    lru11::Cache<std::string, bool> oCacheFileProp;
-
     int nCachedFilesInDirList = 0;
     lru11::Cache<std::string, CachedDirList> oCacheDirList;
 
@@ -303,8 +296,8 @@ class VSICurlFilesystemHandlerBase : public VSIFilesystemHandler
                                   vsi_l_offset startOffset, int nBlocks,
                                   const std::string &osData);
 
-    bool GetCachedFileProp(const char *pszURL, FileProp &oFileProp);
-    void SetCachedFileProp(const char *pszURL, FileProp &oFileProp);
+    static bool GetCachedFileProp(const char *pszURL, FileProp &oFileProp);
+    static void SetCachedFileProp(const char *pszURL, FileProp &oFileProp);
     void InvalidateCachedData(const char *pszURL);
 
     CURLM *GetCurlMultiHandleFor(const std::string &osURL);


### PR DESCRIPTION
Since 84ac83aa93f we have a file property cache that is common to all network virtual file systems. It is unclear why the per-VFS VSICurlFilesystemHandlerBase::oCacheFileProp was kept.

(on-top of prior PR #14725 to make sure we don't regress on it)