### PR TITLE
[Backport release/3.13] OGR_G_SetPoint: restore ability to grow a geometry with a index >= npts

### DIFF
--- a/autotest/ogr/ogr_basic_test.py
+++ b/autotest/ogr/ogr_basic_test.py
@@ -1358,3 +1358,27 @@ def test_ogr_basic_numpy():
 
     with pytest.raises(Exception, match="Unsupported type"):
         f["int"] = np.array([[1, 2, 3], [4, 5, 6]])
+
+
+###############################################################################
+# Test SetPoint with out-of-bounds index
+
+
+@gdaltest.enable_exceptions()
+def test_ogr_setpoint_grows_geometry():
+
+    g = ogr.CreateGeometryFromWkt("LINESTRING (3 3, 2 2)")
+
+    g.SetPoint(5, 1, 1, 1)
+
+    assert g.GetPointCount() == 6
+
+    g.SetPoint_2D(10, 1, 1)
+
+    assert g.GetPointCount() == 11
+
+    g.SetPointM(15, 1, 1, 1)
+
+    assert g.GetPointCount() == 16
+
+    g.SetPointZM(20, 1, 1, 1, 1)

--- a/ogr/ogr_api.cpp
+++ b/ogr/ogr_api.cpp
@@ -943,8 +943,9 @@ OGRErr OGR_G_SetPoint(OGRGeometryH hGeom, int i, double dfX, double dfY,
                 CPLError(CE_Failure, CPLE_NotSupported, "Index out of bounds");
                 return OGRERR_FAILURE;
             }
-            return ToPointer(hGeom)->toSimpleCurve()->setPoint(i, dfX, dfY,
-                                                               dfZ);
+            return ToPointer(hGeom)->toSimpleCurve()->setPoint(i, dfX, dfY, dfZ)
+                       ? OGRERR_NONE
+                       : OGRERR_FAILURE;
         }
 
         default:
@@ -1008,7 +1009,9 @@ OGRErr OGR_G_SetPoint_2D(OGRGeometryH hGeom, int i, double dfX, double dfY)
                 CPLError(CE_Failure, CPLE_NotSupported, "Index out of bounds");
                 return OGRERR_FAILURE;
             }
-            return ToPointer(hGeom)->toSimpleCurve()->setPoint(i, dfX, dfY);
+            return ToPointer(hGeom)->toSimpleCurve()->setPoint(i, dfX, dfY)
+                       ? OGRERR_NONE
+                       : OGRERR_FAILURE;
         }
 
         default:
@@ -1079,7 +1082,9 @@ OGRErr OGR_G_SetPointM(OGRGeometryH hGeom, int i, double dfX, double dfY,
                 return OGRERR_FAILURE;
             }
             return ToPointer(hGeom)->toSimpleCurve()->setPointM(i, dfX, dfY,
-                                                                dfM);
+                                                                dfM)
+                       ? OGRERR_NONE
+                       : OGRERR_FAILURE;
         }
 
         default:


### PR DESCRIPTION
Backport #14746
 **Authored by:** @dbaston