### PR TITLE
[Backport release/3.13] Azure/ADLS GetOptions() XML: document missing AZURE_STORAGE_ACCESS_TOKEN and AZURE_STORAGE_SAS_TOKEN

### DIFF
--- a/port/cpl_azure.cpp
+++ b/port/cpl_azure.cpp
@@ -34,6 +34,7 @@
 #include "cpl_http.h"
 #include "cpl_multiproc.h"
 #include "cpl_vsi_virtual.h"
+#include "cpl_vsil_curl_class.h"
 
 #include <mutex>
 
@@ -1311,6 +1312,36 @@ std::string VSIAzureBlobHandleHelper::GetSignedURL(CSLConstList papszOptions)
     if (!osSignedIdentifier.empty())
         AddQueryParameter("si", osSignedIdentifier);
     return m_osURL;
+}
+
+/************************************************************************/
+/*                             GetOptions()                             */
+/************************************************************************/
+
+/* static */
+const char *VSIAzureBlobHandleHelper::GetOptions()
+{
+    static std::string osOptions(
+        std::string("<Options>") +
+        "  <Option name='AZURE_STORAGE_CONNECTION_STRING' type='string' "
+        "description='Connection string that contains account name and "
+        "secret key'/>"
+        "  <Option name='AZURE_STORAGE_ACCOUNT' type='string' "
+        "description='Storage account. To use with AZURE_STORAGE_ACCESS_KEY'/>"
+        "  <Option name='AZURE_STORAGE_ACCESS_KEY' type='string' "
+        "description='Secret key'/>"
+        "  <Option name='AZURE_STORAGE_ACCESS_TOKEN' type='string' "
+        "description='Access token typically obtained using Microsoft "
+        "Authentication Library (MSAL).'/>"
+        "  <Option name='AZURE_STORAGE_SAS_TOKEN' type='string' "
+        "description='Shared Access Signature'/>"
+        "  <Option name='AZURE_NO_SIGN_REQUEST' type='boolean' "
+        "description='Whether to disable signing of requests' default='NO'/>"
+        "  <Option name='VSIAZ_CHUNK_SIZE' type='int' "
+        "description='Size in MB for chunks of files that are uploaded' "
+        "default='4' min='1' max='4'/>" +
+        cpl::VSICurlFilesystemHandlerBase::GetOptionsStatic() + "</Options>");
+    return osOptions.c_str();
 }
 
 #endif  // HAVE_CURL

--- a/port/cpl_azure.h
+++ b/port/cpl_azure.h
@@ -107,6 +107,8 @@ class VSIAzureBlobHandleHelper final : public IVSIS3LikeHandleHelper
     static std::string GetSAS(const char *pszFilename);
 
     static bool IsNoSignRequest(const char *pszFilename);
+
+    static const char *GetOptions();
 };
 
 namespace cpl

--- a/port/cpl_vsil_adls.cpp
+++ b/port/cpl_vsil_adls.cpp
@@ -2029,20 +2029,7 @@ char **VSIADLSFSHandler::GetFileList(const char *pszDirname, int nMaxFiles,
 
 const char *VSIADLSFSHandler::GetOptions()
 {
-    static std::string osOptions(
-        std::string("<Options>") +
-        "  <Option name='AZURE_STORAGE_CONNECTION_STRING' type='string' "
-        "description='Connection string that contains account name and "
-        "secret key'/>"
-        "  <Option name='AZURE_STORAGE_ACCOUNT' type='string' "
-        "description='Storage account. To use with AZURE_STORAGE_ACCESS_KEY'/>"
-        "  <Option name='AZURE_STORAGE_ACCESS_KEY' type='string' "
-        "description='Secret key'/>"
-        "  <Option name='VSIAZ_CHUNK_SIZE' type='int' "
-        "description='Size in MB for chunks of files that are uploaded' "
-        "default='4' min='1' max='4'/>" +
-        VSICurlFilesystemHandlerBase::GetOptionsStatic() + "</Options>");
-    return osOptions.c_str();
+    return VSIAzureBlobHandleHelper::GetOptions();
 }
 
 /************************************************************************/

--- a/port/cpl_vsil_az.cpp
+++ b/port/cpl_vsil_az.cpp
@@ -2430,22 +2430,7 @@ char **VSIAzureFSHandler::GetFileList(const char *pszDirname, int nMaxFiles,
 
 const char *VSIAzureFSHandler::GetOptions()
 {
-    static std::string osOptions(
-        std::string("<Options>") +
-        "  <Option name='AZURE_STORAGE_CONNECTION_STRING' type='string' "
-        "description='Connection string that contains account name and "
-        "secret key'/>"
-        "  <Option name='AZURE_STORAGE_ACCOUNT' type='string' "
-        "description='Storage account. To use with AZURE_STORAGE_ACCESS_KEY'/>"
-        "  <Option name='AZURE_STORAGE_ACCESS_KEY' type='string' "
-        "description='Secret key'/>"
-        "  <Option name='AZURE_NO_SIGN_REQUEST' type='boolean' "
-        "description='Whether to disable signing of requests' default='NO'/>"
-        "  <Option name='VSIAZ_CHUNK_SIZE' type='int' "
-        "description='Size in MB for chunks of files that are uploaded' "
-        "default='4' min='1' max='4'/>" +
-        VSICurlFilesystemHandlerBase::GetOptionsStatic() + "</Options>");
-    return osOptions.c_str();
+    return VSIAzureBlobHandleHelper::GetOptions();
 }
 
 /************************************************************************/

--- a/port/cpl_vsil_curl_class.h
+++ b/port/cpl_vsil_curl_class.h
@@ -233,8 +233,6 @@ class VSICurlFilesystemHandlerBase : public VSIFilesystemHandler
                               int nMaxFiles, bool &bIsTruncated,
                               std::string &osNextMarker);
 
-    static const char *GetOptionsStatic();
-
     VSICurlFilesystemHandlerBase();
 
   public:
@@ -322,6 +320,8 @@ class VSICurlFilesystemHandlerBase : public VSIFilesystemHandler
     GetStreamingFilename(const std::string &osFilename) const override = 0;
 
     static std::set<std::string> GetS3IgnoredStorageClasses();
+
+    static const char *GetOptionsStatic();
 };
 
 class VSICurlFilesystemHandler final : public VSICurlFilesystemHandlerBase


### PR DESCRIPTION
Backport #14731
 **Authored by:** @rouault