### PR TITLE
Doc: Update broken nabble links

### DIFF
--- a/doc/source/development/rfc/rfc77_drop_python2_support.rst
+++ b/doc/source/development/rfc/rfc77_drop_python2_support.rst
@@ -130,7 +130,7 @@ GDAL Release cycle and regular Python version dropping
 
 When releasing GDAL 3.1.0, Even Rouault suggested GDAL would use fixed release cycles of 6 months between major versions:
 
-http://osgeo-org.1560.x6.nabble.com/gdal-dev-Reconsidering-release-cycle-length-td5436163.html#a5436242
+https://lists.osgeo.org/pipermail/gdal-dev/2020-April/052023.html
 
 Projecting from that suggestion, GDAL 3.3.0 should be released around April-May 2021.
 

--- a/doc/source/development/rfc/rfc78_gdal_utils_package.rst
+++ b/doc/source/development/rfc/rfc78_gdal_utils_package.rst
@@ -218,7 +218,7 @@ Previous discussions
 
 This topic has been discussed in the past in :
 
-- http://osgeo-org.1560.x6.nabble.com/gdal-dev-Call-for-discussion-on-RFC77-Drop-Python-2-support-td5449659.html
+- https://lists.osgeo.org/pipermail/gdal-dev/2020-November/053012.html
 
 Related PRs:
 -------------
@@ -231,7 +231,7 @@ Related PRs:
 Voting history
 --------------
 
-- http://osgeo-org.1560.x6.nabble.com/gdal-dev-Motion-RFC-78-gdal-utils-package-td5482707.html
+- https://lists.osgeo.org/pipermail/gdal-dev/2021-March/053676.html
 
 * +1 from EvenR, HowardB
 * +0 from KurtS, JukkaR

--- a/swig/java/apps/ogrtindex.java
+++ b/swig/java/apps/ogrtindex.java
@@ -45,7 +45,7 @@ public class ogrtindex {
       /* -------------------------------------------------------------------- */
       /*      Register format(s).                                             */
       /* -------------------------------------------------------------------- */
-      // fixed: http://osgeo-org.1803224.n2.nabble.com/GDAL-Java-Binding-meomory-problem-under-intensive-method-calls-td7155011.html#a7157916
+      // fixed: https://lists.osgeo.org/pipermail/gdal-dev/2012-January/031398.html
       if( ogr.GetDriverCount() == 0 )
          ogr.RegisterAll();
 


### PR DESCRIPTION
The nabble links are broken (was looking for background on the Python utils). 
This PR switches the links to use https://lists.osgeo.org/pipermail/gdal-dev