### PR TITLE
grokj2k: add synchronous fallback if AdviseRead hint has not been issued

### DIFF
--- a/autotest/gdrivers/jp2grok.py
+++ b/autotest/gdrivers/jp2grok.py
@@ -1562,3 +1562,90 @@ def test_jp2grok_driver_metadata():
     assert drv.GetMetadataItem(gdal.DCAP_CREATECOPY) == "YES"
     assert "jp2" in drv.GetMetadataItem(gdal.DMD_EXTENSIONS)
     assert "j2k" in drv.GetMetadataItem(gdal.DMD_EXTENSIONS)
+
+
+###############################################################################
+# Sync-decompress fallback (no AdviseRead before a partial read).
+#
+# Without AdviseRead the async path locks decode window to first
+# swath, so later reads outside initial decode window returned zeros.
+# The driver now falls back to a per-swath synchronous decode.
+# Multi-tile-row sources are used so we detect these zeros if still broken.
+
+SYNC_SRC = "data/jpeg2000/513x513.jp2"
+
+
+def _truth(src):
+    # Reference pixels from use of correct AdviseRead async path.
+    ds = gdal.Open(src)
+    ds.AdviseRead(0, 0, ds.RasterXSize, ds.RasterYSize)
+    return ds.GetRasterBand(1).ReadAsArray()
+
+
+def test_jp2grok_sync_fallback_full_image():
+    # Full-image read without AdviseRead - must match async result.
+    np = pytest.importorskip("numpy")
+    ds = gdal.Open(SYNC_SRC)
+    got = ds.GetRasterBand(1).ReadAsArray()
+    assert np.array_equal(got, _truth(SYNC_SRC))
+
+
+def test_jp2grok_sync_fallback_many_swaths():
+    # Disjoint partial reads recreate codec and must match truth.
+    np = pytest.importorskip("numpy")
+    truth = _truth(SYNC_SRC)
+    ds = gdal.Open(SYNC_SRC)
+    band = ds.GetRasterBand(1)
+    for x in (0, 150, 300):
+        for y in (0, 150, 300):
+            got = band.ReadAsArray(x, y, 100, 100)
+            assert np.array_equal(got, truth[y : y + 100, x : x + 100])
+
+
+def test_jp2grok_advise_read_keeps_async_path():
+    # With AdviseRead the driver stays async: no warning, correct pixels.
+    np = pytest.importorskip("numpy")
+    truth = _truth(SYNC_SRC)
+    ds = gdal.Open(SYNC_SRC)
+    ds.AdviseRead(0, 0, 200, 200)
+    gdal.ErrorReset()
+    got = ds.GetRasterBand(1).ReadAsArray(0, 0, 200, 200)
+    assert np.array_equal(got, truth[0:200, 0:200])
+
+
+def test_jp2grok_vrt_read_no_advise():
+    # VRT SimpleSource reads via RasterIO without AdviseRead; this exercises
+    # fallback through the VRT front end.
+    pytest.importorskip("numpy")
+    src = "data/jpeg2000/tile_size_16.jp2"
+    vrt = f"""<VRTDataset rasterXSize="256" rasterYSize="256">
+  <VRTRasterBand dataType="Byte" band="1">
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">{src}</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="256" ySize="256" />
+      <DstRect xOff="0" yOff="0" xSize="256" ySize="256" />
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>"""
+    ds = gdal.Open(vrt)
+    arr = ds.GetRasterBand(1).ReadAsArray()
+    assert arr[:128].max() > 0 and arr[128:].max() > 0
+
+
+def test_jp2grok_translate_scale_multi_tile_row():
+    # gdal_translate -scale wraps source in a VRT and
+    # reads it without AdviseRead. Identity scale preserves pixels, so the
+    # output must match source below first tile row.
+    np = pytest.importorskip("numpy")
+    truth = _truth(SYNC_SRC)
+    src_ds = gdal.Open(SYNC_SRC)
+    smin, smax, _, _ = src_ds.GetRasterBand(1).GetStatistics(False, True)
+    out = "/vsimem/jp2grok_scale.tif"
+    ds = gdal.Translate(
+        out, SYNC_SRC, format="GTiff", scaleParams=[[smin, smax, smin, smax]]
+    )
+    assert ds.RasterYSize == 513
+    assert np.array_equal(ds.GetRasterBand(1).ReadAsArray(), truth)
+    ds = None
+    gdal.Unlink(out)

--- a/doc/source/drivers/raster/jp2grok.rst
+++ b/doc/source/drivers/raster/jp2grok.rst
@@ -70,6 +70,22 @@ When a JPEG2000 file contains multiple tiles, GDAL will additionally
 dispatch tile processing across threads for parallel CopyTileData
 operations during decoding.
 
+Performance: AdviseRead
+-----------------------
+
+The driver decompresses asynchronously, scheduling tile decode in the
+background while the caller is still consuming earlier rows.  To do
+this efficiently it needs to know the read window up front so it can
+restrict the codestream decode to the targeted precincts/tiles and
+overlap T2 parse with T1 decode.
+
+For best performance, callers that know which window they are about
+to read should call ``GDALDataset::AdviseRead`` (or the C API
+``GDALDatasetAdviseRead``) with that window *before* issuing the
+first ``RasterIO`` / ``ReadBlock``.  Without the hint the driver
+falls back to synchronous, per-swath decompression, which can be much
+slower, especially when decompressing over the network.
+
 Open Options
 --------------
 

--- a/frmts/grok/grkdatasetbase.h
+++ b/frmts/grok/grkdatasetbase.h
@@ -1939,6 +1939,9 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
     bool initializedAsync = false;  ///< True after first grk_decompress() call
     PostPreload cachedPostPreload_{};    ///< Cached first-call tile grid info
     bool hasCachedPostPreload_ = false;  ///< True after first decompressAsynch
+    bool bSwathOnlyWarned_ = false;      ///< Throttle no-AdviseRead warning
+    bool bAdviseReadCalled_ = false;     ///< True if AdviseRead() was invoked
+    bool bSyncFallback_ = false;         ///< True when sync fallback taken
     VSILFILE *m_ovFp = nullptr;  ///< Private file handle for overview codec
 
     /**
@@ -2023,6 +2026,7 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
         fullDecompress_ = (nXOff == m_nX0 && nYOff == m_nY0 &&
                            nXSize == nParentXSize && nYSize == nParentYSize);
         initializedAsync = false;
+        bAdviseReadCalled_ = true;
 
         return CE_None;
     }
@@ -2358,9 +2362,9 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
         // trigger post-processing (wait(nullptr) -> postMulti_).
         const int nTotalTiles = (postPreload.tile_x1 - postPreload.tile_x0) *
                                 (postPreload.tile_y1 - postPreload.tile_y0);
-        bool canUseFastPath =
-            (nTotalTiles > 1 && m_codec && m_codec->psImage && iLevel == 0 &&
-             eBufType != GDT_Float32 && eBufType != GDT_Float64);
+        bool canUseFastPath = (nTotalTiles > 1 && m_codec && m_codec->psImage &&
+                               iLevel == 0 && eBufType != GDT_Float32 &&
+                               eBufType != GDT_Float64 && !bSyncFallback_);
         if (canUseFastPath)
         {
             for (int i = 0; i < nBandCount && canUseFastPath; ++i)
@@ -2750,16 +2754,17 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
                     (swath_y0 + swath_height + th - 1) / th);
             }
 
-            // Call grk_decompress_wait with swath coordinates to
-            // trigger TileCompletion row-based tile cleanup.
-            // This avoids re-calling grk_decompress() which would
-            // create a new TileCompletion that never gets notified.
-            grk_wait_swath sw = {};
-            sw.x0 = cached.x0;
-            sw.y0 = cached.y0;
-            sw.x1 = cached.x1;
-            sw.y1 = cached.y1;
-            grk_decompress_wait(m_codec->pCodec, &sw);
+            // Sync fallback already decoded all; no async queue to wait on.
+            if (!bSyncFallback_)
+            {
+                // grk_decompress_wait() triggers row-based tile cleanup.
+                grk_wait_swath sw = {};
+                sw.x0 = cached.x0;
+                sw.y0 = cached.y0;
+                sw.x1 = cached.x1;
+                sw.y1 = cached.y1;
+                grk_decompress_wait(m_codec->pCodec, &sw);
+            }
 
             return cached;
         }
@@ -2772,6 +2777,158 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
             (m_codec && m_codec->psImage) ? m_codec->psImage->numcomps : 0;
         const bool needPersistentTiles =
             (!this->bSingleTiled && nBandCount > 0 && nBandCount < nTotalComps);
+
+        // Partial read with no AdviseRead: async locks the decode window to
+        // the first swath, corrupting later out-of-window reads. Fall back to
+        // synchronous per-swath decode (slower, but order-safe). Full-image
+        // reads are already safe on the async path.
+        const int nFullX = nParentXSize >> iLevel;
+        const int nFullY = nParentYSize >> iLevel;
+        const bool bPartial = (swath_x0 != 0 || swath_y0 != 0 ||
+                               swath_width < nFullX || swath_height < nFullY);
+        const bool bMissingAdviseRead =
+            bPartial && !this->fullDecompress_ && !bAdviseReadCalled_ &&
+            area_x0_ == 0 && area_y0_ == 0 && area_x1_ == 0 && area_y1_ == 0;
+
+        if (bMissingAdviseRead)
+        {
+            if (!bSwathOnlyWarned_)
+            {
+                bSwathOnlyWarned_ = true;
+                CPLDebug("GROK",
+                         "JP2Grok : partial read of '%s' without prior "
+                         "AdviseRead. Falling back to synchronous "
+                         "per-swath decompression for correctness. "
+                         "Call GDALDataset::AdviseRead() with the "
+                         "target window before the first "
+                         "RasterIO/ReadBlock to recover async "
+                         "performance.",
+                         m_osFilename.c_str());
+            }
+
+            // grk_decompress_update() only works pre-decode; recreate the
+            // codec to retarget the swath.
+            if (initializedAsync)
+            {
+                delete m_codec;
+                m_codec = new GRKCodecWrapper();
+
+                // Prefer native I/O: Grok reads the file itself, faster than
+                // routing every block through VSILFILE callbacks (especially
+                // over the network). Only use a VSILFILE when Grok cannot read
+                // the path (e.g. /vsimem, /vsicurl).
+                if (GrokCanRead(m_osFilename.c_str()))
+                {
+                    if (m_ovFp)
+                    {
+                        VSIFCloseL(m_ovFp);
+                        m_ovFp = nullptr;
+                    }
+                    m_codec->open(nullptr, nCodeStreamStart);
+                }
+                else
+                {
+                    VSILFILE *fp = fp_;
+                    if (iLevel > 0)
+                    {
+                        // Overview: fresh private handle resets file position.
+                        if (m_ovFp)
+                        {
+                            VSIFCloseL(m_ovFp);
+                            m_ovFp = nullptr;
+                        }
+                        m_ovFp = VSIFOpenL(m_osFilename.c_str(), "rb");
+                        if (!m_ovFp)
+                        {
+                            CPLError(CE_Failure, CPLE_OpenFailed,
+                                     "sync fallback: reopen failed");
+                            return rc;
+                        }
+                        fp = m_ovFp;
+                    }
+                    m_codec->open(fp, nCodeStreamStart);
+                }
+                uint32_t nTileW = 0, nTileH = 0;
+                int numRes = 0;
+                if (!m_codec->setUpDecompress(
+                        GetNumThreads(), m_osFilename.c_str(),
+                        nCodeStreamLength, &nTileW, &nTileH, &numRes))
+                {
+                    delete m_codec;
+                    m_codec = nullptr;
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "sync fallback: codec reinit failed");
+                    return rc;
+                }
+                CPLErrorReset();
+                initializedAsync = false;
+                hasCachedPostPreload_ = false;
+            }
+
+            grk_decompress_parameters decompressParams = {};
+            decompressParams.asynchronous = false;
+            decompressParams.simulate_synchronous = false;
+            decompressParams.decompress_callback = nullptr;
+            decompressParams.decompress_callback_user_data = nullptr;
+            // Keep tile images cached for CopyTiles.
+            decompressParams.core.tile_cache_strategy = GRK_TILE_CACHE_IMAGE;
+            if (!this->bSingleTiled)
+                decompressParams.core.skip_allocate_composite = true;
+            decompressParams.core.reduce = iLevel;
+            // Decode only the requested swath window (reduced coords).
+            decompressParams.dw_reduced = true;
+            decompressParams.dw_x0 = swath_x0;
+            decompressParams.dw_y0 = swath_y0;
+            decompressParams.dw_x1 = swath_x0 + swath_width;
+            decompressParams.dw_y1 = swath_y0 + swath_height;
+
+            if (!grk_decompress_update(&decompressParams, m_codec->pCodec))
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "grk_decompress_update() failed (sync fallback)");
+                return rc;
+            }
+            if (!grk_decompress(m_codec->pCodec, nullptr))
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "grk_decompress() failed (sync fallback)");
+                return rc;
+            }
+            initializedAsync = true;
+            bSyncFallback_ = true;
+
+            // PostPreload for the swath; CopyTiles runs tile-by-tile, so
+            // rowCopyDone_ stays false.
+            rc.asynch_ = true;
+            rc.rowCopyDone_ = false;
+            rc.x0 = swath_x0;
+            rc.y0 = swath_y0;
+            rc.x1 = swath_x0 + swath_width;
+            rc.y1 = swath_y0 + swath_height;
+
+            const uint32_t tw = m_nTileWidth ? m_nTileWidth : 1;
+            const uint32_t th = m_nTileHeight ? m_nTileHeight : 1;
+            // Size the tile grid from reduced full-image dims; psImage->x1 is
+            // unreliable in sync mode for overview codecs.
+            const uint32_t reducedFullW =
+                static_cast<uint32_t>(nParentXSize >> iLevel);
+            const uint32_t reducedFullH =
+                static_cast<uint32_t>(nParentYSize >> iLevel);
+            rc.num_tile_cols =
+                static_cast<uint16_t>((reducedFullW + tw - 1) / tw);
+            rc.tile_x0 = static_cast<uint16_t>(swath_x0 / tw);
+            rc.tile_y0 = static_cast<uint16_t>(swath_y0 / th);
+            rc.tile_x1 = static_cast<uint16_t>(
+                std::min<uint32_t>((swath_x0 + swath_width + tw - 1) / tw,
+                                   (reducedFullW + tw - 1) / tw));
+            rc.tile_y1 = static_cast<uint16_t>(
+                std::min<uint32_t>((swath_y0 + swath_height + th - 1) / th,
+                                   (reducedFullH + th - 1) / th));
+
+            // Don't cache: the next swath must recreate the codec for its
+            // own window.
+            return rc;
+        }
 
         if (!initializedAsync)
         {
@@ -2797,6 +2954,8 @@ struct JP2GRKDatasetBase : public JP2DatasetBase
                 if (area_x0_ == 0 && area_y0_ == 0 && area_x1_ == 0 &&
                     area_y1_ == 0)
                 {
+                    // No AdviseRead, but this swath covers the full image;
+                    // use it as the decode window.
                     decompressParams.dw_x0 = swath_x0;
                     decompressParams.dw_y0 = swath_y0;
                     decompressParams.dw_x1 = swath_x0 + swath_width;


### PR DESCRIPTION
## What does this PR do?

grokj2k uses asynchronous decompression for maximum performance, provided
that the AdviseRead hint has been issued in advance with desired decompression
window. If hint has not been issued, the driver now falls back to slower synchronous
decompression, ensuring correctness of result.

The driver .rst has been updated to encourage callers to use the AdviseRead hint
for maximum performance

## What are related issues/pull requests?

fixes #14780

## AI tool usage

Claude Opus assisted in making this bug fix.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
