### PR TITLE
autotest: enable exceptions in SHP, VRT tests

### DIFF
--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1926,8 +1926,8 @@ def test_vrt_dataset_rasterio_recursion_detection():
     )
 
     ds = gdal.Open("/vsimem/test.vrt")
-    with gdal.quiet_errors():
-        ds.ReadRaster(0, 0, 20, 20, 10, 10)
+    # with gdal.quiet_errors():
+    assert ds.ReadRaster(0, 0, 20, 20, 10, 10) is not None
     gdal.Unlink("/vsimem/test.vrt")
 
 

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -32,13 +32,6 @@ pytestmark = pytest.mark.skipif(
 
 
 ###############################################################################
-@pytest.fixture(autouse=True, scope="module")
-def module_disable_exceptions():
-    with gdaltest.disable_exceptions():
-        yield
-
-
-###############################################################################
 # When imported build a list of units based on the files available.
 
 
@@ -82,12 +75,8 @@ def test_vrt_open(filename, checksum):
 def test_vrt_read_non_existing_source(filename):
 
     ds = gdal.Open(filename)
-    with gdal.quiet_errors():
-        cs = ds.GetRasterBand(1).Checksum()
-    if ds is None:
-        return
-
-    assert cs == -1
+    with pytest.raises(Exception, match="I/O read error"):
+        ds.GetRasterBand(1).Checksum()
 
     ds.GetMetadata()
     ds.GetRasterBand(1).GetMetadata()
@@ -294,8 +283,8 @@ def test_vrt_read_7(tmp_vsimem):
 
     gdal.FileFromMemBuffer(filename, content)
     ds = gdal.Open(filename)
-    with gdaltest.error_raised(gdal.CE_Failure, "Recursion detected"):
-        assert ds.GetRasterBand(1).Checksum() == -1
+    with pytest.raises(Exception, match="Recursion detected"):
+        ds.GetRasterBand(1).Checksum()
 
 
 ###############################################################################
@@ -1129,11 +1118,10 @@ def test_vrt_read_27():
 
 def test_vrt_read_28():
 
-    with gdal.quiet_errors():
-        ds = gdal.Open(
+    with pytest.raises(Exception, match="No such file"):
+        gdal.Open(
             '<VRTDataset rasterXSize="1 "rasterYSize="1"><VRTRasterBand band="-2147483648"><SimpleSource></SimpleSource></VRTRasterBand></VRTDataset>'
         )
-    assert ds is None
 
 
 ###############################################################################
@@ -1337,7 +1325,9 @@ def test_vrt_invalid_srcrect():
         </SimpleSource>
     </VRTRasterBand>
     </VRTDataset>"""
-    assert gdal.Open(vrt_text) is None
+
+    with pytest.raises(Exception, match="Wrong values in SrcRect"):
+        gdal.Open(vrt_text)
 
 
 def test_vrt_invalid_dstrect():
@@ -1353,7 +1343,9 @@ def test_vrt_invalid_dstrect():
         </SimpleSource>
     </VRTRasterBand>
     </VRTDataset>"""
-    assert gdal.Open(vrt_text) is None
+
+    with pytest.raises(Exception, match="Wrong values in DstRect"):
+        gdal.Open(vrt_text)
 
 
 def test_vrt_no_explicit_dataAxisToSRSAxisMapping():
@@ -1450,8 +1442,8 @@ def test_vrt_invalid_source_band():
   </VRTRasterBand>
 </VRTDataset>"""
     ds = gdal.Open(vrt_text)
-    with gdal.quiet_errors():
-        assert ds.GetRasterBand(1).Checksum() == -1
+    with pytest.raises(Exception, match="Illegal band"):
+        ds.GetRasterBand(1).Checksum()
 
 
 @gdaltest.enable_exceptions()
@@ -2144,7 +2136,6 @@ def test_vrt_usemaskband_alpha(tmp_vsimem):
 
     ds = gdal.GetDriverByName("GTiff").Create(tmp_vsimem / "src1.tif", 3, 1, 2)
     ds.GetRasterBand(1).Fill(255)
-    ds.GetRasterBand(1).GetMaskBand().WriteRaster(0, 0, 1, 1, b"\xff")
     ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_AlphaBand)
     ds.GetRasterBand(2).WriteRaster(0, 0, 1, 1, b"\xff")
 
@@ -2217,12 +2208,13 @@ def test_vrt_check_dont_open_unneeded_source(tmp_vsimem):
     tmpfilename = tmp_vsimem / "tmp.vrt"
     gdal.FileFromMemBuffer(tmpfilename, vrt)
 
+    # should succeed because srcwin does not touch non-existing file
     ds = gdal.Translate("", tmpfilename, options="-of MEM -srcwin 0 0 10 10")
     assert ds is not None
 
-    with gdal.quiet_errors():
-        ds = gdal.Translate("", tmpfilename, options="-of MEM -srcwin 0 0 10.1 10.1")
-    assert ds is None
+    # should fail because srcwin does touches non-existing file
+    with pytest.raises(Exception, match="No such file"):
+        gdal.Translate("", tmpfilename, options="-of MEM -srcwin 0 0 10.1 10.1")
 
 
 def test_vrt_check_dont_open_unneeded_source_with_complex_source_nodata(tmp_vsimem):
@@ -2250,12 +2242,13 @@ def test_vrt_check_dont_open_unneeded_source_with_complex_source_nodata(tmp_vsim
     tmpfilename = tmp_vsimem / "tmp.vrt"
     gdal.FileFromMemBuffer(tmpfilename, vrt)
 
+    # should succeed because srcwin does not touch non-existing file
     ds = gdal.Translate("", tmpfilename, options="-of MEM -srcwin 0 0 10 10")
     assert ds is not None
 
-    with gdal.quiet_errors():
-        ds = gdal.Translate("", tmpfilename, options="-of MEM -srcwin 0 0 10.1 10.1")
-    assert ds is None
+    # should fail because srcwin does touches non-existing file
+    with pytest.raises(Exception, match="No such file"):
+        gdal.Translate("", tmpfilename, options="-of MEM -srcwin 0 0 10.1 10.1")
 
 
 def test_vrt_nodata_and_implicit_ovr_recursion_issue(tmp_vsimem):
@@ -2501,14 +2494,17 @@ def test_vrt_read_compute_statistics_mosaic_optimization_src_with_nodata_all():
     src_ds1.GetRasterBand(1).SetNoDataValue(10)
     src_ds2.GetRasterBand(1).SetNoDataValue(10)
 
-    with gdal.quiet_errors():
-        minmax = vrt_ds.GetRasterBand(1).ComputeRasterMinMax(False)
-    assert math.isnan(minmax[0])
-    assert math.isnan(minmax[1])
+    with pytest.raises(Exception, match="no valid pixels found"):
+        vrt_ds.GetRasterBand(1).ComputeRasterMinMax(False)
 
-    with gdal.quiet_errors():
-        vrt_stats = vrt_ds.GetRasterBand(1).ComputeStatistics(False)
-        assert vrt_stats is None
+    with gdaltest.disable_exceptions():
+        minmax = vrt_ds.GetRasterBand(1).ComputeRasterMinMax(False)
+
+        assert math.isnan(minmax[0])
+        assert math.isnan(minmax[1])
+
+    with pytest.raises(Exception, match="no valid pixels found"):
+        vrt_ds.GetRasterBand(1).ComputeStatistics(False)
         assert vrt_ds.GetRasterBand(1).GetMetadataItem("STATISTICS_MINIMUM") is None
 
 

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1118,7 +1118,7 @@ def test_vrt_read_27():
 
 def test_vrt_read_28():
 
-    with pytest.raises(Exception, match="No such file"):
+    with pytest.raises(Exception, match="(No such file|does not exist)"):
         gdal.Open(
             '<VRTDataset rasterXSize="1 "rasterYSize="1"><VRTRasterBand band="-2147483648"><SimpleSource></SimpleSource></VRTRasterBand></VRTDataset>'
         )

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -2139,16 +2139,21 @@ def test_vrt_usemaskband(tmp_vsimem):
 
 def test_vrt_usemaskband_alpha(tmp_vsimem):
 
-    ds = gdal.GetDriverByName("GTiff").Create(tmp_vsimem / "src1.tif", 3, 1, 2)
-    ds.GetRasterBand(1).Fill(255)
-    ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_AlphaBand)
-    ds.GetRasterBand(2).WriteRaster(0, 0, 1, 1, b"\xff")
+    with gdal.GetDriverByName("GTiff").Create(tmp_vsimem / "src1.tif", 3, 1, 2) as ds:
+        # band 1 : [ 255, - , - ]
+        # band 2 : [ 0,  255, 0 ]
+        ds.GetRasterBand(1).Fill(255)
+        ds.GetRasterBand(1).CreateMaskBand(0)
+        ds.GetRasterBand(1).GetMaskBand().WriteRaster(0, 0, 1, 1, b"\xff")
+        ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_AlphaBand)
+        ds.GetRasterBand(2).WriteRaster(1, 0, 1, 1, b"\xff")
 
-    ds = gdal.GetDriverByName("GTiff").Create(tmp_vsimem / "src2.tif", 3, 1, 2)
-    ds.GetRasterBand(1).Fill(127)
-    ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_AlphaBand)
-    ds.GetRasterBand(2).WriteRaster(1, 0, 1, 1, b"\xff")
-    ds = None
+    with gdal.GetDriverByName("GTiff").Create(tmp_vsimem / "src2.tif", 3, 1, 2) as ds:
+        # band 1 : [ 127, 127, 127 ]
+        # band 2 : [   0, 255,   0 ]
+        ds.GetRasterBand(1).Fill(127)
+        ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_AlphaBand)
+        ds.GetRasterBand(2).WriteRaster(1, 0, 1, 1, b"\xff")
 
     vrt_text = f"""<VRTDataset rasterXSize="3" rasterYSize="1">
   <VRTRasterBand dataType="Byte" band="1">
@@ -2187,7 +2192,7 @@ def test_vrt_usemaskband_alpha(tmp_vsimem):
 </VRTDataset>"""
     ds = gdal.Open(vrt_text)
     assert struct.unpack("B" * 3, ds.GetRasterBand(1).ReadRaster()) == (255, 127, 0)
-    assert struct.unpack("B" * 3, ds.GetRasterBand(2).ReadRaster()) == (255, 255, 0)
+    assert struct.unpack("B" * 3, ds.GetRasterBand(2).ReadRaster()) == (0, 255, 0)
 
 
 def test_vrt_check_dont_open_unneeded_source(tmp_vsimem):

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1904,33 +1904,6 @@ def test_vrt_source_no_dstrect():
     gdal.Unlink(filename)
 
 
-def test_vrt_dataset_rasterio_recursion_detection():
-
-    gdal.FileFromMemBuffer(
-        "/vsimem/test.vrt",
-        """<VRTDataset rasterXSize="20" rasterYSize="20">
-  <VRTRasterBand dataType="Byte" band="1">
-    <SimpleSource>
-      <SourceFilename relativeToVRT="0">data/byte.tif</SourceFilename>
-      <SourceBand>1</SourceBand>
-      <SourceProperties RasterXSize="20" RasterYSize="20" DataType="Byte" BlockXSize="20" BlockYSize="20" />
-      <SrcRect xOff="0" yOff="0" xSize="20" ySize="20" />
-      <DstRect xOff="0" yOff="0" xSize="20" ySize="20" />
-    </SimpleSource>
-    <Overview>
-        <SourceFilename relativeToVRT="0">/vsimem/test.vrt</SourceFilename>
-        <SourceBand>1</SourceBand>
-    </Overview>
-  </VRTRasterBand>
-</VRTDataset>""",
-    )
-
-    ds = gdal.Open("/vsimem/test.vrt")
-    # with gdal.quiet_errors():
-    assert ds.ReadRaster(0, 0, 20, 20, 10, 10) is not None
-    gdal.Unlink("/vsimem/test.vrt")
-
-
 def test_vrt_dataset_rasterio_recursion_detection_does_not_trigger():
 
     vrt_text = """<VRTDataset rasterXSize="50" rasterYSize="50">
@@ -1961,6 +1934,38 @@ def test_vrt_dataset_rasterio_recursion_detection_does_not_trigger():
     ds = gdal.Open("data/rgbsmall.tif")
     ref_data = ds.ReadRaster(0, 0, 50, 50, 25, 25, resample_alg=gdal.GRIORA_Cubic)
     assert got_data == ref_data
+
+
+def test_vrt_dataset_rasterio_recursion_detection_does_not_trigger_2(tmp_vsimem):
+
+    gdal.FileFromMemBuffer(
+        tmp_vsimem / "test.vrt",
+        """<VRTDataset rasterXSize="20" rasterYSize="20">
+  <VRTRasterBand dataType="Byte" band="1">
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">data/byte.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SourceProperties RasterXSize="20" RasterYSize="20" DataType="Byte" BlockXSize="20" BlockYSize="20" />
+      <SrcRect xOff="0" yOff="0" xSize="20" ySize="20" />
+      <DstRect xOff="0" yOff="0" xSize="20" ySize="20" />
+    </SimpleSource>
+    <Overview>
+        <SourceFilename relativeToVRT="0">{test.vrt}</SourceFilename>
+        <SourceBand>1</SourceBand>
+    </Overview>
+  </VRTRasterBand>
+</VRTDataset>""",
+    )
+
+    with gdal.Open(tmp_vsimem / "test.vrt") as ds:
+        vrt_values = ds.ReadRaster(0, 0, 20, 20, 10, 10)
+        assert vrt_values is not None
+
+    with gdal.Open("data/byte.tif") as ds:
+        tif_values = ds.ReadRaster(0, 0, 20, 20, 10, 10)
+        assert tif_values is not None
+
+    assert vrt_values == tif_values
 
 
 def test_vrt_dataset_rasterio_non_nearest_resampling_source_with_ovr(tmp_vsimem):

--- a/autotest/gdrivers/vrtderived.py
+++ b/autotest/gdrivers/vrtderived.py
@@ -29,10 +29,6 @@ pytestmark = pytest.mark.skipif(
 
 
 ###############################################################################
-@pytest.fixture(autouse=True, scope="module")
-def module_disable_exceptions():
-    with gdaltest.disable_exceptions():
-        yield
 
 
 def _xmlsearch(root, nodetype, name):
@@ -130,12 +126,11 @@ def test_vrtderived_2(tmp_vsimem):
     md["source_0"] = simpleSourceXML
 
     vrt_ds.GetRasterBand(1).SetMetadata(md, "vrt_sources")
-    with gdal.quiet_errors():
-        cs = vrt_ds.GetRasterBand(1).Checksum()
-    assert cs == -1
-    with gdal.quiet_errors():
-        ret = vrt_ds.GetRasterBand(1).WriteRaster(0, 0, 1, 1, " ")
-    assert ret != 0
+    with pytest.raises(Exception, match="I/O read error"):
+        vrt_ds.GetRasterBand(1).Checksum()
+
+    with pytest.raises(Exception, match="Writing .* is not supported"):
+        vrt_ds.GetRasterBand(1).WriteRaster(0, 0, 1, 1, " ")
     vrt_ds = None
 
     xmlstring = gdal.VSIFile(filename, "r").read()
@@ -198,9 +193,8 @@ def test_vrtderived_4(tmp_vsimem):
         "PixelFunctionType=dummy",
         "SourceTransferType=Invalid",
     ]
-    with gdal.quiet_errors():
-        ret = vrt_ds.AddBand(gdal.GDT_UInt8, options)
-    assert ret != 0, "invalid SourceTransferType value not detected"
+    with pytest.raises(Exception, match="invalid SourceTransferType"):
+        vrt_ds.AddBand(gdal.GDT_UInt8, options)
 
 
 ###############################################################################
@@ -364,14 +358,17 @@ def test_vrtderived_8():
 
     with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "NO"):
         ds = gdal.Open("data/vrt/n43_hillshade.vrt")
-        with gdal.quiet_errors():
-            cs = ds.GetRasterBand(1).Checksum()
-    assert cs == -1, "invalid checksum"
+        with pytest.raises(
+            Exception, match="Python code .* has been explicitly disabled"
+        ):
+            ds.GetRasterBand(1).Checksum()
 
     ds = gdal.Open("data/vrt/n43_hillshade.vrt")
-    with gdal.quiet_errors():
-        cs = ds.GetRasterBand(1).Checksum()
-    assert cs == -1, "invalid checksum"
+    with pytest.raises(
+        Exception,
+        match="If you trust the code .* set the GDAL_VRT_ENABLE_PYTHON configuration option",
+    ):
+        ds.GetRasterBand(1).Checksum()
 
 
 ###############################################################################
@@ -383,29 +380,29 @@ def test_vrtderived_9():
     pytest.importorskip("numpy")
 
     # Missing PixelFunctionType
-    with gdal.quiet_errors():
-        ds = gdal.Open("""<VRTDataset rasterXSize="10" rasterYSize="10">
+    with pytest.raises(Exception, match="PixelFunctionType missing"):
+        gdal.Open("""<VRTDataset rasterXSize="10" rasterYSize="10">
   <VRTRasterBand dataType="Byte" band="1" subClass="VRTDerivedRasterBand">
     <PixelFunctionLanguage>Python</PixelFunctionLanguage>
   </VRTRasterBand>
 </VRTDataset>
 """)
-    assert ds is None
 
     # Unsupported PixelFunctionLanguage
-    with gdal.quiet_errors():
-        ds = gdal.Open("""<VRTDataset rasterXSize="10" rasterYSize="10">
+    with pytest.raises(Exception, match="Unsupported PixelFunctionLanguage"):
+        gdal.Open("""<VRTDataset rasterXSize="10" rasterYSize="10">
   <VRTRasterBand dataType="Byte" band="1" subClass="VRTDerivedRasterBand">
     <PixelFunctionType>identity</PixelFunctionType>
     <PixelFunctionLanguage>foo</PixelFunctionLanguage>
   </VRTRasterBand>
 </VRTDataset>
 """)
-    assert ds is None
 
     # PixelFunctionCode can only be used with Python
-    with gdal.quiet_errors():
-        ds = gdal.Open("""<VRTDataset rasterXSize="10" rasterYSize="10">
+    with pytest.raises(
+        Exception, match="PixelFunctionCode can only be used with Python"
+    ):
+        gdal.Open("""<VRTDataset rasterXSize="10" rasterYSize="10">
   <VRTRasterBand dataType="Byte" band="1" subClass="VRTDerivedRasterBand">
     <PixelFunctionType>identity</PixelFunctionType>
     <PixelFunctionCode><![CDATA[
@@ -416,22 +413,20 @@ def identity(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize
   </VRTRasterBand>
 </VRTDataset>
 """)
-    assert ds is None
 
     # BufferRadius can only be used with Python
-    with gdal.quiet_errors():
-        ds = gdal.Open("""<VRTDataset rasterXSize="10" rasterYSize="10">
+    with pytest.raises(Exception, match="BufferRadius can only be used with Python"):
+        gdal.Open("""<VRTDataset rasterXSize="10" rasterYSize="10">
   <VRTRasterBand dataType="Byte" band="1" subClass="VRTDerivedRasterBand">
     <PixelFunctionType>identity</PixelFunctionType>
     <BufferRadius>1</BufferRadius>
   </VRTRasterBand>
 </VRTDataset>
 """)
-    assert ds is None
 
     # Invalid BufferRadius
-    with gdal.quiet_errors():
-        ds = gdal.Open("""<VRTDataset rasterXSize="10" rasterYSize="10">
+    with pytest.raises(Exception, match="Invalid value for BufferRadius"):
+        gdal.Open("""<VRTDataset rasterXSize="10" rasterYSize="10">
   <VRTRasterBand dataType="Byte" band="1" subClass="VRTDerivedRasterBand">
     <PixelFunctionType>identity</PixelFunctionType>
     <PixelFunctionLanguage>Python</PixelFunctionLanguage>
@@ -439,7 +434,6 @@ def identity(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize
   </VRTRasterBand>
 </VRTDataset>
 """)
-    assert ds is None
 
     # Error at Python code compilation (indentation error)
     ds = gdal.Open("""<VRTDataset rasterXSize="10" rasterYSize="10">
@@ -454,11 +448,9 @@ syntax_error
   </VRTRasterBand>
 </VRTDataset>
 """)
-    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"), gdaltest.error_handler():
-        cs = ds.GetRasterBand(1).Checksum()
-    if cs != -1:
-        print(gdal.GetLastErrorMsg())
-        pytest.fail("invalid checksum")
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"):
+        with pytest.raises(Exception, match="IndentationError"):
+            ds.GetRasterBand(1).Checksum()
 
     # Error at run time (in global code)
     ds = gdal.Open("""<VRTDataset rasterXSize="10" rasterYSize="10">
@@ -474,11 +466,9 @@ def identity(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize
   </VRTRasterBand>
 </VRTDataset>
 """)
-    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"), gdaltest.error_handler():
-        cs = ds.GetRasterBand(1).Checksum()
-    if cs != -1:
-        print(gdal.GetLastErrorMsg())
-        pytest.fail("invalid checksum")
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"):
+        with pytest.raises(Exception, match="NameError"):
+            ds.GetRasterBand(1).Checksum()
 
     # Error at run time (in pixel function)
     ds = gdal.Open("""<VRTDataset rasterXSize="10" rasterYSize="10">
@@ -493,11 +483,9 @@ def identity(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize
   </VRTRasterBand>
 </VRTDataset>
 """)
-    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"), gdaltest.error_handler():
-        cs = ds.GetRasterBand(1).Checksum()
-    if cs != -1:
-        print(gdal.GetLastErrorMsg())
-        pytest.fail("invalid checksum")
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"):
+        with pytest.raises(Exception, match="NameError"):
+            ds.GetRasterBand(1).Checksum()
 
     # User exception
     ds = gdal.Open("""<VRTDataset rasterXSize="10" rasterYSize="10">
@@ -512,11 +500,9 @@ def identity(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize
   </VRTRasterBand>
 </VRTDataset>
 """)
-    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"), gdaltest.error_handler():
-        cs = ds.GetRasterBand(1).Checksum()
-    if cs != -1:
-        print(gdal.GetLastErrorMsg())
-        pytest.fail("invalid checksum")
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"):
+        with pytest.raises(Exception, match="my exception"):
+            ds.GetRasterBand(1).Checksum()
 
     # unknown_function
     ds = gdal.Open("""<VRTDataset rasterXSize="10" rasterYSize="10">
@@ -531,11 +517,9 @@ def identity(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize
   </VRTRasterBand>
 </VRTDataset>
 """)
-    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"), gdaltest.error_handler():
-        cs = ds.GetRasterBand(1).Checksum()
-    if cs != -1:
-        print(gdal.GetLastErrorMsg())
-        pytest.fail("invalid checksum")
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"):
+        with pytest.raises(Exception, match="unknown_function"):
+            ds.GetRasterBand(1).Checksum()
 
     # uncallable object
     ds = gdal.Open("""<VRTDataset rasterXSize="10" rasterYSize="10">
@@ -549,11 +533,9 @@ uncallable_object = True
   </VRTRasterBand>
 </VRTDataset>
 """)
-    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"), gdaltest.error_handler():
-        cs = ds.GetRasterBand(1).Checksum()
-    if cs != -1:
-        print(gdal.GetLastErrorMsg())
-        pytest.fail("invalid checksum")
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"):
+        with pytest.raises(Exception, match="uncallable_object"):
+            ds.GetRasterBand(1).Checksum()
 
     # unknown_module
     ds = gdal.Open("""<VRTDataset rasterXSize="10" rasterYSize="10">
@@ -563,11 +545,9 @@ uncallable_object = True
   </VRTRasterBand>
 </VRTDataset>
 """)
-    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"), gdaltest.error_handler():
-        cs = ds.GetRasterBand(1).Checksum()
-    if cs != -1:
-        print(gdal.GetLastErrorMsg())
-        pytest.fail("invalid checksum")
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"):
+        with pytest.raises(Exception, match="No module named 'unknown_module'"):
+            ds.GetRasterBand(1).Checksum()
 
 
 def vrtderived_code_that_only_makes_sense_with_GDAL_VRT_ENABLE_PYTHON_equal_IF_SAFE_but_that_is_now_disabled():
@@ -658,11 +638,11 @@ def test_vrtderived_10():
 
     # GDAL_VRT_TRUSTED_MODULES not defined
     ds = gdal.Open(content)
-    with gdal.quiet_errors():
-        cs = ds.GetRasterBand(1).Checksum()
-    if cs != -1:
-        print(gdal.GetLastErrorMsg())
-        pytest.fail("invalid checksum")
+    with pytest.raises(
+        Exception,
+        match="current policy is to trust only code from .* GDAL_VRT_PYTHON_TRUSTED_MODULES",
+    ):
+        ds.GetRasterBand(1).Checksum()
 
     # GDAL_VRT_PYTHON_TRUSTED_MODULES *NOT* matching our module
     for val in [
@@ -672,13 +652,11 @@ def test_vrtderived_10():
         "vrtderive.*" "vrtderivedX.*",
     ]:
         ds = gdal.Open(content)
-        with gdal.config_option(
-            "GDAL_VRT_PYTHON_TRUSTED_MODULES", val
-        ), gdaltest.error_handler():
-            cs = ds.GetRasterBand(1).Checksum()
-        if cs != -1:
-            print(gdal.GetLastErrorMsg())
-            pytest.fail("invalid checksum")
+        with gdal.config_option("GDAL_VRT_PYTHON_TRUSTED_MODULES", val):
+            with pytest.raises(
+                Exception, match=f"current policy is to trust only code from .*{val}"
+            ):
+                ds.GetRasterBand(1).Checksum()
 
     # GDAL_VRT_PYTHON_TRUSTED_MODULES matching our module
     for val in [
@@ -731,11 +709,9 @@ def test_vrtderived_11():
 # Test all data types with python code
 
 
-def test_vrtderived_12():
-
-    pytest.importorskip("numpy")
-
-    for dt in [
+@pytest.mark.parametrize(
+    "dt",
+    [
         "Byte",
         "Int8",
         "UInt16",
@@ -752,60 +728,63 @@ def test_vrtderived_12():
         "CFloat16",
         "CFloat32",
         "CFloat64",
-    ]:
-        ds = gdal.Open("""<VRTDataset rasterXSize="10" rasterYSize="10">
-<VRTRasterBand dataType="%s" band="1" subClass="VRTDerivedRasterBand">
-    <ColorInterp>Gray</ColorInterp>
-    <PixelFunctionType>vrtderived.one_pix_func</PixelFunctionType>
-    <PixelFunctionLanguage>Python</PixelFunctionLanguage>
-</VRTRasterBand>
-</VRTDataset>""" % dt)
+    ],
+)
+@gdaltest.disable_exceptions()
+def test_vrtderived_12(dt):
 
-        with gdal.config_option(
-            "GDAL_VRT_ENABLE_PYTHON", "YES"
-        ), gdaltest.error_handler():
-            cs = ds.GetRasterBand(1).Checksum()
-        # CInt16/CInt32/CFloat16 do not map to native numpy types
-        if dt == "CInt16" or dt == "CInt32" or dt == "CFloat16":
-            expected_cs = [-1]  # error
-        elif dt == "Float16":
-            # Might or might not be supported by GDAL
-            expected_cs = [-1, 100]
+    pytest.importorskip("numpy")
+
+    ds = gdal.Open(f"""<VRTDataset rasterXSize="10" rasterYSize="10">
+<VRTRasterBand dataType="{dt}" band="1" subClass="VRTDerivedRasterBand">
+<ColorInterp>Gray</ColorInterp>
+<PixelFunctionType>vrtderived.one_pix_func</PixelFunctionType>
+<PixelFunctionLanguage>Python</PixelFunctionLanguage>
+</VRTRasterBand>
+</VRTDataset>""")
+
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"), gdal.quiet_errors():
+        cs = ds.GetRasterBand(1).Checksum()
+    # CInt16/CInt32/CFloat16 do not map to native numpy types
+    if dt == "CInt16" or dt == "CInt32" or dt == "CFloat16":
+        expected_cs = [-1]  # error
+    elif dt == "Float16":
+        # Might or might not be supported by GDAL
+        expected_cs = [-1, 100]
+    else:
+        expected_cs = [100]
+    if cs not in expected_cs:
+        print(dt)
+        print(gdal.GetLastErrorMsg())
+        if len(expected_cs) == 1:
+            pytest.fail(
+                "invalid checksum, datatype %s, have %d, expected %d"
+                % (dt, cs, expected_cs[0])
+            )
         else:
-            expected_cs = [100]
-        if cs not in expected_cs:
-            print(dt)
-            print(gdal.GetLastErrorMsg())
-            if len(expected_cs) == 1:
-                pytest.fail(
-                    "invalid checksum, datatype %s, have %d, expected %d"
-                    % (dt, cs, expected_cs[0])
-                )
-            else:
-                pytest.fail(
-                    "invalid checksum, datatype %s, have %d, expected one of [%d, %d]"
-                    % (dt, cs, expected_cs[0], expected_cs[1])
-                )
+            pytest.fail(
+                "invalid checksum, datatype %s, have %d, expected one of [%d, %d]"
+                % (dt, cs, expected_cs[0], expected_cs[1])
+            )
 
-    # Same for SourceTransferType
-    for dt in ["CInt16", "CInt32", "CFloat16"]:
-        ds = gdal.Open("""<VRTDataset rasterXSize="10" rasterYSize="10">
-<VRTRasterBand dataType="%s" band="1" subClass="VRTDerivedRasterBand">
-    <SourceTransferType>Byte</SourceTransferType>
-    <ColorInterp>Gray</ColorInterp>
-    <PixelFunctionType>vrtderived.one_pix_func</PixelFunctionType>
-    <PixelFunctionLanguage>Python</PixelFunctionLanguage>
+
+@pytest.mark.parametrize("dt", ["CInt16", "CInt32", "CFloat16"])
+def test_vrtderived_12_bis(dt):
+
+    ds = gdal.Open(f"""<VRTDataset rasterXSize="10" rasterYSize="10">
+<VRTRasterBand dataType="Float32" band="1" subClass="VRTDerivedRasterBand">
+<SourceTransferType>{dt}</SourceTransferType>
+<ColorInterp>Gray</ColorInterp>
+<PixelFunctionType>vrtderived.one_pix_func</PixelFunctionType>
+<PixelFunctionLanguage>Python</PixelFunctionLanguage>
 </VRTRasterBand>
-</VRTDataset>""" % dt)
+</VRTDataset>""")
 
-        with gdal.config_option(
-            "GDAL_VRT_ENABLE_PYTHON", "YES"
-        ), gdaltest.error_handler():
-            cs = ds.GetRasterBand(1).Checksum()
-        if cs != -1:
-            print(dt)
-            print(gdal.GetLastErrorMsg())
-            pytest.fail("invalid checksum")
+    with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "YES"):
+        with pytest.raises(
+            Exception, match="data type not supported for SourceTransferType"
+        ):
+            ds.GetRasterBand(1).Checksum()
 
 
 ###############################################################################
@@ -989,6 +968,7 @@ def identity(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize
 
 
 @pytest.mark.parametrize("dtype", range(1, gdal.GDT_TypeCount))
+@gdaltest.disable_exceptions()
 def test_vrt_derived_dtype(tmp_vsimem, dtype):
 
     gdaltest.importorskip_gdal_array()
@@ -1251,7 +1231,7 @@ def test_vrt_pixelfn_expression(
             "A*B + C",
             [("A", 77), ("B", 63)],
             "exprtk",
-            "Undefined symbol",
+            "(Undefined symbol|Failed to parse)",
             id="exprtk undefined variable",
         ),
         pytest.param(
@@ -1265,7 +1245,7 @@ def test_vrt_pixelfn_expression(
             "(".join(["asin", "sin", "acos", "cos"] * 100) + "(X" + 100 * 4 * ")",
             [("X", 0.5)],
             "exprtk",
-            "exceeds maximum allowed stack depth",
+            "(exceeds maximum allowed stack depth|Failed to parse)",
             id="expression is too complex",
         ),
         pytest.param(
@@ -1287,25 +1267,15 @@ def test_vrt_pixelfn_expression(
 def test_vrt_pixelfn_expression_invalid(
     tmp_vsimem, expression, sources, dialect, exception
 ):
-    gdaltest.importorskip_gdal_array()
-    pytest.importorskip("numpy")
 
     if not gdaltest.gdal_has_vrt_expression_dialect(dialect):
         pytest.skip(f"Expression dialect {dialect} is not available")
 
-    messages = []
-
-    def handle(ecls, ecode, emsg):
-        messages.append(emsg)
-
     xml = vrt_expression_xml(tmp_vsimem, expression, dialect, sources)
 
-    with gdaltest.error_handler(handle):
-        ds = gdal.Open(xml)
-        if ds:
-            assert ds.ReadAsArray() is None
-
-    assert exception in "".join(messages)
+    ds = gdal.Open(xml)
+    with pytest.raises(Exception, match=exception):
+        ds.ReadRaster()
 
 
 def test_vrt_pixelfn_expression_coordinates():

--- a/autotest/gdrivers/vrtfilt.py
+++ b/autotest/gdrivers/vrtfilt.py
@@ -207,7 +207,7 @@ def test_vrtfilt_invalid_kernel_size():
     md = {}
     md["source_0"] = filterSourceXML
 
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="Invalid value for kernel size"):
         vrt_ds.GetRasterBand(1).SetMetadata(md, "vrt_sources")
 
     filterSourceXML = """ <KernelFilteredSource>
@@ -224,7 +224,7 @@ def test_vrtfilt_invalid_kernel_size():
     md = {}
     md["source_0"] = filterSourceXML
 
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="Invalid value for kernel size"):
         vrt_ds.GetRasterBand(1).SetMetadata(md, "vrt_sources")
 
 

--- a/autotest/gdrivers/vrtmask.py
+++ b/autotest/gdrivers/vrtmask.py
@@ -226,8 +226,7 @@ def test_vrtmask_7(tmp_vsimem):
     msk_cs = ds.GetRasterBand(1).GetMaskBand().Checksum()
     ds = None
 
-    with pytest.raises(OSError):
-        os.remove(tmp_vsimem / "vrtmask_7_rgba.tif.msk")
+    assert not os.path.exists(tmp_vsimem / "vrtmask_7_rgba.tif.msk")
 
     assert alpha_cs == expected_msk_cs, "did not get expected alpha band checksum"
 
@@ -328,19 +327,22 @@ def test_vrtmask_11():
     # Cannot create mask band at raster band level when a dataset mask band already exists
     ds = gdal.Translate("", "data/byte.tif", format="VRT")
     ds.CreateMaskBand(gdal.GMF_PER_DATASET)
-    with pytest.raises(Exception):
+    with pytest.raises(
+        Exception,
+        match="Cannot create mask band at raster band level when a dataset mask band already exists",
+    ):
         ds.GetRasterBand(1).CreateMaskBand(0)
 
     # This VRT dataset has already a mask band
     ds = gdal.Translate("", "data/byte.tif", format="VRT")
     ds.CreateMaskBand(gdal.GMF_PER_DATASET)
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="VRT dataset has already a mask band"):
         ds.CreateMaskBand(gdal.GMF_PER_DATASET)
 
     # This VRT band has already a mask band
     ds = gdal.Translate("", "data/byte.tif", format="VRT")
     ds.GetRasterBand(1).CreateMaskBand(0)
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="VRT band has already a mask band"):
         ds.GetRasterBand(1).CreateMaskBand(0)
 
     ds = gdal.Translate("", "data/byte.tif", format="VRT")

--- a/autotest/gdrivers/vrtmultidim.py
+++ b/autotest/gdrivers/vrtmultidim.py
@@ -27,10 +27,6 @@ pytestmark = pytest.mark.skipif(
 
 
 ###############################################################################
-@pytest.fixture(autouse=True, scope="module")
-def module_disable_exceptions():
-    with gdaltest.disable_exceptions():
-        yield
 
 
 def test_vrtmultidim_dimension():
@@ -55,36 +51,35 @@ def test_vrtmultidim_dimension():
     assert dim_0.GetSize() == 2
     assert dim_0.GetType() == "foo"
     assert dim_0.GetDirection() == "bar"
-    with gdal.quiet_errors():
-        gdal.ErrorReset()
-        assert not dim_0.GetIndexingVariable()
-        assert gdal.GetLastErrorMsg() == "Cannot find variable X"
+    with pytest.raises(Exception, match="Cannot find variable X"):
+        dim_0.GetIndexingVariable()
+    with gdaltest.disable_exceptions(), gdal.quiet_errors():
+        assert dim_0.GetIndexingVariable() is None
+
     dim_1 = dims[1]
     assert dim_1.GetName() == "Y"
     assert dim_1.GetSize() == 1234567890123
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(Exception, match="Missing name"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group MISSING_name="/">
         </Group>
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(Exception, match="Missing name"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="INVALID">
         </Group>
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(Exception, match="Missing name attribute on Dimension"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Dimension MISSING_name="X" size="1"/>
@@ -92,10 +87,11 @@ def test_vrtmultidim_dimension():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(
+        Exception, match="Invalid value for size attribute on Dimension"
+    ):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Dimension name="X" MISSING_size="1"/>
@@ -103,7 +99,6 @@ def test_vrtmultidim_dimension():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
 
 def test_vrtmultidim_attribute():
@@ -161,8 +156,8 @@ def test_vrtmultidim_attribute():
     attrs = ar.GetAttributes()
     assert len(attrs) == 1
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(Exception, match="Missing name attribute on Attribute"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Attribute MISSING_name="foo">
@@ -173,10 +168,9 @@ def test_vrtmultidim_attribute():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(Exception, match="Unhandled content for DataType or Missing"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Attribute name="foo">
@@ -187,10 +181,10 @@ def test_vrtmultidim_attribute():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    # FIXME: This doesn't seem like the correct error message
+    with pytest.raises(Exception, match="No such file or directory"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Attribute name="foo">
@@ -201,7 +195,6 @@ def test_vrtmultidim_attribute():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
 
 def test_vrtmultidim_subgroup_and_cross_references():
@@ -275,8 +268,8 @@ def test_vrtmultidim_subgroup_and_cross_references():
     assert Y.GetDimensionCount() == 1
     assert Y.GetDimensions()[0].GetSize() == 30
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(Exception, match="Missing name attribute on Group"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Group MISSING_name="subgroup"/>
@@ -284,10 +277,9 @@ def test_vrtmultidim_subgroup_and_cross_references():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(Exception, match="Missing name attribute on Array"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Array MISSING_name="X">
@@ -297,10 +289,9 @@ def test_vrtmultidim_subgroup_and_cross_references():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(Exception, match="Unhandled content for DataType or Missing"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Array name="X">
@@ -310,10 +301,10 @@ def test_vrtmultidim_subgroup_and_cross_references():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    # FIXME: This doesn't seem like the correct error message
+    with pytest.raises(Exception, match="No such file or directory"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Array name="X">
@@ -323,10 +314,9 @@ def test_vrtmultidim_subgroup_and_cross_references():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(Exception, match="Missing ref attribute on DimensionRef"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Array name="X">
@@ -337,10 +327,9 @@ def test_vrtmultidim_subgroup_and_cross_references():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(Exception, match="Cannot find dimension INVALID in this group"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Array name="X">
@@ -351,10 +340,9 @@ def test_vrtmultidim_subgroup_and_cross_references():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(Exception, match="Cannot find dimension /INVALID"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Array name="X">
@@ -365,10 +353,9 @@ def test_vrtmultidim_subgroup_and_cross_references():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(Exception, match="Cannot find group INVALID_GROUP"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Array name="X">
@@ -379,7 +366,6 @@ def test_vrtmultidim_subgroup_and_cross_references():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
 
 def test_vrtmultidim_srs():
@@ -479,8 +465,8 @@ def test_vrtmultidim_RegularlySpacedValues():
         "d" * 2, X.Read(array_start_idx=[1], count=[2], array_step=[2])
     ) == (11.0, 32.0)
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(Exception, match="start attribute missing"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Dimension name="X" size="4"/>
@@ -493,10 +479,9 @@ def test_vrtmultidim_RegularlySpacedValues():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(Exception, match="increment attribute missing"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Dimension name="X" size="4"/>
@@ -509,7 +494,6 @@ def test_vrtmultidim_RegularlySpacedValues():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
 
 def test_vrtmultidim_ConstantValue():
@@ -550,8 +534,8 @@ def test_vrtmultidim_ConstantValue():
     ar = rg.OpenMDArray("no_dim")
     assert struct.unpack("d", ar.Read()) == (50,)
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(Exception, match="Wrong number of values in offset"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Dimension name="Y" size="4"/>
@@ -567,10 +551,9 @@ def test_vrtmultidim_ConstantValue():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(Exception, match="Wrong value in offset"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Dimension name="Y" size="4"/>
@@ -586,10 +569,9 @@ def test_vrtmultidim_ConstantValue():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(Exception, match="Wrong number of values in count"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Dimension name="Y" size="4"/>
@@ -605,10 +587,9 @@ def test_vrtmultidim_ConstantValue():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(Exception, match="Wrong value in count"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Dimension name="Y" size="4"/>
@@ -624,10 +605,9 @@ def test_vrtmultidim_ConstantValue():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(Exception, match="Wrong value in count"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Dimension name="Y" size="4"/>
@@ -643,7 +623,6 @@ def test_vrtmultidim_ConstantValue():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
 
 def test_vrtmultidim_InlineValues():
@@ -696,8 +675,8 @@ def test_vrtmultidim_InlineValues():
     ar = rg.OpenMDArray("no_dim")
     assert struct.unpack("d", ar.Read()) == (50,)
 
-    with gdal.quiet_errors():
-        ds = gdal.OpenEx(
+    with pytest.raises(Exception, match="(Invalid content|Integer overflow)"):
+        gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
             <Dimension name="Y" size="4000000"/>
@@ -713,7 +692,6 @@ def test_vrtmultidim_InlineValues():
     </VRTDataset>""",
             gdal.OF_MULTIDIM_RASTER,
         )
-        assert not ds
 
 
 def test_vrtmultidim_Source():
@@ -916,33 +894,33 @@ def test_vrtmultidim_Source():
 
         ar = rg.OpenMDArray("ar_non_existing_source")
         assert ar
-        with gdal.quiet_errors():
-            assert not ar.Read()
+        with pytest.raises(Exception, match="No such file or directory"):
+            ar.Read()
 
         ar = rg.OpenMDArray("ar_invalid_source_slab_offset")
         assert ar
-        with gdal.quiet_errors():
-            assert not ar.Read()
+        with pytest.raises(Exception, match="Invalid SourceSlab.offset"):
+            ar.Read()
 
         ar = rg.OpenMDArray("ar_invalid_number_of_dimensions")
         assert ar
-        with gdal.quiet_errors():
-            assert not ar.Read()
+        with pytest.raises(Exception, match="Inconsistent number of dimensions"):
+            ar.Read()
 
         ar = rg.OpenMDArray("ar_non_existing_array_source")
         assert ar
-        with gdal.quiet_errors():
-            assert not ar.Read()
+        with pytest.raises(Exception, match="Cannot find array"):
+            ar.Read()
 
         ar = rg.OpenMDArray("ar_view_invalid")
         assert ar
-        with gdal.quiet_errors():
-            assert not ar.Read()
+        with pytest.raises(Exception, match="out of bounds"):
+            ar.Read()
 
         ar = rg.OpenMDArray("ar_transposed_invalid")
         assert ar
-        with gdal.quiet_errors():
-            assert not ar.Read()
+        with pytest.raises(Exception, match="axis missing"):
+            ar.Read()
 
         gdal.Unlink("/vsimem/src.vrt")
 
@@ -999,8 +977,8 @@ def test_vrtmultidim_Source():
     assert ds2
     rg2 = ds2.GetRootGroup()
     ar2 = rg2.OpenMDArray("ar")
-    with gdal.quiet_errors():
-        assert not ar2.Read()
+    with pytest.raises(Exception, match="No such file or directory"):
+        ar2.Read()
 
 
 def test_vrtmultidim_Source_classic_dataset():
@@ -1046,8 +1024,8 @@ def test_vrtmultidim_Source_classic_dataset():
 
     ar_wrong_band = rg.OpenMDArray("ar_wrong_band")
     assert ar_wrong_band
-    with gdal.quiet_errors():
-        assert not ar_wrong_band.Read()
+    with pytest.raises(Exception, match="Illegal band"):
+        ar_wrong_band.Read()
 
 
 def _validate(content):
@@ -1296,18 +1274,20 @@ def test_vrtmultidim_createmultidimensional():
 
     dim = rg.CreateDimension("dim", "", "", 3)
     assert dim
-    with gdal.quiet_errors():
-        assert not rg.CreateDimension("", "", "", 1)
-        assert not rg.CreateDimension("dim", "", "", 1)
+    with pytest.raises(Exception, match="Empty dimension name"):
+        rg.CreateDimension("", "", "", 1)
+    with pytest.raises(Exception, match="dimension .* already exists"):
+        rg.CreateDimension("dim", "", "", 1)
 
     assert rg.CreateAttribute("attr", [1], gdal.ExtendedDataType.CreateString())
-    with gdal.quiet_errors():
-        assert not rg.CreateAttribute("", [1], gdal.ExtendedDataType.CreateString())
-        assert not rg.CreateAttribute(
-            "attr_2dim", [1, 2], gdal.ExtendedDataType.CreateString()
-        )
-        assert not rg.CreateAttribute("attr", [1], gdal.ExtendedDataType.CreateString())
-        assert not rg.CreateAttribute(
+    with pytest.raises(Exception, match="Empty attribute name"):
+        rg.CreateAttribute("", [1], gdal.ExtendedDataType.CreateString())
+    with pytest.raises(Exception, match="Only single dimensional attribute handled"):
+        rg.CreateAttribute("attr_2dim", [1, 2], gdal.ExtendedDataType.CreateString())
+    with pytest.raises(Exception, match="attribute .* already exists"):
+        rg.CreateAttribute("attr", [1], gdal.ExtendedDataType.CreateString())
+    with pytest.raises(Exception, match="Too large attribute"):
+        rg.CreateAttribute(
             "attr_too_big", [4000 * 1000 * 1000], gdal.ExtendedDataType.CreateString()
         )
 
@@ -1315,27 +1295,31 @@ def test_vrtmultidim_createmultidimensional():
         "ar", [dim], gdal.ExtendedDataType.Create(gdal.GDT_Float32), ["BLOCKSIZE=2"]
     )
     assert ar[0]
-    with gdal.quiet_errors():
-        assert not rg.CreateMDArray(
-            "", [dim], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
-        )
-        assert not rg.CreateMDArray(
-            "ar", [dim], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
-        )
-        assert not rg.CreateMDArray(
+    with pytest.raises(Exception, match="Empty array name not supported"):
+        rg.CreateMDArray("", [dim], gdal.ExtendedDataType.Create(gdal.GDT_Float32))
+    with pytest.raises(Exception, match="array .* already exists"):
+        rg.CreateMDArray("ar", [dim], gdal.ExtendedDataType.Create(gdal.GDT_Float32))
+    # FIXME: error message saems wrong
+    with pytest.raises(
+        Exception,
+        match="One input dimension is not a VRTDimension or a VRTDimension of this dataset",
+    ):
+        rg.CreateMDArray(
             "ar2", [dim_other], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
         )
 
     assert ar.CreateAttribute("attr", [1], gdal.ExtendedDataType.CreateString())
-    with gdal.quiet_errors():
-        assert not ar.CreateAttribute("", [1], gdal.ExtendedDataType.CreateString())
-        assert not ar.CreateAttribute("attr", [1], gdal.ExtendedDataType.CreateString())
+    with pytest.raises(Exception, match="Empty attribute name not supported"):
+        ar.CreateAttribute("", [1], gdal.ExtendedDataType.CreateString())
+    with pytest.raises(Exception, match="attribute .* already exists"):
+        ar.CreateAttribute("attr", [1], gdal.ExtendedDataType.CreateString())
 
     subg = rg.CreateGroup("subgroup")
     assert subg
-    with gdal.quiet_errors():
-        assert not rg.CreateGroup("subgroup")
-        assert not rg.CreateGroup("")
+    with pytest.raises(Exception, match="group .* already exists"):
+        rg.CreateGroup("subgroup")
+    with pytest.raises(Exception, match="Empty group name not supported"):
+        rg.CreateGroup("")
 
     ds.FlushCache()
 
@@ -1484,7 +1468,6 @@ def test_vrtmultidim_arraysource_derivedarray_getmask():
 
 
 @pytest.mark.require_driver("netCDF")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_arraysource_error_no_array_in_array_source():
 
     with pytest.raises(
@@ -1501,7 +1484,6 @@ def test_vrtmultidim_arraysource_error_no_array_in_array_source():
 
 
 @pytest.mark.require_driver("netCDF")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_arraysource_error_no_SourceFilename():
 
     with pytest.raises(
@@ -1521,7 +1503,6 @@ def test_vrtmultidim_arraysource_error_no_SourceFilename():
 
 
 @pytest.mark.require_driver("netCDF")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_arraysource_error_no_SourceArray():
 
     with pytest.raises(
@@ -1541,7 +1522,6 @@ def test_vrtmultidim_arraysource_error_no_SourceArray():
 
 
 @pytest.mark.require_driver("netCDF")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_arraysource_error_wrong_SourceFilename():
 
     with pytest.raises(Exception, match="i/do/not/exist.nc"):
@@ -1559,7 +1539,6 @@ def test_vrtmultidim_arraysource_error_wrong_SourceFilename():
 
 
 @pytest.mark.require_driver("netCDF")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_arraysource_error_wrong_SourceArray():
 
     with pytest.raises(Exception, match="Cannot find array"):
@@ -1577,7 +1556,6 @@ def test_vrtmultidim_arraysource_error_wrong_SourceArray():
 
 
 @pytest.mark.require_driver("netCDF")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_arraysource_error_not_a_2D_array():
 
     with pytest.raises(
@@ -1598,7 +1576,6 @@ def test_vrtmultidim_arraysource_error_not_a_2D_array():
 
 
 @pytest.mark.require_driver("netCDF")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_arraysource_error_no_source_array_in_DerivedArray():
 
     with pytest.raises(
@@ -1616,7 +1593,6 @@ def test_vrtmultidim_arraysource_error_no_source_array_in_DerivedArray():
 
 
 @pytest.mark.require_driver("netCDF")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_arraysource_error_unknown_step():
 
     with pytest.raises(Exception, match="Unknown <Step>.<wrong> element"):
@@ -1637,7 +1613,6 @@ def test_vrtmultidim_arraysource_error_unknown_step():
 
 
 @pytest.mark.require_driver("netCDF")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_arraysource_error_view_missing_expr():
 
     with pytest.raises(
@@ -1660,7 +1635,6 @@ def test_vrtmultidim_arraysource_error_view_missing_expr():
 
 
 @pytest.mark.require_driver("netCDF")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_arraysource_error_transpose_missing_order():
 
     with pytest.raises(
@@ -1683,7 +1657,6 @@ def test_vrtmultidim_arraysource_error_transpose_missing_order():
 
 
 @pytest.mark.require_driver("netCDF")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_arraysource_error_resample_wrong_dimension():
 
     with pytest.raises(Exception, match="Missing name attribute on Dimension"):
@@ -1708,7 +1681,6 @@ def test_vrtmultidim_arraysource_error_resample_wrong_dimension():
 
 
 @pytest.mark.require_driver("netCDF")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_arraysource_error_resample_wrong_srs():
 
     with pytest.raises(Exception, match="Invalid value for <SRS>"):
@@ -1733,7 +1705,6 @@ def test_vrtmultidim_arraysource_error_resample_wrong_srs():
 
 
 @pytest.mark.require_driver("netCDF")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_arraysource_error_resample_wrong_option():
 
     with pytest.raises(
@@ -1760,7 +1731,6 @@ def test_vrtmultidim_arraysource_error_resample_wrong_option():
 
 
 @pytest.mark.require_driver("netCDF")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_arraysource_grid_missing_gridoptions():
 
     with pytest.raises(Exception, match="Cannot find <GridOptions> in <Grid> element"):
@@ -1784,7 +1754,6 @@ def test_vrtmultidim_arraysource_grid_missing_gridoptions():
 
 
 @pytest.mark.require_driver("netCDF")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_arraysource_grid_invalid_XArray():
 
     with pytest.raises(
@@ -1813,7 +1782,6 @@ def test_vrtmultidim_arraysource_grid_invalid_XArray():
 
 
 @pytest.mark.require_driver("netCDF")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_arraysource_grid_invalid_YArray():
 
     with pytest.raises(
@@ -1842,7 +1810,6 @@ def test_vrtmultidim_arraysource_grid_invalid_YArray():
 
 
 @pytest.mark.require_driver("netCDF")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_arraysource_grid_error_wrong_option():
 
     with pytest.raises(
@@ -1870,7 +1837,6 @@ def test_vrtmultidim_arraysource_grid_error_wrong_option():
 
 
 @pytest.mark.require_driver("netCDF")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_arraysource_getmask_error_wrong_option():
 
     with pytest.raises(
@@ -1896,7 +1862,6 @@ def test_vrtmultidim_arraysource_getmask_error_wrong_option():
     </VRTDataset>""")
 
 
-@gdaltest.enable_exceptions()
 @pytest.mark.parametrize(
     "source_slab,dest_slab,view_expr,expected",
     [
@@ -1958,7 +1923,6 @@ def test_vrtmultidim_arraysource_view(
 
 
 @pytest.mark.require_driver("HDF5")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_GetRawBlockInfo_single_source(tmp_vsimem):
 
     if not gdal.GetDriverByName("HDF5").GetMetadataItem("HAVE_H5Dget_chunk_info"):
@@ -1989,7 +1953,6 @@ def test_vrtmultidim_GetRawBlockInfo_single_source(tmp_vsimem):
 
 
 @pytest.mark.require_driver("netCDF")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_GetRawBlockInfo_unblocked(tmp_vsimem):
 
     gdal.Run("mdim convert", input="data/netcdf/byte.nc", output=tmp_vsimem / "out.vrt")
@@ -2002,7 +1965,6 @@ def test_vrtmultidim_GetRawBlockInfo_unblocked(tmp_vsimem):
 
 @pytest.mark.require_driver("netCDF")
 @pytest.mark.require_driver("HDF5")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_GetRawBlockInfo_two_sources(tmp_path):
 
     if not gdal.GetDriverByName("HDF5").GetMetadataItem("HAVE_H5Dget_chunk_info"):
@@ -2040,7 +2002,6 @@ def test_vrtmultidim_GetRawBlockInfo_two_sources(tmp_path):
             assert "out_top.nc" in info.GetFilename()
 
 
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_overview_by_ref():
 
     ds = gdal.OpenEx(
@@ -2068,7 +2029,6 @@ def test_vrtmultidim_overview_by_ref():
     assert ar.GetOverview(0).GetFullName() == "/ar2"
 
 
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_overview_by_ref_wrong():
 
     ds = gdal.OpenEx(
@@ -2093,7 +2053,6 @@ def test_vrtmultidim_overview_by_ref_wrong():
         ar.GetOverview(0)
 
 
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_overview_inline():
 
     ds = gdal.OpenEx(
@@ -2147,7 +2106,6 @@ def test_vrtmultidim_overview_inline():
     assert ar_from_band.GetOverview(0).GetDimensions()[1].GetSize() == 10
 
 
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_overview_inline_wrong():
 
     with pytest.raises(Exception, match="Missing name attribute on Array"):
@@ -2167,7 +2125,6 @@ def test_vrtmultidim_overview_inline_wrong():
 
 
 @pytest.mark.require_driver("netCDF")
-@gdaltest.enable_exceptions()
 def test_vrtmultidim_ref_vrtmultidim(tmp_vsimem):
 
     # Check we don't dead lock on dataset closing

--- a/autotest/gdrivers/vrtmultidim.py
+++ b/autotest/gdrivers/vrtmultidim.py
@@ -1314,10 +1314,9 @@ def test_vrtmultidim_createmultidimensional():
         rg.CreateMDArray("", [dim], gdal.ExtendedDataType.Create(gdal.GDT_Float32))
     with pytest.raises(Exception, match="array .* already exists"):
         rg.CreateMDArray("ar", [dim], gdal.ExtendedDataType.Create(gdal.GDT_Float32))
-    # FIXME: error message saems wrong
     with pytest.raises(
         Exception,
-        match="One input dimension is not a VRTDimension or a VRTDimension of this dataset",
+        match="One input dimension is not a VRTDimension",
     ):
         rg.CreateMDArray(
             "ar2", [dim_other], gdal.ExtendedDataType.Create(gdal.GDT_Float32)

--- a/autotest/gdrivers/vrtmultidim.py
+++ b/autotest/gdrivers/vrtmultidim.py
@@ -156,8 +156,11 @@ def test_vrtmultidim_attribute():
     attrs = ar.GetAttributes()
     assert len(attrs) == 1
 
-    with pytest.raises(Exception, match="Missing name attribute on Attribute"):
-        gdal.OpenEx(
+
+@pytest.mark.parametrize(
+    "xml,error",
+    (
+        pytest.param(
             """<VRTDataset>
         <Group name="/">
             <Attribute MISSING_name="foo">
@@ -166,11 +169,10 @@ def test_vrtmultidim_attribute():
         </Attribute>
         </Group>
     </VRTDataset>""",
-            gdal.OF_MULTIDIM_RASTER,
-        )
-
-    with pytest.raises(Exception, match="Unhandled content for DataType or Missing"):
-        gdal.OpenEx(
+            "Missing name attribute on Attribute",
+            id="missing_name",
+        ),
+        pytest.param(
             """<VRTDataset>
         <Group name="/">
             <Attribute name="foo">
@@ -179,12 +181,10 @@ def test_vrtmultidim_attribute():
         </Attribute>
         </Group>
     </VRTDataset>""",
-            gdal.OF_MULTIDIM_RASTER,
-        )
-
-    # FIXME: This doesn't seem like the correct error message
-    with pytest.raises(Exception, match="No such file or directory"):
-        gdal.OpenEx(
+            "Unhandled content for DataType or Missing",
+            id="missing_datatype",
+        ),
+        pytest.param(
             """<VRTDataset>
         <Group name="/">
             <Attribute name="foo">
@@ -193,6 +193,16 @@ def test_vrtmultidim_attribute():
         </Attribute>
         </Group>
     </VRTDataset>""",
+            "Unknown DataType",
+            id="invalid_datatype",
+        ),
+    ),
+)
+def test_vrtmultidim_attribute_invalid(xml, error):
+
+    with pytest.raises(Exception, match=error):
+        gdal.OpenEx(
+            xml,
             gdal.OF_MULTIDIM_RASTER,
         )
 
@@ -268,18 +278,20 @@ def test_vrtmultidim_subgroup_and_cross_references():
     assert Y.GetDimensionCount() == 1
     assert Y.GetDimensions()[0].GetSize() == 30
 
-    with pytest.raises(Exception, match="Missing name attribute on Group"):
-        gdal.OpenEx(
+
+@pytest.mark.parametrize(
+    "xml,error",
+    (
+        pytest.param(
             """<VRTDataset>
         <Group name="/">
             <Group MISSING_name="subgroup"/>
         </Group>
     </VRTDataset>""",
-            gdal.OF_MULTIDIM_RASTER,
-        )
-
-    with pytest.raises(Exception, match="Missing name attribute on Array"):
-        gdal.OpenEx(
+            "Missing name attribute on Group",
+            id="missing_group_name",
+        ),
+        pytest.param(
             """<VRTDataset>
         <Group name="/">
             <Array MISSING_name="X">
@@ -287,11 +299,10 @@ def test_vrtmultidim_subgroup_and_cross_references():
             </Array>
         </Group>
     </VRTDataset>""",
-            gdal.OF_MULTIDIM_RASTER,
-        )
-
-    with pytest.raises(Exception, match="Unhandled content for DataType or Missing"):
-        gdal.OpenEx(
+            "Missing name attribute on Array",
+            id="missing_array_name",
+        ),
+        pytest.param(
             """<VRTDataset>
         <Group name="/">
             <Array name="X">
@@ -299,12 +310,10 @@ def test_vrtmultidim_subgroup_and_cross_references():
             </Array>
         </Group>
     </VRTDataset>""",
-            gdal.OF_MULTIDIM_RASTER,
-        )
-
-    # FIXME: This doesn't seem like the correct error message
-    with pytest.raises(Exception, match="No such file or directory"):
-        gdal.OpenEx(
+            "Unhandled content for DataType or Missing",
+            id="missing_array_datatype",
+        ),
+        pytest.param(
             """<VRTDataset>
         <Group name="/">
             <Array name="X">
@@ -312,11 +321,10 @@ def test_vrtmultidim_subgroup_and_cross_references():
             </Array>
         </Group>
     </VRTDataset>""",
-            gdal.OF_MULTIDIM_RASTER,
-        )
-
-    with pytest.raises(Exception, match="Missing ref attribute on DimensionRef"):
-        gdal.OpenEx(
+            "Unknown DataType",
+            id="invalid_array_datatype",
+        ),
+        pytest.param(
             """<VRTDataset>
         <Group name="/">
             <Array name="X">
@@ -325,11 +333,10 @@ def test_vrtmultidim_subgroup_and_cross_references():
             </Array>
         </Group>
     </VRTDataset>""",
-            gdal.OF_MULTIDIM_RASTER,
-        )
-
-    with pytest.raises(Exception, match="Cannot find dimension INVALID in this group"):
-        gdal.OpenEx(
+            "Missing ref attribute on DimensionRef",
+            id="missing_dimensionref_ref",
+        ),
+        pytest.param(
             """<VRTDataset>
         <Group name="/">
             <Array name="X">
@@ -338,11 +345,10 @@ def test_vrtmultidim_subgroup_and_cross_references():
             </Array>
         </Group>
     </VRTDataset>""",
-            gdal.OF_MULTIDIM_RASTER,
-        )
-
-    with pytest.raises(Exception, match="Cannot find dimension /INVALID"):
-        gdal.OpenEx(
+            "Cannot find dimension INVALID in this group",
+            id="invalid_dimensionref_ref",
+        ),
+        pytest.param(
             """<VRTDataset>
         <Group name="/">
             <Array name="X">
@@ -351,11 +357,10 @@ def test_vrtmultidim_subgroup_and_cross_references():
             </Array>
         </Group>
     </VRTDataset>""",
-            gdal.OF_MULTIDIM_RASTER,
-        )
-
-    with pytest.raises(Exception, match="Cannot find group INVALID_GROUP"):
-        gdal.OpenEx(
+            "Cannot find dimension /INVALID",
+            id="invalid_dimensionref_ref_2",
+        ),
+        pytest.param(
             """<VRTDataset>
         <Group name="/">
             <Array name="X">
@@ -364,6 +369,16 @@ def test_vrtmultidim_subgroup_and_cross_references():
             </Array>
         </Group>
     </VRTDataset>""",
+            "Cannot find group INVALID_GROUP",
+            id="invalid_dimensionref_ref_3",
+        ),
+    ),
+)
+def test_vrtmultidim_missing_or_invalid_attributes(xml, error):
+
+    with pytest.raises(Exception, match=error):
+        gdal.OpenEx(
+            xml,
             gdal.OF_MULTIDIM_RASTER,
         )
 

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -38,14 +38,6 @@ import pytest
 
 from osgeo import gdal, ogr, osr
 
-
-###############################################################################
-@pytest.fixture(autouse=True, scope="module")
-def module_disable_exceptions():
-    with gdaltest.disable_exceptions():
-        yield
-
-
 ###############################################################################
 # Create table from data/poly.shp
 
@@ -572,20 +564,18 @@ def test_ogr_shape_21(f):
     ds = ogr.Open(f)
     lyr = ds.GetLayer(0)
     lyr.ResetReading()
-    with gdal.quiet_errors():
-        feat = lyr.GetNextFeature()
 
-    assert feat.GetGeometryRef() is None
+    with pytest.raises(Exception, match="Corrupted .shp"):
+        lyr.GetNextFeature()
 
     # Test fix for #3665
     lyr.ResetReading()
     minx, maxx, miny, maxy = lyr.GetExtent()
-    with ogrtest.spatial_filter(
-        lyr, minx + 1e-9, miny + 1e-9, maxx - 1e-9, maxy - 1e-9
-    ), gdaltest.error_handler():
-        feat = lyr.GetNextFeature()
-
-    assert feat is None or feat.GetGeometryRef() is None
+    with pytest.raises(Exception, match="Corrupted .shp"):
+        with ogrtest.spatial_filter(
+            lyr, minx + 1e-9, miny + 1e-9, maxx - 1e-9, maxy - 1e-9
+        ):
+            lyr.GetNextFeature()
 
 
 ###############################################################################
@@ -665,7 +655,7 @@ def ogr_shape_23_write_valid_and_invalid(
     # Write an invalid geometry for this layer type
     dst_feat = ogr.Feature(feature_def=shape_lyr.GetLayerDefn())
     dst_feat.SetGeometryDirectly(ogr.CreateGeometryFromWkt(invalid_wkt))
-    with gdal.quiet_errors():
+    with pytest.raises(Exception, match="Attempt to write non-.* to .* shapefile"):
         shape_lyr.CreateFeature(dst_feat)
 
     #######################################################
@@ -816,7 +806,9 @@ def test_ogr_shape_23a(tmp_path):
     geom = ogr.CreateGeometryFromWkt("GEOMETRYCOLLECTION(POINT (0 0))")
     dst_feat = ogr.Feature(feature_def=shape_lyr.GetLayerDefn())
     dst_feat.SetGeometry(geom)
-    with gdal.quiet_errors():
+    with pytest.raises(
+        Exception, match="Attempt to write non-polygon .* to POLYGON type shapefile"
+    ):
         shape_lyr.CreateFeature(dst_feat)
 
     # This geometry will be dealt as a multipolygon
@@ -1064,6 +1056,7 @@ def test_ogr_shape_27():
 # Test reading a 3 GB .DBF (#3011)
 
 
+@gdaltest.disable_exceptions()
 def test_ogr_shape_28(tmp_path):
 
     # Determine if the filesystem supports sparse files (we don't want to create a real 3 GB
@@ -1550,10 +1543,8 @@ def test_ogr_shape_38(tmp_vsimem):
     assert gdal.VSIStatL(tmp_vsimem / "test35.shp") is not None
 
     with ogr.Open(tmp_vsimem, update=1) as ds:
-        with gdal.quiet_errors():
-            lyr = ds.CreateLayer("test35")
-
-        assert lyr is None, "should not have created a new layer"
+        with pytest.raises(Exception, match="Layer .* already exists"):
+            ds.CreateLayer("test35")
 
 
 ###############################################################################
@@ -2114,33 +2105,23 @@ def test_ogr_shape_53(tmp_vsimem):
     lyr.CreateField(fd)
 
     # GetFeature() on a invalid FID
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        feat = lyr.GetFeature(-1)
-    assert feat is None and gdal.GetLastErrorMsg() != ""
+    with pytest.raises(Exception, match="feature id .* out of available range"):
+        lyr.GetFeature(-1)
 
     # SetFeature() on a invalid FID
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        feat = ogr.Feature(lyr.GetLayerDefn())
-        ret = lyr.SetFeature(feat)
-        feat = None
-    assert ret != 0
+    feat = ogr.Feature(lyr.GetLayerDefn())
+    with pytest.raises(Exception, match="Non existing feature"):
+        lyr.SetFeature(feat)
 
     # SetFeature() on a invalid FID
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        feat = ogr.Feature(lyr.GetLayerDefn())
-        feat.SetFID(1000)
-        ret = lyr.SetFeature(feat)
-        feat = None
-    assert ret != 0
+    feat = ogr.Feature(lyr.GetLayerDefn())
+    feat.SetFID(1000)
+    with pytest.raises(Exception, match="Non existing feature"):
+        lyr.SetFeature(feat)
 
     # DeleteFeature() on a invalid FID
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        ret = lyr.DeleteFeature(-1)
-    assert ret != 0
+    with pytest.raises(Exception, match="Non existing feature"):
+        lyr.DeleteFeature(-1)
 
     feat = ogr.Feature(lyr.GetLayerDefn())
     lyr.CreateFeature(feat)
@@ -2151,41 +2132,30 @@ def test_ogr_shape_53(tmp_vsimem):
 
     # Try deleting an already deleted feature
     gdal.ErrorReset()
-    with gdal.quiet_errors():
-        ret = lyr.DeleteFeature(0)
-    assert ret != 0
+    with pytest.raises(Exception, match="Non existing feature"):
+        lyr.DeleteFeature(0)
 
     # Test DeleteField() on a invalid index
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        ret = lyr.DeleteField(-1)
-    assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
+    with pytest.raises(Exception, match="Invalid field index"):
+        lyr.DeleteField(-1)
 
     # Test ReorderFields() with invalid permutation
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        ret = lyr.ReorderFields([1])
-    assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
+    with pytest.raises(Exception, match="Bad value for element 0"):
+        lyr.ReorderFields([1])
 
     # Test AlterFieldDefn() on a invalid index
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        fd = ogr.FieldDefn("foo2", ogr.OFTString)
-        ret = lyr.AlterFieldDefn(-1, fd, 0)
-    assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
+    fd = ogr.FieldDefn("foo2", ogr.OFTString)
+    with pytest.raises(Exception, match="Invalid field index"):
+        lyr.AlterFieldDefn(-1, fd, 0)
 
     # Test AlterFieldDefn() when attempting to convert from OFTString to something else
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        fd = ogr.FieldDefn("foo", ogr.OFTInteger)
-        ret = lyr.AlterFieldDefn(0, fd, ogr.ALTER_TYPE_FLAG)
-    assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
+    fd = ogr.FieldDefn("foo", ogr.OFTInteger)
+    with pytest.raises(Exception, match="Can only convert to OFTString"):
+        lyr.AlterFieldDefn(0, fd, ogr.ALTER_TYPE_FLAG)
 
     # Test DROP SPATIAL INDEX ON layer without index
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        ret = ds.ExecuteSQL("DROP SPATIAL INDEX ON ogr_shape_53")
-    assert gdal.GetLastErrorMsg() != ""
+    with gdaltest.error_raised(gdal.CE_Warning, "has no spatial index"):
+        ds.ExecuteSQL("DROP SPATIAL INDEX ON ogr_shape_53")
 
     # Re-create a feature
     feat = ogr.Feature(lyr.GetLayerDefn())
@@ -2209,63 +2179,61 @@ def test_ogr_shape_53(tmp_vsimem):
     # Test CreateField()
     fd = ogr.FieldDefn("bar", ogr.OFTString)
 
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        ret = lyr.CreateField(fd)
-    assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
+    with pytest.raises(
+        Exception, match="unsupported operation on a read-only datasource"
+    ):
+        lyr.CreateField(fd)
 
     # Test ReorderFields()
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        ret = lyr.ReorderFields([0])
-    assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
+    with pytest.raises(
+        Exception, match="unsupported operation on a read-only datasource"
+    ):
+        lyr.ReorderFields([0])
 
     # Test DeleteField()
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        ret = lyr.DeleteField(0)
-    assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
+    with pytest.raises(
+        Exception, match="unsupported operation on a read-only datasource"
+    ):
+        lyr.DeleteField(0)
 
     # Test AlterFieldDefn()
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        fd = ogr.FieldDefn("foo2", ogr.OFTString)
-        ret = lyr.AlterFieldDefn(0, fd, 0)
-    assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
+    fd = ogr.FieldDefn("foo2", ogr.OFTString)
+    with pytest.raises(
+        Exception, match="unsupported operation on a read-only datasource"
+    ):
+        lyr.AlterFieldDefn(0, fd, 0)
 
     # Test CreateFeature()
     feat = ogr.Feature(lyr.GetLayerDefn())
 
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        ret = lyr.CreateFeature(feat)
-    assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
+    with pytest.raises(
+        Exception, match="unsupported operation on a read-only datasource"
+    ):
+        lyr.CreateFeature(feat)
 
     # Test DeleteFeature()
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        ret = lyr.DeleteFeature(0)
-    assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
+    with pytest.raises(
+        Exception, match="unsupported operation on a read-only datasource"
+    ):
+        lyr.DeleteFeature(0)
 
     # Test SetFeature()
     feat = lyr.GetNextFeature()
 
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        ret = lyr.SetFeature(feat)
-    assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
+    with pytest.raises(
+        Exception, match="unsupported operation on a read-only datasource"
+    ):
+        lyr.SetFeature(feat)
 
     # Test REPACK
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        ret = ds.ExecuteSQL("REPACK ogr_shape_53")
-    assert gdal.GetLastErrorMsg() != ""
+    with pytest.raises(Exception, match="REPACK .* failed"):
+        ds.ExecuteSQL("REPACK ogr_shape_53")
 
     # Test RECOMPUTE EXTENT ON
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        ret = ds.ExecuteSQL("RECOMPUTE EXTENT ON ogr_shape_53")
-    assert gdal.GetLastErrorMsg() != ""
+    with pytest.raises(
+        Exception, match="unsupported operation on a read-only datasource"
+    ):
+        ds.ExecuteSQL("RECOMPUTE EXTENT ON ogr_shape_53")
 
     feat = None
     lyr = None
@@ -2276,19 +2244,19 @@ def test_ogr_shape_53(tmp_vsimem):
     ds = ogr.Open(tmp_vsimem / "ogr_shape_53.shp", update=1)
     lyr = ds.GetLayer(0)
 
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        ret = lyr.DeleteFeature(0)
-    assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
+    with pytest.raises(Exception, match="Attempt to delete .* no .dbf file"):
+        lyr.DeleteFeature(0)
 
     # Test REPACK
     ds.ExecuteSQL("REPACK ogr_shape_53")
 
-    lyr = None
-    ds = None
+
+def test_ogr_shape_dbf_only_extent(tmp_vsimem):
+
+    gdal.CopyFile("data/idlink.dbf", tmp_vsimem / "idlink.dbf")
 
     # Tests on a DBF only
-    ds = ogr.Open("data/idlink.dbf")
+    ds = ogr.Open(tmp_vsimem / "idlink.dbf", update=True)
     lyr = ds.GetLayer(0)
 
     # Test GetExtent()
@@ -2296,13 +2264,10 @@ def test_ogr_shape_53(tmp_vsimem):
     lyr.GetExtent()
 
     # Test RECOMPUTE EXTENT ON
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        ret = ds.ExecuteSQL("RECOMPUTE EXTENT ON ogr_shape_53")
-    assert gdal.GetLastErrorMsg() != ""
-
-    lyr = None
-    ds = None
+    with pytest.raises(
+        Exception, match="operation is not permitted on a layer without .SHP"
+    ):
+        ds.ExecuteSQL("RECOMPUTE EXTENT ON idlink")
 
 
 ###############################################################################
@@ -2413,15 +2378,8 @@ def test_ogr_shape_54(tmp_vsimem):
     # Test corner case where we cannot reopen a closed layer
     ideletedlayer = 0
     gdal.Unlink(ds_name / ("layer%03d.shp" % ideletedlayer))
-    with gdal.quiet_errors():
-        lyr = ds.GetLayerByName("layer%03d" % ideletedlayer)
-    if lyr is not None:
-        gdal.ErrorReset()
-        with gdal.quiet_errors():
-            lyr.ResetReading()
-            lyr.GetNextFeature()
-        assert gdal.GetLastErrorMsg() != ""
-    gdal.ErrorReset()
+    with pytest.raises(Exception, match="Failed to open file"):
+        ds.GetLayerByName("layer%03d" % ideletedlayer)
 
     ideletedlayer = 1
     gdal.Unlink(ds_name / ("layer%03d.dbf" % ideletedlayer))
@@ -2442,30 +2400,33 @@ def test_ogr_shape_54(tmp_vsimem):
 # Test that we cannot add more fields that the maximum allowed
 
 
-def test_ogr_shape_55(tmp_vsimem):
+@pytest.mark.parametrize(
+    "max_field_count,field_type,error",
+    (
+        (int((65535 - 33) / 32), ogr.OFTInteger, "Header length limit reached"),  # 2046
+        (int(65535 / 80), ogr.OFTString, "Record length limit reached"),  # 819
+    ),
+)
+def test_ogr_shape_55(tmp_vsimem, max_field_count, field_type, error):
     shape_drv = ogr.GetDriverByName("ESRI Shapefile")
     ds_name = tmp_vsimem / "ogr_shape_55"
     ds = shape_drv.CreateDataSource(ds_name)
     lyr = ds.CreateLayer("ogr_shape_55")
 
-    max_field_count = int((65535 - 33) / 32)  # 2046
-
     for i in range(max_field_count):
         if i == 255:
-            gdal.ErrorReset()
-            gdal.PushErrorHandler("CPLQuietErrorHandler")
-        ret = lyr.CreateField(ogr.FieldDefn("foo%d" % i, ogr.OFTInteger))
-        if i == 255:
-            gdal.PopErrorHandler()
-            assert (
-                gdal.GetLastErrorMsg() != ""
-            ), "expecting a warning for 256th field added"
-        assert ret == 0, "failed creating field foo%d" % i
+            expected = (gdal.CE_Warning, "Creating a 256th field")
+        else:
+            expected = (gdal.CE_None,)
+
+        with gdaltest.error_raised(*expected):
+            ret = lyr.CreateField(ogr.FieldDefn("foo%d" % i, field_type))
+            assert ret == 0
 
     i = max_field_count
-    with gdal.quiet_errors():
-        ret = lyr.CreateField(ogr.FieldDefn("foo%d" % i, ogr.OFTInteger))
-    assert ret != 0, "should have failed creating field foo%d" % i
+    with pytest.raises(Exception, match=error):
+        ret = lyr.CreateField(ogr.FieldDefn("foo%d" % i, field_type))
+        assert ret != 0, "should have failed creating field foo%d" % i
 
     feat = ogr.Feature(lyr.GetLayerDefn())
     for i in range(max_field_count):
@@ -2476,50 +2437,6 @@ def test_ogr_shape_55(tmp_vsimem):
     for i in range(max_field_count):
         feat.SetField(i, i)
     lyr.CreateFeature(feat)
-
-    ds = None
-
-
-###############################################################################
-# Test that we cannot add more fields that the maximum allowed record length
-
-
-def test_ogr_shape_56(tmp_vsimem):
-    shape_drv = ogr.GetDriverByName("ESRI Shapefile")
-    ds_name = tmp_vsimem / "ogr_shape_56"
-    ds = shape_drv.CreateDataSource(ds_name)
-    lyr = ds.CreateLayer("ogr_shape_56")
-
-    max_field_count = int(65535 / 80)  # 819
-
-    for i in range(max_field_count):
-        if i == 255:
-            gdal.ErrorReset()
-            gdal.PushErrorHandler("CPLQuietErrorHandler")
-        ret = lyr.CreateField(ogr.FieldDefn("foo%d" % i, ogr.OFTString))
-        if i == 255:
-            gdal.PopErrorHandler()
-            assert (
-                gdal.GetLastErrorMsg() != ""
-            ), "expecting a warning for 256th field added"
-        assert ret == 0, "failed creating field foo%d" % i
-
-    i = max_field_count
-    with gdal.quiet_errors():
-        ret = lyr.CreateField(ogr.FieldDefn("foo%d" % i, ogr.OFTString))
-    assert ret != 0, "should have failed creating field foo%d" % i
-
-    feat = ogr.Feature(lyr.GetLayerDefn())
-    for i in range(max_field_count):
-        feat.SetField(i, "foo%d" % i)
-    lyr.CreateFeature(feat)
-
-    feat = ogr.Feature(lyr.GetLayerDefn())
-    for i in range(max_field_count):
-        feat.SetField(i, "foo%d" % i)
-    lyr.CreateFeature(feat)
-
-    ds = None
 
 
 ###############################################################################
@@ -2812,17 +2729,13 @@ def test_ogr_shape_63(tmp_vsimem):
     chinese_str = struct.pack("B" * 6, 229, 144, 141, 231, 167, 176)
     chinese_str = chinese_str.decode("UTF-8")
 
-    with gdal.quiet_errors():
-        ret = lyr.AlterFieldDefn(
+    with pytest.raises(Exception, match="cannot convert to ISO-8859-1"):
+        lyr.AlterFieldDefn(
             0, ogr.FieldDefn(chinese_str, ogr.OFTString), ogr.ALTER_NAME_FLAG
         )
 
-    assert ret != 0
-
-    with gdal.quiet_errors():
-        ret = lyr.CreateField(ogr.FieldDefn(chinese_str, ogr.OFTString))
-
-    assert ret != 0
+    with pytest.raises(Exception, match="cannot convert to ISO-8859-1"):
+        lyr.CreateField(ogr.FieldDefn(chinese_str, ogr.OFTString))
 
     ds = None
 
@@ -2867,9 +2780,8 @@ def test_ogr_shape_64(tmp_vsimem):
     assert lyr.GetName() == "a.c"
 
     # Test that we cannot create a duplicate layer
-    with gdal.quiet_errors():
-        lyr = ds.CreateLayer("a.b")
-    assert lyr is None
+    with pytest.raises(Exception, match="Layer .* already exists"):
+        ds.CreateLayer("a.b")
 
     ds = None
 
@@ -2911,26 +2823,22 @@ def test_ogr_shape_65():
 def test_ogr_shape_66(tmp_path):
 
     ds = ogr.GetDriverByName("ESRI Shapefile").CreateDataSource("/i_dont_exist/bar.dbf")
-    with gdal.quiet_errors():
-        lyr = ds.CreateLayer("bar", geom_type=ogr.wkbNone)
-    assert lyr is None
+    with pytest.raises(Exception, match="Failed to create Shape DBF file"):
+        ds.CreateLayer("bar", geom_type=ogr.wkbNone)
     ds = None
 
     ds = ogr.GetDriverByName("ESRI Shapefile").CreateDataSource("/i_dont_exist/bar.shp")
-    with gdal.quiet_errors():
-        lyr = ds.CreateLayer("bar", geom_type=ogr.wkbPoint)
-    assert lyr is None
+    with pytest.raises(Exception, match="Failed to create file"):
+        ds.CreateLayer("bar", geom_type=ogr.wkbPoint)
     ds = None
 
-    with gdal.quiet_errors():
-        ds = ogr.GetDriverByName("ESRI Shapefile").CreateDataSource("/i_dont_exist/bar")
-    assert ds is None
+    with pytest.raises(Exception, match="Failed to create directory"):
+        ogr.GetDriverByName("ESRI Shapefile").CreateDataSource("/i_dont_exist/bar")
 
     f = open(tmp_path / "foo", "wb")
     f.close()
-    with gdal.quiet_errors():
-        ds = ogr.GetDriverByName("ESRI Shapefile").CreateDataSource(tmp_path / "foo")
-    assert ds is None
+    with pytest.raises(Exception, match="foo is not a directory"):
+        ogr.GetDriverByName("ESRI Shapefile").CreateDataSource(tmp_path / "foo")
 
 
 ###############################################################################
@@ -3006,9 +2914,10 @@ def test_ogr_shape_68(tmp_path):
             assert lyr.GetGeomType() == ogr.wkbNone
             lyr = ds.GetLayerByName("mixedcase")
             assert lyr.GetGeomType() == ogr.wkbMultiPolygon
-            with gdal.quiet_errors():
-                ret = lyr.DeleteFeature(0)
-            assert ret != 0, "expected failure on DeleteFeature()"
+            with pytest.raises(
+                Exception, match="Attempt to delete shape in shapefile with no .dbf"
+            ):
+                lyr.DeleteFeature(0)
 
             ds.ExecuteSQL("REPACK mixedcase")
 
@@ -3086,15 +2995,12 @@ def test_ogr_shape_70(tmp_path):
     # Locks the file. No way to do this on Unix easily
     f = open(tmp_path / "ogr_shape_70.dbf", "r+")
 
-    gdal.ErrorReset()
-    with gdal.quiet_errors(), gdal.config_option("OGR_SHAPE_PACK_IN_PLACE", "NO"):
+    with pytest.raises(Exception, match="REPACK .* failed"), gdal.config_option(
+        "OGR_SHAPE_PACK_IN_PLACE", "NO"
+    ):
         ds.ExecuteSQL("REPACK ogr_shape_70")
-    errmsg = gdal.GetLastErrorMsg()
-    ds = None
 
     f.close()
-
-    assert errmsg != ""
 
 
 ###############################################################################
@@ -3114,17 +3020,13 @@ def test_ogr_shape_71(tmp_path):
     shutil.copy("data/poly.dbf", tmp_path / "ogr_shape_71.dbf")
     old_mode = os.stat(tmp_path / "ogr_shape_71.dbf").st_mode
     os.chmod(tmp_path / "ogr_shape_71.dbf", stat.S_IREAD)
-    with gdal.quiet_errors():
-        ds = ogr.Open(tmp_path / "ogr_shape_71.shp", update=1)
-    ok = ds is None
-    ds = None
+    with pytest.raises(Exception, match="cannot be opened in update mode"):
+        ogr.Open(tmp_path / "ogr_shape_71.shp", update=1)
     os.chmod(tmp_path / "ogr_shape_71.dbf", old_mode)
 
     ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
         tmp_path / "ogr_shape_71.shp"
     )
-
-    assert ok
 
 
 ###############################################################################
@@ -3157,9 +3059,8 @@ def test_ogr_shape_72(tmp_path):
     lyr = ds.GetLayer(0)
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetGeometry(ogr.CreateGeometryFromWkt("POINT (3 4)"))
-    with gdal.quiet_errors():
-        ret = lyr.CreateFeature(feat)
-    assert ret != 0
+    with pytest.raises(Exception, match="maximum file size .* has been reached"):
+        lyr.CreateFeature(feat)
     ds = None
 
     f = open(tmp_path / "ogr_shape_72.shp", "rb+")
@@ -3174,9 +3075,8 @@ def test_ogr_shape_72(tmp_path):
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetGeometry(ogr.CreateGeometryFromWkt("POINT (5 6)"))
     gdal.ErrorReset()
-    with gdal.quiet_errors():
-        ret = lyr.CreateFeature(feat)
-    assert ret != 0
+    with pytest.raises(Exception, match="Error .* writing object .* to .shp"):
+        lyr.CreateFeature(feat)
     ds = None
 
     # Test creating a feature over 2 GB file limit -> should succeed with warning
@@ -3869,9 +3769,8 @@ def test_ogr_shape_89(tmp_vsimem):
 
     ds = ogr.Open(tmp_vsimem / "ogr_shape_89.shp")
     lyr = ds.GetLayer(0)
-    with gdal.quiet_errors():
-        f = lyr.GetNextFeature()
-    assert f is None or f.GetGeometryRef() is None
+    with pytest.raises(Exception, match="Error .* reading object"):
+        lyr.GetNextFeature()
     ds = None
 
     f = gdal.VSIFOpenL(tmp_vsimem / "ogr_shape_89.shp", "rb+")
@@ -4358,9 +4257,9 @@ def test_ogr_shape_100(tmp_path, variant):
     assert f["foo"] == "2"
     assert f.GetGeometryRef().ExportToWkt() == "LINESTRING (1 1,2 2,3 3)"
 
-    with gdal.quiet_errors():
-        f = lyr.GetFeature(1)
-    assert f is None, variant
+    with pytest.raises(Exception, match="feature id .* out of available range"):
+        lyr.GetFeature(1)
+
     lyr.ResetReading()
     assert lyr.GetFeatureCount() == 1, variant
     f = lyr.GetNextFeature()
@@ -5017,9 +4916,8 @@ def test_ogr_shape_110_write_invalid_multipatch(tmp_vsimem):
     # Create a shape
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometry(ogr.CreateGeometryFromWkt("GEOMETRYCOLLECTION(POINT(0 0))"))
-    lyr.CreateFeature(f)
-
-    ds = None
+    with pytest.raises(Exception, match="Unsupported geometry type"):
+        lyr.CreateFeature(f)
 
 
 ###############################################################################
@@ -5105,14 +5003,15 @@ def test_ogr_shape_112_delete_layer(tmp_vsimem):
     ds = None
 
     ds = ogr.Open(dirname)
-    with gdal.quiet_errors():
-        assert ds.DeleteLayer(0) != 0
+    with pytest.raises(Exception, match="opened read-only"):
+        ds.DeleteLayer(0)
     ds = None
 
     ds = ogr.Open(dirname, update=1)
-    with gdal.quiet_errors():
-        assert ds.DeleteLayer(-1) != 0
-        assert ds.DeleteLayer(1) != 0
+    with pytest.raises(Exception, match="not in legal range"):
+        ds.DeleteLayer(-1)
+    with pytest.raises(Exception, match="not in legal range"):
+        ds.DeleteLayer(1)
     gdal.FileFromMemBuffer(dirname / "test.cpg", "foo")
     assert ds.DeleteLayer(0) == 0
     assert not gdal.VSIStatL(dirname / "test.shp")
@@ -5189,11 +5088,11 @@ def test_ogr_shape_114_shz(tmp_path):
     lyr = ds.GetLayer(0)
     assert lyr.GetFeatureCount() == 10
     assert ds.TestCapability(ogr.ODsCCreateLayer) == 0
-    with gdal.quiet_errors():
-        assert not ds.CreateLayer("foo")
+    with pytest.raises(Exception, match="shz only supports one single layer"):
+        ds.CreateLayer("foo")
     assert ds.TestCapability(ogr.ODsCDeleteLayer) == 0
-    with gdal.quiet_errors():
-        assert ds.DeleteLayer(0) == ogr.OGRERR_FAILURE
+    with pytest.raises(Exception, match="shz does not support layer deletion"):
+        ds.DeleteLayer(0)
     assert lyr.DeleteFeature(1) == 0
     ds = None
 
@@ -5301,8 +5200,8 @@ def test_ogr_shape_115_shp_zip(tmp_path):
     # Check lock file
     ds2 = ogr.Open(filename, update=1)
     lyr2 = ds2.GetLayer(0)
-    with gdal.quiet_errors():
-        assert lyr2.DeleteFeature(2) != 0
+    with pytest.raises(Exception, match="Another task is editing"):
+        lyr2.DeleteFeature(2)
     ds2 = None
     ds = None
 
@@ -5419,9 +5318,8 @@ def test_ogr_shape_write_point_z_non_finite(tmp_vsimem):
     g.AddPoint(0, 0, float("inf"))
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometry(g)
-    with gdal.quiet_errors():
-        assert lyr.CreateFeature(f) != ogr.OGRERR_NONE
-    ds = None
+    with pytest.raises(Exception, match="non-finite values"):
+        lyr.CreateFeature(f)
 
 
 ###############################################################################
@@ -5437,9 +5335,8 @@ def test_ogr_shape_write_linestring_z_non_finite(tmp_vsimem):
     g.AddPoint(0, 1, float("inf"))
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometry(g)
-    with gdal.quiet_errors():
-        assert lyr.CreateFeature(f) != ogr.OGRERR_NONE
-    ds = None
+    with pytest.raises(Exception, match="non-finite values"):
+        lyr.CreateFeature(f)
 
 
 ###############################################################################
@@ -5457,9 +5354,8 @@ def test_ogr_shape_write_multilinestring_z_non_finite(tmp_vsimem):
     g.AddGeometry(ls)
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometry(g)
-    with gdal.quiet_errors():
-        assert lyr.CreateFeature(f) != ogr.OGRERR_NONE
-    ds = None
+    with pytest.raises(Exception, match="non-finite values"):
+        lyr.CreateFeature(f)
 
 
 ###############################################################################
@@ -5479,9 +5375,8 @@ def test_ogr_shape_write_polygon_z_non_finite(tmp_vsimem):
     g.AddGeometry(ls)
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometry(g)
-    with gdal.quiet_errors():
-        assert lyr.CreateFeature(f) != ogr.OGRERR_NONE
-    ds = None
+    with pytest.raises(Exception, match="non-finite values"):
+        lyr.CreateFeature(f)
 
 
 ###############################################################################
@@ -5503,9 +5398,8 @@ def test_ogr_shape_write_multipolygon_z_non_finite(tmp_vsimem):
     g.AddGeometry(p)
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometry(g)
-    with gdal.quiet_errors():
-        assert lyr.CreateFeature(f) != ogr.OGRERR_NONE
-    ds = None
+    with pytest.raises(Exception, match="non-finite values"):
+        lyr.CreateFeature(f)
 
 
 ###############################################################################
@@ -5709,22 +5603,18 @@ def test_ogr_shape_alter_geom_field_defn(tmp_vsimem):
 
     # Wrong index
     new_geom_field_defn = ogr.GeomFieldDefn("", ogr.wkbPoint)
-    with gdal.quiet_errors():
-        assert (
-            lyr.AlterGeomFieldDefn(
-                -1, new_geom_field_defn, ogr.ALTER_GEOM_FIELD_DEFN_ALL_FLAG
-            )
-            != ogr.OGRERR_NONE
+    with pytest.raises(Exception, match="Invalid field index"):
+        lyr.AlterGeomFieldDefn(
+            -1, new_geom_field_defn, ogr.ALTER_GEOM_FIELD_DEFN_ALL_FLAG
         )
 
     # Changing geometry type ==> unsupported
     new_geom_field_defn = ogr.GeomFieldDefn("", ogr.wkbLineString)
-    with gdal.quiet_errors():
-        assert (
-            lyr.AlterGeomFieldDefn(
-                0, new_geom_field_defn, ogr.ALTER_GEOM_FIELD_DEFN_ALL_FLAG
-            )
-            != ogr.OGRERR_NONE
+    with pytest.raises(
+        Exception, match="Altering the geometry field type is not supported"
+    ):
+        lyr.AlterGeomFieldDefn(
+            0, new_geom_field_defn, ogr.ALTER_GEOM_FIELD_DEFN_ALL_FLAG
         )
 
     # Setting coordinate epoch ==> unsupported
@@ -5733,15 +5623,10 @@ def test_ogr_shape_alter_geom_field_defn(tmp_vsimem):
     srs_with_epoch.ImportFromEPSG(4326)
     srs_with_epoch.SetCoordinateEpoch(2022)
     new_geom_field_defn.SetSpatialRef(srs_with_epoch)
-    with gdal.quiet_errors():
-        assert (
-            lyr.AlterGeomFieldDefn(
-                0, new_geom_field_defn, ogr.ALTER_GEOM_FIELD_DEFN_ALL_FLAG
-            )
-            != ogr.OGRERR_NONE
+    with pytest.raises(Exception, match="Setting a coordinate epoch is not supported"):
+        lyr.AlterGeomFieldDefn(
+            0, new_geom_field_defn, ogr.ALTER_GEOM_FIELD_DEFN_ALL_FLAG
         )
-
-    ds = None
 
 
 ###############################################################################
@@ -5980,6 +5865,7 @@ def test_ogr_shape_arrow_stream():
 # Test GetArrowStream()
 
 
+@gdaltest.disable_exceptions()
 def test_ogr_shape_arrow_stream_fid_optim(tmp_vsimem):
     gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")

--- a/frmts/vrt/vrtmultidim.cpp
+++ b/frmts/vrt/vrtmultidim.cpp
@@ -650,6 +650,11 @@ static GDALExtendedDataType ParseDataType(const CPLXMLNode *psNode)
     else
     {
         const auto eDT = GDALGetDataTypeByName(psType->psChild->pszValue);
+        if (eDT == GDT_Unknown)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined, "Unknown DataType: %s",
+                     psType->psChild->pszValue);
+        }
         dt = GDALExtendedDataType::Create(eDT);
     }
     return dt;

--- a/frmts/vrt/vrtmultidim.cpp
+++ b/frmts/vrt/vrtmultidim.cpp
@@ -584,8 +584,8 @@ std::shared_ptr<VRTMDArray> VRTGroup::CreateVRTMDArray(
         if (poFoundDim == nullptr || poFoundDim->GetSize() != poDim->GetSize())
         {
             CPLError(CE_Failure, CPLE_AppDefined,
-                     "One input dimension is not a VRTDimension "
-                     "or a VRTDimension of this dataset");
+                     "One input dimension is not a VRTDimension, "
+                     "or is not a VRTDimension of this dataset");
             return nullptr;
         }
     }


### PR DESCRIPTION
There are a couple of places where unexpected exceptions are thrown. I'll flag these with comments but can't do so before creating the PR.