### PR TITLE
Drivers: replace GDALOpen() either by driver::Open() method or GDALDataset::Open()

### DIFF
--- a/frmts/aigrid/aigdataset.cpp
+++ b/frmts/aigrid/aigdataset.cpp
@@ -892,8 +892,8 @@ static CPLErr AIGRename(const char *pszNewName, const char *pszOldName)
     /* -------------------------------------------------------------------- */
     /*      Get file list.                                                  */
     /* -------------------------------------------------------------------- */
-
-    GDALDatasetH hDS = GDALOpen(osOldPath, GA_ReadOnly);
+    GDALOpenInfo oOpenInfo(osOldPath, GA_ReadOnly);
+    GDALDatasetH hDS = GDALDataset::ToHandle(AIGDataset::Open(&oOpenInfo));
     if (hDS == nullptr)
         return CE_Failure;
 
@@ -985,7 +985,8 @@ static CPLErr AIGDelete(const char *pszDatasetname)
     /* -------------------------------------------------------------------- */
     /*      Get file list.                                                  */
     /* -------------------------------------------------------------------- */
-    GDALDatasetH hDS = GDALOpen(pszDatasetname, GA_ReadOnly);
+    GDALOpenInfo oOpenInfo(pszDatasetname, GA_ReadOnly);
+    GDALDatasetH hDS = GDALDataset::ToHandle(AIGDataset::Open(&oOpenInfo));
     if (hDS == nullptr)
         return CE_Failure;
 

--- a/frmts/bsb/bsbdataset.cpp
+++ b/frmts/bsb/bsbdataset.cpp
@@ -1187,7 +1187,8 @@ static GDALDataset *BSBCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
         return NULL;
     }
 
-    return (GDALDataset *)GDALOpen(pszFilename, GA_ReadOnly);
+    GDALOpenInfo oOpenInfo(pszFilename, GA_ReadOnly);
+    return Open(&oOpenInfo);
 }
 #endif
 

--- a/frmts/dted/dteddataset.cpp
+++ b/frmts/dted/dteddataset.cpp
@@ -54,6 +54,7 @@ class DTEDDataset final : public GDALPamDataset
 
     void SetFileName(const char *pszFilename);
 
+    static GDALPamDataset *OpenPAM(GDALOpenInfo *);
     static GDALDataset *Open(GDALOpenInfo *);
     static int Identify(GDALOpenInfo *);
 };
@@ -312,6 +313,11 @@ int DTEDDataset::Identify(GDALOpenInfo *poOpenInfo)
 /************************************************************************/
 
 GDALDataset *DTEDDataset::Open(GDALOpenInfo *poOpenInfo)
+{
+    return OpenPAM(poOpenInfo);
+}
+
+GDALPamDataset *DTEDDataset::OpenPAM(GDALOpenInfo *poOpenInfo)
 
 {
     if (!Identify(poOpenInfo) || poOpenInfo->fpL == nullptr)
@@ -966,7 +972,8 @@ static GDALDataset *DTEDCreateCopy(const char *pszFilename,
     /* -------------------------------------------------------------------- */
     /*      Reopen and copy missing information into a PAM file.            */
     /* -------------------------------------------------------------------- */
-    GDALPamDataset *poDS = (GDALPamDataset *)GDALOpen(pszFilename, GA_ReadOnly);
+    GDALOpenInfo oOpenInfo(pszFilename, GA_ReadOnly);
+    GDALPamDataset *poDS = DTEDDataset::OpenPAM(&oOpenInfo);
 
     if (poDS)
         poDS->CloneInfo(poSrcDS, GCIF_PAM_DEFAULT);

--- a/frmts/ers/ersdataset.cpp
+++ b/frmts/ers/ersdataset.cpp
@@ -1007,8 +1007,9 @@ GDALDataset *ERSDataset::Open(GDALOpenInfo *poOpenInfo)
     if (EQUAL(poHeader->Find("DataSetType", ""), "Translated"))
     {
         nRecLevel++;
-        poDS->poDepFile = GDALDataset::FromHandle(
-            GDALOpen(osDataFilePath, poOpenInfo->eAccess));
+        poDS->poDepFile = GDALDataset::FromHandle(GDALDataset::Open(
+            osDataFilePath,
+            poOpenInfo->eAccess | GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR));
         nRecLevel--;
 
         if (poDS->poDepFile != nullptr &&

--- a/frmts/esric/esric_dataset.cpp
+++ b/frmts/esric/esric_dataset.cpp
@@ -929,7 +929,8 @@ CPLErr ECBand::IReadBlock(int nBlockXOff, int nBlockYOff, void *pData)
     auto mfh = VSIFileFromMemBuffer(magic.c_str(), fbuffer.data(), size, false);
     VSIFCloseL(mfh);
     // Can't open a raster by handle?
-    auto inds = GDALOpen(magic.c_str(), GA_ReadOnly);
+    auto inds = std::unique_ptr<GDALDataset>(GDALDataset::Open(
+        magic.c_str(), GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR));
     if (!inds)
     {
         VSIUnlink(magic.c_str());
@@ -937,7 +938,7 @@ CPLErr ECBand::IReadBlock(int nBlockXOff, int nBlockYOff, void *pData)
         return CE_Failure;
     }
     // Duplicate first band if not sufficient bands are provided
-    auto inbands = GDALGetRasterCount(inds);
+    auto inbands = inds->GetRasterCount();
     int ubands[4] = {1, 1, 1, 1};
     int *usebands = nullptr;
     int bandcount = parent->nBands;
@@ -962,7 +963,8 @@ CPLErr ECBand::IReadBlock(int nBlockXOff, int nBlockYOff, void *pData)
             // Grayscale, expecting color
             usebands = ubands;
             // Check for the color table of 1 band rasters
-            hCT = GDALGetRasterColorTable(GDALGetRasterBand(inds, 1));
+            hCT = GDALGetRasterColorTable(
+                GDALGetRasterBand(GDALDataset::ToHandle(inds.get()), 1));
         }
     }
 
@@ -970,9 +972,10 @@ CPLErr ECBand::IReadBlock(int nBlockXOff, int nBlockYOff, void *pData)
     if (nullptr != hCT)
     {
         // Expand color indexed to RGB(A)
-        errcode = GDALDatasetRasterIO(
-            inds, GF_Read, 0, 0, TSZ, TSZ, buffer.data(), TSZ, TSZ, GDT_UInt8,
-            1, usebands, parent->nBands, parent->nBands * TSZ, 1);
+        errcode = GDALDatasetRasterIO(GDALDataset::ToHandle(inds.get()),
+                                      GF_Read, 0, 0, TSZ, TSZ, buffer.data(),
+                                      TSZ, TSZ, GDT_UInt8, 1, usebands,
+                                      parent->nBands, parent->nBands * TSZ, 1);
         if (CE_None == errcode)
         {
             GByte abyCT[4 * 256];
@@ -1028,11 +1031,12 @@ CPLErr ECBand::IReadBlock(int nBlockXOff, int nBlockYOff, void *pData)
     }
     else
     {
-        errcode = GDALDatasetRasterIO(
-            inds, GF_Read, 0, 0, TSZ, TSZ, buffer.data(), TSZ, TSZ, GDT_UInt8,
-            bandcount, usebands, parent->nBands, parent->nBands * TSZ, 1);
+        errcode = GDALDatasetRasterIO(GDALDataset::ToHandle(inds.get()),
+                                      GF_Read, 0, 0, TSZ, TSZ, buffer.data(),
+                                      TSZ, TSZ, GDT_UInt8, bandcount, usebands,
+                                      parent->nBands, parent->nBands * TSZ, 1);
     }
-    GDALClose(inds);
+    inds.reset();
     VSIUnlink(magic.c_str());
     // Error while unpacking tile
     if (CE_None != errcode)

--- a/frmts/georaster/georaster_dataset.cpp
+++ b/frmts/georaster/georaster_dataset.cpp
@@ -2577,21 +2577,6 @@ CSLConstList GeoRasterDataset::GetMetadata(const char *pszDomain)
 CPLErr GeoRasterDataset::Delete(const char *pszFilename)
 {
     (void)pszFilename;
-    /***
-        GeoRasterDataset* poGRD = nullptr;
-
-        poGRD = (GeoRasterDataset*) GDALOpen( pszFilename, GA_Update );
-
-        if( ! poGRD )
-        {
-            return CE_Failure;
-        }
-
-        if( ! poGRD->poGeoRaster->Delete() )
-        {
-            return CE_Failure;
-        }
-    ***/
     return CE_None;
 }
 

--- a/frmts/gif/gifdataset.cpp
+++ b/frmts/gif/gifdataset.cpp
@@ -82,6 +82,7 @@ class GIFDataset final : public GIFAbstractDataset
     ~GIFDataset() override;
 
     static GDALDataset *Open(GDALOpenInfo *);
+    static GDALPamDataset *OpenPAM(GDALOpenInfo *);
 
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
@@ -157,6 +158,11 @@ GIFDataset::GIFDataset()
 /************************************************************************/
 
 GDALDataset *GIFDataset::Open(GDALOpenInfo *poOpenInfo)
+{
+    return OpenPAM(poOpenInfo);
+}
+
+GDALPamDataset *GIFDataset::OpenPAM(GDALOpenInfo *poOpenInfo)
 
 {
     if (!GIFDriverIdentify(poOpenInfo))
@@ -625,9 +631,11 @@ GDALDataset *GIFDataset::CreateCopy(const char *pszFilename,
 
     // If writing to stdout, we can't reopen it, so return
     // a fake dataset to make the caller happy.
-    CPLPushErrorHandler(CPLQuietErrorHandler);
-    poDS = static_cast<GDALPamDataset *>(GDALOpen(pszFilename, GA_ReadOnly));
-    CPLPopErrorHandler();
+    {
+        CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
+        GDALOpenInfo oOpenInfo(pszFilename, GA_ReadOnly);
+        poDS = OpenPAM(&oOpenInfo);
+    }
     if (poDS)
     {
         poDS->CloneInfo(poSrcDS, GCIF_PAM_DEFAULT);

--- a/frmts/grib/degrib/g2clib/dec_jpeg2000.cpp
+++ b/frmts/grib/degrib/g2clib/dec_jpeg2000.cpp
@@ -60,8 +60,9 @@ int dec_jpeg2000(const void *injpc,g2int bufsize,g2int **outfld,g2int outpixels)
                     FALSE ) ); // TRUE to let vsi delete the buffer when done
 
     // Open memory buffer for reading
-    GDALDataset* poJ2KDataset = (GDALDataset *)
-        GDALOpen( osFileName, GA_ReadOnly );
+    const char* const apszAllowedDrivers[] = {"JP2KAK", "JP2ECW", "JP2MRSID", "JP2GROK", "JP2OPENJPEG", nullptr };
+    auto poJ2KDataset = std::unique_ptr<GDALDataset>(
+        GDALDataset::Open(osFileName, GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR, apszAllowedDrivers ));
 
     if( poJ2KDataset == nullptr )
     {
@@ -74,7 +75,6 @@ int dec_jpeg2000(const void *injpc,g2int bufsize,g2int **outfld,g2int outpixels)
     if( poJ2KDataset->GetRasterCount() != 1 )
     {
        fprintf(stderr, "dec_jpeg2000: Found color image.  Grayscale expected.\n");
-       GDALClose( poJ2KDataset );
        VSIUnlink( osFileName );
        return (-5);
     }
@@ -88,7 +88,6 @@ int dec_jpeg2000(const void *injpc,g2int bufsize,g2int **outfld,g2int outpixels)
     {
         fprintf(stderr, "dec_jpeg2000: Image contains %ld pixels > %d.\n",
                 (long)nXSize * nYSize, outpixels);
-       GDALClose( poJ2KDataset );
        VSIUnlink( osFileName );
        return (-5);
     }
@@ -97,7 +96,6 @@ int dec_jpeg2000(const void *injpc,g2int bufsize,g2int **outfld,g2int outpixels)
     {
         fprintf(stderr, "dec_jpeg2000: Image contains %ld pixels << %d.\n",
                 (long)nXSize * nYSize, outpixels);
-       GDALClose( poJ2KDataset );
        VSIUnlink( osFileName );
        return (-5);
     }
@@ -105,7 +103,6 @@ int dec_jpeg2000(const void *injpc,g2int bufsize,g2int **outfld,g2int outpixels)
     if ( *outfld == nullptr ) {
         fprintf(stderr, "Could not allocate space in jpcunpack.\n"
                 "Data field NOT unpacked.\n");
-        GDALClose( poJ2KDataset );
         VSIUnlink( osFileName );
         return(-5);
     }
@@ -127,7 +124,7 @@ int dec_jpeg2000(const void *injpc,g2int bufsize,g2int **outfld,g2int outpixels)
                             nPixelSpace, nLineSpace, nBandSpace, nullptr );
 
     // close source file, and "unlink" it.
-    GDALClose( poJ2KDataset );
+    poJ2KDataset.reset();
     VSIUnlink( osFileName );
 
     return (eErr == CE_None) ? 0 : -3;

--- a/frmts/gsg/gs7bgdataset.cpp
+++ b/frmts/gsg/gs7bgdataset.cpp
@@ -63,6 +63,7 @@ class GS7BGDataset final : public GDALPamDataset
 
     static int Identify(GDALOpenInfo *);
     static GDALDataset *Open(GDALOpenInfo *);
+    static GDALPamDataset *OpenPAM(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eType, CSLConstList);
     static GDALDataset *CreateCopy(const char *pszFilename,
@@ -500,6 +501,11 @@ int GS7BGDataset::Identify(GDALOpenInfo *poOpenInfo)
 /************************************************************************/
 
 GDALDataset *GS7BGDataset::Open(GDALOpenInfo *poOpenInfo)
+{
+    return OpenPAM(poOpenInfo);
+}
+
+GDALPamDataset *GS7BGDataset::OpenPAM(GDALOpenInfo *poOpenInfo)
 
 {
     if (!Identify(poOpenInfo) || poOpenInfo->fpL == nullptr)
@@ -1107,7 +1113,8 @@ GDALDataset *GS7BGDataset::Create(const char *pszFilename, int nXSize,
 
     VSIFCloseL(fp);
 
-    return (GDALDataset *)GDALOpen(pszFilename, GA_Update);
+    GDALOpenInfo oOpenInfo(pszFilename, GA_Update);
+    return Open(&oOpenInfo);
 }
 
 /************************************************************************/
@@ -1263,12 +1270,12 @@ GDALDataset *GS7BGDataset::CreateCopy(const char *pszFilename,
 
     VSIFCloseL(fp);
 
-    GDALPamDataset *poDS = (GDALPamDataset *)GDALOpen(pszFilename, GA_Update);
+    GDALOpenInfo oOpenInfo(pszFilename, GA_Update);
+    GDALPamDataset *poDS = OpenPAM(&oOpenInfo);
     if (poDS)
     {
         poDS->CloneInfo(poSrcDS, GCIF_PAM_DEFAULT);
     }
-
     return poDS;
 }
 

--- a/frmts/gsg/gsagdataset.cpp
+++ b/frmts/gsg/gsagdataset.cpp
@@ -58,6 +58,7 @@ class GSAGDataset final : public GDALPamDataset
 
     static int Identify(GDALOpenInfo *);
     static GDALDataset *Open(GDALOpenInfo *);
+    static GDALPamDataset *OpenPAM(GDALOpenInfo *);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
                                    CSLConstList papszOptions,
@@ -812,6 +813,11 @@ int GSAGDataset::Identify(GDALOpenInfo *poOpenInfo)
 /************************************************************************/
 
 GDALDataset *GSAGDataset::Open(GDALOpenInfo *poOpenInfo)
+{
+    return OpenPAM(poOpenInfo);
+}
+
+GDALPamDataset *GSAGDataset::OpenPAM(GDALOpenInfo *poOpenInfo)
 
 {
     if (!Identify(poOpenInfo) || poOpenInfo->fpL == nullptr)
@@ -1658,7 +1664,8 @@ GDALDataset *GSAGDataset::CreateCopy(const char *pszFilename,
 
     VSIFCloseL(fp);
 
-    GDALPamDataset *poDS = (GDALPamDataset *)GDALOpen(pszFilename, GA_Update);
+    GDALOpenInfo oOpenInfo(pszFilename, GA_Update);
+    GDALPamDataset *poDS = OpenPAM(&oOpenInfo);
     if (poDS)
     {
         poDS->CloneInfo(poSrcDS, GCIF_PAM_DEFAULT);

--- a/frmts/gsg/gsbgdataset.cpp
+++ b/frmts/gsg/gsbgdataset.cpp
@@ -54,6 +54,7 @@ class GSBGDataset final : public GDALPamDataset
 
     static int Identify(GDALOpenInfo *);
     static GDALDataset *Open(GDALOpenInfo *);
+    static GDALPamDataset *OpenPAM(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBands, GDALDataType eType, CSLConstList);
     static GDALDataset *CreateCopy(const char *pszFilename,
@@ -483,6 +484,11 @@ int GSBGDataset::Identify(GDALOpenInfo *poOpenInfo)
 /************************************************************************/
 
 GDALDataset *GSBGDataset::Open(GDALOpenInfo *poOpenInfo)
+{
+    return OpenPAM(poOpenInfo);
+}
+
+GDALPamDataset *GSBGDataset::OpenPAM(GDALOpenInfo *poOpenInfo)
 
 {
     if (!Identify(poOpenInfo) || poOpenInfo->fpL == nullptr)
@@ -863,7 +869,8 @@ GDALDataset *GSBGDataset::Create(const char *pszFilename, int nXSize,
 
     VSIFCloseL(fp);
 
-    return (GDALDataset *)GDALOpen(pszFilename, GA_Update);
+    GDALOpenInfo oOpenInfo(pszFilename, GA_Update);
+    return Open(&oOpenInfo);
 }
 
 /************************************************************************/
@@ -1019,7 +1026,8 @@ GDALDataset *GSBGDataset::CreateCopy(const char *pszFilename,
 
     VSIFCloseL(fp);
 
-    GDALPamDataset *poDS = (GDALPamDataset *)GDALOpen(pszFilename, GA_Update);
+    GDALOpenInfo oOpenInfo(pszFilename, GA_Update);
+    GDALPamDataset *poDS = OpenPAM(&oOpenInfo);
     if (poDS)
     {
         poDS->CloneInfo(poSrcDS, GCIF_PAM_DEFAULT);

--- a/frmts/gta/gtadataset.cpp
+++ b/frmts/gta/gtadataset.cpp
@@ -246,6 +246,7 @@ class GTADataset final : public GDALPamDataset
     ~GTADataset() override;
 
     static GDALDataset *Open(GDALOpenInfo *);
+    static GDALPamDataset *OpenPAM(GDALOpenInfo *);
 
     CPLErr GetGeoTransform(GDALGeoTransform &gt) const override;
     CPLErr SetGeoTransform(const GDALGeoTransform &gt) override;
@@ -1012,6 +1013,11 @@ CPLErr GTADataset::SetGCPs(int, const GDAL_GCP *, const OGRSpatialReference *)
 /************************************************************************/
 
 GDALDataset *GTADataset::Open(GDALOpenInfo *poOpenInfo)
+{
+    return OpenPAM(poOpenInfo);
+}
+
+GDALPamDataset *GTADataset::OpenPAM(GDALOpenInfo *poOpenInfo)
 
 {
     if (GTADriverIdentify(poOpenInfo) == GDAL_IDENTIFY_FALSE)
@@ -1725,8 +1731,9 @@ static GDALDataset *GTACreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
     /*      Re-open dataset, and copy any auxiliary pam information.         */
     /* -------------------------------------------------------------------- */
 
-    GTADataset *poDS = (GTADataset *)GDALOpen(
+    GDALOpenInfo oOpenInfo(
         pszFilename, eGTACompression == gta::none ? GA_Update : GA_ReadOnly);
+    auto poDS = GTADataset::OpenPAM(&oOpenInfo);
 
     if (poDS)
         poDS->CloneInfo(poSrcDS, GCIF_PAM_DEFAULT);

--- a/frmts/hdf4/hdf4dataset.cpp
+++ b/frmts/hdf4/hdf4dataset.cpp
@@ -1246,8 +1246,8 @@ GDALDataset *HDF4Dataset::Open(GDALOpenInfo *poOpenInfo)
         delete poDS;
         poDS = nullptr;
 
-        GDALDataset *poRetDS =
-            GDALDataset::FromHandle(GDALOpen(pszSDSName, poOpenInfo->eAccess));
+        GDALOpenInfo oOpenInfo(pszSDSName, poOpenInfo->eAccess);
+        GDALDataset *poRetDS = HDF4ImageDataset::Open(&oOpenInfo);
         CPLFree(pszSDSName);
 
         CPLAcquireMutex(hHDF4Mutex, 1000.0);

--- a/frmts/hdf4/hdf4dataset.h
+++ b/frmts/hdf4/hdf4dataset.h
@@ -19,6 +19,10 @@
 #include "cpl_list.h"
 #include "gdal_pam.h"
 
+constexpr int HDF4_SDS_MAXNAMELEN = 65;
+
+constexpr int N_BUF_SIZE = 8192;
+
 typedef enum  // Types of dataset:
 {
     HDF4_SDS,  // Scientific Dataset
@@ -94,6 +98,92 @@ class HDF4Dataset CPL_NON_FINAL : public GDALPamDataset
     char **GetMetadataDomainList() override;
     CSLConstList GetMetadata(const char *pszDomain = "") override;
     static GDALDataset *Open(GDALOpenInfo *);
+};
+
+/************************************************************************/
+/* ==================================================================== */
+/*                              HDF4ImageDataset                        */
+/* ==================================================================== */
+/************************************************************************/
+
+constexpr int N_COLOR_ENTRIES = 256;
+
+class HDF4ImageDataset final : public HDF4Dataset
+{
+    friend class HDF4ImageRasterBand;
+
+    char *pszFilename;
+    int32 hHDF4;
+    int32 iGR;
+    int32 iPal;
+    int32 iDataset;
+    int32 iRank;
+    int32 iNumType;
+    int32 nAttrs;
+    int32 iInterlaceMode;
+    int32 iPalInterlaceMode;
+    int32 iPalDataType;
+    int32 nComps;
+    int32 nPalEntries;
+    int32 aiDimSizes[H4_MAX_VAR_DIMS];
+    int iXDim;
+    int iYDim;
+    int iBandDim;
+    int i4Dim;
+    int nBandCount;
+    char **papszLocalMetadata{};
+    uint8 aiPaletteData[N_COLOR_ENTRIES][3];  // XXX: Static array for now
+    char szName[HDF4_SDS_MAXNAMELEN];
+    char *pszSubdatasetName;
+    char *pszFieldName;
+
+    GDALColorTable *poColorTable;
+
+    OGRSpatialReference m_oSRS{};
+    OGRSpatialReference m_oGCPSRS{};
+    bool bHasGeoTransform;
+    GDALGeoTransform m_gt{};
+    std::vector<gdal::GCP> m_aoGCPs{};
+
+    HDF4DatasetType iDatasetType;
+
+    int32 iSDS;
+
+    int nBlockPreferredXSize;
+    int nBlockPreferredYSize;
+    bool bReadTile;
+
+    void ToGeoref(double *, double *);
+    void GetImageDimensions(char *);
+    void GetSwatAttrs(int32);
+    void GetGridAttrs(int32 hGD);
+    void CaptureNRLGeoTransform(void);
+    void CaptureL1GMTLInfo(void);
+    void CaptureCoastwatchGCTPInfo(void);
+    void ProcessModisSDSGeolocation(void);
+    int ProcessSwathGeolocation(int32, char **);
+
+    static long USGSMnemonicToCode(const char *);
+    static void ReadCoordinates(const char *, double *, double *);
+
+    CPL_DISALLOW_COPY_ASSIGN(HDF4ImageDataset)
+
+  public:
+    HDF4ImageDataset();
+    ~HDF4ImageDataset() override;
+
+    static GDALDataset *Open(GDALOpenInfo *);
+    static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
+                               int nBandsIn, GDALDataType eType,
+                               CSLConstList papszParamList);
+    CPLErr FlushCache(bool bAtClosing) override;
+    CPLErr GetGeoTransform(GDALGeoTransform &gt) const override;
+    CPLErr SetGeoTransform(const GDALGeoTransform &gt) override;
+    const OGRSpatialReference *GetSpatialRef() const override;
+    CPLErr SetSpatialRef(const OGRSpatialReference *poSRS) override;
+    int GetGCPCount() override;
+    const OGRSpatialReference *GetGCPSpatialRef() const override;
+    const GDAL_GCP *GetGCPs() override;
 };
 
 char *SPrintArray(GDALDataType eDataType, const void *paDataArray, int nValues,

--- a/frmts/hdf4/hdf4imagedataset.cpp
+++ b/frmts/hdf4/hdf4imagedataset.cpp
@@ -41,8 +41,6 @@
 
 #include <algorithm>
 
-constexpr int HDF4_SDS_MAXNAMELEN = 65;
-
 extern const char *const pszGDALSignature;
 
 // Signature to recognize files written by GDAL.
@@ -50,8 +48,6 @@ const char *const pszGDALSignature =
     "Created with GDAL (http://www.remotesensing.org/gdal/)";
 
 extern CPLMutex *hHDF4Mutex;
-
-constexpr int N_BUF_SIZE = 8192;
 
 /************************************************************************/
 /* ==================================================================== */
@@ -69,92 +65,6 @@ enum HDF4EOSProduct
     PROD_AST14DEM,
     PROD_MODIS_L1B,
     PROD_MODIS_L2
-};
-
-/************************************************************************/
-/* ==================================================================== */
-/*                              HDF4ImageDataset                        */
-/* ==================================================================== */
-/************************************************************************/
-
-constexpr int N_COLOR_ENTRIES = 256;
-
-class HDF4ImageDataset final : public HDF4Dataset
-{
-    friend class HDF4ImageRasterBand;
-
-    char *pszFilename;
-    int32 hHDF4;
-    int32 iGR;
-    int32 iPal;
-    int32 iDataset;
-    int32 iRank;
-    int32 iNumType;
-    int32 nAttrs;
-    int32 iInterlaceMode;
-    int32 iPalInterlaceMode;
-    int32 iPalDataType;
-    int32 nComps;
-    int32 nPalEntries;
-    int32 aiDimSizes[H4_MAX_VAR_DIMS];
-    int iXDim;
-    int iYDim;
-    int iBandDim;
-    int i4Dim;
-    int nBandCount;
-    char **papszLocalMetadata{};
-    uint8 aiPaletteData[N_COLOR_ENTRIES][3];  // XXX: Static array for now
-    char szName[HDF4_SDS_MAXNAMELEN];
-    char *pszSubdatasetName;
-    char *pszFieldName;
-
-    GDALColorTable *poColorTable;
-
-    OGRSpatialReference m_oSRS{};
-    OGRSpatialReference m_oGCPSRS{};
-    bool bHasGeoTransform;
-    GDALGeoTransform m_gt{};
-    std::vector<gdal::GCP> m_aoGCPs{};
-
-    HDF4DatasetType iDatasetType;
-
-    int32 iSDS;
-
-    int nBlockPreferredXSize;
-    int nBlockPreferredYSize;
-    bool bReadTile;
-
-    void ToGeoref(double *, double *);
-    void GetImageDimensions(char *);
-    void GetSwatAttrs(int32);
-    void GetGridAttrs(int32 hGD);
-    void CaptureNRLGeoTransform(void);
-    void CaptureL1GMTLInfo(void);
-    void CaptureCoastwatchGCTPInfo(void);
-    void ProcessModisSDSGeolocation(void);
-    int ProcessSwathGeolocation(int32, char **);
-
-    static long USGSMnemonicToCode(const char *);
-    static void ReadCoordinates(const char *, double *, double *);
-
-    CPL_DISALLOW_COPY_ASSIGN(HDF4ImageDataset)
-
-  public:
-    HDF4ImageDataset();
-    ~HDF4ImageDataset() override;
-
-    static GDALDataset *Open(GDALOpenInfo *);
-    static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
-                               int nBandsIn, GDALDataType eType,
-                               CSLConstList papszParamList);
-    CPLErr FlushCache(bool bAtClosing) override;
-    CPLErr GetGeoTransform(GDALGeoTransform &gt) const override;
-    CPLErr SetGeoTransform(const GDALGeoTransform &gt) override;
-    const OGRSpatialReference *GetSpatialRef() const override;
-    CPLErr SetSpatialRef(const OGRSpatialReference *poSRS) override;
-    int GetGCPCount() override;
-    const OGRSpatialReference *GetGCPSpatialRef() const override;
-    const GDAL_GCP *GetGCPs() override;
 };
 
 /************************************************************************/
@@ -3767,6 +3677,8 @@ GDALDataset *HDF4ImageDataset::Open(GDALOpenInfo *poOpenInfo)
 
     poDS->oOvManager.Initialize(poDS, ":::VIRTUAL:::");
     CPLAcquireMutex(hHDF4Mutex, 1000.0);
+
+    poDS->poDriver = GetGDALDriverManager()->GetDriverByName("HDF4Image");
 
     return poDS;
 }

--- a/frmts/hfa/hfadataset.cpp
+++ b/frmts/hfa/hfadataset.cpp
@@ -4589,6 +4589,11 @@ int HFADataset::Identify(GDALOpenInfo *poOpenInfo)
 /************************************************************************/
 
 GDALDataset *HFADataset::Open(GDALOpenInfo *poOpenInfo)
+{
+    return OpenHFA(poOpenInfo);
+}
+
+HFADataset *HFADataset::OpenHFA(GDALOpenInfo *poOpenInfo)
 
 {
     // Verify that this is a HFA file.
@@ -5114,7 +5119,8 @@ GDALDataset *HFADataset::Create(const char *pszFilenameIn, int nXSize,
     }
 
     // Open the dataset normally.
-    HFADataset *poDS = (HFADataset *)GDALOpen(pszFilenameIn, GA_Update);
+    GDALOpenInfo oOpenInfo(pszFilenameIn, GA_Update);
+    HFADataset *poDS = OpenHFA(&oOpenInfo);
 
     // Special creation option to disable checking for UTM
     // parameters when writing the projection.  This is a special

--- a/frmts/hfa/hfadataset.h
+++ b/frmts/hfa/hfadataset.h
@@ -71,6 +71,7 @@ class HFADataset final : public GDALPamDataset
     static CPLErr Rename(const char *pszNewName, const char *pszOldName);
     static CPLErr CopyFiles(const char *pszNewName, const char *pszOldName);
     static GDALDataset *Open(GDALOpenInfo *);
+    static HFADataset *OpenHFA(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
                                CSLConstList papszParamList);

--- a/frmts/idrisi/IdrisiDataset.cpp
+++ b/frmts/idrisi/IdrisiDataset.cpp
@@ -992,7 +992,8 @@ GDALDataset *IdrisiDataset::Create(const char *pszFilename, int nXSize,
                   static_cast<vsi_l_offset>(nXSize) * nYSize * nTargetDTSize);
     VSIFCloseL(fp);
 
-    return (IdrisiDataset *)GDALOpen(pszFilename, GA_Update);
+    GDALOpenInfo oOpenInfo(pszFilename, GA_Update);
+    return Open(&oOpenInfo);
 }
 
 /************************************************************************/

--- a/frmts/mrsid/mrsiddataset.cpp
+++ b/frmts/mrsid/mrsiddataset.cpp
@@ -258,6 +258,7 @@ class MrSIDDataset final : public GDALJP2AbstractDataset
     explicit MrSIDDataset(int bIsJPEG2000);
     ~MrSIDDataset() override;
 
+    static GDALPamDataset *OpenPAM(GDALOpenInfo *poOpenInfo, int bIsJP2);
     static GDALDataset *Open(GDALOpenInfo *poOpenInfo, int bIsJP2);
 
     char **GetFileList() override;
@@ -1411,6 +1412,11 @@ static GDALDataset *JP2Open(GDALOpenInfo *poOpenInfo)
 /************************************************************************/
 
 GDALDataset *MrSIDDataset::Open(GDALOpenInfo *poOpenInfo, int bIsJP2)
+{
+    return OpenPAM(poOpenInfo, bIsJP2);
+}
+
+GDALPamDataset *MrSIDDataset::OpenPAM(GDALOpenInfo *poOpenInfo, int bIsJP2)
 {
     if (poOpenInfo->fpL)
     {
@@ -3412,7 +3418,8 @@ static GDALDataset *MrSIDCreateCopy(const char *pszFilename,
     /* -------------------------------------------------------------------- */
     /*      Re-open dataset, and copy any auxiliary pam information.         */
     /* -------------------------------------------------------------------- */
-    GDALPamDataset *poDS = (GDALPamDataset *)GDALOpen(pszFilename, GA_ReadOnly);
+    GDALOpenInfo oOpenInfo(pszFilename, GA_ReadOnly);
+    GDALPamDataset *poDS = OpenPAM(&oOpenInfo, /* bIsJP2 = */ false);
 
     if (poDS)
         poDS->CloneInfo(poSrcDS, GCIF_PAM_DEFAULT);
@@ -3544,7 +3551,7 @@ static GDALDataset *JP2CreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
     /*      Re-open dataset, and copy any auxiliary pam information.         */
     /* -------------------------------------------------------------------- */
     GDALOpenInfo oOpenInfo(pszFilename, GA_ReadOnly);
-    GDALPamDataset *poDS = (GDALPamDataset *)JP2Open(&oOpenInfo);
+    GDALPamDataset *poDS = OpenPAM(&oOpenInfo, /* bIsJP2 = */ true);
 
     if (poDS)
         poDS->CloneInfo(poSrcDS, GCIF_PAM_DEFAULT);

--- a/frmts/nitf/nitfdataset.cpp
+++ b/frmts/nitf/nitfdataset.cpp
@@ -3953,7 +3953,7 @@ CPLErr NITFDataset::ReadJPEGBlock(int iBlockX, int iBlockY)
                       panJPEGBlockOffset[iBlock], 0, osNITFFilename.c_str());
 
     GDALDataset *poDS =
-        GDALDataset::FromHandle(GDALOpen(osFilename, GA_ReadOnly));
+        GDALDataset::Open(osFilename, GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR);
     if (poDS == nullptr)
         return CE_Failure;
 

--- a/frmts/pcidsk/gdal_edb.cpp
+++ b/frmts/pcidsk/gdal_edb.cpp
@@ -72,12 +72,9 @@ EDBFile *GDAL_EDBOpen(const std::string &osFilename,
 {
     GDALDataset *poDS = nullptr;
 
-    if (osAccess == "r")
-        poDS =
-            GDALDataset::FromHandle(GDALOpen(osFilename.c_str(), GA_ReadOnly));
-    else
-        poDS = GDALDataset::FromHandle(GDALOpen(osFilename.c_str(), GA_Update));
-
+    const int nFlags = (osAccess == "r") ? GDAL_OF_READONLY : GDAL_OF_UPDATE;
+    poDS = GDALDataset::Open(osFilename.c_str(),
+                             nFlags | GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR);
     if (poDS == nullptr)
         ThrowPCIDSKException("%s", CPLGetLastErrorMsg());
 

--- a/frmts/pdf/pdfcreatecopy.cpp
+++ b/frmts/pdf/pdfcreatecopy.cpp
@@ -2077,10 +2077,9 @@ void GDALPDFBaseWriter::GetObjectStyle(
                         if (oMapSymbolFilenameToDesc.find(os.osSymbolId) ==
                             oMapSymbolFilenameToDesc.end())
                         {
-                            CPLPushErrorHandler(CPLQuietErrorHandler);
                             GDALDatasetH hImageDS =
-                                GDALOpen(os.osSymbolId, GA_ReadOnly);
-                            CPLPopErrorHandler();
+                                GDALDataset::ToHandle(GDALDataset::Open(
+                                    os.osSymbolId, GDAL_OF_RASTER));
                             if (hImageDS != nullptr)
                             {
                                 os.nImageWidth = GDALGetRasterXSize(hImageDS);

--- a/frmts/pds/isis3dataset.cpp
+++ b/frmts/pds/isis3dataset.cpp
@@ -2228,7 +2228,7 @@ GDALDataset *ISIS3Dataset::Open(GDALOpenInfo *poOpenInfo)
             return nullptr;
         }
         poDS->m_poExternalDS =
-            GDALDataset::FromHandle(GDALOpen(osQubeFile, poOpenInfo->eAccess));
+            GDALDataset::Open(osQubeFile, poOpenInfo->eAccess);
         if (poDS->m_poExternalDS == nullptr)
         {
             return nullptr;
@@ -2264,8 +2264,10 @@ GDALDataset *ISIS3Dataset::Open(GDALOpenInfo *poOpenInfo)
         // TIFF file
         if (EQUAL(CPLGetExtensionSafe(osQubeFile).c_str(), "tif"))
         {
-            GDALDataset *poTIF_DS =
-                GDALDataset::FromHandle(GDALOpen(osQubeFile, GA_ReadOnly));
+            const char *const apszAllowedDrivers[] = {"GTiff", nullptr};
+            auto poTIF_DS = std::unique_ptr<GDALDataset>(GDALDataset::Open(
+                osQubeFile, GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR,
+                apszAllowedDrivers));
             if (poTIF_DS)
             {
                 bool bWarned = false;
@@ -2342,8 +2344,6 @@ GDALDataset *ISIS3Dataset::Open(GDALOpenInfo *poOpenInfo)
                         }
                     }
                 }
-
-                delete poTIF_DS;
             }
         }
     }

--- a/frmts/pds/pdsdataset.cpp
+++ b/frmts/pds/pdsdataset.cpp
@@ -1386,8 +1386,8 @@ int PDSDataset::ParseCompressedImage()
     const CPLString osFullFileName =
         CPLFormFilenameSafe(osPath, osFileName, nullptr);
 
-    poCompressedDS =
-        GDALDataset::FromHandle(GDALOpen(osFullFileName, GA_ReadOnly));
+    poCompressedDS = GDALDataset::Open(osFullFileName,
+                                       GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR);
 
     if (poCompressedDS == nullptr)
         return FALSE;

--- a/frmts/raw/gtxdataset.cpp
+++ b/frmts/raw/gtxdataset.cpp
@@ -433,7 +433,8 @@ GDALDataset *GTXDataset::Create(const char *pszFilename, int nXSize, int nYSize,
     CPL_IGNORE_RET_VAL(VSIFWriteL(header, 40, 1, fp));
     CPL_IGNORE_RET_VAL(VSIFCloseL(fp));
 
-    return GDALDataset::FromHandle(GDALOpen(pszFilename, GA_Update));
+    GDALOpenInfo oOpenInfo(pszFilename, GA_Update);
+    return Open(&oOpenInfo);
 }
 
 /************************************************************************/

--- a/frmts/raw/krodataset.cpp
+++ b/frmts/raw/krodataset.cpp
@@ -303,7 +303,8 @@ GDALDataset *KRODataset::Create(const char *pszFilename, int nXSize, int nYSize,
     if (nRet != 6)
         return nullptr;
 
-    return GDALDataset::FromHandle(GDALOpen(pszFilename, GA_Update));
+    GDALOpenInfo oOpenInfo(pszFilename, GA_Update);
+    return Open(&oOpenInfo);
 }
 
 /************************************************************************/

--- a/frmts/raw/lcpdataset.cpp
+++ b/frmts/raw/lcpdataset.cpp
@@ -1627,7 +1627,9 @@ GDALDataset *LCPDataset::CreateCopy(const char *pszFilename,
         }
         CPLFree(pszESRIProjection);
     }
-    return static_cast<GDALDataset *>(GDALOpen(pszFilename, GA_ReadOnly));
+
+    GDALOpenInfo oOpenInfo(pszFilename, GA_ReadOnly);
+    return Open(&oOpenInfo);
 }
 
 /************************************************************************/

--- a/frmts/raw/roipacdataset.cpp
+++ b/frmts/raw/roipacdataset.cpp
@@ -650,7 +650,8 @@ GDALDataset *ROIPACDataset::Create(const char *pszFilename, int nXSize,
     CPL_IGNORE_RET_VAL(VSIFPrintfL(fp, "%-40s %d\n", "FILE_LENGTH", nYSize));
     CPL_IGNORE_RET_VAL(VSIFCloseL(fp));
 
-    return GDALDataset::FromHandle(GDALOpen(pszFilename, GA_Update));
+    GDALOpenInfo oOpenInfo(pszFilename, GA_Update);
+    return Open(&oOpenInfo);
 }
 
 /************************************************************************/

--- a/frmts/saga/sagadataset.cpp
+++ b/frmts/saga/sagadataset.cpp
@@ -977,7 +977,8 @@ GDALDataset *SAGADataset::Create(const char *pszFilename, int nXSize,
 
     VSIFCloseL(fp);
 
-    return GDALDataset::FromHandle(GDALOpen(pszFilename, GA_Update));
+    GDALOpenInfo oOpenInfo(pszFilename, GA_Update);
+    return Open(&oOpenInfo);
 }
 
 /************************************************************************/

--- a/frmts/terragen/terragendataset.cpp
+++ b/frmts/terragen/terragendataset.cpp
@@ -966,10 +966,7 @@ GDALDataset *TerragenDataset::Create(const char *pszFilename, int nXSize,
     // --------------------------------------------------------------------
     poDS->SetBand(1, new TerragenRasterBand(poDS));
 
-    // VSIFClose( poDS->m_fp );
-
-    // return (GDALDataset *) GDALOpen( pszFilename, GA_Update );
-    return GDALDataset::FromHandle(poDS);
+    return poDS;
 }
 
 /************************************************************************/

--- a/frmts/tiledb/tiledbdense.cpp
+++ b/frmts/tiledb/tiledbdense.cpp
@@ -1724,8 +1724,8 @@ GDALDataset *TileDBRasterDataset::OpenInternal(GDALOpenInfo *poOpenInfo,
                     const char *pszSubDSName =
                         poDS->m_aosSubdatasetMD.FetchNameValueDef(
                             "SUBDATASET_1_NAME", "");
-                    return GDALDataset::FromHandle(
-                        GDALOpen(pszSubDSName, poOpenInfo->eAccess));
+                    GDALOpenInfo oOpenInfo(pszSubDSName, poOpenInfo->eAccess);
+                    return OpenInternal(&oOpenInfo, objectType);
                 }
             }
             else if (poDS->eIndexMode == ATTRIBUTES)

--- a/frmts/tsx/tsxdataset.cpp
+++ b/frmts/tsx/tsxdataset.cpp
@@ -639,8 +639,8 @@ GDALDataset *TSXDataset::Open(GDALOpenInfo *poOpenInfo)
                                                               : GDT_UInt16;
 
             /* try opening the file that represents that band */
-            GDALDataset *poBandData =
-                GDALDataset::FromHandle(GDALOpen(osPath.c_str(), GA_ReadOnly));
+            GDALDataset *poBandData = GDALDataset::Open(
+                osPath.c_str(), GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR);
             if (poBandData != nullptr)
             {
                 TSXRasterBand *poBand =

--- a/frmts/wcs/wcsdataset.cpp
+++ b/frmts/wcs/wcsdataset.cpp
@@ -714,8 +714,8 @@ GDALDataset *WCSDataset::GDALOpenResult(CPLHTTPResult *psResult)
     /* -------------------------------------------------------------------- */
     /*      Try opening this result as a gdaldataset.                       */
     /* -------------------------------------------------------------------- */
-    GDALDataset *poDS =
-        (GDALDataset *)GDALOpen(osResultFilename.c_str(), GA_ReadOnly);
+    GDALDataset *poDS = GDALDataset::Open(
+        osResultFilename.c_str(), GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR);
 
     /* -------------------------------------------------------------------- */
     /*      If opening it in memory didn't work, perhaps we need to         */

--- a/ogr/ogrsf_frmts/cad/gdalcaddataset.cpp
+++ b/ogr/ogrsf_frmts/cad/gdalcaddataset.cpp
@@ -230,8 +230,9 @@ int GDALCADDataset::Open(GDALOpenInfo *poOpenInfo, CADFileIO *pFileIO,
                                  nullptr))
                 return poOpenInfo->nOpenFlags & GDAL_OF_VECTOR;
 
-            poRasterDS = GDALDataset::FromHandle(
-                GDALOpen(osImgFilename, poOpenInfo->eAccess));
+            poRasterDS = GDALDataset::Open(
+                osImgFilename,
+                poOpenInfo->eAccess | GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR);
             if (poRasterDS == nullptr)
             {
                 delete pImage;

--- a/ogr/ogrsf_frmts/libkml/ogrlibkmlfeature.cpp
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmlfeature.cpp
@@ -264,7 +264,8 @@ FeaturePtr feat2kml(OGRLIBKMLDataSource *poOgrDS, OGRLIBKMLLayer *poOgrLayer,
                 CPLString osURL = OGRLIBKMLReplaceLevelXYInURL(pszURL, 0, 0, 0);
                 if (strstr(osURL, ".kmz/"))
                     osURL = "/vsizip/" + osURL;
-                GDALDatasetH hDS = GDALOpen(osURL, GA_ReadOnly);
+                GDALDatasetH hDS = GDALDataset::ToHandle(GDALDataset::Open(
+                    osURL, GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR));
                 if (hDS != nullptr)
                 {
                     nTileSize = GDALGetRasterXSize(hDS);


### PR DESCRIPTION
A number of drivers had their Create()/CreateCopy() method using GDALOpen() at its end, which is inefficient since that iterates over all drivers.
Replacing it by {driver_dataset_class}::Open() is clearer and makes it more obvious when we actually probe all drivers
