### PR TITLE
[Backport release/3.13] VSISync(): fix missed empty files when sync'ing from/to cloud with multithreaded enabled

### DIFF
--- a/autotest/gcore/vsis3.py
+++ b/autotest/gcore/vsis3.py
@@ -211,6 +211,12 @@ def test_vsis3_sync_multithreaded_download(
         ).size
         == 4
     )
+    assert (
+        gdal.VSIStatL(
+            tmp_vsimem / "test_vsis3_no_sign_request_sync/test_dummy/empty_file"
+        ).size
+        == 0
+    )
 
 
 ###############################################################################

--- a/port/cpl_vsil_s3.cpp
+++ b/port/cpl_vsil_s3.cpp
@@ -4596,7 +4596,9 @@ bool IVSIS3LikeFSHandler::Sync(const char *pszSource, const char *pszTarget,
                 const vsi_l_offset nChunksLarge =
                     nMaxChunkSize == 0
                         ? 1
-                        : cpl::div_round_up(entry->nSize, nMaxChunkSize);
+                        : std::max<vsi_l_offset>(
+                              1,
+                              cpl::div_round_up(entry->nSize, nMaxChunkSize));
                 if (nChunksLarge >
                     1000)  // must also be below knMAX_PART_NUMBER for upload
                 {


### PR DESCRIPTION
Backport #14721
 **Authored by:** @rouault