### PR TITLE
Doc: Fix gpkg option links

### DIFF
--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -526,13 +526,13 @@ The following configuration options are available:
 
 - :copy-config:`OGR_SQLITE_JOURNAL`
 
-- .. config:: OGR_SQLITE_CACHE
+- :copy-config:`OGR_SQLITE_CACHE`
 
-     see :ref:`Performance hints <target_drivers_vector_sqlite_performance_hints>`.
+  see :ref:`Performance hints <target_drivers_vector_sqlite_performance_hints>`.
 
-- .. config:: OGR_SQLITE_SYNCHRONOUS
+- :copy-config:`OGR_SQLITE_SYNCHRONOUS`
 
-     see :ref:`Performance hints <target_drivers_vector_sqlite_performance_hints>`.
+  see :ref:`Performance hints <target_drivers_vector_sqlite_performance_hints>`.
 
 - :copy-config:`OGR_SQLITE_LOAD_EXTENSIONS`
 

--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -526,9 +526,13 @@ The following configuration options are available:
 
 - :copy-config:`OGR_SQLITE_JOURNAL`
 
-- :copy-config:`OGR_SQLITE_CACHE`
+- .. config:: OGR_SQLITE_CACHE
 
-- :copy-config:`OGR_SQLITE_SYNCHRONOUS`
+     see :ref:`Performance hints <target_drivers_vector_sqlite_performance_hints>`.
+
+- .. config:: OGR_SQLITE_SYNCHRONOUS
+
+     see :ref:`Performance hints <target_drivers_vector_sqlite_performance_hints>`.
 
 - :copy-config:`OGR_SQLITE_LOAD_EXTENSIONS`
 

--- a/doc/source/drivers/vector/sqlite.rst
+++ b/doc/source/drivers/vector/sqlite.rst
@@ -466,11 +466,15 @@ The following configuration options are available:
 
 - .. config:: OGR_SQLITE_CACHE
 
-     see :ref:`Performance hints <target_drivers_vector_sqlite_performance_hints>`.
+     increases SQLite’s internal page cache (in MB).
+
+  see :ref:`Performance hints <target_drivers_vector_sqlite_performance_hints>`.
 
 - .. config:: OGR_SQLITE_SYNCHRONOUS
 
-     see :ref:`Performance hints <target_drivers_vector_sqlite_performance_hints>`.
+     setting to OFF can improve write performance but reduces crash safety
+
+  see :ref:`Performance hints <target_drivers_vector_sqlite_performance_hints>`.
 
 - .. config:: OGR_SQLITE_LOAD_EXTENSIONS
      :choices: <extension1\,...\,extensionN>, ENABLE_SQL_LOAD_EXTENSION


### PR DESCRIPTION
Fixes #10218 by simply copying the options from the SQLite page so the `:ref:`s point to the correct location. 

I tried (and failed) to update the `copy-config` directive to allow for links on the same page. The refs are already resolved pointing to anchors on the the page they are first declared, when copied in https://github.com/OSGeo/gdal/blame/cb541139e8c4a6fdf267fff69b9fd57ee2c373fa/doc/source/_extensions/configoptions.py#L165 so maybe the original RST should be stored and inserted instead. The caching in the function also probably needs to be ignored in some cases. 

Just to note, this is only an issue for `:ref:` in a `config::` which points to a link *on the same page*, and is then used in `:copy-config:`. There are no other cases of this currently in the docs apart from the 2 fixed here, so there is probably little value in spending any more time on this. 

If the `:ref:` points to a *different page* (and is used in `:copy-config:` (e.g. in the case of `SQLITE_USE_OGR_VFS also on the gpkg.rst page) then there is no issue. 

```
# works fine in - :copy-config:`SQLITE_USE_OGR_VFS`

- .. config:: SQLITE_USE_OGR_VFS
     :choices: YES, NO

     YES enables extra buffering/caching
     by the GDAL/OGR I/O layer and can speed up I/O. More information
     :ref:`here <vsicached>`.
     Be aware that no file locking will occur if this option is activated, so
     concurrent edits may lead to database corruption.
```