### PR TITLE
[Backport release/3.13] /vsicurl?: restrict filenames allowed in the 'header_file' key-value pair

### DIFF
--- a/autotest/gcore/vsicurl.py
+++ b/autotest/gcore/vsicurl.py
@@ -1808,6 +1808,156 @@ def test_vsicurl_header_option(server):
 
 
 ###############################################################################
+# Test /vsicurl?header_file=<filename>&
+
+
+@gdaltest.enable_exceptions()
+@pytest.mark.parametrize(
+    "CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED", [None, "ONLY_IN_TEMP", "YES", "NO"]
+)
+@pytest.mark.parametrize("location", ["vsimem", "tmp", "TEMP"])
+def test_vsicurl_header_file_kvp_in_temp(
+    server, tmp_vsimem, CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED, location
+):
+
+    gdal.VSICurlClearCache()
+
+    def run_test(header_file):
+
+        with gdal.VSIFile(header_file, "wb") as f:
+            f.write(b"foo: bar\n")
+
+        try:
+
+            handler = webserver.SequentialHandler()
+            handler.add(
+                "HEAD",
+                "/test_vsicurl_header_file.bin",
+                200,
+                {"Content-Length": "3"},
+                expected_headers=(
+                    {}
+                    if CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED == "NO"
+                    else {"foo": "bar"}
+                ),
+            )
+
+            with gdal.config_option(
+                "CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED",
+                CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED,
+            ), webserver.install_http_handler(handler):
+                full_filename = f"/vsicurl?header_file={header_file}&url=http%3A%2F%2Flocalhost%3A{server.port}%2Ftest_vsicurl_header_file.bin"
+                if CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED == "NO":
+                    with pytest.raises(
+                        Exception,
+                        match=r"Use of 'header_file' key-value pair in /vsicurl\? is disabled by the CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED configuration option",
+                    ):
+                        statres = gdal.VSIStatL(full_filename)
+                else:
+                    statres = gdal.VSIStatL(full_filename)
+                    assert statres.size == 3
+
+        finally:
+            gdal.Unlink(header_file)
+
+    if location == "vsimem":
+        header_file = tmp_vsimem / "subdir" / ".." / "header_file.txt"
+        run_test(header_file)
+
+    elif location == "tmp":
+        if not gdal.VSIStatL("/tmp"):
+            pytest.skip("/tmp does not exist")
+        import uuid
+
+        header_file = f"/tmp/header_file_{uuid.uuid1()}.txt"
+        run_test(header_file)
+
+    else:
+        assert location == "TEMP"
+        import uuid
+
+        header_file = f"tmp/header_file{uuid.uuid1()}_.txt"
+        with gdal.config_option("TEMP", "tmp"):
+            run_test(header_file)
+
+
+###############################################################################
+# Test /vsicurl?header_file=<filename>&
+
+
+@gdaltest.enable_exceptions()
+def test_vsicurl_header_file_kvp_path_traversal(server):
+
+    gdal.VSICurlClearCache()
+
+    handler = webserver.SequentialHandler()
+    handler.add(
+        "HEAD",
+        "/test_vsicurl_header_file.bin",
+        200,
+        {"Content-Length": "3"},
+    )
+
+    with webserver.install_http_handler(handler):
+        full_filename = f"/vsicurl?header_file=/vsimem/../etc/passwd&url=http%3A%2F%2Flocalhost%3A{server.port}%2Ftest_vsicurl_header_file.bin"
+        with pytest.raises(
+            Exception,
+            match=r"Use of 'header_file=/vsimem/../etc/passwd' key-value pair in /vsicurl\? is disabled because it refers to a file stored in a non-temporary location",
+        ):
+            gdal.VSIStatL(full_filename)
+
+
+###############################################################################
+# Test /vsicurl?header_file=<filename>&
+
+
+@gdaltest.enable_exceptions()
+@pytest.mark.parametrize(
+    "CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED,expected_headers",
+    [
+        (None, {}),
+        ("ONLY_IN_TEMP", {}),
+        ("YES", {"foo": "bar"}),
+        ("NO", {}),
+    ],
+)
+def test_vsicurl_header_file_kvp_not_in_temp(
+    server, CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED, expected_headers
+):
+
+    gdal.VSICurlClearCache()
+
+    header_file = "tmp/header_file.txt"
+    try:
+        with gdal.VSIFile(header_file, "wb") as f:
+            f.write(b"foo: bar\n")
+
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "HEAD",
+            "/test_vsicurl_header_file.bin",
+            200,
+            {"Content-Length": "3"},
+            expected_headers=expected_headers,
+        )
+
+        with gdal.config_option(
+            "CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED",
+            CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED,
+        ), webserver.install_http_handler(handler):
+            full_filename = f"/vsicurl?header_file={header_file}&url=http%3A%2F%2Flocalhost%3A{server.port}%2Ftest_vsicurl_header_file.bin"
+            if CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED != "YES":
+                with pytest.raises(Exception):
+                    statres = gdal.VSIStatL(full_filename)
+            else:
+                statres = gdal.VSIStatL(full_filename)
+                assert statres.size == 3
+
+    finally:
+        gdal.Unlink(header_file)
+
+
+###############################################################################
 # Test GDAL_HTTP_MAX_CACHED_CONNECTIONS
 # This test is rather dummy as it cannot check the effect of setting the option
 

--- a/doc/source/spelling_wordlist.txt
+++ b/doc/source/spelling_wordlist.txt
@@ -817,6 +817,7 @@ eWorkingDataType
 eXchange
 exe
 executables
+exfiltration
 Exif
 explodeCollections
 eXploration

--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -642,6 +642,24 @@ Networking options
       content. Value is assumed to represent bytes unless memory units are
       specified (since GDAL 3.11).
 
+-  .. config:: CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED
+      :choices: ONLY_IN_TEMP, YES, NO
+      :default: ONLY_IN_TEMP (since GDAL 3.13.2)
+      :since: 3.13.2
+
+      Sets the policy for accepted filenames passed in the ``header_file`` key-value
+      pair of ``/vsicurl?`` filenames.
+
+      Starting with GDAL 3.13.2, for security reasons, the filename is restricted
+      by default to be located under ``/vsimem/``, ``/tmp`` or the value of the
+      ``TEMP`` or ``TMP`` environment variable.
+      All locations can be allowed by setting the configuration option to ``YES``.
+      Or all locations can be disabled by setting the configuration option to to ``NO``.
+
+      GDAL can also be built with the ``CPL_VSIL_CURL_HEADER_FILE_KVP_DISABLED``
+      compilation definitions (passed in ``CXXFLAGS``) to entirely disable
+      ``header_file`` key-value.
+
 -  .. config:: CPL_VSIL_CURL_USE_HEAD
       :choices: YES, NO
       :default: YES

--- a/doc/source/user/security.rst
+++ b/doc/source/user/security.rst
@@ -122,6 +122,12 @@ recovered by untrusted code that would run in the same process as GDAL code.
 The same applies for connection strings to some drivers such as PostgreSQL, MySQL, etc.
 which may include passwords.
 
+Known issues in networking
+--------------------------
+
+See the :config:`CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED` configuration option
+to limit potential exfiltration of content from local files.
+
 Known issues in API
 -------------------
 

--- a/doc/source/user/virtual_file_systems.rst
+++ b/doc/source/user/virtual_file_systems.rst
@@ -469,7 +469,8 @@ Options can be passed in the filename with the following syntax: ``/vsicurl?[opt
 - useragent=value: HTTP UserAgent header
 - referer=value: HTTP Referer header
 - cookie=value: HTTP Cookie header
-- header_file=value: Filename that contains one or several "Header: Value" lines
+- header_file=filename: Filename that contains one or several "Header: Value" lines.
+  Starting with GDAL 3.13.2, for security reasons, the filename is restricted by default to be located under ``/vsimem/``, ``/tmp`` or the value of the ``TEMP`` environment variable (or ``TMP`` if ``TEMP`` not defined). See the :config:`CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED` configuration option to define the policy.
 - header.<key>=<value>: HTTP request header of name <key> and value <value>. (GDAL >= 3.11). e.g. ``header.Accept=application%2Fjson``
 - unsafessl=yes/no
 - low_speed_time=value

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -140,6 +140,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "CPL_VSIL_CURL_AUTHORIZATION_HEADER_ALLOWED_IF_REDIRECT", // from cpl_http.cpp, cpl_vsil_curl.cpp
    "CPL_VSIL_CURL_CACHE_SIZE", // from cpl_vsil_curl.cpp
    "CPL_VSIL_CURL_CHUNK_SIZE", // from cpl_vsil_curl.cpp
+   "CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED", // from cpl_vsil_curl.cpp
    "CPL_VSIL_CURL_HONOR_CACHE_CONTROL", // from cpl_vsil_curl.cpp
    "CPL_VSIL_CURL_IGNORE_GLACIER_STORAGE", // from cpl_vsil_curl.cpp
    "CPL_VSIL_CURL_IGNORE_STORAGE_CLASSES", // from cpl_vsil_curl.cpp

--- a/port/cpl_vsil_curl.cpp
+++ b/port/cpl_vsil_curl.cpp
@@ -422,9 +422,103 @@ static std::string VSICurlGetURLFromFilename(
                     if (pbEmptyDir)
                         *pbEmptyDir = CPLTestBool(pszValue);
                 }
+                else if (EQUAL(pszKey, "header_file"))
+                {
+#if defined(CPL_VSIL_CURL_HEADER_FILE_KVP_DISABLED)
+                    constexpr bool CPL_VSIL_CURL_HEADER_FILE_KVP_DISABLED =
+                        true;
+#else
+                    constexpr bool CPL_VSIL_CURL_HEADER_FILE_KVP_DISABLED =
+                        false;
+#endif
+                    if (CPL_VSIL_CURL_HEADER_FILE_KVP_DISABLED)
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Use of 'header_file' key-value pair in "
+                                 "/vsicurl? is disabled in this build");
+                    }
+                    else
+                    {
+                        bool bSetValue = false;
+                        const char *pszAllowHeaderFileKVP = CPLGetConfigOption(
+                            "CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED", nullptr);
+                        if (!pszAllowHeaderFileKVP ||
+                            pszAllowHeaderFileKVP[0] == 0 ||
+                            EQUAL(pszAllowHeaderFileKVP, "ONLY_IN_TEMP"))
+                        {
+                            if (STARTS_WITH(pszValue, "/vsimem/"))
+                            {
+                                bSetValue = !CPLHasUnbalancedPathTraversal(
+                                    pszValue + strlen("/vsimem/"));
+                            }
+                            else if (STARTS_WITH(pszValue, "/tmp/"))
+                            {
+                                bSetValue = !CPLHasUnbalancedPathTraversal(
+                                    pszValue + strlen("/tmp/"));
+                            }
+                            else
+                            {
+                                for (const char *pszEnvVar : {"TEMP", "TMP"})
+                                {
+                                    if (const char *pszTemp =
+                                            CPLGetConfigOption(pszEnvVar,
+                                                               nullptr))
+                                    {
+                                        std::string osTemp = pszTemp;
+                                        if (!osTemp.empty() &&
+                                            (osTemp.back() == '/' ||
+                                             osTemp.back() == '\\'))
+                                            osTemp.pop_back();
+                                        if (!osTemp.empty() &&
+                                            cpl::starts_with(
+                                                std::string_view(pszValue),
+                                                osTemp) &&
+                                            (pszValue[osTemp.size()] == '/' ||
+                                             pszValue[osTemp.size()] == '\\'))
+                                        {
+                                            bSetValue =
+                                                !CPLHasUnbalancedPathTraversal(
+                                                    pszValue + osTemp.size());
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                            if (!bSetValue)
+                            {
+                                CPLError(CE_Failure, CPLE_AppDefined,
+                                         "Use of 'header_file=%s' "
+                                         "key-value pair in /vsicurl? is "
+                                         "disabled because it refers to a "
+                                         "file stored in a non-temporary "
+                                         "location. You may set the "
+                                         "CPL_VSIL_CURL_HEADER_FILE_KVP_"
+                                         "ENABLED configuration option to "
+                                         "YES to remove that restriction.",
+                                         pszValue);
+                            }
+                        }
+                        else if (CPLTestBool(pszAllowHeaderFileKVP))
+                        {
+                            bSetValue = true;
+                        }
+                        else
+                        {
+                            CPLError(CE_Failure, CPLE_AppDefined,
+                                     "Use of 'header_file' key-value pair in "
+                                     "/vsicurl? is disabled by the "
+                                     "CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED "
+                                     "configuration option");
+                        }
+
+                        if (bSetValue && paosHTTPOptions)
+                        {
+                            paosHTTPOptions->SetNameValue(pszKey, pszValue);
+                        }
+                    }
+                }
                 else if (EQUAL(pszKey, "useragent") ||
                          EQUAL(pszKey, "referer") || EQUAL(pszKey, "cookie") ||
-                         EQUAL(pszKey, "header_file") ||
                          EQUAL(pszKey, "unsafessl") ||
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
                          EQUAL(pszKey, "timeout") ||
@@ -4470,6 +4564,13 @@ const char *VSICurlFilesystemHandlerBase::GetActualURL(const char *pszFilename)
     "  <Option name='CPL_VSIL_CURL_ADVISE_READ_TOTAL_BYTES_LIMIT' "            \
     "type='integer' description='Maximum number of bytes AdviseRead() is "     \
     "allowed to fetch at once' default='104857600'/>"                          \
+    "  <Option name='CPL_VSIL_CURL_HEADER_FILE_KVP_ENABLED' "                  \
+    "type='string-select' description='Whether the header-file key-value "     \
+    "pair can be used in /vsicurl? filenames' default='ONLY_IN_TEMP'>"         \
+    "       <Value>ONLY_IN_TEMP</Value>"                                       \
+    "       <Value>NO</Value>"                                                 \
+    "       <Value>YES</Value>"                                                \
+    "  </Option>"                                                              \
     "  <Option name='GDAL_HTTP_MAX_CACHED_CONNECTIONS' type='integer' "        \
     "description='Maximum amount of connections that libcurl may keep alive "  \
     "in its connection cache after use'/>"                                     \


### PR DESCRIPTION
Backport #14740
 **Authored by:** @rouault