### PR TITLE
[Backport release/3.13] NITF: accept IC=C4 when PRODUCT_TYPE=CADRG

### DIFF
--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -7520,6 +7520,7 @@ def test_nitf_create_copy_cadrg_color_table_per_frame(
     creationOptions = [
         "PRODUCT_TYPE=CADRG",
         "SCALE=10000000",
+        "IC=C4",  # just to test bugfix for https://github.com/OSGeo/gdal/issues/14709
     ]
     if color_table_per_frame:
         creationOptions.append("COLOR_TABLE_PER_FRAME=YES")

--- a/frmts/nitf/nitfdataset.cpp
+++ b/frmts/nitf/nitfdataset.cpp
@@ -4634,7 +4634,7 @@ NITFDataset::CreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
             return nullptr;
         }
 
-        if (EQUAL(pszIC, "NC"))
+        else if (EQUAL(pszIC, "NC"))
             /* ok */;
         else if (EQUAL(pszIC, "C8"))
         {

--- a/frmts/nitf/rpfframewriter.cpp
+++ b/frmts/nitf/rpfframewriter.cpp
@@ -3485,6 +3485,9 @@ CADRGCreateCopy(const char *pszFilename, GDALDataset *poSrcDS, int bStrict,
                 return nullptr;
             }
 
+            if (pfnProgress)
+                pfnProgress(1.0, "", pProgressData);
+
             return std::make_unique<NITFDummyDataset>();
         }
     }


### PR DESCRIPTION
Backport #14710
 **Authored by:** @rouault