### PR TITLE
gdal pipeline: avoid error/creating file named '[ ... ]' when an inner read pipeline is a VRT

### DIFF
--- a/apps/gdalalg_abstract_pipeline.cpp
+++ b/apps/gdalalg_abstract_pipeline.cpp
@@ -22,6 +22,8 @@
 #include "gdalalg_vector_read.h"
 #include "gdalalg_tee.h"
 
+#include "vrtdataset.h"
+
 #include <algorithm>
 #include <cassert>
 
@@ -1567,6 +1569,9 @@ std::string GDALAbstractPipelineAlgorithm::BuildNestedPipeline(
         curAlg->m_oMapDatasetNameToDataset[datasetNameOut] = poDS;
 
         poDS->SetDescription(argsStr.c_str());
+        auto poVRTDataset = dynamic_cast<VRTDataset *>(poDS);
+        if (poVRTDataset)
+            poVRTDataset->SetWritable(false);
     }
 
     m_apoNestedPipelines.emplace_back(std::move(nestedPipeline));

--- a/autotest/utilities/test_gdalalg_pipeline.py
+++ b/autotest/utilities/test_gdalalg_pipeline.py
@@ -835,6 +835,18 @@ def test_gdalalg_pipeline_nested_nominal():
         ]
 
 
+def test_gdalalg_pipeline_inner_pipeline_vrt(tmp_path):
+    """Test bugfix for https://github.com/OSGeo/gdal/issues/14732"""
+
+    shutil.copy("data/color_file.txt", tmp_path)
+
+    with gdal.alg.pipeline(
+        pipeline=f"read ../gcore/data/byte.tif ! blend --overlay [ read ../gcore/data/byte.tif ! color-map --color-map {tmp_path}/color_file.txt ]"
+    ) as alg:
+        ds = alg.Output()
+        assert ds.GetRasterBand(1).Checksum() == 4475
+
+
 def test_gdalalg_pipeline_nested_serialize_to_gdalg(tmp_vsimem):
 
     out_filename = tmp_vsimem / "out.gdalg.json"


### PR DESCRIPTION
Fixes #14732
