### PR TITLE
grokj2k: CopyTileData was using tile origin as region offset

### DIFF
--- a/.github/workflows/ubuntu_26.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_26.04/Dockerfile.ci
@@ -232,7 +232,7 @@ RUN curl -LO -fsS https://github.com/apache/arrow/archive/refs/heads/main.zip \
     && rm -rf arrow-main
 
 # Build Grok JPEG 2000 library
-ARG GROK_VERSION=v20.3.3
+ARG GROK_VERSION=v20.3.4
 
 RUN git clone --recursive --depth 1 --branch ${GROK_VERSION} \
     https://github.com/GrokImageCompression/grok.git grok-git && \

--- a/cmake/helpers/CheckDependentLibrariesGrok.cmake
+++ b/cmake/helpers/CheckDependentLibrariesGrok.cmake
@@ -2,4 +2,4 @@ gdal_check_package(Grok "Enable JPEG2000 support with Grok library"
                    CONFIG
                    CAN_DISABLE
                    TARGETS GROK::grokj2k
-                   VERSION 20.3.3)
+                   VERSION 20.3.4)

--- a/frmts/grok/grkdatasetbase.h
+++ b/frmts/grok/grkdatasetbase.h
@@ -2118,9 +2118,12 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
                                GSpacing nPixelSpace, GSpacing nLineSpace,
                                GSpacing nBandSpace, int nPromoteAlphaBandIdx)
     {
-        // Get tile position and size from component 0 (full resolution)
-        const int tileXOff = img->x0;
-        const int tileYOff = img->y0;
+        // Use origin AND size from component 0.  For partial (dw_reduced)
+        // decompression, img->x0/y0 describe the full tile canvas bounds while
+        // comps[0].x0/y0/w/h describe the cropped decode window; mixing
+        // the two can produce a corrupt output
+        const int tileXOff = static_cast<int>(img->comps[0].x0);
+        const int tileYOff = static_cast<int>(img->comps[0].y0);
         const int tileWidth = static_cast<int>(img->comps[0].w);
         const int tileHeight = static_cast<int>(img->comps[0].h);
 


### PR DESCRIPTION
## What does this PR do?

CopyTileData now uses correct decompress region offset, rather than tile origin

## What are related issues/pull requests?

#14748

I have verified that the reported `gdalwarp` corruption is fixed by these changes.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))

Note: this gdal bug also exposed a long-standing bug in Grok library. This is now fixed and released in version `v20.3.4`.
I have updated the driver and docker to reflect this new version.

