### PR TITLE
MRF: security fixes for caching mode

### DIFF
--- a/autotest/gdrivers/mrf.py
+++ b/autotest/gdrivers/mrf.py
@@ -15,7 +15,6 @@ import glob
 
 import gdaltest
 import pytest
-from os import environ
 
 from osgeo import gdal, osr
 
@@ -520,92 +519,92 @@ def test_raw_lerc():
 def test_mrf_cached_source():
 
     # Test empty cache creation
-    environ["MRF_ENABLE_CACHING"]="ON"
-    gdal.Translate(
-        "/vsimem/out.mrf",
-        "data/byte.tif",
-        format="MRF",
-        creationOptions=["CACHEDSOURCE=invalid_source", "NOCOPY=TRUE"],
-    )
-    ds = gdal.Open("/vsimem/out.mrf")
-    with gdal.quiet_errors():
+    with gdal.config_option("MRF_ENABLE_CACHING","ON"):
+        gdal.Translate(
+            "/vsimem/out.mrf",
+            "data/byte.tif",
+            format="MRF",
+            creationOptions=["CACHEDSOURCE=invalid_source", "NOCOPY=TRUE"],
+        )
+        ds = gdal.Open("/vsimem/out.mrf")
+        with gdal.quiet_errors():
+            cs = ds.GetRasterBand(1).Checksum()
+        expected_cs = -1
+        assert cs == expected_cs
+        ds = None
+        cleanup()
+
+        open("tmp/byte.tif", "wb").write(open("data/byte.tif", "rb").read())
+        gdal.Translate(
+            "tmp/out.mrf",
+            "tmp/byte.tif",
+            format="MRF",
+            creationOptions=["CACHEDSOURCE=byte.tif", "NOCOPY=TRUE"],
+        )
+        ds = gdal.Open("tmp/out.mrf")
         cs = ds.GetRasterBand(1).Checksum()
-    expected_cs = -1
-    assert cs == expected_cs
-    ds = None
-    cleanup()
+        expected_cs = 4672
+        assert cs == expected_cs
+        ds = None
 
-    open("tmp/byte.tif", "wb").write(open("data/byte.tif", "rb").read())
-    gdal.Translate(
-        "tmp/out.mrf",
-        "tmp/byte.tif",
-        format="MRF",
-        creationOptions=["CACHEDSOURCE=byte.tif", "NOCOPY=TRUE"],
-    )
-    ds = gdal.Open("tmp/out.mrf")
-    cs = ds.GetRasterBand(1).Checksum()
-    expected_cs = 4672
-    assert cs == expected_cs
-    ds = None
+        gdal.Unlink("tmp/byte.tif")
+        ds = gdal.Open("tmp/out.mrf")
+        cs = ds.GetRasterBand(1).Checksum()
+        expected_cs = 4672
+        assert cs == expected_cs
+        ds = None
+        cleanup("tmp/out.")
 
-    gdal.Unlink("tmp/byte.tif")
-    ds = gdal.Open("tmp/out.mrf")
-    cs = ds.GetRasterBand(1).Checksum()
-    expected_cs = 4672
-    assert cs == expected_cs
-    ds = None
-    cleanup("tmp/out.")
+        # Caching MRF in mp_safe mode
+        open("tmp/byte.tif", "wb").write(open("data/byte.tif", "rb").read())
+        open("tmp/out.mrf", "wt").write("""<MRF_META>
+    <CachedSource>
+        <Source>byte.tif</Source>
+    </CachedSource>
+    <Raster mp_safe="on">
+        <Size x="20" y="20" c="1" />
+        <PageSize x="512" y="512" c="1" />
+    </Raster>
+    </MRF_META>""")
+        ds = gdal.Open("tmp/out.mrf")
+        cs = ds.GetRasterBand(1).Checksum()
+        expected_cs = 4672
+        assert cs == expected_cs
+        ds = None
 
-    # Caching MRF in mp_safe mode
-    open("tmp/byte.tif", "wb").write(open("data/byte.tif", "rb").read())
-    open("tmp/out.mrf", "wt").write("""<MRF_META>
-  <CachedSource>
-    <Source>byte.tif</Source>
-  </CachedSource>
-  <Raster mp_safe="on">
-    <Size x="20" y="20" c="1" />
-    <PageSize x="512" y="512" c="1" />
-  </Raster>
-</MRF_META>""")
-    ds = gdal.Open("tmp/out.mrf")
-    cs = ds.GetRasterBand(1).Checksum()
-    expected_cs = 4672
-    assert cs == expected_cs
-    ds = None
+        # Read it again, from the cache
+        gdal.Unlink("tmp/byte.tif")
+        ds = gdal.Open("tmp/out.mrf")
+        cs = ds.GetRasterBand(1).Checksum()
+        expected_cs = 4672
+        assert cs == expected_cs
+        ds = None
+        # No cleanup, will test cloning next
 
-    # Read it again, from the cache
-    gdal.Unlink("tmp/byte.tif")
-    ds = gdal.Open("tmp/out.mrf")
-    cs = ds.GetRasterBand(1).Checksum()
-    expected_cs = 4672
-    assert cs == expected_cs
-    ds = None
-    # No cleanup, will test cloning next
+        # Cloning MRF
+        open("tmp/cloning.mrf", "wt").write("""<MRF_META>
+    <CachedSource>
+        <Source clone="true">out.mrf</Source>
+    </CachedSource>
+    <Raster>
+        <Size x="20" y="20" c="1" />
+        <PageSize x="512" y="512" c="1" />
+    </Raster>
+    </MRF_META>""")
+        ds = gdal.Open("tmp/cloning.mrf")
+        cs = ds.GetRasterBand(1).Checksum()
+        expected_cs = 4672
+        assert cs == expected_cs
+        ds = None
+        cleanup("tmp/out.")
 
-    # Cloning MRF
-    open("tmp/cloning.mrf", "wt").write("""<MRF_META>
-  <CachedSource>
-    <Source clone="true">out.mrf</Source>
-  </CachedSource>
-  <Raster>
-    <Size x="20" y="20" c="1" />
-    <PageSize x="512" y="512" c="1" />
-  </Raster>
-</MRF_META>""")
-    ds = gdal.Open("tmp/cloning.mrf")
-    cs = ds.GetRasterBand(1).Checksum()
-    expected_cs = 4672
-    assert cs == expected_cs
-    ds = None
-    cleanup("tmp/out.")
-
-    # Read it again, from the cache
-    ds = gdal.Open("tmp/cloning.mrf")
-    cs = ds.GetRasterBand(1).Checksum()
-    expected_cs = 4672
-    assert cs == expected_cs
-    ds = None
-    cleanup("tmp/cloning.")
+        # Read it again, from the cache
+        ds = gdal.Open("tmp/cloning.mrf")
+        cs = ds.GetRasterBand(1).Checksum()
+        expected_cs = 4672
+        assert cs == expected_cs
+        ds = None
+        cleanup("tmp/cloning.")
 
 
 def test_mrf_versioned():

--- a/autotest/gdrivers/mrf.py
+++ b/autotest/gdrivers/mrf.py
@@ -15,6 +15,7 @@ import glob
 
 import gdaltest
 import pytest
+from os import environ
 
 from osgeo import gdal, osr
 
@@ -519,6 +520,7 @@ def test_raw_lerc():
 def test_mrf_cached_source():
 
     # Test empty cache creation
+    environ["MRF_ENABLE_CACHING"]="ON"
     gdal.Translate(
         "/vsimem/out.mrf",
         "data/byte.tif",

--- a/autotest/gdrivers/mrf.py
+++ b/autotest/gdrivers/mrf.py
@@ -519,7 +519,7 @@ def test_raw_lerc():
 def test_mrf_cached_source():
 
     # Test empty cache creation
-    with gdal.config_option("MRF_ENABLE_CACHING","ON"):
+    with gdal.config_option("MRF_ENABLE_CACHING", "ON"):
         gdal.Translate(
             "/vsimem/out.mrf",
             "data/byte.tif",

--- a/frmts/mrf/marfa_dataset.cpp
+++ b/frmts/mrf/marfa_dataset.cpp
@@ -67,9 +67,6 @@
 #include <algorithm>
 #include <limits>
 #include <vector>
-#if defined(ZSTD_SUPPORT)
-#include <zstd.h>
-#endif
 using std::string;
 using std::vector;
 
@@ -79,7 +76,7 @@ NAMESPACE_MRF_START
 MRFDataset::MRFDataset()
     : zslice(0), idxSize(0), clonedSource(FALSE), nocopy(FALSE),
       bypass_cache(
-          CPLTestBool(CPLGetConfigOption("MRF_BYPASSCACHING", "FALSE"))),
+          !CPLTestBool(CPLGetConfigOption("MRF_ENABLE_CACHING", "FALSE"))),
       mp_safe(FALSE), hasVersions(FALSE), verCount(0),
       bCrystalized(TRUE),  // Assume not in create mode
       spacing(0), no_errors(0), missing(0), poSrcDS(nullptr), level(-1),
@@ -688,6 +685,15 @@ GDALDataset *MRFDataset::Open(GDALOpenInfo *poOpenInfo)
     if (ret != CE_None)
     {
         delete ds;
+        return nullptr;
+    }
+
+    // Caching requires a tile compression
+    if (!ds->source.empty() && IL_NONE == ds->current.comp)
+    {
+        delete ds;
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "GDAL MRF: Cached MRF must use some compression");
         return nullptr;
     }
 
@@ -2161,6 +2167,9 @@ void MRFDataset::ProcessCreateOptions(CSLConstList papszOptions)
     val = opt.FetchNameValue("CACHEDSOURCE");
     if (val)
     {
+        if (IL_NONE == img.comp)
+            throw CPLString(
+                "GDAL MRF: Compression is required when caching");
         source = val;
         nocopy = opt.FetchBoolean("NOCOPY", FALSE);
     }
@@ -2192,8 +2201,6 @@ void MRFDataset::ProcessCreateOptions(CSLConstList papszOptions)
     // General Fixups
     if (img.order == IL_Interleaved)
         img.pagesize.c = img.size.c;
-
-    // Compression dependent fixups
 }
 
 /**

--- a/frmts/mrf/marfa_dataset.cpp
+++ b/frmts/mrf/marfa_dataset.cpp
@@ -2168,8 +2168,7 @@ void MRFDataset::ProcessCreateOptions(CSLConstList papszOptions)
     if (val)
     {
         if (IL_NONE == img.comp)
-            throw CPLString(
-                "GDAL MRF: Compression is required when caching");
+            throw CPLString("GDAL MRF: Compression is required when caching");
         source = val;
         nocopy = opt.FetchBoolean("NOCOPY", FALSE);
     }

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -660,7 +660,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "MITAB_MAX_LINE_LENGTH", // from mitab_middatafile.cpp
    "MITAB_SET_TOWGS84_ON_KNOWN_DATUM", // from ogrmitabspatialref.cpp
    "MRF_ALL_OVERVIEW_LEVELS", // from marfa_dataset.cpp
-   "MRF_BYPASSCACHING", // from marfa_dataset.cpp
+   "MRF_ENABLE_CACHING", // from marfa_dataset.cpp
    "MSSQLSPATIAL_ALWAYS_OUTPUT_FID", // from ogrmssqlspatialdatasource.cpp
    "MSSQLSPATIAL_BCP_SIZE", // from ogrmssqlspatialdatasource.cpp
    "MSSQLSPATIAL_LIST_ALL_TABLES", // from ogrmssqlspatialdatasource.cpp


### PR DESCRIPTION
## What does this PR do?

Replaces the MRF_BYPASSCACHING environment with MRF_ENABLE_CACHING, which defaults to off, preventing unintended creation of files. In addition, a tile compression is required in caching mode (not NONE), to block raw malicious input to be copied into MRF caching files that could act as code.

## What are related issues/pull requests?

#14739 

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [X] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [X] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
