### PR TITLE
Python bindings: alias gdal.Open() and gdal.OpenEx() to match gdal.OpenEx()

### DIFF
--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -53,12 +53,10 @@ def test_basic_test_1():
 
 
 def test_basic_test_invalid_open_flag():
-    with pytest.raises(Exception, match="invalid value for GDALAccess"):
+    with pytest.raises(Exception, match="not a uint64 value"):
         gdal.Open("data/byte.tif", "invalid")
 
     assert gdal.OF_RASTER not in (gdal.GA_ReadOnly, gdal.GA_Update)
-    with pytest.raises(Exception, match="invalid value for GDALAccess"):
-        gdal.Open("data/byte.tif", gdal.OF_RASTER)
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="Incorrect platform")
@@ -66,7 +64,8 @@ def test_basic_test_strace_non_existing_file():
 
     python_exe = sys.executable
     cmd = 'strace -f %s -c "from osgeo import gdal; ' % python_exe + (
-        "gdal.DontUseExceptions(); gdal.OpenEx('non_existing_ds', gdal.OF_RASTER)" ' " '
+        "gdal.DontUseExceptions(); gdal.OpenEx('non_existing_ds', gdal.OF_RASTER | gdal.OF_SILENT_ERROR)"
+        ' " '
     )
     try:
         _, err = gdaltest.runexternal_out_and_err(cmd, encoding="UTF-8")
@@ -416,7 +415,7 @@ def test_basic_test_11():
     ds = gdal.OpenEx("../ogr/data/poly.shp", gdal.OF_RASTER | gdal.OF_VECTOR)
     assert ds is not None
 
-    ds = gdal.OpenEx("non existing")
+    ds = gdal.OpenEx("non existing", gdal.OF_SILENT_ERROR)
     assert ds is None and gdal.GetLastErrorMsg() == ""
 
     with gdal.quiet_errors():

--- a/autotest/gdrivers/fits.py
+++ b/autotest/gdrivers/fits.py
@@ -145,7 +145,7 @@ def test_fits_read_empty_primary_hdu():
     filename = "data/fits/empty_primary_hdu.fits"
     assert os.path.exists(filename)
     with gdal.quiet_errors():
-        assert gdal.Open(filename) is None
+        assert gdal.Open(filename, gdal.OF_RASTER) is None
 
 
 def test_fits_read_image_in_second_hdu():
@@ -257,7 +257,7 @@ def test_fits_open_vector_only_in_raster_mode():
     filename = "data/fits/binary_table.fits"
     assert os.path.exists(filename)
     with gdal.quiet_errors():
-        assert gdal.Open(filename) is None
+        assert gdal.Open(filename, gdal.OF_RASTER) is None
     assert "but contains binary table" in gdal.GetLastErrorMsg()
 
 

--- a/autotest/gdrivers/gti.py
+++ b/autotest/gdrivers/gti.py
@@ -118,7 +118,7 @@ def test_gti_no_metadata(tmp_vsimem):
     del index_ds
 
     with pytest.raises(Exception):
-        gdal.Open(index_filename)
+        gdal.Open(index_filename, gdal.OF_RASTER)
 
     vrt_ds = gdal.OpenEx(index_filename, allowed_drivers=["GTI"])
     assert vrt_ds.GetDriver().GetDescription() == "GTI"

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -6085,7 +6085,7 @@ def test_netcdf_short_as_unsigned(tmp_path):
 def test_netcdf_read_unrelated_dim():
     """Test https://github.com/OSGeo/gdal/issues/6367"""
 
-    ds = gdal.Open("data/netcdf/test_not_report_unrelated_dim.nc")
+    ds = gdal.Open("data/netcdf/test_not_report_unrelated_dim.nc", gdal.OF_RASTER)
     # Test that "unrelated_dim" metadata is not reported
     assert ds.GetMetadata() == {"Band1#foo": "bar"}
 

--- a/autotest/gdrivers/pds4.py
+++ b/autotest/gdrivers/pds4.py
@@ -886,11 +886,15 @@ def test_pds4_13():
     assert ds is None
 
     with gdal.quiet_errors():
-        ds = gdal.Open("PDS4:data/pds4/byte_pds4_cart_1700_multi_sds.xml:3:1")
+        ds = gdal.Open(
+            "PDS4:data/pds4/byte_pds4_cart_1700_multi_sds.xml:3:1", gdal.OF_RASTER
+        )
     assert ds is None
 
     with gdal.quiet_errors():
-        ds = gdal.Open("PDS4:data/pds4/byte_pds4_cart_1700_multi_sds.xml:1:3")
+        ds = gdal.Open(
+            "PDS4:data/pds4/byte_pds4_cart_1700_multi_sds.xml:1:3", gdal.OF_RASTER
+        )
     assert ds is None
 
 
@@ -981,7 +985,7 @@ def test_pds4_14():
 </Product_Observational>""",
     )
     with gdal.quiet_errors():
-        ds = gdal.Open(filename)
+        ds = gdal.Open(filename, gdal.OF_RASTER)
     assert ds is None
 
     gdal.FileFromMemBuffer(
@@ -1018,7 +1022,7 @@ def test_pds4_14():
 </Product_Observational>""",
     )
     with gdal.quiet_errors():
-        ds = gdal.Open(filename)
+        ds = gdal.Open(filename, gdal.OF_RASTER)
     assert ds is None
 
     gdal.FileFromMemBuffer(
@@ -1050,7 +1054,7 @@ def test_pds4_14():
 </Product_Observational>""",
     )
     with gdal.quiet_errors():
-        ds = gdal.Open(filename)
+        ds = gdal.Open(filename, gdal.OF_RASTER)
     assert ds is None
 
     gdal.FileFromMemBuffer(

--- a/autotest/gdrivers/tiledb_multidim.py
+++ b/autotest/gdrivers/tiledb_multidim.py
@@ -734,7 +734,7 @@ def test_tiledb_multidim_translate_from_netcdf():
 def test_tiledb_multidim_open_converted_by_tiledb_cf_netcdf_convert():
 
     filename = "data/tiledb/byte_epsg_3949_cf1.tiledb"
-    ds = gdal.Open(filename)
+    ds = gdal.Open(filename, gdal.OF_RASTER)
     assert (
         ds.GetSpatialRef().ExportToProj4()
         == "+proj=lcc +lat_0=49 +lon_0=3 +lat_1=48.25 +lat_2=49.75 +x_0=1700000 +y_0=8200000 +ellps=GRS80 +units=m +no_defs"

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -152,12 +152,11 @@ class GDALTest:
         else:
             wrk_filename = "data/" + self.filename
 
-        if self.open_options:
-            ds = gdal.OpenEx(
-                wrk_filename, gdal.OF_RASTER, open_options=self.open_options
-            )
-        else:
-            ds = gdal.Open(wrk_filename, gdal.GA_ReadOnly)
+        ds = gdal.Open(
+            wrk_filename,
+            gdal.OF_RASTER,
+            open_options=self.open_options if self.open_options else [],
+        )
 
         assert ds is not None, "Failed to open dataset: " + wrk_filename
 
@@ -208,7 +207,11 @@ class GDALTest:
                 main_virtual_filename = "/vsimem/tmp_testOpen/" + os.path.basename(
                     fl[0]
                 )
-                virtual_ds = gdal.Open(main_virtual_filename)
+                virtual_ds = gdal.Open(
+                    main_virtual_filename,
+                    gdal.OF_RASTER,
+                    open_options=self.open_options if self.open_options else [],
+                )
                 virtual_ds_is_None = virtual_ds is None
                 virtual_ds = None
 
@@ -238,8 +241,10 @@ class GDALTest:
                         drivers += [drv_name]
                 other_ds = None
                 with gdal.ExceptionMgr(useExceptions=False):
-                    other_ds = gdal.OpenEx(
-                        main_virtual_filename, gdal.OF_RASTER, allowed_drivers=drivers
+                    other_ds = gdal.Open(
+                        main_virtual_filename,
+                        gdal.OF_RASTER | gdal.OF_SILENT_ERROR,
+                        allowed_drivers=drivers,
                     )
                 other_ds_is_None = other_ds is None
                 other_ds_driver_name = None

--- a/doc/source/user/migration_guide.rst
+++ b/doc/source/user/migration_guide.rst
@@ -22,6 +22,32 @@ From GDAL 3.13 to GDAL 3.14
     * All methods accepting or returning ``OGRBoolean`` (aliased to ``int``)
       have been changed to use ``bool`` instead.
 
+- Changes impacting Python users:
+
+  * Past :py:func:`osgeo.gdal.Open` is now mapped onto :py:func:`osgeo.gdal.OpenEx`, and
+    :py:func:`osgeo.gdal.OpenEx` functionality is available as :py:func:`osgeo.gdal.Open`,
+    making both functions strict aliases.
+
+    This change is *mostly* backwards compatible, except the 2 following
+    situations:
+
+    + :py:func:`osgeo.gdal.Open` used to open only datasets in raster mode, or fail.
+      If no ``flags`` parameter is passed (or none of ``gdal.OF_RASTER``,
+      ``gdal.OF_VECTOR``,  ``gdal.OF_MULTIDIM_RASTER`` is set), all of them are
+      set to allow any GDAL-recognized dataset to be opened. This is a change of
+      behavior for GDAL < 3.14 users of :py:func:`Open` where this method
+      behaved as setting only ``gdal.OF_RASTER``. If opening vector or
+      multidimensional raster datasets with :py:func:`Open` is not desired,
+      ``gdal.OF_RASTER`` must be explicitly passed.
+
+    + For GDAL < 3.14 users of :py:func:`osgeo.gdal.OpenEx` in the ``gdal.DontUseExceptions()`` (default)
+      mode, that method did not set ``gdal.OF_VERBOSE_ERROR`` automatically.
+      But :py:func:`osgeo.gdal.Open` did. As that later behavior is desired, and both
+      functions are now aliases, :py:func:`osgeo.gdal.OpenEx` in the
+      ``gdal.DontUseExceptions()`` mode now also sets ``gdal.OF_VERBOSE_ERROR``
+      automatically, unless the new ``gdal.OF_SILENT_ERROR`` flag is set.
+
+
 From GDAL 3.12 to GDAL 3.13
 ---------------------------
 

--- a/swig/include/gdal.i
+++ b/swig/include/gdal.i
@@ -77,6 +77,8 @@ typedef GDALMDArrayHS GDALMDArrayHS;
 typedef GDALAttributeHS GDALAttributeHS;
 typedef GDALDimensionHS GDALDimensionHS;
 
+#define GDAL_OF_SILENT_ERROR    (1ULL << 63)
+
 %}
 
 #if defined(SWIGPYTHON) || defined(SWIGJAVA) || defined(SWIGCSHARP)
@@ -927,7 +929,7 @@ GDALDatasetShadow* Open( char const* name ) {
 }
 %}
 
-#else
+#elif !defined(SWIGPYTHON)
 %newobject Open;
 %inline %{
 GDALDatasetShadow* Open( char const* path, GDALAccess eAccess = GA_ReadOnly ) {
@@ -948,6 +950,9 @@ GDALDatasetShadow* Open( char const* path, GDALAccess eAccess = GA_ReadOnly ) {
 #endif
 
 %newobject OpenEx;
+#ifdef SWIGPYTHON
+%rename (Open) OpenEx;
+#endif
 #ifndef SWIGJAVA
 %feature( "kwargs" ) OpenEx;
 #endif
@@ -955,15 +960,32 @@ GDALDatasetShadow* Open( char const* path, GDALAccess eAccess = GA_ReadOnly ) {
 %apply (char **options) {char** open_options};
 %apply (char **options) {char** sibling_files};
 %inline %{
-GDALDatasetShadow* OpenEx( char const* path, unsigned int nOpenFlags = 0,
+GDALDatasetShadow* OpenEx( char const* path,
+#ifdef SWIGPYTHON
+                           GUIntBig nOpenFlags = 0,
+#else
+                           unsigned int nOpenFlags = 0,
+#endif
                            char** allowed_drivers = NULL, char** open_options = NULL,
                            char** sibling_files = NULL ) {
   CPLErrorReset();
 #ifdef SWIGPYTHON
-  if( GetUseExceptions() )
+  if ((nOpenFlags & GDAL_OF_SILENT_ERROR) == 0)
+  {
       nOpenFlags |= GDAL_OF_VERBOSE_ERROR;
+  }
+  else
+  {
+      if ((nOpenFlags & GDAL_OF_VERBOSE_ERROR) != 0)
+      {
+          CPLError(CE_Failure, CPLE_IllegalArg,
+                   "gdal.OF_VERBOSE_ERROR and gdal.OF_SILENT_ERROR cannot both be set");
+          return NULL;
+      }
+      nOpenFlags &= ~GDAL_OF_SILENT_ERROR;
+  }
 #endif
-  GDALDatasetShadow *ds = GDALOpenEx( path, nOpenFlags, allowed_drivers,
+  GDALDatasetShadow *ds = GDALOpenEx( path, (unsigned int)nOpenFlags, allowed_drivers,
                                       open_options, sibling_files );
 #ifndef SWIGPYTHON
   if( ds != NULL && CPLGetLastErrorType() == CE_Failure )
@@ -2398,6 +2420,9 @@ GDALDatasetShadow* wrapper_GDALMultiDimTranslateDestName( const char* dest,
 // return True for a gdal.Dataset. We can't include it in gdal_python.i
 // because Dataset is not defined at that point.
 %pythoncode %{
+
+OpenEx = Open
+
 ogr.DataSource = Dataset
 ogr.Driver = Driver
 %}

--- a/swig/include/gdalconst.i
+++ b/swig/include/gdalconst.i
@@ -193,6 +193,17 @@
 %constant OF_UPDATE = GDAL_OF_UPDATE;
 %constant OF_SHARED = GDAL_OF_SHARED;
 %constant OF_VERBOSE_ERROR = GDAL_OF_VERBOSE_ERROR;
+#if defined(SWIGPYTHON)
+// Extension to C valid open flags to be able to restore GDAL < 3.14
+// behavior of gdal.OpenEx() being silent by default on errors when
+// GDAL_OF_VERBOSE_ERROR isn't set when exceptions are disabled.
+// With GDAL 3.14, GDAL_OF_VERBOSE_ERROR is always implictly set, unless
+// GDAL_OF_SILENT_ERROR is set.
+%{
+#define GDAL_OF_SILENT_ERROR    (1ULL << 63)
+%}
+%constant unsigned long long OF_SILENT_ERROR = GDAL_OF_SILENT_ERROR;
+#endif
 %constant OF_THREAD_SAFE = GDAL_OF_THREAD_SAFE;
 
 #if !defined(SWIGCSHARP) && !defined(SWIGJAVA)

--- a/swig/include/python/docs/gdal_docs.i
+++ b/swig/include/python/docs/gdal_docs.i
@@ -295,44 +295,37 @@ Examples
 
 "
 
-// gdal.Open
-%feature("docstring") Open "
-
-Opens a raster file as a :py:class:`Dataset` using default options.
-See :cpp:func:`GDALOpen`.
-For more control over how the file is opened, use :py:func:`OpenEx`.
-
-Parameters
-----------
-path : str
-    name of the file to open
-eAccess : int, default = :py:const:`gdal.GA_ReadOnly`
-
-Returns
--------
-Dataset or None
-    A dataset if successful, or ``None`` on failure.
-
-See Also
---------
-:py:func:`OpenEx`
-:py:func:`OpenShared`
-
-";
-
-// gdal.OpenEx
+// gdal.Open / gdal.OpenEx
 %feature("docstring") OpenEx "
 
 Open a raster or vector file as a :py:class:`Dataset`.
 See :cpp:func:`GDALOpenEx`.
 
+Prior to GDAL 3.14, that method was named :py:func:`OpenEx`. Since GDAL 3.14,
+:py:func:`Open` and :py:func:`OpenEx` are aliases.
+
 Parameters
 ----------
 path : str
-    name of the file to open
+        name of the file / dataset to open
 flags : int
         Flags controlling how the Dataset is opened. Multiple ``gdal.OF_XXX`` flags
         may be combined using the ``|`` operator. See :cpp:func:`GDALOpenEx`.
+
+        If no flag is passed (or none of ``gdal.OF_RASTER``, ``gdal.OF_VECTOR``,
+        ``gdal.OF_MULTIDIM_RASTER`` is set), all of them will be set to allow any
+        GDAL-recognized dataset to be opened. This is a change of behavior for
+        GDAL < 3.14 users of :py:func:`Open` where this method behaved as
+        setting only ``gdal.OF_RASTER``. If opening vector or multidimensional
+        raster datasets with :py:func:`Open` is not desired, ``gdal.OF_RASTER``
+        must be explicitly passed
+
+        Since GDAL 3.14, it is possible to set the ``gdal.OF_SILENT_ERROR`` flag
+        to avoid ``gdal.OF_VERBOSE_ERROR`` to be automatically set. This is
+        mostly of interest for users wanting to restore GDAL < 3.14 behavior
+        when calling :py:func:`OpenEx` in the (default) mode where GDAL errors are
+        not turned into Python exceptions.
+
 allowed_drivers : list, optional
         A list of the names of drivers that may attempt to open the dataset.
 open_options : dict or list, optional
@@ -347,7 +340,6 @@ Dataset or None
 
 See Also
 --------
-:py:func:`Open`
 :py:func:`OpenShared`
 
 ";

--- a/swig/include/python/typemaps_python.i
+++ b/swig/include/python/typemaps_python.i
@@ -55,7 +55,13 @@
 
 %typemap(in) GUIntBig
 {
-    $1 = (GIntBig)PyLong_AsUnsignedLongLong($input);
+    PyErr_Clear();
+    $1 = (GUIntBig)PyLong_AsUnsignedLongLong($input);
+    if( $1 == (GUIntBig)-1 && PyErr_Occurred() )
+    {
+        PyErr_SetString( PyExc_RuntimeError, "not a uint64 value");
+        SWIG_fail;
+    }
 }
 
 %typemap(out) GUIntBig


### PR DESCRIPTION
The naming of gdal.OpenEx() felt always a bit awkward. The signatures of the 2 methods were compatible in that gdal.ReadOnly == gdal.OF_READONLY and gdal.Update == gdal.OF_UPDATE.

Another advantage is that you can now gdal.Open() both a raster or a vector.

There are 2 (hopefully to be considered minor?) changes of behavior associated with that change:

1. :py:func:`gdal.Open` used to open only datasets in raster mode, or fail. If no ``flags`` parameter is passed (or none of ``gdal.OF_RASTER``, ``gdal.OF_VECTOR``,  ``gdal.OF_MULTIDIM_RASTER`` is set), all of them are set to allow any GDAL-recognized dataset to be opened. This is a change of behavior for GDAL < 3.14 users of :py:func:`Open` where this method behaved as setting only ``gdal.OF_RASTER``. If opening vector or multidimensional raster datasets with :py:func:`Open` is not desired, ``gdal.OF_RASTER`` must be explicitly passed.

2. Another change is related to error handling. Before that PR:
  - gdal.Open() was indirectly calling GDALOpenEx() with GDAL_OF_VERBOSE_ERROR set
  - gdal.OpenEx() in gdal.UseException() mode was also setting GDAL_OF_VERBOSE_ERROR, even if the open_flags parameter did not set it.
  - gdal.OpenEx() in gdal.DontUseExceptions() mode was *not* setting automatially GDAL_OF_VERBOSE_ERROR

  To minimize disruption for existing gdal.Open() users that relied on
  GDAL_OF_VERBOSE_ERROR being set, the new unified gdal.Open/gdal.OpenEx
  also always set it.
  The only backward incompabible change is for users of gdal.OpenEx() that
  used the gdal.DontUseExceptions() mode and didn't pass GDAL_OF_VERBOSE_ERROR.
  They can get back past behavior by setting the new gdal.OF_SILENT_ERROR
  constant. It is hoped that this change only causes minor disruption.

This commit only contains the minimum changes to make regression test suite pass. If accepted, all gdal.OpenEx() uses will be renamed to gdal.Open()
