### PR TITLE
/vsis3/: add support for NASA Earthdata credentials

### DIFF
--- a/autotest/gcore/vsis3.py
+++ b/autotest/gcore/vsis3.py
@@ -7325,3 +7325,415 @@ def test_vsis3_invalid_filenames():
 
     with pytest.raises(Exception, match="Invalid filename"):
         gdal.OpenDir("/vsis3/../traversal")
+
+
+###############################################################################
+# Test NASA Earthdata credentials provider
+
+
+@gdaltest.enable_exceptions()
+def test_vsis3_earthdata_credentials_from_username_password(
+    aws_test_config, webserver_port
+):
+
+    gdal.VSICurlClearCache()
+
+    config_options = {
+        "VSIS3_EARTHDATA_CREDENTIALS_URL": f"http://127.0.0.1:{webserver_port}/get_credentials",
+        "EARTHDATA_HOST": f"http://127.0.0.1:{webserver_port}/earthdata_login",
+        "EARTHDATA_USERNAME": "username",
+        "EARTHDATA_PASSWORD": "password",
+        "GDAL_DISABLE_READDIR_ON_OPEN": "YES",
+    }
+    with gdaltest.config_options(config_options):
+
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "POST",
+            "/earthdata_login/api/users/find_or_create_token",
+            200,
+            {"Content-Type": "application/json"},
+            """{"access_token":"access_token_1","token_type":"Bearer","expiration_date":"12/31/9999"}""",
+            expected_headers={
+                "Accept": "application/json",
+                "Authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+            },
+        )
+        handler.add(
+            "GET",
+            "/get_credentials",
+            200,
+            {"Content-Type": "application/json"},
+            """{"accessKeyId":"accessKeyId","secretAccessKey":"secretAccessKey","sessionToken":"sessionToken","expiration":"9999-12-31 23:59:59+00:00"}""",
+            expected_headers={"Authorization": "Bearer access_token_1"},
+        )
+        handler.add(
+            "GET",
+            "/test_vsis3_earthdata_credentials/test.bin",
+            206,
+            {"Content-Length": "3", "Content-Range": "bytes 0-2/3"},
+            "foo",
+            expected_headers={"X-Amz-Security-Token": "sessionToken"},
+        )
+        handler.add(
+            "GET",
+            "/test_vsis3_earthdata_credentials/test2.bin",
+            206,
+            {"Content-Length": "3", "Content-Range": "bytes 0-2/3"},
+            "bar",
+            expected_headers={"X-Amz-Security-Token": "sessionToken"},
+        )
+        with webserver.install_http_handler(handler):
+            with gdal.VSIFile(
+                "/vsis3/test_vsis3_earthdata_credentials/test.bin", "rb"
+            ) as f:
+                assert f.read() == b"foo"
+            with gdal.VSIFile(
+                "/vsis3/test_vsis3_earthdata_credentials/test2.bin", "rb"
+            ) as f:
+                assert f.read() == b"bar"
+
+
+###############################################################################
+# Test NASA Earthdata credentials provider
+
+
+@gdaltest.enable_exceptions()
+def test_vsis3_earthdata_credentials_from_token(aws_test_config, webserver_port):
+
+    gdal.VSICurlClearCache()
+
+    config_options = {
+        "VSIS3_EARTHDATA_CREDENTIALS_URL": f"http://127.0.0.1:{webserver_port}/get_credentials",
+        "EARTHDATA_TOKEN": "access_token_1",
+        "GDAL_DISABLE_READDIR_ON_OPEN": "YES",
+    }
+    with gdaltest.config_options(config_options):
+
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "GET",
+            "/get_credentials",
+            200,
+            {"Content-Type": "application/json"},
+            """{"accessKeyId":"accessKeyId","secretAccessKey":"secretAccessKey","sessionToken":"sessionToken","expiration":"9999-12-31 23:59:59+00:00"}""",
+            expected_headers={"Authorization": "Bearer access_token_1"},
+        )
+        handler.add(
+            "GET",
+            "/test_vsis3_earthdata_credentials/test.bin",
+            206,
+            {"Content-Length": "3", "Content-Range": "bytes 0-2/3"},
+            "foo",
+            expected_headers={"X-Amz-Security-Token": "sessionToken"},
+        )
+        with webserver.install_http_handler(handler):
+            with gdal.VSIFile(
+                "/vsis3/test_vsis3_earthdata_credentials/test.bin", "rb"
+            ) as f:
+                assert f.read() == b"foo"
+
+
+###############################################################################
+# Test NASA Earthdata credentials provider
+
+
+@gdaltest.enable_exceptions()
+def test_vsis3_earthdata_credentials_login_failed_with_error(
+    aws_test_config, webserver_port
+):
+
+    gdal.VSICurlClearCache()
+
+    config_options = {
+        "VSIS3_EARTHDATA_CREDENTIALS_URL": f"http://127.0.0.1:{webserver_port}/get_credentials",
+        "EARTHDATA_HOST": f"http://127.0.0.1:{webserver_port}/earthdata_login",
+        "EARTHDATA_USERNAME": "username",
+        "EARTHDATA_PASSWORD": "password",
+        "GDAL_DISABLE_READDIR_ON_OPEN": "YES",
+    }
+    with gdaltest.config_options(config_options):
+
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "POST",
+            "/earthdata_login/api/users/find_or_create_token",
+            401,
+            {"Content-Type": "application/json"},
+            """{"error":"invalid_credentials","error_description":"Invalid user credentials"}""",
+            expected_headers={
+                "Accept": "application/json",
+                "Authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+            },
+        )
+        with webserver.install_http_handler(handler):
+            with pytest.raises(
+                Exception,
+                match="Earthdata credentials provider: invalid_credentials in response of ",
+            ):
+                with gdal.VSIFile(
+                    "/vsis3/test_vsis3_earthdata_credentials/test.bin", "rb"
+                ):
+                    pass
+
+
+###############################################################################
+# Test NASA Earthdata credentials provider
+
+
+@gdaltest.enable_exceptions()
+def test_vsis3_earthdata_credentials_login_failed_missing_access_token(
+    aws_test_config, webserver_port
+):
+
+    gdal.VSICurlClearCache()
+
+    config_options = {
+        "VSIS3_EARTHDATA_CREDENTIALS_URL": f"http://127.0.0.1:{webserver_port}/get_credentials",
+        "EARTHDATA_HOST": f"http://127.0.0.1:{webserver_port}/earthdata_login",
+        "EARTHDATA_USERNAME": "username",
+        "EARTHDATA_PASSWORD": "password",
+        "GDAL_DISABLE_READDIR_ON_OPEN": "YES",
+    }
+    with gdaltest.config_options(config_options):
+
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "POST",
+            "/earthdata_login/api/users/find_or_create_token",
+            200,
+            {"Content-Type": "application/json"},
+            """{}""",
+            expected_headers={
+                "Accept": "application/json",
+                "Authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+            },
+        )
+        with webserver.install_http_handler(handler):
+            with pytest.raises(
+                Exception,
+                match="Earthdata credentials provider: missing 'access_token' in response of",
+            ):
+                with gdal.VSIFile(
+                    "/vsis3/test_vsis3_earthdata_credentials/test.bin", "rb"
+                ):
+                    pass
+
+
+###############################################################################
+# Test NASA Earthdata credentials provider
+
+
+@gdaltest.enable_exceptions()
+def test_vsis3_earthdata_credentials_get_credentials_failed(
+    aws_test_config, webserver_port
+):
+
+    gdal.VSICurlClearCache()
+
+    config_options = {
+        "VSIS3_EARTHDATA_CREDENTIALS_URL": f"http://127.0.0.1:{webserver_port}/get_credentials",
+        "EARTHDATA_TOKEN": "access_token_1",
+        "GDAL_DISABLE_READDIR_ON_OPEN": "YES",
+    }
+    with gdaltest.config_options(config_options):
+
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "GET",
+            "/get_credentials",
+            200,
+            {"Content-Type": "text/html"},
+            """Some error""",
+            expected_headers={"Authorization": "Bearer access_token_1"},
+        )
+        with webserver.install_http_handler(handler):
+            with pytest.raises(
+                Exception,
+                match=r"Earthdata credentials provider: request to .* failed to return one of 'accessKeyId', 'secretAccessKey', 'sessionToken' and/or 'expiration'",
+            ):
+                with gdal.VSIFile(
+                    "/vsis3/test_vsis3_earthdata_credentials/test.bin", "rb"
+                ):
+                    pass
+
+
+###############################################################################
+# Test NASA Earthdata credentials provider
+
+
+@gdaltest.enable_exceptions()
+def test_vsis3_earthdata_credentials_expired(aws_test_config, webserver_port):
+
+    gdal.VSICurlClearCache()
+
+    config_options = {
+        "VSIS3_EARTHDATA_CREDENTIALS_URL": f"http://127.0.0.1:{webserver_port}/get_credentials",
+        "EARTHDATA_TOKEN": "access_token_1",
+        "GDAL_DISABLE_READDIR_ON_OPEN": "YES",
+    }
+    with gdaltest.config_options(config_options):
+
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "GET",
+            "/get_credentials",
+            200,
+            {"Content-Type": "application/json"},
+            """{"accessKeyId":"accessKeyId","secretAccessKey":"secretAccessKey","sessionToken":"sessionToken","expiration":"1970-01-01 00:00:00+00:00"}""",
+            expected_headers={"Authorization": "Bearer access_token_1"},
+        )
+        handler.add(
+            "GET",
+            "/get_credentials",
+            200,
+            {"Content-Type": "application/json"},
+            """{"accessKeyId":"accessKeyId","secretAccessKey":"secretAccessKey","sessionToken":"sessionToken","expiration":"9999-01-01 00:00:00+00:00"}""",
+            expected_headers={"Authorization": "Bearer access_token_1"},
+        )
+        handler.add(
+            "GET",
+            "/test_vsis3_earthdata_credentials/test.bin",
+            206,
+            {"Content-Length": "3", "Content-Range": "bytes 0-2/3"},
+            "foo",
+            expected_headers={"X-Amz-Security-Token": "sessionToken"},
+        )
+        with webserver.install_http_handler(handler):
+            with gdal.VSIFile(
+                "/vsis3/test_vsis3_earthdata_credentials/test.bin", "rb"
+            ) as f:
+                assert f.read() == b"foo"
+
+
+###############################################################################
+# Test NASA Earthdata credentials provider
+
+
+@gdaltest.enable_exceptions()
+def test_vsis3_earthdata_credentials_from_netrc(
+    tmp_vsimem, aws_test_config, webserver_port
+):
+
+    gdal.VSICurlClearCache()
+
+    netrc_filename = tmp_vsimem / "mynetrc"
+
+    config_options = {
+        "VSIS3_EARTHDATA_CREDENTIALS_URL": f"http://127.0.0.1:{webserver_port}/get_credentials",
+        "EARTHDATA_HOST": f"http://127.0.0.1:{webserver_port}/earthdata_login",
+        "NETRC": str(netrc_filename),
+        "GDAL_DISABLE_READDIR_ON_OPEN": "YES",
+    }
+
+    with gdal.VSIFile(netrc_filename, "wb") as f:
+        f.write(
+            f"machine {config_options['EARTHDATA_HOST']} login username password password".encode(
+                "utf-8"
+            )
+        )
+
+    with gdaltest.config_options(config_options):
+
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "POST",
+            "/earthdata_login/api/users/find_or_create_token",
+            200,
+            {"Content-Type": "application/json"},
+            """{"access_token":"access_token_1","token_type":"Bearer","expiration_date":"12/31/9999"}""",
+            expected_headers={
+                "Accept": "application/json",
+                "Authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+            },
+        )
+        handler.add(
+            "GET",
+            "/get_credentials",
+            200,
+            {"Content-Type": "application/json"},
+            """{"accessKeyId":"accessKeyId","secretAccessKey":"secretAccessKey","sessionToken":"sessionToken","expiration":"9999-12-31 23:59:59+00:00"}""",
+            expected_headers={"Authorization": "Bearer access_token_1"},
+        )
+        handler.add(
+            "GET",
+            "/test_vsis3_earthdata_credentials/test.bin",
+            206,
+            {"Content-Length": "3", "Content-Range": "bytes 0-2/3"},
+            "foo",
+            expected_headers={"X-Amz-Security-Token": "sessionToken"},
+        )
+        with webserver.install_http_handler(handler):
+            with gdal.VSIFile(
+                "/vsis3/test_vsis3_earthdata_credentials/test.bin", "rb"
+            ) as f:
+                assert f.read() == b"foo"
+
+
+###############################################################################
+# Test NASA Earthdata credentials provider
+
+
+@gdaltest.enable_exceptions()
+def test_vsis3_earthdata_credentials_from_netrc_not_existing(
+    tmp_vsimem, aws_test_config, webserver_port
+):
+
+    gdal.VSICurlClearCache()
+
+    config_options = {
+        "VSIS3_EARTHDATA_CREDENTIALS_URL": f"http://127.0.0.1:{webserver_port}/get_credentials",
+        "EARTHDATA_HOST": f"http://127.0.0.1:{webserver_port}/earthdata_login",
+        "NETRC": "/i_do/not/exist",
+        "GDAL_DISABLE_READDIR_ON_OPEN": "YES",
+    }
+
+    with gdaltest.config_options(config_options):
+
+        handler = webserver.SequentialHandler()
+        with webserver.install_http_handler(handler):
+            with pytest.raises(
+                Exception,
+                match=r"Earthdata credentials provider: cannot open /i_do/not/exist, and no other Earthdata login mechanism defined \(EARTHDATA_TOKEN or EARTHDATA_USERNAME\+EARTHDATA_PASSWORD\)",
+            ):
+                with gdal.VSIFile(
+                    "/vsis3/test_vsis3_earthdata_credentials/test.bin", "rb"
+                ):
+                    pass
+
+
+###############################################################################
+# Test NASA Earthdata credentials provider
+
+
+@gdaltest.enable_exceptions()
+def test_vsis3_earthdata_credentials_from_netrc_no_entry(
+    tmp_vsimem, aws_test_config, webserver_port
+):
+
+    gdal.VSICurlClearCache()
+
+    netrc_filename = tmp_vsimem / "mynetrc"
+
+    config_options = {
+        "VSIS3_EARTHDATA_CREDENTIALS_URL": f"http://127.0.0.1:{webserver_port}/get_credentials",
+        "EARTHDATA_HOST": f"http://127.0.0.1:{webserver_port}/earthdata_login",
+        "NETRC": str(netrc_filename),
+        "GDAL_DISABLE_READDIR_ON_OPEN": "YES",
+    }
+
+    with gdal.VSIFile(netrc_filename, "wb"):
+        pass
+
+    with gdaltest.config_options(config_options):
+
+        handler = webserver.SequentialHandler()
+        with webserver.install_http_handler(handler):
+            with pytest.raises(
+                Exception,
+                match="Earthdata credentials provider: no credentials for host",
+            ):
+                with gdal.VSIFile(
+                    "/vsis3/test_vsis3_earthdata_credentials/test.bin", "rb"
+                ):
+                    pass

--- a/doc/source/user/virtual_file_systems.rst
+++ b/doc/source/user/virtual_file_systems.rst
@@ -779,6 +779,50 @@ The following configuration options can be set to access a
 - AWS_SECRET_ACCESS_KEY="your_secret_access_key"
 - AWS_ACCESS_KEY_ID="your_access_key"
 
+.. _vsis3_nasa_edl:
+
+/vsis3/ and NASA Earthdata login (EDL)
+++++++++++++++++++++++++++++++++++++++
+
+Starting with GDAL 3.14, it is possible to automatically retrieve S3 credentials
+for resources protected by
+`NASA Earthdata login (EDL) <https://urs.earthdata.nasa.gov/documentation>`__.
+
+.. warning::
+
+    This mechanism only works when running GDAL on EC2 instances in
+    the ``us-west-2`` region.
+
+To enable the automatic retrieval of those S3 credentials, the
+``VSIS3_EARTHDATA_CREDENTIALS_URL`` configuration option, or path-specific option,
+must be set to a URL of the form ``https://{hostname}/s3credentials``,
+as indicated in the documentation of the data product to access.
+
+The request to obtain those S3 credentials must itself include an authentication token.
+That token can be obtained through one of the following methods, in decreasing order of
+priority:
+
+- ``EARTHDATA_TOKEN`` configuration option with value of a token from
+  ``https://urs.earthdata.nasa.gov/users/{your_account}/user_tokens``
+
+- ``EARTHDATA_USERNAME`` and ``EARTHDATA_PASSWORD`` configuration options with
+  the username and password of the EDL account, which will cause a request to
+  be emitted to ``urs.earthdata.nasa.gov`` to get or create a token.
+
+- Username and password retrieved from the file whose path is given by the
+  ``NETRC`` configuration option.
+
+- Username and password retrieved from the file in ``$HOME/.netrc`` on Unix systems,
+  or ``$USERPROFILE/_netrc`` on Windows
+
+.. note::
+
+    This is similar to how the Python
+    `earthaccess <https://earthaccess.readthedocs.io/en/latest/user/authenticate/>`__ package works.
+
+.. spelling:word-list::
+    Earthdata
+
 .. _vsis3_streaming:
 
 /vsis3_streaming/ (AWS S3 files: streaming)

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -59,6 +59,7 @@ set(CPL_SOURCES
     cpl_hash_set.cpp
     cplgetcurrentthreadcount.cpp
     cplkeywordparser.cpp
+    cpl_nasa_earthdata.cpp
     cpl_recode.cpp
     cpl_recode_stub.cpp
     cpl_quad_tree.cpp

--- a/port/cpl_aws.cpp
+++ b/port/cpl_aws.cpp
@@ -21,6 +21,7 @@
 #include "cpl_time.h"
 #include "cpl_minixml.h"
 #include "cpl_multiproc.h"
+#include "cpl_nasa_earthdata.h"
 #include "cpl_spawn.h"
 #include "cpl_http.h"
 #include <algorithm>
@@ -1942,6 +1943,32 @@ bool VSIS3HandleHelper::GetConfiguration(
 {
     eCredentialsSource = AWSCredentialsSource::UNINITIALIZED;
 
+    bool bErrorEDL = false;
+    auto poEarthdataCredentialProvider =
+        CPLNasaEarthdataCredentialProvider::Get(osPathForOption, &bErrorEDL);
+    if (poEarthdataCredentialProvider)
+    {
+        osAccessKeyId = poEarthdataCredentialProvider->GetAccessKeyId();
+        if (!osAccessKeyId.empty())
+        {
+            osSecretAccessKey =
+                poEarthdataCredentialProvider->GetSecretAccessKey();
+            osSessionToken = poEarthdataCredentialProvider->GetSessionToken();
+            eCredentialsSource = AWSCredentialsSource::NASA_EARTHDATA;
+
+            // Earthdata uses us-west-2 region and requires in-bound requests
+            // to come from that region.
+            osRegion = VSIGetPathSpecificOption(osPathForOption.c_str(),
+                                                "AWS_REGION", "us-west-2");
+
+            return true;
+        }
+        else
+            return false;
+    }
+    else if (bErrorEDL)
+        return false;
+
     // AWS_REGION is GDAL specific. Later overloaded by standard
     // AWS_DEFAULT_REGION
     osRegion = CSLFetchNameValueDef(
@@ -2255,6 +2282,8 @@ void VSIS3HandleHelper::CleanMutex()
 
 void VSIS3HandleHelper::ClearCache()
 {
+    CPLNasaEarthdataCredentialProvider::ClearCache();
+
     CPLMutexHolder oHolder(&ghMutex);
 
     geCredentialsSource = AWSCredentialsSource::UNINITIALIZED;
@@ -2305,17 +2334,20 @@ VSIS3HandleHelper *VSIS3HandleHelper::BuildFromURI(const char *pszURI,
         return nullptr;
     }
 
-    // According to
-    // http://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html "
-    // This variable overrides the default region of the in-use profile, if
-    // set."
-    std::string osDefaultRegion = CSLFetchNameValueDef(
-        papszOptions, "AWS_DEFAULT_REGION",
-        VSIGetPathSpecificOption(osPathForOption.c_str(), "AWS_DEFAULT_REGION",
-                                 ""));
-    if (!osDefaultRegion.empty())
+    if (eCredentialsSource != AWSCredentialsSource::NASA_EARTHDATA)
     {
-        osRegion = std::move(osDefaultRegion);
+        // According to
+        // http://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html "
+        // This variable overrides the default region of the in-use profile, if
+        // set."
+        std::string osDefaultRegion = CSLFetchNameValueDef(
+            papszOptions, "AWS_DEFAULT_REGION",
+            VSIGetPathSpecificOption(osPathForOption.c_str(),
+                                     "AWS_DEFAULT_REGION", ""));
+        if (!osDefaultRegion.empty())
+        {
+            osRegion = std::move(osDefaultRegion);
+        }
     }
 
     std::string osEndpoint = VSIGetPathSpecificOption(

--- a/port/cpl_aws.h
+++ b/port/cpl_aws.h
@@ -115,6 +115,7 @@ enum class AWSCredentialsSource
     // credentials from credential_process command
     // See https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html
     CREDENTIAL_PROCESS,
+    NASA_EARTHDATA,  // credentials from Nasa Earthdata login mechanism
 };
 
 class VSIS3HandleHelper final : public IVSIS3LikeHandleHelper

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -170,6 +170,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "CREATE_RASTER_TABLES", // from ogrgeopackagedatasource.cpp
    "CREATE_TRIGGERS", // from ogrgeopackagedatasource.cpp
    "CURL_CA_BUNDLE", // from cpl_http.cpp
+   "DEFAULT_EARTHDATA_HOST", // from cpl_nasa_earthdata.cpp
    "DGN_LINK_FORMAT", // from ogrdgnlayer.cpp
    "DISABLE_OPEN_REAL_NETCDF_FILES", // from netcdfdataset.cpp, netcdfdrivercore.cpp
    "DRIVER_WISHED", // from test_ogrsf.cpp
@@ -195,6 +196,10 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "DXF_MERGE_BLOCK_GEOMETRIES", // from ogrdxfdatasource.cpp
    "DXF_TRANSLATE_ESCAPE_SEQUENCES", // from ogrdxfdatasource.cpp
    "DXF_WRITE_HATCH", // from ogrdxfwriterlayer.cpp
+   "EARTHDATA_HOST", // from cpl_nasa_earthdata.cpp
+   "EARTHDATA_PASSWORD", // from cpl_nasa_earthdata.cpp
+   "EARTHDATA_TOKEN", // from cpl_nasa_earthdata.cpp
+   "EARTHDATA_USERNAME", // from cpl_nasa_earthdata.cpp
    "ECW_ALWAYS_UPWARD", // from ecwdataset.cpp
    "ECW_AUTOGEN_J2I", // from ecwdataset.cpp
    "ECW_CACHE_MAXMEM", // from ecwdataset.cpp
@@ -678,6 +683,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "NAS_INDICATOR", // from ogrnasdriver.cpp
    "NAS_SKIP_CORRUPTED_FEATURES", // from ogrnaslayer.cpp
    "NETCDF_TMP_FILE", // from netcdfdataset.cpp, netcdfmultidim.cpp
+   "NETRC", // from cpl_nasa_earthdata.cpp
    "NGW_BATCH_SIZE", // from gdalngwdataset.cpp
    "NGW_CACHE_EXPIRES", // from gdalngwdataset.cpp
    "NGW_CACHE_MAX_SIZE", // from gdalngwdataset.cpp
@@ -1090,6 +1096,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "VSIKERCHUNK_USE_CACHE", // from vsikerchunk_json_ref.cpp
    "VSIKERCHUNK_USE_STREAMING_PARSER", // from vsikerchunk_json_ref.cpp
    "VSIS3_COPYFILE_USE_STREAMING_SOURCE", // from cpl_vsil_s3.cpp
+   "VSIS3_EARTHDATA_CREDENTIALS_URL", // from cpl_nasa_earthdata.cpp
    "VSIS3_SIMULATE_THREADING", // from cpl_vsil_s3.cpp
    "VSIS3_SYNC_MULTITHREADING", // from cpl_vsil_s3.cpp
    "VSIWEBHDFS_SIZE", // from cpl_vsil_webhdfs.cpp

--- a/port/cpl_nasa_earthdata.cpp
+++ b/port/cpl_nasa_earthdata.cpp
@@ -1,0 +1,412 @@
+/******************************************************************************
+ *
+ * Project:  CPL - Common Portability Library
+ * Purpose:  Implement credential provider for accessing NASA Earthdata resources
+ * Author:   Even Rouault, even.rouault at spatialys.com
+ *
+ ******************************************************************************
+ * Copyright (c) 2026, Even Rouault <even.rouault at spatialys.com>
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#ifdef HAVE_CURL
+
+#include "cpl_error.h"
+#include "cpl_json.h"
+#include "cpl_http.h"
+#include "cpl_mem_cache.h"
+#include "cpl_nasa_earthdata.h"
+#include "cpl_time.h"
+#include "cpl_vsi.h"
+#include "cpl_vsi_virtual.h"
+
+#include <mutex>
+
+/************************************************************************/
+/*                 CPLNasaEarthdataCredentialProvider()                 */
+/************************************************************************/
+
+CPLNasaEarthdataCredentialProvider::CPLNasaEarthdataCredentialProvider() =
+    default;
+
+/************************************************************************/
+/*             CPLNasaEarthdataCredentialProvider::Build()              */
+/************************************************************************/
+
+/* static */
+std::unique_ptr<CPLNasaEarthdataCredentialProvider>
+CPLNasaEarthdataCredentialProvider::Build(
+    const std::string &osGetCredentialsURL, const std::string &osEarthdataHost,
+    const std::string &osEarthdataToken, const std::string &osEarthdataUsername,
+    const std::string &osEarthdataPassword, const std::string &osNetrcFilename)
+{
+    if (osGetCredentialsURL.empty())
+    {
+        CPLError(CE_Failure, CPLE_IllegalArg,
+                 "Earthdata credentials provider: Credentials URL must not be "
+                 "empty");
+        return nullptr;
+    }
+
+    std::string l_osEarthdataHost = osEarthdataHost;
+    if (l_osEarthdataHost.empty())
+        l_osEarthdataHost = "urs.earthdata.nasa.gov";
+
+    std::string l_osEarthdataToken = osEarthdataToken;
+    std::string l_osEarthdataUsername = osEarthdataUsername;
+    std::string l_osEarthdataPassword = osEarthdataPassword;
+
+#define osEarthdataHost no_longer_use_me
+#define osEarthdataToken no_longer_use_me
+#define osEarthdataUsername no_longer_use_me
+#define osEarthdataPassword no_longer_use_me
+
+    if (l_osEarthdataToken.empty() &&
+        (l_osEarthdataUsername.empty() != l_osEarthdataPassword.empty()))
+    {
+        CPLError(
+            CE_Failure, CPLE_IllegalArg,
+            "Both Earthdata username and password must be provided, or none");
+        return nullptr;
+    }
+
+    if (l_osEarthdataToken.empty() && l_osEarthdataUsername.empty())
+    {
+        std::string l_osNetrcFilename = osNetrcFilename;
+        if (l_osNetrcFilename.empty())
+        {
+            l_osNetrcFilename = CPLGetConfigOption("NETRC", "");
+        }
+        if (l_osNetrcFilename.empty())
+        {
+            const char *pszHomeDir = CPLGetHomeDir();
+            if (!pszHomeDir)
+            {
+                CPLError(
+                    CE_Failure, CPLE_AppDefined,
+                    "Earthdata credentials provider: HOME is not set, and no "
+                    "other Earthdata login mechanism defined (EARTHDATA_TOKEN, "
+                    "EARTHDATA_USERNAME+EARTHDATA_PASSWORD or NETRC)");
+                return nullptr;
+            }
+#ifdef _WIN32
+            constexpr const char *pszNetrcFile = "_netrc";
+#else
+            constexpr const char *pszNetrcFile = ".netrc";
+#endif
+            l_osNetrcFilename =
+                CPLFormFilenameSafe(pszHomeDir, pszNetrcFile, nullptr);
+        }
+        auto fp =
+            VSIFilesystemHandler::OpenStatic(l_osNetrcFilename.c_str(), "rb");
+        if (!fp)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Earthdata credentials provider: cannot open %s, and no "
+                     "other Earthdata login mechanism defined (EARTHDATA_TOKEN "
+                     "or EARTHDATA_USERNAME+EARTHDATA_PASSWORD)",
+                     l_osNetrcFilename.c_str());
+            return nullptr;
+        }
+        constexpr int MAXLINE_LENGTH = 1024;  // Arbitrary
+        std::string osExpectedLineStart("machine ");
+        osExpectedLineStart += l_osEarthdataHost;
+        osExpectedLineStart += ' ';
+        bool bMatchFound = false;
+        while (const char *pszLine =
+                   CPLReadLine2L(fp.get(), MAXLINE_LENGTH, nullptr))
+        {
+            if (STARTS_WITH(pszLine, osExpectedLineStart.c_str()))
+            {
+                bMatchFound = true;
+                const CPLStringList aosTokens(CSLTokenizeString2(
+                    pszLine + osExpectedLineStart.size(), " ", 0));
+                for (int i = 0; i < aosTokens.size(); ++i)
+                {
+                    if (EQUAL(aosTokens[i], "login") &&
+                        i + 1 < aosTokens.size())
+                    {
+                        l_osEarthdataUsername = aosTokens[i + 1];
+                        ++i;
+                    }
+                    else if (EQUAL(aosTokens[i], "password") &&
+                             i + 1 < aosTokens.size())
+                    {
+                        l_osEarthdataPassword = aosTokens[i + 1];
+                        ++i;
+                    }
+                }
+                break;
+            }
+        }
+        if (!bMatchFound)
+        {
+            CPLError(
+                CE_Failure, CPLE_AppDefined,
+                "Earthdata credentials provider: no credentials for host %s "
+                "found in %s, and no other Earthdata login mechanism defined "
+                "(EARTHDATA_TOKEN or EARTHDATA_USERNAME+EARTHDATA_PASSWORD)",
+                l_osEarthdataHost.c_str(), l_osNetrcFilename.c_str());
+            return nullptr;
+        }
+        if (l_osEarthdataUsername.empty())
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Earthdata credentials provider: line with credentials "
+                     "for host %s fonud in %s, but missing 'login'",
+                     l_osEarthdataHost.c_str(), l_osNetrcFilename.c_str());
+            return nullptr;
+        }
+        if (l_osEarthdataPassword.empty())
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Earthdata credentials provider: line with credentials "
+                     "for host %s fonud in %s, but missing 'password'",
+                     l_osEarthdataHost.c_str(), l_osNetrcFilename.c_str());
+            return nullptr;
+        }
+    }
+
+    if (l_osEarthdataToken.empty())
+    {
+        CPLStringList aosOptions;
+        aosOptions.SetNameValue("CUSTOMREQUEST", "POST");
+        aosOptions.SetNameValue("USERPWD", std::string(l_osEarthdataUsername)
+                                               .append(":")
+                                               .append(l_osEarthdataPassword)
+                                               .c_str());
+        aosOptions.SetNameValue("ACCEPT", "application/json");
+        std::string osURL;
+        if (!cpl::starts_with(l_osEarthdataHost, "http://") &&
+            !cpl::starts_with(l_osEarthdataHost, "https://"))
+        {
+            osURL += "https://";
+        }
+        osURL += l_osEarthdataHost;
+        osURL += "/api/users/find_or_create_token";
+        CPLHTTPResult *psResult =
+            CPLHTTPFetch(osURL.c_str(), aosOptions.List());
+        if (!psResult || psResult->nStatus != 0 || !psResult->pabyData)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Earthdata credentials provider: request to %s to get "
+                     "access token failed: %s",
+                     osURL.c_str(),
+                     psResult && psResult->pszErrBuf ? psResult->pszErrBuf
+                                                     : "(null)");
+            CPLHTTPDestroyResult(psResult);
+            return nullptr;
+        }
+
+        const CPLStringList aosResponse =
+            CPLParseKeyValueJson(reinterpret_cast<char *>(psResult->pabyData));
+        CPLHTTPDestroyResult(psResult);
+
+        if (const char *pszError = aosResponse.FetchNameValue("error"))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Earthdata credentials provider: %s in response of %s",
+                     pszError, osURL.c_str());
+            return nullptr;
+        }
+
+        const char *pszAccessToken = aosResponse.FetchNameValue("access_token");
+        if (!pszAccessToken)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Earthdata credentials provider: missing 'access_token' "
+                     "in response of %s",
+                     osURL.c_str());
+            return nullptr;
+        }
+        const char *pszTokenType = aosResponse.FetchNameValue("token_type");
+        if (!pszTokenType)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Earthdata credentials provider: missing 'token_type' in "
+                     "response of %s",
+                     osURL.c_str());
+            return nullptr;
+        }
+        constexpr const char *pszExpectedTokenType = "Bearer";
+        if (!EQUAL(pszTokenType, pszExpectedTokenType))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Earthdata credentials provider: in response of %s, got "
+                     "'token_type'='%s'. Expected '%s'",
+                     osURL.c_str(), pszTokenType, pszExpectedTokenType);
+            return nullptr;
+        }
+        l_osEarthdataToken = pszAccessToken;
+    }
+
+    auto poProvider = std::unique_ptr<CPLNasaEarthdataCredentialProvider>(
+        new CPLNasaEarthdataCredentialProvider());
+    poProvider->m_osGetCredentialsURL = osGetCredentialsURL;
+    poProvider->m_osEarthdataToken = l_osEarthdataToken;
+    if (!poProvider->RefreshIfNeeded())
+        return nullptr;
+    return poProvider;
+}
+
+/************************************************************************/
+/*        CPLNasaEarthdataCredentialProvider::RefreshIfNeeded()         */
+/************************************************************************/
+
+bool CPLNasaEarthdataCredentialProvider::RefreshIfNeeded()
+{
+    std::lock_guard oLock(m_oMutex);
+
+    constexpr int knExpirationDelayMargin = 60;
+    if (m_osAccessKeyId.empty() ||
+        time(nullptr) + knExpirationDelayMargin > m_nTokenExpirationTimestamp)
+    {
+        m_osAccessKeyId.clear();
+        m_osSecretAccessKey.clear();
+        m_osSessionToken.clear();
+        m_nTokenExpirationTimestamp = 0;
+
+        CPLStringList aosOptions;
+        aosOptions.SetNameValue("HTTPAUTH", "BEARER");
+        aosOptions.SetNameValue("HTTP_BEARER", m_osEarthdataToken.c_str());
+        CPLHTTPResult *psResult =
+            CPLHTTPFetch(m_osGetCredentialsURL.c_str(), aosOptions.List());
+        if (!psResult || psResult->nStatus != 0 || !psResult->pabyData)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Earthdata credentials provider: request to %s to get "
+                     "access token failed: %s",
+                     m_osGetCredentialsURL.c_str(),
+                     psResult && psResult->pszErrBuf ? psResult->pszErrBuf
+                                                     : "(null)");
+            CPLHTTPDestroyResult(psResult);
+            return false;
+        }
+
+        const CPLStringList aosResponse =
+            CPLParseKeyValueJson(reinterpret_cast<char *>(psResult->pabyData));
+        CPLHTTPDestroyResult(psResult);
+
+        m_osAccessKeyId = aosResponse.FetchNameValueDef("accessKeyId", "");
+        m_osSecretAccessKey =
+            aosResponse.FetchNameValueDef("secretAccessKey", "");
+        m_osSessionToken = aosResponse.FetchNameValueDef("sessionToken", "");
+        const char *pszExpiration = aosResponse.FetchNameValue("expiration");
+        if (m_osAccessKeyId.empty() || m_osSecretAccessKey.empty() ||
+            m_osSessionToken.empty() || !pszExpiration)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Earthdata credentials provider: request to %s failed to "
+                     "return one of 'accessKeyId', 'secretAccessKey', "
+                     "'sessionToken' and/or 'expiration'",
+                     m_osGetCredentialsURL.c_str());
+            return false;
+        }
+
+        int nYear = 0, nMonth = 0, nDay = 0, nHour = 0, nMin = 0, nSec = 0;
+        if (sscanf(pszExpiration, "%04d-%02d-%02d %02d:%02d:%02d+00:00", &nYear,
+                   &nMonth, &nDay, &nHour, &nMin, &nSec) != 6)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Earthdata credentials provider: request to %s returned "
+                     "expiration='%s' which is an unexpected time format",
+                     m_osGetCredentialsURL.c_str(), pszExpiration);
+            return false;
+        }
+        struct tm brokendowntime;
+        brokendowntime.tm_year = nYear - 1900;
+        brokendowntime.tm_mon = nMonth - 1;
+        brokendowntime.tm_mday = nDay;
+        brokendowntime.tm_hour = nHour;
+        brokendowntime.tm_min = nMin;
+        brokendowntime.tm_sec = nSec;
+        m_nTokenExpirationTimestamp = CPLYMDHMSToUnixTime(&brokendowntime);
+
+        CPLDebug("EARTHDATA", "Got S3 credentials until %s", pszExpiration);
+    }
+
+    return true;
+}
+
+/************************************************************************/
+/*                              GetCache()                              */
+/************************************************************************/
+
+using EarthdataCacheType =
+    lru11::Cache<std::string,
+                 std::shared_ptr<CPLNasaEarthdataCredentialProvider>,
+                 std::mutex>;
+
+static EarthdataCacheType &GetCache()
+{
+    static EarthdataCacheType oCache;
+    return oCache;
+}
+
+/************************************************************************/
+/*              CPLNasaEarthdataCredentialProvider::Get()               */
+/************************************************************************/
+
+/* static */
+std::shared_ptr<CPLNasaEarthdataCredentialProvider>
+CPLNasaEarthdataCredentialProvider::Get(const std::string &osFilename,
+                                        bool *pbErrorOccured)
+{
+    if (pbErrorOccured)
+        *pbErrorOccured = false;
+
+    const char *pszCredentialsURL = VSIGetPathSpecificOption(
+        osFilename.c_str(), "VSIS3_EARTHDATA_CREDENTIALS_URL", nullptr);
+    if (!pszCredentialsURL)
+        return nullptr;
+
+    const char *pszEarthdataHost = VSIGetPathSpecificOption(
+        osFilename.c_str(), "EARTHDATA_HOST",
+        VSIGetPathSpecificOption(osFilename.c_str(), "DEFAULT_EARTHDATA_HOST",
+                                 ""));
+    const char *pszEarthdataToken =
+        VSIGetPathSpecificOption(osFilename.c_str(), "EARTHDATA_TOKEN", "");
+    const char *pszEarthdataUserame =
+        VSIGetPathSpecificOption(osFilename.c_str(), "EARTHDATA_USERNAME", "");
+    const char *pszEarthdataPassword =
+        VSIGetPathSpecificOption(osFilename.c_str(), "EARTHDATA_PASSWORD", "");
+
+    auto &oCache = GetCache();
+    std::shared_ptr<CPLNasaEarthdataCredentialProvider> ret;
+    std::string osCacheKey = pszCredentialsURL;
+    osCacheKey += '|';
+    osCacheKey += pszEarthdataHost;
+    osCacheKey += '|';
+    osCacheKey += pszEarthdataToken;
+    osCacheKey += '|';
+    osCacheKey += pszEarthdataUserame;
+    osCacheKey += '|';
+    osCacheKey += pszEarthdataPassword;
+    if (!oCache.tryGet(osCacheKey, ret))
+    {
+        ret = Build(pszCredentialsURL, pszEarthdataHost, pszEarthdataToken,
+                    pszEarthdataUserame, pszEarthdataPassword);
+        if (ret)
+        {
+            oCache.insert(osCacheKey, ret);
+        }
+        else if (pbErrorOccured)
+        {
+            *pbErrorOccured = true;
+        }
+    }
+    return ret;
+}
+
+/************************************************************************/
+/*           CPLNasaEarthdataCredentialProvider::ClearCache()           */
+/************************************************************************/
+
+/* static */
+void CPLNasaEarthdataCredentialProvider::ClearCache()
+{
+    GetCache().clear();
+}
+
+#endif  // HAVE_CURL

--- a/port/cpl_nasa_earthdata.h
+++ b/port/cpl_nasa_earthdata.h
@@ -1,0 +1,126 @@
+/******************************************************************************
+ *
+ * Project:  CPL - Common Portability Library
+ * Purpose:  Implement credential provider for accessing NASA Earthdata resources
+ * Author:   Even Rouault, even.rouault at spatialys.com
+ *
+ ******************************************************************************
+ * Copyright (c) 2026, Even Rouault <even.rouault at spatialys.com>
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#ifndef CPL_NASA_EARTHDATA_H
+#define CPL_NASA_EARTHDATA_H
+
+#ifdef HAVE_CURL
+
+#include <memory>
+#include <mutex>
+#include <string>
+
+/************************************************************************/
+/*                  CPLNasaEarthdataCredentialProvider                  */
+/************************************************************************/
+
+// Cf https://earthaccess.readthedocs.io/en/latest/user/authenticate/
+// and https://developmentseed.org/obstore/latest/api/auth/earthdata/
+
+/** Credential provider for accessing NASA Earthdata resources with /vsis3/
+ */
+class CPLNasaEarthdataCredentialProvider
+{
+  public:
+    /** Builds a new credential provider instance.
+     *
+     * Users generally want to use GetNasaEarthdataCredentialProviderFor() instead
+     * that calls Build() with values from the environment.
+     *
+     * @param osGetCredentialsURL URL that returns a JSON document with S3
+     *                            temporary credentials. Required
+     *                            e.g. "https://data.asdc.earthdata.nasa.gov/s3credentials"
+     * @param osEarthdataHost Hostname for NASA Earthdata authentication.
+     *                        If empty, defaults to "urs.earthdata.nasa.gov"
+     * @param osEarthdataToken Access token to osGetCredentialsURL obtained from osEarthdataHost
+     * @param osEarthdataUsername Login to osEarthdataHost
+     * @param osEarthdataPassword Password to osEarthdataHost
+     * @param osNetrcFilename Full path to ".netrc" / "_netrc" file
+     *
+     * @return thread-safe new instance, or nullptr.
+     */
+    static std::unique_ptr<CPLNasaEarthdataCredentialProvider>
+    Build(const std::string &osGetCredentialsURL,
+          const std::string &osEarthdataHost = std::string(),
+          const std::string &osEarthdataToken = std::string(),
+          const std::string &osEarthdataUsername = std::string(),
+          const std::string &osEarthdataPassword = std::string(),
+          const std::string &osNetrcFilename = std::string());
+
+    /** Returns a (cached) instance corresponding to /vsis3/ osFilename.
+     *
+     * Takes into account the following path-specific / configuration options:
+     *
+     * - VSIS3_EARTHDATA_CREDENTIALS_URL: Setting this one is required.
+     *   e.g. https://data.asdc.earthdata.nasa.gov/s3credentials .
+     * - DEFAULT_EARTHDATA_HOST / EARTHDATA_HOST: defaults to "urs.earthdata.nasa.gov"
+     * - EARTHDATA_TOKEN: access token to the URL pointed by VSIS3_EARTHDATA_CREDENTIALS_URL
+     * - EARTHDATA_USERNAME + EARTHDATA_PASSWORD: alternate way of getting EARTHDATA_TOKEN
+     *
+     * @return thread-safe cached instance, or nullptr if VSIS3_EARTHDATA_CREDENTIALS_URL
+     *         is not set, or nullptr in case of error
+     */
+    static std::shared_ptr<CPLNasaEarthdataCredentialProvider>
+    Get(const std::string &osFilename, bool *pbErrorOccured = nullptr);
+
+    /** Returns S3 access key id, or empty string if invalid.
+     *
+     * This method takes care of refreshing credentials if needed.
+     */
+    const std::string &GetAccessKeyId()
+    {
+        RefreshIfNeeded();
+        return m_osAccessKeyId;
+    }
+
+    /** Returns S3 secret access key, or empty string if invalid.
+     *
+     * This method takes care of refreshing credentials if needed.
+     */
+    const std::string &GetSecretAccessKey()
+    {
+        RefreshIfNeeded();
+        return m_osSecretAccessKey;
+    }
+
+    /** Returns S3 session token, or empty string if invalid.
+     *
+     * This method takes care of refreshing credentials if needed.
+     */
+    const std::string &GetSessionToken()
+    {
+        RefreshIfNeeded();
+        return m_osSessionToken;
+    }
+
+    /** Clear credentials cache */
+    static void ClearCache();
+
+  private:
+    CPLNasaEarthdataCredentialProvider();
+
+    bool RefreshIfNeeded();
+
+    std::string m_osGetCredentialsURL{};
+    std::string m_osEarthdataToken{};
+
+    // Output of RefreshIfNeeded()
+    std::mutex m_oMutex{};
+    std::string m_osAccessKeyId{};
+    std::string m_osSecretAccessKey{};
+    std::string m_osSessionToken{};
+    GIntBig m_nTokenExpirationTimestamp = 0;
+};
+
+#endif  // HAVE_CURL
+
+#endif

--- a/port/cpl_vsil_s3.cpp
+++ b/port/cpl_vsil_s3.cpp
@@ -2129,6 +2129,26 @@ const char *VSIS3FSHandler::GetOptions()
             .append("' max='")
             .append(CPLSPrintf("%d", GetMaximumPartSizeInMiB()))
             .append("'/>")
+            .append(
+                "  <Option name='VSIS3_EARTHDATA_CREDENTIALS_URL' "
+                "type='string' "
+                "description='URL from which to retrieve temporary S3 "
+                "credentials for a ressource protected by NASA Earthdata "
+                "login (EDL)'/>"
+                "  <Option name='EARTHDATA_TOKEN' type='string' description='"
+                "Authorization token to transmit to "
+                "VSIS3_EARTHDATA_CREDENTIALS_URL'/>"
+                "  <Option name='EARTHDATA_USERNAME' type='string' "
+                "description='"
+                "Username of the EDL account to transmit to "
+                "urs.earthdata.nasa.gov to get a token to transmit to "
+                "VSIS3_EARTHDATA_CREDENTIALS_URL. Must be used together with "
+                "EARTHDATA_PASSWORD. Mutually exclusive with EARTHDATA_TOKEN'/>"
+                "  <Option name='EARTHDATA_PASSWORD' type='string' "
+                "description='"
+                "Password of the EDL account to transmit to "
+                "urs.earthdata.nasa.gov to get a token to transmit to "
+                "VSIS3_EARTHDATA_CREDENTIALS_URL'/>")
             .append(VSICurlFilesystemHandlerBase::GetOptionsStatic())
             .append("</Options>"));
     return osOptions.c_str();


### PR DESCRIPTION
```
/vsis3/ and NASA Earthdata login (EDL)
++++++++++++++++++++++++++++++++++++++

Starting with GDAL 3.14, it is possible to automatically retrieve S3 credentials
for resources protected by
`NASA Earthdata login (EDL) <https://urs.earthdata.nasa.gov/documentation>`__.

.. warning::

    This mechanism only works when running GDAL on EC2 instances in
    the ``us-west-2`` region.

To enable the automatic retrieval of those S3 credentials, the
``VSIS3_EARTHDATA_CREDENTIALS_URL`` configuration option, or path-specific option,
must be set to a URL of the form ``https://{hostname}/s3credentials``,
as indicated in the documentation of the data product to access.

The request to obtain those S3 credentials must itself include an authentication token.
That token can be obtained through one of the following methods, in decreasing order of
priority:

- ``EARTHDATA_TOKEN`` configuration option with value of a token from
  ``https://urs.earthdata.nasa.gov/users/{your_account}/user_tokens``

- ``EARTHDATA_USERNAME`` and ``EARTHDATA_PASSWORD`` configuration options with
  the username and password of the EDL account, which will cause a request to
  be emitted to ``urs.earthdata.nasa.gov`` to get or create a token.

- Username and password retrieved from the file whose path is given by the
  ``NETRC`` configuration option.

- Username and password retrieved from the file in ``$HOME/.netrc`` on Unix systems,
  or ``$USERPROFILE/_netrc`` on Windows

.. note::

    This is similar to how the Python
    `earthaccess <https://earthaccess.readthedocs.io/en/latest/user/authenticate/>`__ package works.
```
