### PR TITLE
DIMAP2: report CLOUD_COVERAGE and SNOW_COVERAGE metadata items

### DIFF
--- a/autotest/gdrivers/data/dimap2/single_component/DIM_foo.XML
+++ b/autotest/gdrivers/data/dimap2/single_component/DIM_foo.XML
@@ -9,6 +9,8 @@
   </Metadata_Identification>
   <Dataset_Content>
       <SURFACE_AREA unit="square km">1</SURFACE_AREA>
+      <CLOUD_COVERAGE unit="percent">2</CLOUD_COVERAGE>
+      <SNOW_COVERAGE unit="percent">3</SNOW_COVERAGE>
       <Dataset_Components>
          <Component>
             <COMPONENT_TITLE>Strip Source</COMPONENT_TITLE>

--- a/autotest/gdrivers/dimap.py
+++ b/autotest/gdrivers/dimap.py
@@ -96,7 +96,6 @@ def test_dimap_2_single_component():
             "EPHEMERIS_NADIR_LON": "NADIR_LON",
             "EPHEMERIS_ACQUISITION_ORBIT_NUMBER": "ACQUISITION_ORBIT_NUMBER",
             "SPECTRAL_PROCESSING": "PMS",
-            "CLOUDCOVER_MEASURE_TYPE": "AUTOMATIC",
             "DATASET_JOB_ID": "JOB_ID",
             "MISSION": "PHR",
             "GEOMETRIC_GROUND_SETTING": "true",
@@ -104,7 +103,6 @@ def test_dimap_2_single_component():
             "DATASET_PRODUCTION_DATE": "PRODUCTION_DATE",
             "DATASET_PRODUCER_CONTACT": "PRODUCER_CONTACT",
             "IMAGING_DATE": "2016-06-17",
-            "CLOUDCOVER_QUALITY_TABLES": "PHR",
             "DATASET_PRODUCER_NAME": "PRODUCER_NAME",
             "GEOMETRIC_GEOMETRIC_PROCESSING": "SENSOR",
             "GEOMETRIC_EPHEMERIS_USED": "CORRECTED",
@@ -116,7 +114,6 @@ def test_dimap_2_single_component():
             "INSTRUMENT_INDEX": "1A",
             "EPHEMERIS_NADIR_LAT": "NADIR_LAT",
             "INSTRUMENT": "PHR",
-            "CLOUDCOVER_MEASURE_NAME": "Cloud_Cotation (CLD)",
             "FACILITY_SOFTWARE": "SOFTWARE",
             "IMAGING_TIME": "12:34:56",
             "MISSION_INDEX": "1A",
@@ -141,8 +138,14 @@ def test_dimap_2_single_component():
             "RADIOMETRIC_INTER_ARRAY_RECONSTRUCTION": "true",
             "RADIOMETRIC_RADIOMETRIC_STRETCH": "false",
             "RADIOMETRIC_OUT_OF_ORDER_THRESHOLD": "0.5",
+            "CLOUD_COVERAGE": "2",
+            "CLOUD_COVERAGE_UNIT": "percent",
+            "SNOW_COVERAGE": "3",
+            "SNOW_COVERAGE_UNIT": "percent",
         }
         assert md == expected_md, "metadata wrong."
+
+        assert ds.GetMetadata("IMAGERY") == {"CLOUDCOVER": "2"}
 
         rpc = ds.GetMetadata("RPC")
         expected_rpc = {

--- a/frmts/dimap/dimapdataset.cpp
+++ b/frmts/dimap/dimapdataset.cpp
@@ -1545,26 +1545,52 @@ int DIMAPDataset::ReadImageInformation2()
         "GEOMETRIC_",
         "Processing_Information.Product_Settings.Radiometric_Settings",
         "RADIOMETRIC_",
-        "Quality_Assessment.Imaging_Quality_Measurement",
-        "CLOUDCOVER_",
         nullptr,
         nullptr};
 
     SetMetadataFromXML(psProductDim, apszMetadataTranslationDim);
+
+    if (const CPLXMLNode *psCloudCoverage = CPLGetXMLNode(
+            psProductDim, "=Dimap_Document.Dataset_Content.CLOUD_COVERAGE"))
+    {
+        if (const char *pszValue = CPLGetXMLValue(psCloudCoverage, "", nullptr))
+        {
+            SetMetadataItem("CLOUD_COVERAGE", pszValue);
+            if (const char *pszUnit =
+                    CPLGetXMLValue(psCloudCoverage, "unit", nullptr))
+            {
+                SetMetadataItem("CLOUD_COVERAGE_UNIT", pszUnit);
+                if (EQUAL(pszUnit, "percent"))
+                {
+                    // GDAL standardized metadata domain
+                    SetMetadataItem("CLOUDCOVER", pszValue, "IMAGERY");
+                }
+            }
+        }
+    }
+
+    if (const CPLXMLNode *psSnowCoverage = CPLGetXMLNode(
+            psProductDim, "=Dimap_Document.Dataset_Content.SNOW_COVERAGE"))
+    {
+        if (const char *pszValue = CPLGetXMLValue(psSnowCoverage, "", nullptr))
+        {
+            SetMetadataItem("SNOW_COVERAGE", pszValue);
+            if (const char *pszUnit =
+                    CPLGetXMLValue(psSnowCoverage, "unit", nullptr))
+            {
+                SetMetadataItem("SNOW_COVERAGE_UNIT", pszUnit);
+            }
+        }
+    }
 
     /* -------------------------------------------------------------------- */
     /*      Translate other metadata of interest: STRIP_<product_name>.XML    */
     /* -------------------------------------------------------------------- */
 
     static const char *const apszMetadataTranslationStrip[] = {
-        "Catalog.Full_Strip.Notations.Cloud_And_Quality_Notation."
-        "Data_Strip_Notation",
-        "CLOUDCOVER_",
         "Acquisition_Configuration.Platform_Configuration."
         "Ephemeris_Configuration",
-        "EPHEMERIS_",
-        nullptr,
-        nullptr};
+        "EPHEMERIS_", nullptr, nullptr};
 
     if (psProductStrip != nullptr)
         SetMetadataFromXML(psProductStrip, apszMetadataTranslationStrip);


### PR DESCRIPTION
Fixes #14706

Previous CLOUDCOVER_ metadata items look plain wrong and dates back to initial DIMAP2 support of f81dcfb0b40
