### PR TITLE
GTiff: Avoid value-initialization of vector of forward declared class

### DIFF
--- a/frmts/gtiff/gtiffdataset.cpp
+++ b/frmts/gtiff/gtiffdataset.cpp
@@ -70,7 +70,10 @@ const GTIFFTag *GTiffDataset::GetTIFFTags()
 /************************************************************************/
 
 GTiffDataset::GTiffDataset()
-    : m_bStreamingIn(false), m_bStreamingOut(false), m_bScanDeferred(true),
+    : m_apoJPEGOverviewDS(std::vector<std::unique_ptr<GTiffJPEGOverviewDS>>{}),
+      m_apoJPEGOverviewDSOld(
+          std::vector<std::unique_ptr<GTiffJPEGOverviewDS>>{}),
+      m_bStreamingIn(false), m_bStreamingOut(false), m_bScanDeferred(true),
       m_bSingleIFDOpened(false), m_bLoadedBlockDirty(false),
       m_bWriteError(false), m_bLookedForProjection(false),
       m_bLookedForMDAreaOrPoint(false), m_bGeoTransformValid(false),

--- a/frmts/gtiff/gtiffdataset.h
+++ b/frmts/gtiff/gtiffdataset.h
@@ -133,8 +133,8 @@ class GTiffDataset final : public GDALPamDataset
     GTiffDataset *m_poBaseDS = nullptr;
     // Used with MASK_OVERVIEW_DATASET open option
     std::unique_ptr<GDALDataset> m_poMaskExtOvrDS{};
-    std::vector<std::unique_ptr<GTiffJPEGOverviewDS>> m_apoJPEGOverviewDS{};
-    std::vector<std::unique_ptr<GTiffJPEGOverviewDS>> m_apoJPEGOverviewDSOld{};
+    std::vector<std::unique_ptr<GTiffJPEGOverviewDS>> m_apoJPEGOverviewDS;
+    std::vector<std::unique_ptr<GTiffJPEGOverviewDS>> m_apoJPEGOverviewDSOld;
     std::vector<gdal::GCP> m_aoGCPs{};
     std::unique_ptr<GDALColorTable> m_poColorTable{};
     char **m_papszMetadataFiles = nullptr;


### PR DESCRIPTION


<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

Trigger default-initialisation instead of value-initialisation of vector of forward declared class (in frmts/gtiff/gtiffdataset.h).

Addresses "_invalid application of 'sizeof' to an incomplete type 'GTiffJPEGOverviewDS'_" compiler error on macOS 12 and earlier (with AppleClang 13 and earlier):

```
In file included from /opt/local/var/macports/build/gdal-ab2406e0/work/gdal-3.13.0/frmts/gtiff/cogdriver.cpp:15:
In file included from /opt/local/var/macports/build/gdal-ab2406e0/work/gdal-3.13.0/gcore/gdalalgorithm.h:16:
In file included from /opt/local/var/macports/build/gdal-ab2406e0/work/gdal-3.13.0/gcore/gdalalgorithm_c.h:19:
In file included from /opt/local/var/macports/build/gdal-ab2406e0/work/gdal-3.13.0/gcore/gdal.h:30:
In file included from /opt/local/var/macports/build/gdal-ab2406e0/work/gdal-3.13.0/port/cpl_error.h:395:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/c++/v1/memory:682:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/c++/v1/__memory/shared_ptr.h:25:
/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/c++/v1/__memory/unique_ptr.h:53:19: error: invalid application of 'sizeof' to an incomplete type 'GTiffJPEGOverviewDS'
    static_assert(sizeof(_Tp) > 0,
                  ^~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/c++/v1/__memory/unique_ptr.h:318:7: note: in instantiation of member function 'std::default_delete<GTiffJPEGOverviewDS>::operator()' requested here
      __ptr_.second()(__tmp);
      ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/c++/v1/__memory/unique_ptr.h:272:19: note: in instantiation of member function 'std::unique_ptr<GTiffJPEGOverviewDS>::reset' requested here
  ~unique_ptr() { reset(); }
                  ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/c++/v1/__memory/allocator.h:159:15: note: in instantiation of member function 'std::unique_ptr<GTiffJPEGOverviewDS>::~unique_ptr' requested here
        __p->~_Tp();
              ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/c++/v1/__memory/allocator_traits.h:309:13: note: in instantiation of member function 'std::allocator<std::unique_ptr<GTiffJPEGOverviewDS>>::destroy' requested here
        __a.destroy(__p);
            ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/c++/v1/vector:450:25: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<std::unique_ptr<GTiffJPEGOverviewDS>>>::destroy<std::unique_ptr<GTiffJPEGOverviewDS>, void>' requested here
        __alloc_traits::destroy(__alloc(), _VSTD::__to_address(--__soon_to_be_end));
                        ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/c++/v1/vector:374:29: note: in instantiation of member function 'std::__vector_base<std::unique_ptr<GTiffJPEGOverviewDS>, std::allocator<std::unique_ptr<GTiffJPEGOverviewDS>>>::__destruct_at_end' requested here
    void clear() _NOEXCEPT {__destruct_at_end(__begin_);}
                            ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/c++/v1/vector:487:9: note: in instantiation of member function 'std::__vector_base<std::unique_ptr<GTiffJPEGOverviewDS>, std::allocator<std::unique_ptr<GTiffJPEGOverviewDS>>>::clear' requested here
        clear();
        ^
/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/usr/include/c++/v1/vector:519:5: note: in instantiation of member function 'std::__vector_base<std::unique_ptr<GTiffJPEGOverviewDS>, std::allocator<std::unique_ptr<GTiffJPEGOverviewDS>>>::~__vector_base' requested here
    vector() _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value)
    ^
/opt/local/var/macports/build/gdal-ab2406e0/work/gdal-3.13.0/frmts/gtiff/gtiffdataset.h:136:74: note: in instantiation of member function 'std::vector<std::unique_ptr<GTiffJPEGOverviewDS>>::vector' requested here
    std::vector<std::unique_ptr<GTiffJPEGOverviewDS>> m_apoJPEGOverviewDS{};
                                                                         ^
/opt/local/var/macports/build/gdal-ab2406e0/work/gdal-3.13.0/frmts/gtiff/gtiffdataset.h:43:7: note: forward declaration of 'GTiffJPEGOverviewDS'
class GTiffJPEGOverviewDS;
      ^
```

This wasn't an issue on macOS 13 and newer, I can't test this fix on the failing platform but it compiles fine on macOS 26. I noticed this failure on MacPorts' build logs.

## What are related issues/pull requests?

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS: macOS 12.7.6
* Compiler: AppleClang 13.1.6.13160021
