### PR TITLE
gdal raster stack/mosaic: fix to allow inner pipelines to be allowed as input datasets

### DIFF
--- a/apps/gdalbuildvrt_lib.cpp
+++ b/apps/gdalbuildvrt_lib.cpp
@@ -1181,6 +1181,20 @@ static void WriteAbsolutePath(VRTSimpleSource *poSource, const char *dsFileName)
 }
 
 /************************************************************************/
+/*                       IsTransientSrcDataset()                        */
+/************************************************************************/
+
+static bool IsTransientSrcDataset(const char *dsFileName, GDALDatasetH hDS)
+{
+    auto hDriver = GDALGetDatasetDriver(hDS);
+    return !hDriver || dsFileName[0] == '\0' ||  // could be a unnamed VRT file
+                                                 // Inner pipeline
+           (dsFileName[0] == '[' &&
+            dsFileName[strlen(dsFileName) - 1] == ']') ||
+           EQUAL(GDALGetDescription(hDriver), "MEM");
+}
+
+/************************************************************************/
 /*                         CreateVRTSeparate()                          */
 /************************************************************************/
 
@@ -1221,10 +1235,7 @@ void VRTBuilder::CreateVRTSeparate(VRTDataset *poVRTDS)
         GDALDatasetH hSourceDS;
         bool bDropRef = false;
         if (nSrcDSCount == nInputFiles &&
-            GDALGetDatasetDriver(pahSrcDS[i]) != nullptr &&
-            (dsFileName[0] == '\0' ||  // could be a unnamed VRT file
-             EQUAL(GDALGetDescription(GDALGetDatasetDriver(pahSrcDS[i])),
-                   "MEM")))
+            IsTransientSrcDataset(dsFileName, pahSrcDS[i]))
         {
             hSourceDS = pahSrcDS[i];
         }
@@ -1505,10 +1516,7 @@ void VRTBuilder::CreateVRTNonSeparate(VRTDataset *poVRTDS)
         bool bDropRef = false;
 
         if (nSrcDSCount == nInputFiles &&
-            GDALGetDatasetDriver(pahSrcDS[i]) != nullptr &&
-            (dsFileName[0] == '\0' ||  // could be a unnamed VRT file
-             EQUAL(GDALGetDescription(GDALGetDatasetDriver(pahSrcDS[i])),
-                   "MEM")))
+            IsTransientSrcDataset(dsFileName, pahSrcDS[i]))
         {
             hSourceDS = pahSrcDS[i];
         }

--- a/autotest/utilities/test_gdalalg_raster_stack.py
+++ b/autotest/utilities/test_gdalalg_raster_stack.py
@@ -95,3 +95,12 @@ def test_gdalalg_raster_stack_pipeline():
         out_ds = alg.Output()
         assert out_ds.GetRasterBand(1).Checksum() == 3
         assert out_ds.GetRasterBand(2).Checksum() == 6
+
+
+def test_gdalalg_raster_stack_pipeline_inner_pipeline():
+
+    with gdal.alg.raster.pipeline(
+        pipeline="stack [ read ../gcore/data/byte.tif ! edit ] ! edit"
+    ) as alg:
+        ds = alg.Output()
+        assert ds.GetRasterBand(1).Checksum() == 4672


### PR DESCRIPTION
Fixes #14794
