### PR TITLE
Add gdal vector explode

### DIFF
--- a/.github/workflows/ubuntu_26.04/reference_arg_names.txt
+++ b/.github/workflows/ubuntu_26.04/reference_arg_names.txt
@@ -121,6 +121,7 @@ include-geom
 include-row-col
 include-valid
 include-xy
+index-field
 init
 input
 input-crs

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -123,6 +123,7 @@ target_sources(appslib PRIVATE
   gdalalg_vector_limit.cpp
   gdalalg_vector_make_point.cpp
   gdalalg_vector_set_geom_type.cpp
+  gdalalg_vector_explode.cpp
   gdalalg_vector_explode_collections.cpp
   gdalalg_vector_make_valid.cpp
   gdalalg_vector_segmentize.cpp

--- a/apps/gdalalg_vector.cpp
+++ b/apps/gdalalg_vector.cpp
@@ -28,6 +28,7 @@
 #include "gdalalg_vector_create.h"
 #include "gdalalg_vector_dissolve.h"
 #include "gdalalg_vector_edit.h"
+#include "gdalalg_vector_explode.h"
 #include "gdalalg_vector_explode_collections.h"
 #include "gdalalg_vector_export_schema.h"
 #include "gdalalg_vector_grid.h"
@@ -86,6 +87,7 @@ GDALVectorAlgorithm::GDALVectorAlgorithm()
     RegisterSubAlgorithm<GDALVectorDissolveAlgorithmStandalone>();
     RegisterSubAlgorithm<GDALVectorEditAlgorithmStandalone>();
     RegisterSubAlgorithm<GDALVectorExportSchemaAlgorithmStandalone>();
+    RegisterSubAlgorithm<GDALVectorExplodeAlgorithmStandalone>();
     RegisterSubAlgorithm<GDALVectorExplodeCollectionsAlgorithmStandalone>();
     RegisterSubAlgorithm<GDALVectorGridAlgorithmStandalone>();
     RegisterSubAlgorithm<GDALVectorRasterizeAlgorithmStandalone>();

--- a/apps/gdalalg_vector_check_geometry.cpp
+++ b/apps/gdalalg_vector_check_geometry.cpp
@@ -136,7 +136,7 @@ class GDALInvalidLocationLayer final : public GDALVectorPipelineOutputLayer
         return poErrorFeature;
     }
 
-    void TranslateFeature(
+    bool TranslateFeature(
         std::unique_ptr<OGRFeature> poSrcFeature,
         std::vector<std::unique_ptr<OGRFeature>> &apoOutputFeatures) override
     {
@@ -294,6 +294,8 @@ class GDALInvalidLocationLayer final : public GDALVectorPipelineOutputLayer
             poErrorFeature->SetFID(poSrcFeature->GetFID());
             apoOutputFeatures.push_back(std::move(poErrorFeature));
         }
+
+        return true;
     }
 
     CPL_DISALLOW_COPY_ASSIGN(GDALInvalidLocationLayer)

--- a/apps/gdalalg_vector_clip.cpp
+++ b/apps/gdalalg_vector_clip.cpp
@@ -94,7 +94,7 @@ class GDALVectorClipAlgorithmLayer final : public GDALVectorPipelineOutputLayer
         return m_poFeatureDefn.get();
     }
 
-    void TranslateFeature(
+    bool TranslateFeature(
         std::unique_ptr<OGRFeature> poSrcFeature,
         std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures) override
     {
@@ -102,11 +102,11 @@ class GDALVectorClipAlgorithmLayer final : public GDALVectorPipelineOutputLayer
         auto poGeom = poSrcFeature->GetGeometryRef();
 
         if (poGeom == nullptr)
-            return;
+            return true;
 
         poIntersection.reset(poGeom->Intersection(m_poClipGeom.get()));
         if (!poIntersection)
-            return;
+            return false;
         poIntersection->assignSpatialReference(
             m_poFeatureDefn->GetGeomFieldDefn(0)->GetSpatialRef());
 
@@ -158,6 +158,8 @@ class GDALVectorClipAlgorithmLayer final : public GDALVectorPipelineOutputLayer
             poSrcFeature->SetGeometry(std::move(poIntersection));
             apoOutFeatures.push_back(std::move(poSrcFeature));
         }
+
+        return true;
     }
 
     int TestCapability(const char *pszCap) const override

--- a/apps/gdalalg_vector_edit.cpp
+++ b/apps/gdalalg_vector_edit.cpp
@@ -186,7 +186,7 @@ class GDALVectorEditAlgorithmLayer final : public GDALVectorPipelineOutputLayer
         return m_poFeatureDefn.get();
     }
 
-    void TranslateFeature(
+    bool TranslateFeature(
         std::unique_ptr<OGRFeature> poSrcFeature,
         std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures) override
     {
@@ -203,6 +203,8 @@ class GDALVectorEditAlgorithmLayer final : public GDALVectorPipelineOutputLayer
         if (m_unsetFID)
             poSrcFeature->SetFID(OGRNullFID);
         apoOutFeatures.push_back(std::move(poSrcFeature));
+
+        return true;
     }
 
     int TestCapability(const char *pszCap) const override

--- a/apps/gdalalg_vector_explode.cpp
+++ b/apps/gdalalg_vector_explode.cpp
@@ -1,0 +1,577 @@
+/******************************************************************************
+ *
+ * Project:  GDAL
+ * Purpose:  "explode" step of "vector pipeline"
+ * Author:   Daniel Baston
+ *
+ ******************************************************************************
+ * Copyright (c) 2026, ISciences LLC
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#include "gdalalg_vector_explode.h"
+
+#include "cpl_conv.h"
+#include "cpl_string.h"
+#include "gdal_priv.h"
+#include "ogr_p.h"
+#include "ogrsf_frmts.h"
+
+#include <algorithm>
+#include <cinttypes>
+#include <list>
+#include <memory>
+#include <numeric>
+#include <vector>
+
+//! @cond Doxygen_Suppress
+
+#ifndef _
+#define _(x) (x)
+#endif
+
+/************************************************************************/
+/*       GDALVectorExplodeAlgorithm::GDALVectorExplodeAlgorithm()       */
+/************************************************************************/
+
+GDALVectorExplodeAlgorithm::GDALVectorExplodeAlgorithm(bool standaloneStep)
+    : GDALVectorPipelineStepAlgorithm(NAME, DESCRIPTION, HELP_URL,
+                                      standaloneStep)
+{
+    AddActiveLayerArg(&m_activeLayer);
+
+    {
+        auto &arg =
+            AddArg("field", 0, _("Attribute fields(s) to explode"), &m_fields)
+                .SetMetaVar("FIELD");
+
+        SetAutoCompleteFunctionForFieldName(
+            arg, nullptr, true, false, m_inputDataset, {"ALL"},
+            [](const OGRFieldDefn *defn)
+            { return OGR_GetFieldTypeIsList(defn->GetType()); });
+    }
+
+    AddArg("geometry", 0, _("Explode default geometry field"), &m_defaultGeom);
+
+    {
+        auto &arg = AddArg("geometry-field", 0,
+                           _("Geometry field(s) to explode"), &m_geomFields)
+                        .SetMetaVar("GEOMETRY-FIELD");
+        SetAutoCompleteFunctionForFieldName(arg, nullptr, false, true,
+                                            m_inputDataset, {"ALL"});
+    }
+
+    AddArg("index-field", 0, _("Name of the output index field"),
+           &m_indexFieldName)
+        .SetDefault(m_indexFieldName);
+}
+
+GDALVectorExplodeAlgorithmStandalone::~GDALVectorExplodeAlgorithmStandalone() =
+    default;
+
+namespace
+{
+
+class GDALVectorExplodeLayer final : public GDALVectorPipelineOutputLayer
+{
+  public:
+    GDALVectorExplodeLayer(OGRLayer &srcLayer,
+                           const std::vector<std::string> &fieldsToExplode,
+                           const std::vector<std::string> &geomFieldsToExplode,
+                           const std::string &indexFieldName)
+        : GDALVectorPipelineOutputLayer(srcLayer),
+          m_fieldsToExplode(fieldsToExplode),
+          m_geomFieldsToExplode(geomFieldsToExplode),
+          m_indexFieldName(indexFieldName)
+    {
+        if (!PrepareFeatureDefn())
+        {
+            m_setupError = true;
+        }
+    }
+
+    bool PrepareFeatureDefn()
+    {
+        m_poFeatureDefn.reset(
+            OGRFeatureDefn::CreateFeatureDefn(m_srcLayer.GetName()));
+
+        // Avoid creating geometry field with null SRS
+        // We'll copy it in later from the source layer
+        m_poFeatureDefn->DeleteGeomFieldDefn(0);
+
+        const bool addIndexField = !m_indexFieldName.empty();
+
+        if (addIndexField)
+        {
+            auto poIdxField = std::make_unique<OGRFieldDefn>(
+                m_indexFieldName.c_str(), OFTInteger);
+            m_poFeatureDefn->AddFieldDefn(std::move(poIdxField));
+        }
+
+        const OGRFeatureDefn *poSrcDefn = m_srcLayer.GetLayerDefn();
+
+        // By default, all fields copied as-is.
+        m_unnestedFieldSrcToDstMap.resize(poSrcDefn->GetFieldCount(), -1);
+        m_passThroughFieldSrcToDstMap.resize(poSrcDefn->GetFieldCount());
+        std::iota(m_passThroughFieldSrcToDstMap.begin(),
+                  m_passThroughFieldSrcToDstMap.end(), addIndexField ? 1 : 0);
+
+        m_geomFieldExploded.resize(poSrcDefn->GetGeomFieldCount(), false);
+
+        for (const auto &fieldName : m_fieldsToExplode)
+        {
+            const int iSrcField = poSrcDefn->GetFieldIndex(fieldName.c_str());
+            if (iSrcField < 0)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Field '%s' not found in source layer.",
+                         fieldName.c_str());
+                return false;
+            }
+
+            const OGRFieldDefn *poSrcFieldDefn =
+                poSrcDefn->GetFieldDefn(iSrcField);
+            const auto eSrcType = poSrcFieldDefn->GetType();
+            if (OGR_GetFieldTypeIsList(eSrcType))
+            {
+                m_passThroughFieldSrcToDstMap[iSrcField] = -1;
+                m_unnestedFieldSrcToDstMap[iSrcField] =
+                    iSrcField + addIndexField;
+            }
+        }
+
+        for (const auto &fieldName : m_geomFieldsToExplode)
+        {
+            // Is it a geometry field?
+            int iSrcGeomField = poSrcDefn->GetGeomFieldIndex(fieldName.c_str());
+
+            // Interpret --geometry-field _OGR_GEOMETRY_ as the first geometry
+            // field, regardless of what it is actually named
+            if (iSrcGeomField < 0)
+            {
+                if (poSrcDefn->GetGeomFieldCount() > 0 &&
+                    EQUAL(fieldName.c_str(),
+                          OGR_GEOMETRY_DEFAULT_NON_EMPTY_NAME))
+                {
+                    iSrcGeomField = 0;
+                }
+            }
+
+            // Didn't find anything by name. Check by index.
+            if (iSrcGeomField < 0 &&
+                std::all_of(
+                    fieldName.begin(), fieldName.end(), [](char c)
+                    { return std::isdigit(static_cast<unsigned char>(c)); }))
+            {
+                const int iGeomField = std::atoi(fieldName.c_str());
+
+                if (iGeomField < poSrcDefn->GetGeomFieldCount())
+                {
+                    iSrcGeomField = iGeomField;
+                }
+            }
+
+            if (iSrcGeomField < 0)
+            {
+                CPLError(
+                    CE_Failure, CPLE_AppDefined,
+                    "Could not find geometry field '%s' in source layer '%s'",
+                    fieldName.c_str(), m_srcLayer.GetName());
+                return false;
+            }
+
+            m_geomFieldExploded[iSrcGeomField] = true;
+        }
+
+        // Create attribute fields
+        for (int iSrcField = 0; iSrcField < poSrcDefn->GetFieldCount();
+             iSrcField++)
+        {
+            const auto *poSrcFieldDefn = poSrcDefn->GetFieldDefn(iSrcField);
+            std::unique_ptr<OGRFieldDefn> poDstFieldDefn;
+
+            if (m_passThroughFieldSrcToDstMap[iSrcField] != -1)
+            {
+                poDstFieldDefn =
+                    std::make_unique<OGRFieldDefn>(*poSrcFieldDefn);
+            }
+            else
+            {
+                const auto eScalarType =
+                    OGR_GetFieldTypeAsScalar(poSrcFieldDefn->GetType());
+                poDstFieldDefn = std::make_unique<OGRFieldDefn>(
+                    poSrcFieldDefn->GetNameRef(), eScalarType);
+            }
+
+            m_poFeatureDefn->AddFieldDefn(std::move(poDstFieldDefn));
+        }
+
+        // Create geometry fields
+        for (int iSrcGeomField = 0;
+             iSrcGeomField < poSrcDefn->GetGeomFieldCount(); iSrcGeomField++)
+        {
+            const OGRGeomFieldDefn *poSrcGeomFieldDefn =
+                poSrcDefn->GetGeomFieldDefn(iSrcGeomField);
+            std::unique_ptr<OGRGeomFieldDefn> poDstGeomFieldDefn;
+
+            if (m_geomFieldExploded[iSrcGeomField])
+            {
+                const auto eDstType =
+                    OGR_GT_GetSingle(poSrcGeomFieldDefn->GetType());
+                poDstGeomFieldDefn = std::make_unique<OGRGeomFieldDefn>(
+                    poSrcGeomFieldDefn->GetNameRef(), eDstType);
+                poDstGeomFieldDefn->SetSpatialRef(
+                    poSrcGeomFieldDefn->GetSpatialRef());
+            }
+            else
+            {
+                poDstGeomFieldDefn =
+                    std::make_unique<OGRGeomFieldDefn>(*poSrcGeomFieldDefn);
+            }
+
+            m_poFeatureDefn->AddGeomFieldDefn(std::move(poDstGeomFieldDefn));
+        }
+
+        return true;
+    }
+
+    const char *GetDescription() const override
+    {
+        return m_poFeatureDefn->GetName();
+    }
+
+    const OGRFeatureDefn *GetLayerDefn() const override
+    {
+        return m_poFeatureDefn.get();
+    }
+
+    void ResetReading() override
+    {
+        m_nextFID = 1;
+        GDALVectorPipelineOutputLayer::ResetReading();
+    }
+
+    int TestCapability(const char *pszCap) const override
+    {
+        if (EQUAL(pszCap, OLCFastGetExtent) ||
+            EQUAL(pszCap, OLCFastGetExtent3D) ||
+            EQUAL(pszCap, OLCStringsAsUTF8) ||
+            EQUAL(pszCap, OLCCurveGeometries) ||
+            EQUAL(pszCap, OLCMeasuredGeometries) ||
+            EQUAL(pszCap, OLCZGeometries))
+        {
+            return m_srcLayer.TestCapability(pszCap);
+        }
+
+        return false;
+    }
+
+    bool TranslateFeature(
+        std::unique_ptr<OGRFeature> poSrcFeature,
+        std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures) override
+    {
+        if (m_setupError)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Failed to prepare output layer.");
+            return false;
+        }
+
+        int nDstFeatures = 1;
+
+        for (int iDstFeature = 0; iDstFeature < nDstFeatures; iDstFeature++)
+        {
+            auto poDstFeature =
+                std::make_unique<OGRFeature>(m_poFeatureDefn.get());
+            if (!m_indexFieldName.empty())
+            {
+                poDstFeature->SetField(0, iDstFeature);
+            }
+
+            if (poDstFeature->SetFieldsFrom(
+                    poSrcFeature.get(), m_passThroughFieldSrcToDstMap.data(),
+                    true) != OGRERR_NONE)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Failed to set fields of output feature");
+                return false;
+            }
+
+            for (int iSrcArrayField = 0;
+                 iSrcArrayField <
+                 static_cast<int>(m_unnestedFieldSrcToDstMap.size());
+                 iSrcArrayField++)
+            {
+                const int iDstField =
+                    m_unnestedFieldSrcToDstMap[iSrcArrayField];
+                if (iDstField < 0)
+                {
+                    continue;
+                }
+
+                const auto poSrcFieldDefn =
+                    poSrcFeature->GetFieldDefnRef(iSrcArrayField);
+                const auto eSrcType = poSrcFieldDefn->GetType();
+                int nArrayLength = -1;
+                if (eSrcType == OFTIntegerList)
+                {
+                    const int *pnArray = poSrcFeature->GetFieldAsIntegerList(
+                        iSrcArrayField, &nArrayLength);
+                    if (iDstFeature >= nArrayLength)
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Field '%s' of source feature %" PRId64
+                                 " does not have enough elements.",
+                                 poSrcFieldDefn->GetNameRef(),
+                                 static_cast<int64_t>(poSrcFeature->GetFID()));
+                        return false;
+                    }
+                    poDstFeature->SetField(iDstField, pnArray[iDstFeature]);
+                }
+                else if (eSrcType == OFTInteger64List)
+                {
+                    const GIntBig *pnArray =
+                        poSrcFeature->GetFieldAsInteger64List(iSrcArrayField,
+                                                              &nArrayLength);
+                    if (iDstFeature >= nArrayLength)
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Field '%s' of source feature %" PRId64
+                                 " does not have enough elements.",
+                                 poSrcFieldDefn->GetNameRef(),
+                                 static_cast<int64_t>(poSrcFeature->GetFID()));
+                        return false;
+                    }
+                    poDstFeature->SetField(iDstField, pnArray[iDstFeature]);
+                }
+                else if (eSrcType == OFTRealList)
+                {
+                    const double *padfArray =
+                        poSrcFeature->GetFieldAsDoubleList(iSrcArrayField,
+                                                           &nArrayLength);
+                    if (iDstFeature >= nArrayLength)
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Field '%s' of source feature %" PRId64
+                                 " does not have enough elements.",
+                                 poSrcFieldDefn->GetNameRef(),
+                                 static_cast<int64_t>(poSrcFeature->GetFID()));
+                        return false;
+                    }
+                    poDstFeature->SetField(iDstField, padfArray[iDstFeature]);
+                }
+                else if (eSrcType == OFTStringList)
+                {
+                    CSLConstList papszArray =
+                        poSrcFeature->GetFieldAsStringList(iSrcArrayField);
+                    nArrayLength = CSLCount(papszArray);
+                    if (iDstFeature >= nArrayLength)
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Field '%s' of source feature %" PRId64
+                                 " does not have enough elements.",
+                                 poSrcFieldDefn->GetNameRef(),
+                                 static_cast<int64_t>(poSrcFeature->GetFID()));
+                        return false;
+                    }
+                    poDstFeature->SetField(iDstField, papszArray[iDstFeature]);
+                }
+                nDstFeatures = std::max(nDstFeatures, nArrayLength);
+            }
+
+            for (int iGeomField = 0;
+                 iGeomField < poSrcFeature->GetGeomFieldCount(); iGeomField++)
+            {
+                if (m_geomFieldExploded[iGeomField])
+                {
+                    std::unique_ptr<OGRGeometry> poDstGeom;
+
+                    OGRGeometry *poSrcGeom(
+                        poSrcFeature->GetGeomFieldRef(iGeomField));
+
+                    const bool bSrcIsCollection =
+                        poSrcGeom != nullptr &&
+                        OGR_GT_IsSubClassOf(
+                            wkbFlatten(poSrcGeom->getGeometryType()),
+                            wkbGeometryCollection);
+
+                    if (bSrcIsCollection)
+                    {
+                        OGRGeometryCollection *poColl =
+                            poSrcGeom->toGeometryCollection();
+
+                        auto nGeoms = poColl->getNumGeometries();
+                        nDstFeatures = std::max(nDstFeatures, nGeoms);
+
+                        if (nGeoms == 0)
+                        {
+                            CPLError(
+                                CE_Failure, CPLE_AppDefined,
+                                "Geometry field '%s' of source feature %" PRId64
+                                " has %d elements (expected %d)",
+                                poSrcFeature->GetDefnRef()
+                                    ->GetGeomFieldDefn(iGeomField)
+                                    ->GetNameRef(),
+                                static_cast<int64_t>(poSrcFeature->GetFID()),
+                                nGeoms + iDstFeature, nDstFeatures);
+                            return false;
+                        }
+
+                        poDstGeom = poColl->stealGeometry(0);
+                    }
+                    else
+                    {
+                        if (iDstFeature > 1 &&
+                            apoOutFeatures.front()->GetGeomFieldRef(
+                                iGeomField) != nullptr)
+                        {
+                            CPLError(
+                                CE_Failure, CPLE_AppDefined,
+                                "Geometry field '%s' of source feature %" PRId64
+                                " is not a collection.",
+                                poSrcFeature->GetDefnRef()
+                                    ->GetGeomFieldDefn(iGeomField)
+                                    ->GetNameRef(),
+                                static_cast<int64_t>(poSrcFeature->GetFID()));
+                            return false;
+                        }
+
+                        poDstGeom.reset(
+                            poSrcFeature->StealGeometry(iGeomField));
+                    }
+
+                    poDstFeature->SetGeomField(iGeomField,
+                                               std::move(poDstGeom));
+                }
+                else
+                {
+                    std::unique_ptr<OGRGeometry> poSrcGeom;
+
+                    if (iDstFeature == 0)
+                    {
+                        poSrcGeom.reset(
+                            poSrcFeature->StealGeometry(iGeomField));
+                    }
+                    else
+                    {
+                        poSrcGeom.reset(apoOutFeatures.front()
+                                            ->GetGeomFieldRef(iGeomField)
+                                            ->clone());
+                    }
+
+                    poDstFeature->SetGeomField(iGeomField,
+                                               std::move(poSrcGeom));
+                }
+            }
+
+            poDstFeature->SetFID(m_nextFID++);
+            apoOutFeatures.push_back(std::move(poDstFeature));
+        }
+
+        return true;
+    }
+
+  protected:
+    OGRErr IGetExtent(int iGeomField, OGREnvelope *psExtent,
+                      bool bForce) override
+    {
+        return m_srcLayer.GetExtent(iGeomField, psExtent, bForce);
+    }
+
+    OGRErr IGetExtent3D(int iGeomField, OGREnvelope3D *psExtent3D,
+                        bool bForce) override
+    {
+        return m_srcLayer.GetExtent3D(iGeomField, psExtent3D, bForce);
+    }
+
+  private:
+    std::vector<int> m_passThroughFieldSrcToDstMap{};
+    std::vector<int> m_unnestedFieldSrcToDstMap{};
+    std::vector<bool> m_geomFieldExploded{};
+    std::vector<std::string> m_fieldsToExplode{};
+    std::vector<std::string> m_geomFieldsToExplode{};
+    std::string m_indexFieldName{};
+    bool m_setupError{false};
+    OGRFeatureDefnRefCountedPtr m_poFeatureDefn{nullptr};
+    GIntBig m_nextFID{1};
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALVectorExplodeLayer)
+};
+
+}  // namespace
+
+/************************************************************************/
+/*                GDALVectorExplodeAlgorithm::RunStep()                 */
+/************************************************************************/
+
+bool GDALVectorExplodeAlgorithm::RunStep(GDALPipelineStepRunContext &)
+{
+    auto poSrcDS = m_inputDataset[0].GetDatasetRef();
+    CPLAssert(poSrcDS);
+
+    auto poOutDS = std::make_unique<GDALVectorPipelineOutputDataset>(*poSrcDS);
+
+    if (m_defaultGeom)
+    {
+        m_geomFields.emplace_back(OGR_GEOMETRY_DEFAULT_NON_EMPTY_NAME);
+    }
+
+    if (m_fields.empty() && m_geomFields.empty())
+    {
+        ReportError(CE_Failure, CPLE_IllegalArg,
+                    "At least one field or geometry field must be specified");
+        return false;
+    }
+
+    for (OGRLayer *poSrcLayer : poSrcDS->GetLayers())
+    {
+        if (!poSrcLayer)
+            continue;
+
+        if (!m_activeLayer.empty() &&
+            poSrcLayer->GetDescription() != m_activeLayer)
+        {
+            poOutDS->AddLayer(
+                *poSrcLayer,
+                std::make_unique<GDALVectorPipelinePassthroughLayer>(
+                    *poSrcLayer));
+        }
+
+        const auto *poLayerDefn = poSrcLayer->GetLayerDefn();
+
+        auto fieldsForLayer = m_fields;
+        auto geomFieldsForLayer = m_geomFields;
+
+        if (geomFieldsForLayer.size() == 1 && geomFieldsForLayer[0] == "ALL")
+        {
+            geomFieldsForLayer.clear();
+            for (int iGeomField = 0;
+                 iGeomField < poLayerDefn->GetGeomFieldCount(); iGeomField++)
+            {
+                geomFieldsForLayer.emplace_back(
+                    poLayerDefn->GetGeomFieldDefn(iGeomField)->GetNameRef());
+            }
+        }
+
+        if (fieldsForLayer.size() == 1 && fieldsForLayer[0] == "ALL")
+        {
+            fieldsForLayer.clear();
+            for (int iField = 0; iField < poLayerDefn->GetFieldCount();
+                 iField++)
+            {
+                fieldsForLayer.emplace_back(
+                    poLayerDefn->GetFieldDefn(iField)->GetNameRef());
+            }
+        }
+
+        auto poOutLayer = std::make_unique<GDALVectorExplodeLayer>(
+            *poSrcLayer, fieldsForLayer, geomFieldsForLayer, m_indexFieldName);
+        poOutDS->AddLayer(*poSrcLayer, std::move(poOutLayer));
+    }
+
+    m_outputDataset.Set(std::move(poOutDS));
+    return true;
+}
+
+//! @endcond

--- a/apps/gdalalg_vector_explode.h
+++ b/apps/gdalalg_vector_explode.h
@@ -1,0 +1,65 @@
+/******************************************************************************
+ *
+ * Project:  GDAL
+ * Purpose:  "explode" step of "vector pipeline"
+ * Author:   Daniel Baston
+ *
+ ******************************************************************************
+ * Copyright (c) 2026, ISciences LLC
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#ifndef GDALALG_VECTOR_EXPLODE_INCLUDED
+#define GDALALG_VECTOR_EXPLODE_INCLUDED
+
+#include "gdalalg_vector_pipeline.h"
+
+//! @cond Doxygen_Suppress
+
+/************************************************************************/
+/*                      GDALVectorExplodeAlgorithm                      */
+/************************************************************************/
+
+class GDALVectorExplodeAlgorithm /* non final */
+    : public GDALVectorPipelineStepAlgorithm
+{
+  public:
+    static constexpr const char *NAME = "explode";
+    static constexpr const char *DESCRIPTION =
+        "Explode fields or geometries of a vector dataset.";
+    static constexpr const char *HELP_URL =
+        "/programs/gdal_vector_explode.html";
+
+    explicit GDALVectorExplodeAlgorithm(bool standaloneStep = false);
+
+  protected:
+    bool RunStep(GDALPipelineStepRunContext &ctxt) override;
+
+  private:
+    std::string m_activeLayer{};
+    std::vector<std::string> m_fields{};
+    std::vector<std::string> m_geomFields{};
+    bool m_defaultGeom{false};
+    std::string m_indexFieldName{};
+};
+
+/************************************************************************/
+/*                 GDALVectorExplodeAlgorithmStandalone                 */
+/************************************************************************/
+
+class GDALVectorExplodeAlgorithmStandalone final
+    : public GDALVectorExplodeAlgorithm
+{
+  public:
+    GDALVectorExplodeAlgorithmStandalone()
+        : GDALVectorExplodeAlgorithm(/* standaloneStep = */ true)
+    {
+    }
+
+    ~GDALVectorExplodeAlgorithmStandalone() override;
+};
+
+//! @endcond
+
+#endif /* GDALALG_VECTOR_EXPLODE_INCLUDED */

--- a/apps/gdalalg_vector_explode_collections.cpp
+++ b/apps/gdalalg_vector_explode_collections.cpp
@@ -78,7 +78,7 @@ class GDALVectorExplodeCollectionsAlgorithmLayer final
 
     CPL_DISALLOW_COPY_ASSIGN(GDALVectorExplodeCollectionsAlgorithmLayer)
 
-    void TranslateFeature(
+    bool TranslateFeature(
         std::unique_ptr<OGRFeature> poSrcFeature,
         std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures) override;
 
@@ -163,7 +163,7 @@ GDALVectorExplodeCollectionsAlgorithmLayer::
 /*                          TranslateFeature()                          */
 /************************************************************************/
 
-void GDALVectorExplodeCollectionsAlgorithmLayer::TranslateFeature(
+bool GDALVectorExplodeCollectionsAlgorithmLayer::TranslateFeature(
     std::unique_ptr<OGRFeature> poSrcFeature,
     std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures)
 {
@@ -255,6 +255,8 @@ void GDALVectorExplodeCollectionsAlgorithmLayer::TranslateFeature(
             apoOutFeatures.push_back(std::move(poCurFeature));
         }
     }
+
+    return true;
 }
 
 }  // namespace

--- a/apps/gdalalg_vector_geom.h
+++ b/apps/gdalalg_vector_geom.h
@@ -125,13 +125,14 @@ class GDALVectorGeomOneToOneAlgorithmLayer /* non final */
     virtual std::unique_ptr<OGRFeature>
     TranslateFeature(std::unique_ptr<OGRFeature> poSrcFeature) const = 0;
 
-    void TranslateFeature(
+    bool TranslateFeature(
         std::unique_ptr<OGRFeature> poSrcFeature,
         std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures) override
     {
         auto poDstFeature = TranslateFeature(std::move(poSrcFeature));
         if (poDstFeature)
             apoOutFeatures.push_back(std::move(poDstFeature));
+        return true;
     }
 
   private:

--- a/apps/gdalalg_vector_make_point.cpp
+++ b/apps/gdalalg_vector_make_point.cpp
@@ -127,7 +127,7 @@ class GDALVectorMakePointAlgorithmLayer final
                 CPLError(CE_Failure, CPLE_AppDefined,
                          "Invalid value in field %s: %s ", pszFieldName,
                          pszValue);
-                FailTranslation();
+                m_fatalError = true;
             }
             return dfValue;
         }
@@ -145,7 +145,7 @@ class GDALVectorMakePointAlgorithmLayer final
             CPLError(CE_Failure, CPLE_AppDefined,
                      "Specified %s field name '%s' does not exist", dim.c_str(),
                      fieldName.c_str());
-            FailTranslation();
+            m_fatalError = true;
             return false;
         }
 
@@ -158,7 +158,7 @@ class GDALVectorMakePointAlgorithmLayer final
         {
             CPLError(CE_Failure, CPLE_AppDefined, "Invalid %s field type: %s",
                      dim.c_str(), OGR_GetFieldTypeName(eType));
-            FailTranslation();
+            m_fatalError = true;
             return false;
         }
 
@@ -175,11 +175,12 @@ class GDALVectorMakePointAlgorithmLayer final
         return m_srcLayer.TestCapability(pszCap);
     }
 
-  private:
-    void TranslateFeature(
+  protected:
+    bool TranslateFeature(
         std::unique_ptr<OGRFeature> poSrcFeature,
         std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures) override;
 
+  private:
     const std::string m_xField;
     const std::string m_yField;
     const std::string m_zField;
@@ -190,6 +191,7 @@ class GDALVectorMakePointAlgorithmLayer final
     const int m_mFieldIndex;
     const bool m_hasZ;
     const bool m_hasM;
+    bool m_fatalError = false;
     bool m_xFieldIsString = false;
     bool m_yFieldIsString = false;
     bool m_zFieldIsString = false;
@@ -204,7 +206,7 @@ class GDALVectorMakePointAlgorithmLayer final
 /*                          TranslateFeature()                          */
 /************************************************************************/
 
-void GDALVectorMakePointAlgorithmLayer::TranslateFeature(
+bool GDALVectorMakePointAlgorithmLayer::TranslateFeature(
     std::unique_ptr<OGRFeature> poSrcFeature,
     std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures)
 {
@@ -214,6 +216,11 @@ void GDALVectorMakePointAlgorithmLayer::TranslateFeature(
         m_hasZ ? GetField(*poSrcFeature, m_zFieldIndex, m_zFieldIsString) : 0;
     const double m =
         m_hasM ? GetField(*poSrcFeature, m_mFieldIndex, m_mFieldIsString) : 0;
+
+    if (m_fatalError)
+    {
+        return false;
+    }
 
     std::unique_ptr<OGRPoint> poGeom;
 
@@ -245,6 +252,8 @@ void GDALVectorMakePointAlgorithmLayer::TranslateFeature(
     poDstFeature->SetGeometry(std::move(poGeom));
 
     apoOutFeatures.push_back(std::move(poDstFeature));
+
+    return true;
 }
 
 }  // namespace

--- a/apps/gdalalg_vector_partition.cpp
+++ b/apps/gdalalg_vector_partition.cpp
@@ -14,6 +14,7 @@
 
 #include "cpl_vsi.h"
 #include "cpl_mem_cache.h"
+#include "ogr_p.h"
 
 #include <algorithm>
 #include <set>
@@ -1008,9 +1009,21 @@ bool GDALVectorPartitionAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
             int nIdx = poSrcFeatureDefn->GetFieldIndex(fieldName.c_str());
             if (nIdx < 0)
             {
-                if (fieldName == "OGR_GEOMETRY" &&
+                if (EQUAL(fieldName.c_str(), "OGR_GEOMETRY") &&
                     poSrcFeatureDefn->GetGeomFieldCount() > 0)
+                {
+                    CPLError(CE_Warning, CPLE_AppDefined,
+                             "'%s' is deprecated. Please use '%s' instead",
+                             "OGR_GEOMETRY",
+                             OGR_GEOMETRY_DEFAULT_NON_EMPTY_NAME);
                     nIdx = 0;
+                }
+                else if (EQUAL(fieldName.c_str(),
+                               OGR_GEOMETRY_DEFAULT_NON_EMPTY_NAME) &&
+                         poSrcFeatureDefn->GetGeomFieldCount() > 0)
+                {
+                    nIdx = 0;
+                }
                 else
                     nIdx =
                         poSrcFeatureDefn->GetGeomFieldIndex(fieldName.c_str());
@@ -1029,7 +1042,8 @@ bool GDALVectorPartitionAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
                     f.nIdx = nIdx;
                     f.bIsGeom = true;
                     if (fieldName.empty())
-                        f.encodedFieldName = "OGR_GEOMETRY";
+                        f.encodedFieldName =
+                            OGR_GEOMETRY_DEFAULT_NON_EMPTY_NAME;
                     else
                         f.encodedFieldName = PercentEncode(fieldName);
                     asFields.push_back(std::move(f));

--- a/apps/gdalalg_vector_pipeline.cpp
+++ b/apps/gdalalg_vector_pipeline.cpp
@@ -419,8 +419,7 @@ OGRFeature *GDALVectorPipelineOutputLayer::GetNextRawFeature()
             std::unique_ptr<OGRFeature>(m_srcLayer.GetNextFeature());
         if (!poSrcFeature)
             return nullptr;
-        TranslateFeature(std::move(poSrcFeature), m_pendingFeatures);
-        if (m_translateError)
+        if (!TranslateFeature(std::move(poSrcFeature), m_pendingFeatures))
         {
             return nullptr;
         }
@@ -558,8 +557,12 @@ OGRFeature *GDALVectorPipelineOutputDataset::GetNextFeature(
         if (iterToDstLayer != m_mapSrcLayerToNewLayer.end())
         {
             m_belongingLayer = iterToDstLayer->second;
-            m_belongingLayer->TranslateFeature(std::move(poSrcFeature),
-                                               m_pendingFeatures);
+
+            if (!m_belongingLayer->TranslateFeature(std::move(poSrcFeature),
+                                                    m_pendingFeatures))
+            {
+                return nullptr;
+            }
 
             if (!m_pendingFeatures.empty())
                 break;
@@ -585,7 +588,7 @@ const OGRFeatureDefn *GDALVectorPipelinePassthroughLayer::GetLayerDefn() const
 /*          GDALVectorPipelinePassthroughLayer::GetLayerDefn()          */
 /************************************************************************/
 
-void GDALVectorPipelinePassthroughLayer::TranslateFeature(
+bool GDALVectorPipelinePassthroughLayer::TranslateFeature(
     std::unique_ptr<OGRFeature> poSrcFeature,
     std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures)
 {
@@ -594,6 +597,8 @@ void GDALVectorPipelinePassthroughLayer::TranslateFeature(
     {
         apoOutFeatures.push_back(std::move(poSrcFeature));
     }
+
+    return true;
 }
 
 /************************************************************************/

--- a/apps/gdalalg_vector_pipeline.cpp
+++ b/apps/gdalalg_vector_pipeline.cpp
@@ -26,6 +26,7 @@
 #include "gdalalg_vector_create.h"
 #include "gdalalg_vector_dissolve.h"
 #include "gdalalg_vector_edit.h"
+#include "gdalalg_vector_explode.h"
 #include "gdalalg_vector_explode_collections.h"
 #include "gdalalg_vector_export_schema.h"
 #include "gdalalg_vector_filter.h"
@@ -180,6 +181,7 @@ void GDALVectorPipelineAlgorithm::RegisterAlgorithms(
     registry.Register<GDALVectorEditAlgorithm>(
         addSuffixIfNeeded(GDALVectorEditAlgorithm::NAME));
 
+    registry.Register<GDALVectorExplodeAlgorithm>();
     registry.Register<GDALVectorExplodeCollectionsAlgorithm>();
     registry.Register<GDALVectorExportSchemaAlgorithm>();
 

--- a/apps/gdalalg_vector_rename_layer.cpp
+++ b/apps/gdalalg_vector_rename_layer.cpp
@@ -110,12 +110,13 @@ class GDALVectorRenameLayerAlgorithmLayer final
 
     CPL_DISALLOW_COPY_ASSIGN(GDALVectorRenameLayerAlgorithmLayer)
 
-    void TranslateFeature(
+    bool TranslateFeature(
         std::unique_ptr<OGRFeature> poSrcFeature,
         std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures) override
     {
         poSrcFeature->SetFDefnUnsafe(m_poFeatureDefn.get());
         apoOutFeatures.push_back(std::move(poSrcFeature));
+        return true;
     }
 
   public:

--- a/apps/gdalalg_vector_select.cpp
+++ b/apps/gdalalg_vector_select.cpp
@@ -111,11 +111,12 @@ class GDALVectorSelectAlgorithmLayer final
         return poFeature;
     }
 
-    void TranslateFeature(
+    bool TranslateFeature(
         std::unique_ptr<OGRFeature> poSrcFeature,
         std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures) override
     {
         apoOutFeatures.push_back(TranslateFeature(std::move(poSrcFeature)));
+        return true;
     }
 
   public:

--- a/apps/gdalalg_vector_set_field_type.cpp
+++ b/apps/gdalalg_vector_set_field_type.cpp
@@ -184,7 +184,7 @@ class GDALVectorSetFieldTypeAlgorithmLayer final
         return m_poFeatureDefn.get();
     }
 
-    void TranslateFeature(
+    bool TranslateFeature(
         std::unique_ptr<OGRFeature> poSrcFeature,
         std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures) override
     {
@@ -215,6 +215,8 @@ class GDALVectorSetFieldTypeAlgorithmLayer final
                 apoOutFeatures.push_back(std::move(poDstFeature));
             }
         }
+
+        return true;
     }
 
     int TestCapability(const char *pszCap) const override

--- a/apps/gdalvectorpipelinestepalgorithm.h
+++ b/apps/gdalvectorpipelinestepalgorithm.h
@@ -323,7 +323,7 @@ class GDALVectorPipelinePassthroughLayer /* non final */
         return m_srcLayer.GetExtent3D(iGeomField, psExtent, bForce);
     }
 
-    void TranslateFeature(
+    bool TranslateFeature(
         std::unique_ptr<OGRFeature> poSrcFeature,
         std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures) override;
 };

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -2234,3 +2234,37 @@ def run_and_parse_completion_output(cmd_line):
     if res and res.endswith(sep):
         res = res[0 : -len(sep)]
     return res.split(sep)
+
+
+###############################################################################
+#
+
+
+def algorithm_check_ogrsf(alg, tmp_path):
+
+    if gdal.GetDriverByName("GDALG") is None:
+        pytest.skip("requires GDALG driver")
+
+    import test_cli_utilities
+
+    if test_cli_utilities.get_test_ogrsf_path() is None:
+        pytest.skip("test_ogrsf not available")
+
+    gdalg_filename = tmp_path / "tmp.gdalg.json"
+
+    alg["output"] = gdalg_filename
+    alg["output-format"] = "GDALG"
+
+    assert alg.Run()
+
+    gdalg_contents = json.load(open(gdalg_filename))
+    gdalg_contents["relative_paths_relative_to_this_file"] = False
+    json.dump(gdalg_contents, open(gdalg_filename, "w"))
+
+    ret = runexternal(
+        test_cli_utilities.get_test_ogrsf_path() + f" -ro {gdalg_filename}"
+    )
+
+    assert "INFO" in ret
+    assert "ERROR" not in ret
+    assert "FAILURE" not in ret

--- a/autotest/utilities/test_gdalalg_vector_explode.py
+++ b/autotest/utilities/test_gdalalg_vector_explode.py
@@ -1,0 +1,597 @@
+#!/usr/bin/env pytest
+# -*- coding: utf-8 -*-
+###############################################################################
+# Project:  GDAL/OGR Test Suite
+# Purpose:  'gdal vector explode' testing
+# Author:   Dan Baston
+#
+###############################################################################
+# Copyright (c) 2026, ISciences LLC
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+
+import string
+import sys
+
+import gdaltest
+import ogrtest
+import pytest
+import test_cli_utilities
+
+from osgeo import gdal, ogr, osr
+
+
+@pytest.fixture()
+def alg():
+    return gdal.Algorithm("vector", "explode")
+
+
+@pytest.fixture()
+def source_with_arrays():
+
+    np = pytest.importorskip("numpy")
+
+    nfeat = 3
+    array_length = 3
+
+    src_ds = gdal.GetDriverByName("MEM").CreateVector("")
+    src_lyr = src_ds.CreateLayer(
+        "test", geom_type=ogr.wkbPoint, srs=osr.SpatialReference(epsg=4326)
+    )
+    src_lyr.CreateField(ogr.FieldDefn("name", ogr.OFTString))
+    src_lyr.CreateField(ogr.FieldDefn("my_real_list", ogr.OFTRealList))
+    src_lyr.CreateField(ogr.FieldDefn("my_int_list", ogr.OFTIntegerList))
+    src_lyr.CreateField(ogr.FieldDefn("my_int64_list", ogr.OFTInteger64List))
+    src_lyr.CreateField(ogr.FieldDefn("my_string_list", ogr.OFTStringList))
+
+    feature = ogr.Feature(src_lyr.GetLayerDefn())
+    for i in range(nfeat):
+        feature["name"] = f"feat_{i}"
+        feature["my_real_list"] = (i ** (np.arange(1, 1 + array_length))).tolist()
+        feature["my_int_list"] = ((i + 1) * np.arange(array_length)).tolist()
+        if sys.maxsize < (1 << 63) - 1:
+            feature["my_int64_list"] = feature["my_int_list"]
+        else:
+            feature["my_int64_list"] = (2**32 + np.arange(array_length)).tolist()
+        feature["my_string_list"] = list(string.ascii_letters[i : i + array_length])
+        feature.SetGeometry(ogr.CreateGeometryFromWkt(f"POINT ({i} {2 * i})"))
+        src_lyr.CreateFeature(feature)
+
+    return src_ds
+
+
+def test_gdalalg_vector_explode_basic(alg, source_with_arrays):
+
+    alg["input"] = source_with_arrays
+    alg["field"] = [
+        "name",
+        "my_real_list",
+        "my_int_list",
+        "my_int64_list",
+        "my_string_list",
+    ]
+    alg["index-field"] = "index"
+    alg["output-format"] = "MEM"
+
+    assert alg.Run()
+
+    out_ds = alg.Output()
+    assert out_ds.GetLayerCount() == 1
+
+    src_lyr = source_with_arrays.GetLayer(0)
+    out_lyr = out_ds.GetLayer(0)
+
+    assert out_lyr.GetName() == "test"
+
+    assert out_lyr.GetSpatialRef().IsSame(src_lyr.GetSpatialRef())
+    assert out_lyr.GetFeatureCount() == 9
+
+    out_defn = out_lyr.GetLayerDefn()
+    out_fields = [
+        out_defn.GetFieldDefn(i).GetName() for i in range(out_defn.GetFieldCount())
+    ]
+
+    assert out_fields == [
+        "index",
+        "name",
+        "my_real_list",
+        "my_int_list",
+        "my_int64_list",
+        "my_string_list",
+    ]
+
+    for i, src_feat in enumerate(src_lyr):
+        for j in range(3):
+            dst_feat = out_lyr.GetNextFeature()
+
+            assert dst_feat["index"] == j
+            assert dst_feat["name"] == src_feat["name"]
+            assert dst_feat["my_real_list"] == src_feat["my_real_list"][j]
+            assert dst_feat["my_int_list"] == src_feat["my_int_list"][j]
+            assert dst_feat["my_int64_list"] == src_feat["my_int64_list"][j]
+            assert dst_feat["my_string_list"] == src_feat["my_string_list"][j]
+
+            assert dst_feat.GetGeometryRef().ExportToWkt() == f"POINT ({i} {2 * i})"
+
+
+@pytest.mark.parametrize(
+    "field_type",
+    (ogr.OFTIntegerList, ogr.OFTInteger64List, ogr.OFTRealList, ogr.OFTStringList),
+)
+def test_gdalalg_vector_explode_arrays_unequal_length(alg, field_type):
+
+    src_ds = gdal.GetDriverByName("MEM").CreateVector("")
+    src_lyr = src_ds.CreateLayer("test", geom_type=ogr.wkbNone)
+    src_lyr.CreateField(ogr.FieldDefn("field_a", field_type))
+    src_lyr.CreateField(ogr.FieldDefn("field_b", field_type))
+
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+
+    f["field_a"] = [1, 2, 3]
+    f["field_b"] = [4, 5, 6]
+    src_lyr.CreateFeature(f)
+
+    f["field_a"] = [7, 8, 9]
+    f["field_b"] = [10, 11]
+    src_lyr.CreateFeature(f)
+
+    alg["input"] = src_ds
+    alg["field"] = ["field_a", "field_b"]
+    alg["output-format"] = "MEM"
+
+    with pytest.raises(
+        Exception,
+        match="Field 'field_b' of source feature 1 does not have enough elements",
+    ):
+        alg.Run()
+
+
+def test_gdalalg_vector_explode_invalid_field(alg):
+
+    alg["input"] = "../ogr/data/poly.shp"
+    alg["field"] = "does_not_exist"
+    alg["output-format"] = "MEM"
+
+    with pytest.raises(Exception, match="Field 'does_not_exist' not found"):
+        alg.Run()
+
+
+def test_gdalalg_vector_explode_geometry(alg):
+
+    src_ds = gdal.GetDriverByName("MEM").CreateVector("")
+    src_lyr = src_ds.CreateLayer(
+        "test", geom_type=ogr.wkbMultiPoint, srs=osr.SpatialReference(epsg=4326)
+    )
+
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f.SetGeometry(ogr.CreateGeometryFromWkt("MULTIPOINT (3 2, 4 7, 1 9)"))
+    src_lyr.CreateFeature(f)
+
+    f.SetGeometry(ogr.CreateGeometryFromWkt("MULTIPOINT (2 4, 6 1, 0 6)"))
+    src_lyr.CreateFeature(f)
+
+    alg["input"] = src_ds
+    alg["geometry"] = True
+    alg["output-format"] = "MEM"
+
+    assert alg.Run()
+
+    dst_ds = alg.Output()
+    dst_lyr = dst_ds.GetLayer(0)
+
+    assert dst_lyr.GetFeatureCount() == 6
+
+    assert dst_lyr.GetNextFeature().GetGeometryRef().ExportToWkt() == "POINT (3 2)"
+    assert dst_lyr.GetNextFeature().GetGeometryRef().ExportToWkt() == "POINT (4 7)"
+    assert dst_lyr.GetNextFeature().GetGeometryRef().ExportToWkt() == "POINT (1 9)"
+    assert dst_lyr.GetNextFeature().GetGeometryRef().ExportToWkt() == "POINT (2 4)"
+    assert dst_lyr.GetNextFeature().GetGeometryRef().ExportToWkt() == "POINT (6 1)"
+    assert dst_lyr.GetNextFeature().GetGeometryRef().ExportToWkt() == "POINT (0 6)"
+
+
+def test_gdalalg_vector_explode_field_and_geometry(alg):
+
+    src_ds = gdal.GetDriverByName("MEM").CreateVector("")
+    src_lyr = src_ds.CreateLayer(
+        "test", geom_type=ogr.wkbMultiPoint, srs=osr.SpatialReference(epsg=4326)
+    )
+    src_lyr.CreateField(ogr.FieldDefn("ints", ogr.OFTIntegerList))
+
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f.SetGeometry(ogr.CreateGeometryFromWkt("MULTIPOINT (3 2, 4 7, 1 9)"))
+    f["ints"] = [6, 3, 2]
+    src_lyr.CreateFeature(f)
+
+    alg["input"] = src_ds
+    alg["field"] = "ints"
+    alg["geometry-field"] = "_ogr_geometry_"
+    alg["output-format"] = "MEM"
+
+    assert alg.Run()
+
+    dst_ds = alg.Output()
+    dst_lyr = dst_ds.GetLayer(0)
+
+    assert dst_lyr.GetFeatureCount() == 3
+
+    features = [f for f in dst_lyr]
+
+    assert features[0].GetGeometryRef().ExportToWkt() == "POINT (3 2)"
+    assert features[0]["ints"] == 6
+
+    assert features[1].GetGeometryRef().ExportToWkt() == "POINT (4 7)"
+    assert features[1]["ints"] == 3
+
+    assert features[2].GetGeometryRef().ExportToWkt() == "POINT (1 9)"
+    assert features[2]["ints"] == 2
+
+
+@pytest.mark.require_driver("GeoJSON")
+def test_gdalalg_vector_explode_geometry_limit_type_with_pipeline(alg, tmp_vsimem):
+
+    src_fname = tmp_vsimem / "src.json"
+    dst_fname = tmp_vsimem / "dst.json"
+
+    with gdal.GetDriverByName("GeoJSON").CreateVector(src_fname) as src_ds:
+        src_lyr = src_ds.CreateLayer(
+            "test",
+            geom_type=ogr.wkbGeometryCollection,
+            srs=osr.SpatialReference(epsg=4326),
+        )
+
+        f = ogr.Feature(src_lyr.GetLayerDefn())
+
+        f.SetGeometry(
+            ogr.CreateGeometryFromWkt(
+                "GEOMETRYCOLLECTION (POINT (6 6), MULTIPOINT (2 1, 2 8), LINESTRING (3 3, 7 6))"
+            )
+        )
+        src_lyr.CreateFeature(f)
+
+        f.SetGeometry(
+            ogr.CreateGeometryFromWkt(
+                "GEOMETRYCOLLECTION (LINESTRING (0 0, 2 1), POINT (2 2), LINESTRING (6 0, 2 1))"
+            )
+        )
+        src_lyr.CreateFeature(f)
+
+    gdal.alg.vector.pipeline(
+        pipeline=f'read {src_fname} ! explode --geometry-field 0"" ! set-geom-type --geometry-type LINESTRING --skip ! write -f GeoJSON {dst_fname}'
+    )
+
+    with gdal.OpenEx(dst_fname) as dst_ds:
+        assert dst_ds.GetLayerCount() == 1
+
+        dst_lyr = dst_ds.GetLayer(0)
+
+        assert dst_lyr.GetFeatureCount() == 3
+
+        wkt = [f.GetGeometryRef().ExportToWkt() for f in dst_lyr]
+
+        assert wkt[0] == "LINESTRING (3 3,7 6)"
+        assert wkt[1] == "LINESTRING (0 0,2 1)"
+        assert wkt[2] == "LINESTRING (6 0,2 1)"
+
+
+def test_gdalalg_vector_explode_geometry_multiple(alg):
+
+    src_ds = gdal.GetDriverByName("MEM").CreateVector("")
+    src_lyr = src_ds.CreateLayer(
+        "test", geom_type=ogr.wkbMultiPoint, srs=osr.SpatialReference(epsg=4326)
+    )
+    src_lyr.CreateGeomField(ogr.GeomFieldDefn("geom2", ogr.wkbGeometryCollection))
+
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f.SetGeomField(0, ogr.CreateGeometryFromWkt("MULTIPOINT (3 2, 4 7, 1 9)"))
+    f.SetGeomField(
+        1,
+        ogr.CreateGeometryFromWkt(
+            "GEOMETRYCOLLECTION (POINT (6 6), MULTIPOINT (2 1, 2 8), LINESTRING (3 3, 7 6))"
+        ),
+    )
+
+    src_lyr.CreateFeature(f)
+
+    alg["input"] = src_ds
+    alg["geometry-field"] = ["_ogr_geometry_", "geom2"]
+    alg["output-format"] = "MEM"
+
+    assert alg.Run()
+
+    dst_ds = alg.Output()
+    dst_lyr = dst_ds.GetLayer(0)
+
+    assert dst_lyr.GetFeatureCount() == 3
+
+    features = [f for f in dst_lyr]
+
+    assert features[0].GetGeomFieldRef(0).ExportToWkt() == "POINT (3 2)"
+    assert features[0].GetGeomFieldRef(1).ExportToWkt() == "POINT (6 6)"
+
+    assert features[1].GetGeomFieldRef(0).ExportToWkt() == "POINT (4 7)"
+    assert features[1].GetGeomFieldRef(1).ExportToWkt() == "MULTIPOINT (2 1,2 8)"
+
+    assert features[2].GetGeomFieldRef(0).ExportToWkt() == "POINT (1 9)"
+    assert features[2].GetGeomFieldRef(1).ExportToWkt() == "LINESTRING (3 3,7 6)"
+
+
+def test_gdalalg_vector_explode_geometry_multiple_unmatched(alg):
+
+    src_ds = gdal.GetDriverByName("MEM").CreateVector("")
+    src_lyr = src_ds.CreateLayer(
+        "test", geom_type=ogr.wkbMultiPoint, srs=osr.SpatialReference(epsg=4326)
+    )
+    src_lyr.CreateGeomField(ogr.GeomFieldDefn("geom2", ogr.wkbGeometryCollection))
+
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f.SetGeomField(0, ogr.CreateGeometryFromWkt("MULTIPOINT (3 2, 4 7, 1 9)"))
+    f.SetGeomField(
+        1,
+        ogr.CreateGeometryFromWkt("MULTIPOINT (4 3, 2 2)"),
+    )
+
+    src_lyr.CreateFeature(f)
+
+    alg["input"] = src_ds
+    alg["geometry-field"] = ["_ogr_geometry_", "geom2"]
+    alg["output-format"] = "MEM"
+
+    with pytest.raises(Exception, match="Geometry field 'geom2' .* has 2 elements"):
+        alg.Run()
+
+
+def test_gdalalg_vector_explode_geometry_multiple_multipart_and_singlepart(alg):
+
+    src_ds = gdal.GetDriverByName("MEM").CreateVector("")
+    src_lyr = src_ds.CreateLayer(
+        "test", geom_type=ogr.wkbMultiPoint, srs=osr.SpatialReference(epsg=4326)
+    )
+    src_lyr.CreateGeomField(ogr.GeomFieldDefn("geom2", ogr.wkbLineString))
+
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f.SetGeomField(0, ogr.CreateGeometryFromWkt("MULTIPOINT (3 2, 4 7, 1 9)"))
+    f.SetGeomField(
+        1,
+        ogr.CreateGeometryFromWkt("LINESTRING (2 2, 3 3)"),
+    )
+
+    src_lyr.CreateFeature(f)
+
+    alg["input"] = src_ds
+    alg["geometry-field"] = ["_ogr_geometry_", "geom2"]
+    alg["output-format"] = "MEM"
+
+    with pytest.raises(Exception, match="geom2.* is not a collection"):
+        assert alg.Run()
+
+
+def test_gdalalg_vector_explode_geometry_multiple_multipart_and_null(alg):
+
+    src_ds = gdal.GetDriverByName("MEM").CreateVector("")
+    src_lyr = src_ds.CreateLayer(
+        "test", geom_type=ogr.wkbMultiPoint, srs=osr.SpatialReference(epsg=4326)
+    )
+    src_lyr.CreateGeomField(ogr.GeomFieldDefn("geom2", ogr.wkbMultiLineString))
+
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f.SetGeomField(0, ogr.CreateGeometryFromWkt("MULTIPOINT (3 2, 4 7, 1 9)"))
+
+    src_lyr.CreateFeature(f)
+
+    alg["input"] = src_ds
+    alg["geometry-field"] = ["_ogr_geometry_", "geom2"]
+    alg["output-format"] = "MEM"
+
+    assert alg.Run()
+
+    dst_ds = alg.Output()
+    dst_lyr = dst_ds.GetLayer(0)
+
+    assert dst_lyr.GetFeatureCount() == 3
+
+    features = [f for f in dst_lyr]
+
+    assert features[0].GetGeomFieldRef(0).ExportToWkt() == "POINT (3 2)"
+    assert features[0].GetGeomFieldRef(1) is None
+
+    assert features[1].GetGeomFieldRef(0).ExportToWkt() == "POINT (4 7)"
+    assert features[1].GetGeomFieldRef(1) is None
+
+    assert features[2].GetGeomFieldRef(0).ExportToWkt() == "POINT (1 9)"
+    assert features[2].GetGeomFieldRef(1) is None
+
+
+def test_gdalalg_vector_explode_geometry_null(alg):
+
+    src_ds = gdal.GetDriverByName("MEM").CreateVector("")
+    src_lyr = src_ds.CreateLayer(
+        "test", geom_type=ogr.wkbMultiPoint, srs=osr.SpatialReference(epsg=4326)
+    )
+    src_lyr.CreateField(ogr.FieldDefn("int_array", ogr.OFTIntegerList))
+
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f["int_array"] = [1, 2]
+    src_lyr.CreateFeature(f)
+
+    alg["input"] = src_ds
+    alg["field"] = "ALL"
+    alg["geometry-field"] = "ALL"
+    alg["output-format"] = "MEM"
+
+    assert alg.Run()
+
+    dst_ds = alg.Output()
+    dst_lyr = dst_ds.GetLayer(0)
+
+    assert dst_lyr.GetFeatureCount() == 2
+
+    features = [f for f in dst_lyr]
+
+    assert features[0]["int_array"] == 1
+    assert features[0].GetGeometryRef() is None
+
+    assert features[1]["int_array"] == 2
+    assert features[1].GetGeometryRef() is None
+
+
+@pytest.mark.require_driver("GML")
+def test_gdalalg_vector_explode_geometry_multiple_cartesian_product_using_pipeline(
+    alg, tmp_vsimem
+):
+
+    src_fname = tmp_vsimem / "in.gml"
+    dst_fname = tmp_vsimem / "out.gml"
+
+    with gdal.GetDriverByName("GML").CreateVector(src_fname) as src_ds:
+        src_lyr = src_ds.CreateLayer(
+            "test", geom_type=ogr.wkbNone, srs=osr.SpatialReference(epsg=4326)
+        )
+        src_lyr.CreateGeomField(ogr.GeomFieldDefn("geom1", ogr.wkbPoint))
+        src_lyr.CreateGeomField(ogr.GeomFieldDefn("geom2", ogr.wkbPoint))
+
+        f = ogr.Feature(src_lyr.GetLayerDefn())
+        f.SetGeomField(0, ogr.CreateGeometryFromWkt("MULTIPOINT (3 2, 4 7, 1 9)"))
+        f.SetGeomField(
+            1,
+            ogr.CreateGeometryFromWkt("MULTIPOINT (4 3, 2 2)"),
+        )
+
+        src_lyr.CreateFeature(f)
+
+    gdal.alg.vector.pipeline(
+        pipeline=f"read {src_fname} ! explode --geometry ! explode --geometry-field 1 ! write {dst_fname} --of GML"
+    )
+
+    with gdal.OpenEx(dst_fname) as dst_ds:
+        assert dst_ds.GetLayerCount() == 1
+
+        dst_lyr = dst_ds.GetLayer(0)
+
+        assert dst_lyr.GetFeatureCount() == 6
+
+        wkt = [
+            (f.GetGeomFieldRef(0).ExportToWkt(), f.GetGeomFieldRef(1).ExportToWkt())
+            for f in dst_lyr
+        ]
+
+        assert wkt[0] == ("POINT (3 2)", "POINT (4 3)")
+        assert wkt[1] == ("POINT (3 2)", "POINT (2 2)")
+        assert wkt[2] == ("POINT (4 7)", "POINT (4 3)")
+        assert wkt[3] == ("POINT (4 7)", "POINT (2 2)")
+        assert wkt[4] == ("POINT (1 9)", "POINT (4 3)")
+        assert wkt[5] == ("POINT (1 9)", "POINT (2 2)")
+
+
+def test_gdalalg_vector_explode_geometry_with_singlepart(alg):
+
+    src_ds = gdal.GetDriverByName("MEM").CreateVector("")
+    src_lyr = src_ds.CreateLayer(
+        "test", geom_type=ogr.wkbPoint, srs=osr.SpatialReference(epsg=4326)
+    )
+    src_lyr.CreateField(ogr.FieldDefn("int_array", ogr.OFTIntegerList))
+
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f["int_array"] = [5]
+    f.SetGeomField(0, ogr.CreateGeometryFromWkt("POINT (8 2)"))
+
+    src_lyr.CreateFeature(f)
+
+    alg["input"] = src_ds
+    alg["field"] = "ALL"
+    alg["geometry-field"] = "ALL"
+    alg["output-format"] = "MEM"
+
+    assert alg.Run()
+
+    dst_ds = alg.Output()
+    dst_lyr = dst_ds.GetLayer(0)
+
+    assert dst_lyr.GetFeatureCount() == 1
+
+    f = dst_lyr.GetNextFeature()
+
+    assert f["int_array"] == 5
+    assert f.GetGeometryRef().ExportToWkt() == "POINT (8 2)"
+
+
+def test_gdalalg_vector_explode_active_layer(alg):
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 0, 0, 0, gdal.GDT_Unknown)
+
+    src_lyr = src_ds.CreateLayer("the_layer", geom_type=ogr.wkbMultiPoint)
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f.SetGeomField(0, ogr.CreateGeometryFromWkt("MULTIPOINT (1 2,3 4)"))
+    src_lyr.CreateFeature(f)
+
+    src_lyr = src_ds.CreateLayer("other_layer", geom_type=ogr.wkbUnknown)
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f.SetGeomField(0, ogr.CreateGeometryFromWkt("MULTIPOINT (5 6,7 8)"))
+    src_lyr.CreateFeature(f)
+
+    alg["input"] = src_ds
+    alg["output"] = ""
+    alg["output-format"] = "stream"
+    alg["active-layer"] = "the_layer"
+    alg["geometry"] = True
+
+    assert alg.Run()
+
+    out_ds = alg["output"].GetDataset()
+
+    out_lyr = out_ds.GetLayer(0)
+    assert out_lyr.GetLayerDefn().GetGeomFieldDefn(0).GetType() == ogr.wkbPoint
+
+    out_f = out_lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(out_f.GetGeomFieldRef(0), "POINT (1 2)")
+    assert out_f.GetFID() == 1
+
+    out_f = out_lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(out_f.GetGeomFieldRef(0), "POINT (3 4)")
+    assert out_f.GetFID() == 2
+
+    out_lyr = out_ds.GetLayer(1)
+    assert out_lyr.GetLayerDefn().GetGeomFieldDefn(0).GetType() == ogr.wkbUnknown
+
+    out_f = out_lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(out_f.GetGeomFieldRef(0), "MULTIPOINT (5 6,7 8)")
+    assert out_f.GetFID() == 0
+
+
+@pytest.mark.require_driver("GeoJSON")
+def test_gdalalg_vector_explode_autocomplete(tmp_path):
+
+    gdal_path = test_cli_utilities.get_gdal_path()
+    if gdal_path is None:
+        pytest.skip("gdal binary not available")
+
+    src_fname = tmp_path / "src.geojson"
+
+    with gdal.GetDriverByName("GeoJSON").CreateVector(src_fname) as ds:
+        lyr = ds.CreateLayer("layer")
+        lyr.CreateField(ogr.FieldDefn("field1", ogr.OFTReal))
+        lyr.CreateField(ogr.FieldDefn("field2", ogr.OFTIntegerList))
+
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f["field1"] = 8.02
+        f["field2"] = [8, 0, 2]
+
+        lyr.CreateFeature(f)
+
+    out = gdaltest.run_and_parse_completion_output(
+        f"{gdal_path} completion gdal vector explode {src_fname} --field last_word_is_complete=true"
+    )
+
+    assert out == ["ALL", "field2"]
+
+
+@pytest.mark.require_driver("GeoJSON")
+def test_gdalalg_vector_explode_ogrsf(alg, source_with_arrays, tmp_path):
+
+    src_fname = tmp_path / "in.geojson"
+    gdal.VectorTranslate(src_fname, source_with_arrays)
+
+    alg["input"] = src_fname
+    alg["field"] = ["name", "my_int_list"]
+
+    gdaltest.algorithm_check_ogrsf(alg, tmp_path)

--- a/autotest/utilities/test_gdalalg_vector_partition.py
+++ b/autotest/utilities/test_gdalalg_vector_partition.py
@@ -1105,11 +1105,11 @@ def test_gdalalg_vector_partition_geometry(tmp_vsimem):
         input=src_ds,
         output=tmp_vsimem / "out",
         output_format="GPKG",
-        field="OGR_GEOMETRY",
+        field="_ogr_geometry_",
     )
 
     with ogr.Open(
-        tmp_vsimem / "out/test/OGR_GEOMETRY=POLYGON/part_0000000001.gpkg"
+        tmp_vsimem / "out/test/_ogr_geometry_=POLYGON/part_0000000001.gpkg"
     ) as ds:
         lyr = ds.GetLayer(0)
         assert lyr.GetGeomType() == ogr.wkbPolygon
@@ -1120,7 +1120,7 @@ def test_gdalalg_vector_partition_geometry(tmp_vsimem):
         )
 
     with ogr.Open(
-        tmp_vsimem / "out/test/OGR_GEOMETRY=POINT/part_0000000001.gpkg"
+        tmp_vsimem / "out/test/_ogr_geometry_=POINT/part_0000000001.gpkg"
     ) as ds:
         lyr = ds.GetLayer(0)
         assert lyr.GetGeomType() == ogr.wkbPoint
@@ -1129,7 +1129,7 @@ def test_gdalalg_vector_partition_geometry(tmp_vsimem):
         assert lyr.GetFeature(2).GetGeometryRef().ExportToIsoWkt() == "POINT (3 4)"
 
     with ogr.Open(
-        tmp_vsimem / "out/test/OGR_GEOMETRY=POINTZ/part_0000000001.gpkg"
+        tmp_vsimem / "out/test/_ogr_geometry_=POINTZ/part_0000000001.gpkg"
     ) as ds:
         lyr = ds.GetLayer(0)
         assert lyr.GetGeomType() == ogr.wkbPoint25D
@@ -1137,7 +1137,7 @@ def test_gdalalg_vector_partition_geometry(tmp_vsimem):
         assert lyr.GetFeature(3).GetGeometryRef().ExportToIsoWkt() == "POINT Z (1 2 3)"
 
     with ogr.Open(
-        tmp_vsimem / "out/test/OGR_GEOMETRY=POINTM/part_0000000001.gpkg"
+        tmp_vsimem / "out/test/_ogr_geometry_=POINTM/part_0000000001.gpkg"
     ) as ds:
         lyr = ds.GetLayer(0)
         assert lyr.GetGeomType() == ogr.wkbPointM
@@ -1145,7 +1145,7 @@ def test_gdalalg_vector_partition_geometry(tmp_vsimem):
         assert lyr.GetFeature(4).GetGeometryRef().ExportToIsoWkt() == "POINT M (1 2 4)"
 
     with ogr.Open(
-        tmp_vsimem / "out/test/OGR_GEOMETRY=POINTZM/part_0000000001.gpkg"
+        tmp_vsimem / "out/test/_ogr_geometry_=POINTZM/part_0000000001.gpkg"
     ) as ds:
         lyr = ds.GetLayer(0)
         assert lyr.GetGeomType() == ogr.wkbPointZM
@@ -1156,7 +1156,7 @@ def test_gdalalg_vector_partition_geometry(tmp_vsimem):
 
     with ogr.Open(
         tmp_vsimem
-        / "out/test/OGR_GEOMETRY=__HIVE_DEFAULT_PARTITION__/part_0000000001.gpkg"
+        / "out/test/_ogr_geometry_=__HIVE_DEFAULT_PARTITION__/part_0000000001.gpkg"
     ) as ds:
         lyr = ds.GetLayer(0)
         assert lyr.GetGeomType() == ogr.wkbNone
@@ -1260,4 +1260,4 @@ def test_gdalalg_vector_partition_completion(tmp_path):
         f"{gdal_path} completion gdal vector partition ../ogr/data/poly.shp --field"
     )
     assert "EAS_ID" in out
-    assert "OGR_GEOMETRY" in out
+    assert "_ogr_geometry_" in out

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -983,6 +983,13 @@ man_pages = [
         1,
     ),
     (
+        "programs/gdal_vector_explode",
+        "gdal-vector-explode",
+        "Explode fields or geometries of a vector dataset",
+        [author_dbaston],
+        1,
+    ),
+    (
         "programs/gdal_vector_explode_collections",
         "gdal-vector-explode-collections",
         "Explode geometries of type collection of a vector dataset",

--- a/doc/source/programs/gdal_raster_zonal_stats.rst
+++ b/doc/source/programs/gdal_raster_zonal_stats.rst
@@ -238,7 +238,7 @@ Examples
 
    .. code-block:: bash
 
-      gdal pipeline read dem.tif !
+      gdal pipeline read dem.tif ! \
           zonal-stats \
             --zones watersheds.shp \
             --stat max_center_x \
@@ -248,3 +248,24 @@ Examples
             --y max_center_y \
             --output-crs EPSG:4326 ! \
           write out.geojson
+
+
+.. example::
+   :title: Extract locations of pixels having a nonzero population
+
+   .. code-block:: bash
+
+      gdal pipeline read pop.tif ! \
+          zonal-stats \
+            --zones admin.shp \
+            --include-field NAME \
+            --stat center_x \
+            --stat center_y \
+            --stat values ! \
+          explode --fields ALL ! \
+          make-point \
+            --x center_x \
+            --y center_y \
+            --output-crs EPSG:4326 ! \
+          write out.gpkg
+

--- a/doc/source/programs/gdal_vector_explode.rst
+++ b/doc/source/programs/gdal_vector_explode.rst
@@ -1,0 +1,116 @@
+.. _gdal_vector_explode:
+
+.. program:: gdal_vector_explode
+
+================================================================================
+``gdal vector explode``
+================================================================================
+
+.. versionadded:: 3.14
+
+.. only:: html
+
+    Explode fields or geometries of a vector dataset.
+
+.. Index:: gdal vector explode
+
+Synopsis
+--------
+
+.. program-output:: gdal vector explode --help-doc
+
+Description
+-----------
+
+:program:`gdal vector explode` explodes features with array fields or multipart geometries, producing
+a single feature for each element in the array or geometry. Fields that are not specified with ``--field``
+``--geometry``, or ``--geometry-field`` are passed through unmodified.
+
+For example, if exploding a geometry field with the value ``MULTIPOINT(1 2,3 4)``, two
+corresponding target features will be generated: one with a geometry
+``POINT(1 2)`` and another one with geometry ``POINT(3 4)``. Note that collections
+are not recursively exploded, i.e. ``GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT (1 2),POINT(3 4))``
+will be exploded as ``GEOMETRYCOLLECTION(POINT (1 2),POINT(3 4))``.
+
+Multiple fields can be exploded in a single invocation; however, all fields must have the same length / 
+number of geometry components.
+
+It can also be used as a step of :ref:`gdal_vector_pipeline`.
+
+.. GDALG output (on-the-fly / streamed dataset)
+.. --------------------------------------------
+
+.. include:: gdal_cli_include/gdalg_vector_compatible.rst
+
+
+Program-Specific Options
+------------------------
+
+.. option:: --field <FIELD>
+
+   Name of attribute field(s) to explode. The special value ``ALL`` can be used to explode all attribute fields with array types.
+
+.. option:: --geometry
+
+   Explode the default geometry field.
+
+.. option:: --geometry-field <GEOMETRY-FIELD>
+
+   Name or position (0-indexed) of geometry field(s) to explode. The special value ``ALL`` can be used to explode all geometry fields.
+   The special value ``_OGR_GEOMETRY_`` can be used to explode the default geometry field. 
+
+.. option:: --index-field <INDEX-FIELD>
+
+   Optional name of a field to be added to the output containing the (0-indexed) value of each output feature in the
+   input feature.
+
+
+Standard Options
+----------------
+
+.. collapse:: Details
+
+    .. include:: gdal_options/active_layer.rst
+
+    .. include:: gdal_options/append_vector.rst
+
+    .. include:: gdal_options/co_vector.rst
+
+    .. include:: gdal_options/if.rst
+
+    .. include:: gdal_options/input_layer.rst
+
+    .. include:: gdal_options/lco.rst
+
+    .. include:: gdal_options/oo.rst
+
+    .. include:: gdal_options/of_vector.rst
+
+    .. include:: gdal_options/output_layer.rst
+
+    .. include:: gdal_options/output_oo.rst
+
+    .. include:: gdal_options/overwrite.rst
+
+    .. include:: gdal_options/overwrite_layer.rst
+
+    .. include:: gdal_options/skip_errors.rst
+
+    .. include:: gdal_options/update.rst
+
+    .. include:: gdal_options/upsert.rst
+
+.. Return status code
+.. ------------------
+
+.. include:: return_code.rst
+
+Examples
+--------
+
+.. example::
+   :title: Only retain parts of geometry collections that are of type Point
+
+   .. code-block:: bash
+
+        $ gdal vector pipeline read in.gpkg ! explode --geometry-field 0 ! set-geom-type --geometry-type=POINT --skip ! write points.shp --overwrite

--- a/doc/source/programs/gdal_vector_partition.rst
+++ b/doc/source/programs/gdal_vector_partition.rst
@@ -71,7 +71,7 @@ Program-Specific Options
     The order into which fields are specified matter to determine the directory
     hierarchy.
 
-    Starting with GDAL 3.13, geometry field names can be specified (``OGR_GEOMETRY``
+    Starting with GDAL 3.14, geometry field names can be specified (``_ogr_geometry_``
     being the generic name for the first geometry field). Partitioning on
     geometry fields is done on the geometry type. This can be useful for file
     formats where a single geometry type per layer is allowed.
@@ -179,7 +179,7 @@ Examples
 
    .. code-block:: bash
 
-        $ gdal vector pipeline ! read input.gpkg ! set-geom-type --multi ! partition out_directory --scheme flat --field OGR_GEOMETRY --format "ESRI Shapefile"
+        $ gdal vector pipeline ! read input.gpkg ! set-geom-type --multi ! partition out_directory --scheme flat --field _ogr_geometry_ --format "ESRI Shapefile"
 
 .. example::
    :title: Split a file into files with at most 100,000 features.

--- a/doc/source/programs/index.rst
+++ b/doc/source/programs/index.rst
@@ -215,6 +215,7 @@ Vector commands
    gdal_vector_filter
    gdal_vector_info
    gdal_vector_export_schema
+   gdal_vector_explode
    gdal_vector_explode_collections
    gdal_vector_grid
    gdal_vector_index
@@ -257,6 +258,7 @@ Vector commands
     - :ref:`gdal_vector_convex_hull`: Compute the convex hull of geometries of a vector dataset
     - :ref:`gdal_vector_create`: Create a vector dataset
     - :ref:`gdal_vector_edit`: Edit metadata of a vector dataset
+    - :ref:`gdal_vector_explode`: Explode fields or geometries of a vector dataset
     - :ref:`gdal_vector_explode_collections`: Explode geometries of type collection of a vector dataset
     - :ref:`gdal_vector_export_schema`: Export the OGR_SCHEMA from a vector dataset
     - :ref:`gdal_vector_filter`: Filter a vector dataset

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -5246,28 +5246,36 @@ void GDALAlgorithm::SetAutoCompleteFunctionForLayerName(
 void GDALAlgorithm::SetAutoCompleteFunctionForFieldName(
     GDALInConstructionAlgorithmArg &fieldArg,
     const GDALAlgorithmArg *layerNameArg, bool attributeFields,
-    bool geometryFields, std::vector<GDALArgDatasetValue> &datasetArg)
+    bool geometryFields, std::vector<GDALArgDatasetValue> &datasetArg,
+    const std::vector<std::string> &extraValues,
+    std::function<bool(const OGRFieldDefn *)> filterFn)
 {
 
     fieldArg.SetAutoCompleteFunction(
-        [&datasetArg, layerNameArg, attributeFields,
-         geometryFields](const std::string &currentValue)
+        [&datasetArg, layerNameArg, attributeFields, geometryFields,
+         extraValues, filterFn](const std::string &currentValue)
         {
-            std::set<std::string> ret;
+            std::set<std::string> ret{};
             if (!datasetArg.empty())
             {
                 CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
 
                 const auto getLayerFields =
-                    [&ret, &currentValue, attributeFields,
-                     geometryFields](const OGRLayer *poLayer)
+                    [&ret, &currentValue, attributeFields, geometryFields,
+                     &extraValues, &filterFn](const OGRLayer *poLayer)
                 {
                     const auto poDefn = poLayer->GetLayerDefn();
                     if (attributeFields)
                     {
                         for (const auto poFieldDefn : poDefn->GetFields())
                         {
+                            if (filterFn && !filterFn(poFieldDefn))
+                            {
+                                continue;
+                            }
+
                             const char *fieldName = poFieldDefn->GetNameRef();
+
                             if (currentValue == fieldName)
                             {
                                 ret.clear();
@@ -5292,6 +5300,16 @@ void GDALAlgorithm::SetAutoCompleteFunctionForFieldName(
                             }
                             ret.insert(fieldName);
                         }
+                    }
+                    for (const auto &value : extraValues)
+                    {
+                        if (currentValue == value)
+                        {
+                            ret.clear();
+                            ret.insert(value);
+                            break;
+                        }
+                        ret.insert(value);
                     }
                 };
 

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -26,6 +26,7 @@
 #include "gdal_thread_pool.h"
 #include "memdataset.h"
 #include "ogrsf_frmts.h"
+#include "ogr_p.h"
 #include "ogr_spatialref.h"
 #include "vrtdataset.h"
 
@@ -5291,7 +5292,7 @@ void GDALAlgorithm::SetAutoCompleteFunctionForFieldName(
                         {
                             const char *fieldName = poFieldDefn->GetNameRef();
                             if (fieldName[0] == 0)
-                                fieldName = "OGR_GEOMETRY";
+                                fieldName = OGR_GEOMETRY_DEFAULT_NON_EMPTY_NAME;
                             if (currentValue == fieldName)
                             {
                                 ret.clear();

--- a/gcore/gdalalgorithm_cpp.h
+++ b/gcore/gdalalgorithm_cpp.h
@@ -32,6 +32,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -3046,7 +3047,9 @@ class CPL_DLL GDALAlgorithmRegistry
     static void SetAutoCompleteFunctionForFieldName(
         GDALInConstructionAlgorithmArg &fieldArg,
         const GDALAlgorithmArg *layerNameArg, bool attributeFields,
-        bool geometryFields, std::vector<GDALArgDatasetValue> &datasetArg);
+        bool geometryFields, std::vector<GDALArgDatasetValue> &datasetArg,
+        const std::vector<std::string> &extraValues = {},
+        std::function<bool(const OGRFieldDefn *)> filterFn = {});
 
     /** Add a field name argument */
     GDALInConstructionAlgorithmArg &

--- a/ogr/ogr_api.h
+++ b/ogr/ogr_api.h
@@ -407,7 +407,7 @@ const char CPL_DLL *OGR_GetFieldSubTypeName(OGRFieldSubType);
 OGRFieldSubType CPL_DLL OGR_GetFieldSubTypeByName(const char *);
 int CPL_DLL OGR_AreTypeSubTypeCompatible(OGRFieldType eType,
                                          OGRFieldSubType eSubType);
-int CPL_DLL OGR_GetFieldTypeIsList(OGRFieldType);
+bool CPL_DLL OGR_GetFieldTypeIsList(OGRFieldType);
 OGRFieldType CPL_DLL OGR_GetFieldTypeAsScalar(OGRFieldType);
 
 /* OGRGeomFieldDefnH */

--- a/ogr/ogr_api.h
+++ b/ogr/ogr_api.h
@@ -407,6 +407,8 @@ const char CPL_DLL *OGR_GetFieldSubTypeName(OGRFieldSubType);
 OGRFieldSubType CPL_DLL OGR_GetFieldSubTypeByName(const char *);
 int CPL_DLL OGR_AreTypeSubTypeCompatible(OGRFieldType eType,
                                          OGRFieldSubType eSubType);
+int CPL_DLL OGR_GetFieldTypeIsList(OGRFieldType);
+OGRFieldType CPL_DLL OGR_GetFieldTypeAsScalar(OGRFieldType);
 
 /* OGRGeomFieldDefnH */
 

--- a/ogr/ogrfielddefn.cpp
+++ b/ogr/ogrfielddefn.cpp
@@ -1130,11 +1130,11 @@ int OGR_AreTypeSubTypeCompatible(OGRFieldType eType, OGRFieldSubType eSubType)
  * \brief Return if a type represents a list type
  *
  * @param eType the field type.
- * @return TRUE if type and subtype are compatible
+ * @return TRUE if the type represents is a list type
  * @since GDAL 3.14
  */
 
-int OGR_GetFieldTypeIsList(OGRFieldType eType)
+bool OGR_GetFieldTypeIsList(OGRFieldType eType)
 {
     return eType == OFTIntegerList || eType == OFTInteger64List ||
            eType == OFTRealList || eType == OFTStringList;

--- a/ogr/ogrfielddefn.cpp
+++ b/ogr/ogrfielddefn.cpp
@@ -1124,6 +1124,52 @@ int OGR_AreTypeSubTypeCompatible(OGRFieldType eType, OGRFieldSubType eSubType)
 }
 
 /************************************************************************/
+/*                        OGR_GetFieldTypeIsList                        */
+/************************************************************************/
+/**
+ * \brief Return if a type represents a list type
+ *
+ * @param eType the field type.
+ * @return TRUE if type and subtype are compatible
+ * @since GDAL 3.14
+ */
+
+int OGR_GetFieldTypeIsList(OGRFieldType eType)
+{
+    return eType == OFTIntegerList || eType == OFTInteger64List ||
+           eType == OFTRealList || eType == OFTStringList;
+}
+
+/************************************************************************/
+/*                       OGR_GetFieldTypeAsScalar                       */
+/************************************************************************/
+/**
+ * \brief Return the scalar type associated with a list type, or the
+ *        input type (if input is already a scalar type)
+ *
+ * @param eType the field type.
+ * @return a scalar type
+ * @since GDAL 3.14
+ */
+
+OGRFieldType OGR_GetFieldTypeAsScalar(OGRFieldType eType)
+{
+    switch (eType)
+    {
+        case OFTIntegerList:
+            return OFTInteger;
+        case OFTInteger64List:
+            return OFTInteger64;
+        case OFTRealList:
+            return OFTReal;
+        case OFTStringList:
+            return OFTString;
+        default:
+            return eType;
+    }
+}
+
+/************************************************************************/
 /*                             GetJustify()                             */
 /************************************************************************/
 

--- a/ogr/ogrsf_frmts/generic/ogrlayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayer.cpp
@@ -3104,8 +3104,7 @@ const OGRSpatialReference *OGRLayer::GetSpatialRef() const
 {
     const auto poLayerDefn = GetLayerDefn();
     if (poLayerDefn->GetGeomFieldCount() > 0)
-        return const_cast<OGRSpatialReference *>(
-            poLayerDefn->GetGeomFieldDefn(0)->GetSpatialRef());
+        return poLayerDefn->GetGeomFieldDefn(0)->GetSpatialRef();
     else
         return nullptr;
 }

--- a/ogr/ogrsf_frmts/generic/ogrlayerwithtranslatefeature.h
+++ b/ogr/ogrsf_frmts/generic/ogrlayerwithtranslatefeature.h
@@ -26,7 +26,7 @@ class OGRLayerWithTranslateFeature /* non final */ : virtual public OGRLayer
     ~OGRLayerWithTranslateFeature() override;
 
     /** Translate the source feature into one or several output features */
-    virtual void TranslateFeature(
+    virtual bool TranslateFeature(
         std::unique_ptr<OGRFeature> poSrcFeature,
         std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures) = 0;
 };

--- a/ogr/ogrsf_frmts/generic/ogrwarpedlayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrwarpedlayer.cpp
@@ -107,12 +107,13 @@ OGRErr OGRWarpedLayer::ISetSpatialFilter(int iGeomField,
 /*                          TranslateFeature()                          */
 /************************************************************************/
 
-void OGRWarpedLayer::TranslateFeature(
+bool OGRWarpedLayer::TranslateFeature(
     std::unique_ptr<OGRFeature> poSrcFeature,
     std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures)
 {
     apoOutFeatures.push_back(
         SrcFeatureToWarpedFeature(std::move(poSrcFeature)));
+    return true;
 }
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/generic/ogrwarpedlayer.h
+++ b/ogr/ogrsf_frmts/generic/ogrwarpedlayer.h
@@ -65,7 +65,7 @@ class CPL_DLL OGRWarpedLayer final : public OGRLayerDecorator,
                    std::unique_ptr<OGRCoordinateTransformation> poReversedCT);
     ~OGRWarpedLayer() override;
 
-    void TranslateFeature(
+    bool TranslateFeature(
         std::unique_ptr<OGRFeature> poSrcFeature,
         std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures) override;
 


### PR DESCRIPTION
Related: #14454 

Idea is that `gdal vector explode-collections` would be deprecated, but I have not done that in this PR.