### PR TITLE
JP2Grok: handle output to Float32 or Float64 buffer

### DIFF
--- a/autotest/gdrivers/jp2grok.py
+++ b/autotest/gdrivers/jp2grok.py
@@ -1069,6 +1069,30 @@ def test_jp2grok_multitile_multirow(tmp_vsimem):
 
 
 ###############################################################################
+# Test DirectRasterIO decompression path into a Float32/Float64 buffer
+
+
+def test_jp2grok_directrasterio_float():
+    gdaltest.importorskip_gdal_array()
+    np = pytest.importorskip("numpy")
+
+    ds = gdal.Open("data/jpeg2000/byte.jp2")
+    assert ds is not None
+
+    arr_f32 = ds.GetRasterBand(1).ReadAsArray(buf_type=gdal.GDT_Float32)
+    assert arr_f32.dtype == np.float32
+
+    arr_u8 = ds.GetRasterBand(1).ReadAsArray()
+    assert np.array_equal(arr_f32, arr_u8.astype(np.float32))
+
+    arr_f64 = ds.GetRasterBand(1).ReadAsArray(buf_type=gdal.GDT_Float64)
+    assert arr_f64.dtype == np.float64
+
+    arr_u8 = ds.GetRasterBand(1).ReadAsArray()
+    assert np.array_equal(arr_f64, arr_u8.astype(np.float64))
+
+
+###############################################################################
 # Test in-place rewrite of JP2 boxes via GA_Update
 
 

--- a/frmts/grok/grkdatasetbase.h
+++ b/frmts/grok/grkdatasetbase.h
@@ -2190,6 +2190,18 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
                             for (int x = 0; x < copyWidth; ++x)
                                 dst32[x] = src[x];
                         }
+                        else if (eBufType == GDT_Float32)
+                        {
+                            auto dstF = reinterpret_cast<float *>(dst);
+                            for (int x = 0; x < copyWidth; ++x)
+                                dstF[x] = static_cast<float>(src[x]);
+                        }
+                        else if (eBufType == GDT_Float64)
+                        {
+                            auto dstD = reinterpret_cast<double *>(dst);
+                            for (int x = 0; x < copyWidth; ++x)
+                                dstD[x] = static_cast<double>(src[x]);
+                        }
                     }
                     else
                     {
@@ -2211,6 +2223,18 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
                         {
                             for (int x = 0; x < copyWidth; ++x)
                                 dst[x] = static_cast<GByte>(src[x]);
+                        }
+                        else if (eBufType == GDT_Float32)
+                        {
+                            auto dstF = reinterpret_cast<float *>(dst);
+                            for (int x = 0; x < copyWidth; ++x)
+                                dstF[x] = static_cast<float>(src[x]);
+                        }
+                        else if (eBufType == GDT_Float64)
+                        {
+                            auto dstD = reinterpret_cast<double *>(dst);
+                            for (int x = 0; x < copyWidth; ++x)
+                                dstD[x] = static_cast<double>(src[x]);
                         }
                     }
                 }
@@ -2285,6 +2309,16 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
                         static_cast<GUInt32 *>(pData)[dstOffset / 4] =
                             static_cast<GUInt32>(value);
                     }
+                    else if (eBufType == GDT_Float32)
+                    {
+                        static_cast<float *>(pData)[dstOffset / 4] =
+                            static_cast<float>(value);
+                    }
+                    else if (eBufType == GDT_Float64)
+                    {
+                        static_cast<double *>(pData)[dstOffset / 8] =
+                            static_cast<double>(value);
+                    }
                 }
             }
         }
@@ -2322,7 +2356,8 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
         const int nTotalTiles = (postPreload.tile_x1 - postPreload.tile_x0) *
                                 (postPreload.tile_y1 - postPreload.tile_y0);
         bool canUseFastPath =
-            (nTotalTiles > 1 && m_codec && m_codec->psImage && iLevel == 0);
+            (nTotalTiles > 1 && m_codec && m_codec->psImage && iLevel == 0 &&
+             eBufType != GDT_Float32 && eBufType != GDT_Float64);
         if (canUseFastPath)
         {
             for (int i = 0; i < nBandCount && canUseFastPath; ++i)
@@ -2499,7 +2534,8 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
         // Validate buffer data type
         if (eBufType != GDT_Byte && eBufType != GDT_Int16 &&
             eBufType != GDT_UInt16 && eBufType != GDT_Int32 &&
-            eBufType != GDT_UInt32)
+            eBufType != GDT_UInt32 && eBufType != GDT_Float32 &&
+            eBufType != GDT_Float64)
         {
             CPLError(CE_Failure, CPLE_NotSupported,
                      "DirectRasterIO: unsupported buffer data type %s",


### PR DESCRIPTION
## What does this PR do?

fixes grok driver failure to output to float32/float64

## What are related issues/pull requests?

#14734

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)