### PR TITLE
VRT multidim: add a GUESS_REGULARLY_SPACED_ARRAYS=NO multidim dataset creation option

### DIFF
--- a/autotest/gdrivers/vrtmultidim.py
+++ b/autotest/gdrivers/vrtmultidim.py
@@ -2176,3 +2176,15 @@ def test_vrtmultidim_ref_vrtmultidim(tmp_vsimem):
     ) as ds:
         array = ds.GetRootGroup().OpenMDArrayFromFullname("/Band1")
         array.Read()
+
+
+@pytest.mark.require_driver("netCDF")
+@gdaltest.enable_exceptions()
+def test_vrtmultidim_GUESS_REGULARLY_SPACED_ARRAYS_disabled(tmp_vsimem):
+
+    src_ds = gdal.OpenEx("data/netcdf/byte.nc", gdal.OF_MULTIDIM_RASTER)
+    gdal.GetDriverByName("VRT").CreateCopy(
+        tmp_vsimem / "out.vrt", src_ds, options=["GUESS_REGULARLY_SPACED_ARRAYS=NO"]
+    )
+    with gdal.VSIFile(tmp_vsimem / "out.vrt", "rb") as f:
+        assert b"RegularlySpacedValues" not in f.read()

--- a/doc/source/drivers/raster/vrt_multidimensional.rst
+++ b/doc/source/drivers/raster/vrt_multidimensional.rst
@@ -205,3 +205,15 @@ data type as the full resolution array.
             </Array>
         </Overviews>
     </Array>
+
+
+Multidimensional dataset creation option
+----------------------------------------
+
+-  .. co:: GUESS_REGULARLY_SPACED_ARRAYS
+      :choices: YES, NO
+      :default: YES
+
+      Whether content of 1D-arrays should be read to deduce if they are
+      regularly spaced. This is enabled by default, but can be slow on huge
+      remote datasets.

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -1944,6 +1944,7 @@ class VRTGroup final : public GDALGroup
 
     std::string m_osFilename{};
     mutable bool m_bDirty = false;
+    bool m_bGuessRegularySpacedArrays = true;
     std::string m_osVRTPath{};
     std::vector<std::string> m_aosGroupNames{};
     std::map<std::string, std::shared_ptr<VRTGroup>> m_oMapGroups{};
@@ -2060,6 +2061,16 @@ class VRTGroup final : public GDALGroup
     void SetVRTPath(const std::string &osVRTPath)
     {
         m_osVRTPath = osVRTPath;
+    }
+
+    inline bool GetGuessRegularySpacedArrays() const
+    {
+        return m_bGuessRegularySpacedArrays;
+    }
+
+    void SetGuessRegularySpacedArrays(bool b)
+    {
+        m_bGuessRegularySpacedArrays = b;
     }
 
     void SetDirty();

--- a/frmts/vrt/vrtdriver.cpp
+++ b/frmts/vrt/vrtdriver.cpp
@@ -259,13 +259,16 @@ static GDALDataset *VRTCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
     auto poSrcGroup = poSrcDS->GetRootGroup();
     if (poSrcGroup != nullptr)
     {
-        auto poDstDS = std::unique_ptr<GDALDataset>(
-            VRTDataset::CreateMultiDimensional(pszFilename, nullptr, nullptr));
+        auto poDstDS = VRTDataset::CreateVRTMultiDimensional(pszFilename,
+                                                             nullptr, nullptr);
         if (!poDstDS)
             return nullptr;
-        auto poDstGroup = poDstDS->GetRootGroup();
+        auto poDstGroup = poDstDS->GetRootVRTGroup();
         if (!poDstGroup)
             return nullptr;
+        poDstGroup->SetGuessRegularySpacedArrays(
+            CPLTestBool(CSLFetchNameValueDef(
+                papszOptions, "GUESS_REGULARLY_SPACED_ARRAYS", "YES")));
         if (GDALDriver::DefaultCreateCopyMultiDimensional(
                 poSrcDS, poDstDS.get(), false, nullptr, nullptr, nullptr) !=
             CE_None)
@@ -565,6 +568,15 @@ void GDALRegister_VRT()
                                       ocoList.c_str());
         }
     }
+
+    poDriver->SetMetadataItem(
+        GDAL_DMD_MULTIDIM_DATASET_CREATIONOPTIONLIST,
+        "<MultiDimDatasetCreationOptionList>"
+        "   <Option name='GUESS_REGULARLY_SPACED_ARRAYS' type='boolean' "
+        "description='Whether content of 1D-arrays should be read to deduce "
+        "if they are regularly spaced. Can be slow on huge remote datasets' "
+        "default='YES'/>"
+        "</MultiDimDatasetCreationOptionList>");
 
     poDriver->SetMetadataItem(
         GDAL_DMD_MULTIDIM_ARRAY_CREATIONOPTIONLIST,

--- a/frmts/vrt/vrtmultidim.cpp
+++ b/frmts/vrt/vrtmultidim.cpp
@@ -2662,8 +2662,11 @@ bool VRTMDArray::CopyFrom(GDALDataset *poSrcDS, const GDALMDArray *poSrcArray,
 
     if (poSrcDS)
     {
+        auto poVRTRootGroup = GetRootVRTGroup();
         const auto nDims(GetDimensionCount());
-        if (nDims == 1 && m_dims[0]->GetSize() > 2 &&
+        if ((!poVRTRootGroup ||
+             poVRTRootGroup->GetGuessRegularySpacedArrays()) &&
+            nDims == 1 && m_dims[0]->GetSize() > 2 &&
             m_dims[0]->GetSize() < 10 * 1000 * 1000)
         {
             std::vector<double> adfTmp(

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -5934,6 +5934,11 @@ GDALAlgorithm::AddCreationOptionsArg(std::vector<std::string> *pValue,
                 datasetType = outputArg->GetDatasetType();
             }
 
+            const char *pszMDCreationOptionList =
+                (datasetType == GDAL_OF_MULTIDIM_RASTER)
+                    ? GDAL_DMD_MULTIDIM_DATASET_CREATIONOPTIONLIST
+                    : GDAL_DMD_CREATIONOPTIONLIST;
+
             auto outputFormat = GetArg(GDAL_ARG_NAME_OUTPUT_FORMAT);
             if (outputFormat && outputFormat->GetType() == GAAT_STRING &&
                 outputFormat->IsExplicitlySet())
@@ -5943,7 +5948,7 @@ GDALAlgorithm::AddCreationOptionsArg(std::vector<std::string> *pValue,
                 if (poDriver)
                 {
                     AddOptionsSuggestions(
-                        poDriver->GetMetadataItem(GDAL_DMD_CREATIONOPTIONLIST),
+                        poDriver->GetMetadataItem(pszMDCreationOptionList),
                         datasetType, currentValue, oRet);
                 }
                 return oRet;
@@ -5984,7 +5989,7 @@ GDALAlgorithm::AddCreationOptionsArg(std::vector<std::string> *pValue,
                                         oVisitedExtensions.insert(pszExt);
                                         if (AddOptionsSuggestions(
                                                 poDriver->GetMetadataItem(
-                                                    GDAL_DMD_CREATIONOPTIONLIST),
+                                                    pszMDCreationOptionList),
                                                 datasetType, currentValue,
                                                 oRet))
                                         {

--- a/gcore/gdaldriver.cpp
+++ b/gcore/gdaldriver.cpp
@@ -1340,7 +1340,14 @@ GDALDataset *GDALDriver::CreateCopy(const char *pszFilename,
                 if (!STARTS_WITH_CI(pszOption, "ARRAY:"))
                     aosDatasetCO.AddString(pszOption);
             }
-            GDALValidateCreationOptions(this, aosDatasetCO.List());
+
+            const char *pszOptionList =
+                GetMetadataItem(GDAL_DMD_MULTIDIM_DATASET_CREATIONOPTIONLIST);
+            CPLString osDriver;
+            osDriver.Printf("driver %s", GetDescription());
+            GDALValidateOptions(GDALDriver::ToHandle(this), pszOptionList,
+                                aosDatasetCO.List(),
+                                "mulitdim dataset creation option", osDriver);
         }
         else
         {


### PR DESCRIPTION
VRT multidim: add a GUESS_REGULARLY_SPACED_ARRAYS=NO multidim dataset creation option

Speeds up scenarios like:
```
gdal mdim convert "ICECHUNK:/vsis3/earthmover-icechunk-era5/icechunkV2" /tmp/icechunk.vrt  --config AWS_NO_SIGN_REQUEST YES --creation-option GUESS_REGULARLY_SPACED_ARRAYS=NO
```
