### PR TITLE
gdal mdim info: add --format=text/json, and defaults to text format when invoked from command line

### DIFF
--- a/apps/gdalalg_mdim_info.cpp
+++ b/apps/gdalalg_mdim_info.cpp
@@ -48,8 +48,7 @@ GDALMdimInfoAlgorithm::GDALMdimInfoAlgorithm(bool standaloneStep,
         AddMdimHiddenInputDatasetArg();
     }
 
-    AddOutputFormatArg(&m_format).SetHidden().SetDefault("json").SetChoices(
-        "json", "text");
+    AddOutputFormatArg(&m_format).SetChoices("json", "text");
     AddArg("summary", 0,
            _("Report only group and array hierarchy, without detailed "
              "information on attributes or dimensions."),
@@ -120,8 +119,13 @@ bool GDALMdimInfoAlgorithm::RunStep(GDALPipelineStepRunContext &)
     auto poSrcDS = m_inputDataset[0].GetDatasetRef();
     CPLAssert(poSrcDS);
 
+    if (m_format.empty())
+        m_format = IsCalledFromCommandLine() ? "text" : "json";
+
     CPLStringList aosOptions;
 
+    aosOptions.AddString("-format");
+    aosOptions.AddString(m_format);
     if (m_stdout)
         aosOptions.AddString("-stdout");
     if (m_summary)

--- a/apps/gdalmdiminfo_lib.cpp
+++ b/apps/gdalmdiminfo_lib.cpp
@@ -14,11 +14,14 @@
 #include "gdal_utils.h"
 #include "gdal_utils_priv.h"
 
+#include "cpl_enumerate.h"
 #include "cpl_json.h"
 #include "cpl_json_streaming_writer.h"
 #include "gdal_priv.h"
 #include "gdal_rat.h"
 #include "gdalargumentparser.h"
+
+#include <algorithm>
 #include <limits>
 #include <set>
 
@@ -45,6 +48,7 @@ struct GDALMultiDimInfoOptions
     CPLStringList aosArrayOptions{};
     std::string osArrayName{};
     bool bStats = false;
+    std::string osFormat = "json";
 };
 
 /************************************************************************/
@@ -1196,6 +1200,798 @@ static void DumpGroup(const std::shared_ptr<GDALGroup> &rootGroup,
 }
 
 /************************************************************************/
+/*                     GDALMultiDimTextOutputDumper                     */
+/************************************************************************/
+
+using TableType = std::vector<std::vector<std::string>>;
+
+struct GDALMultiDimTextOutputDumper
+{
+    const GDALMultiDimInfoOptions &m_sOptions;
+    std::string m_osOutput{};
+
+    explicit GDALMultiDimTextOutputDumper(
+        const GDALMultiDimInfoOptions *psOptions)
+        : m_sOptions(*psOptions)
+    {
+    }
+
+    void AddLine(const std::string &osLine = std::string())
+    {
+        if (m_sOptions.bStdoutOutput)
+        {
+            printf("%s\n", osLine.c_str());
+        }
+        else
+        {
+            m_osOutput += osLine;
+            m_osOutput += '\n';
+        }
+    }
+
+    void DumpTable(const TableType &lines, int nIndentSpaces = 2,
+                   const std::vector<size_t> &anColSizeIn = {},
+                   bool headerLineSeparator = true,
+                   bool bLeftPadNumbers = true);
+
+    void
+    DumpAttributes(const std::vector<std::shared_ptr<GDALAttribute>> &apoAttrs,
+                   int nIndentSpaces);
+
+    void DumpStructuralInfo(CSLConstList papszStructuralInfo,
+                            int nIndentSpaces);
+
+    void DumpArray(const std::shared_ptr<GDALMDArray> &poArray);
+
+    std::set<std::string>
+    DumpDimensionsSummary(const std::shared_ptr<GDALGroup> &group);
+
+    void DumpArraysSummary(
+        const std::shared_ptr<GDALGroup> &group,
+        const std::vector<std::shared_ptr<GDALMDArray>> &apoArrays);
+
+    void DrumpGroupsSummary(const std::shared_ptr<GDALGroup> &group);
+};
+
+/************************************************************************/
+/*                             DumpTable()                              */
+/************************************************************************/
+
+void GDALMultiDimTextOutputDumper::DumpTable(
+    const TableType &lines, int nIndentSpaces,
+    const std::vector<size_t> &anColSizeIn, bool headerLineSeparator,
+    bool bLeftPadNumbers)
+{
+    // Compute column max size if needed
+    std::vector<size_t> anColSizeTmp;
+    if (anColSizeIn.empty())
+    {
+        for (const auto &line : lines)
+        {
+            if (line.size() > anColSizeTmp.size())
+                anColSizeTmp.resize(line.size());
+            for (const auto [idxCol, col] : cpl::enumerate(line))
+            {
+                anColSizeTmp[idxCol] =
+                    std::max(anColSizeTmp[idxCol], col.size());
+            }
+        }
+    }
+    const auto &anColSize = anColSizeIn.empty() ? anColSizeTmp : anColSizeIn;
+
+    // Check which columns are numeric-only
+    std::vector<bool> abIsNumbersOnly(anColSize.size(), true);
+    for (const auto [idxLine, line] : cpl::enumerate(lines))
+    {
+        CPLAssert(abIsNumbersOnly.size() >= line.size());
+        if (!headerLineSeparator || idxLine > 0)
+        {
+            for (const auto [idxCol, col] : cpl::enumerate(line))
+            {
+                abIsNumbersOnly[idxCol] =
+                    abIsNumbersOnly[idxCol] &&
+                    CPLGetValueType(col.c_str()) != CPL_VALUE_STRING;
+            }
+        }
+    }
+
+    // Now actually print table
+    for (const auto [idxLine, line] : cpl::enumerate(lines))
+    {
+        CPLAssert(anColSize.size() >= line.size());
+        std::string osFormattedLine(nIndentSpaces, ' ');
+        for (const auto [idxCol, col] : cpl::enumerate(line))
+        {
+            if (idxCol > 0)
+                osFormattedLine += "  ";
+            if (idxLine == 0 && headerLineSeparator)
+            {
+                const size_t nLeftPadding =
+                    (anColSize[idxCol] - col.size()) / 2;
+                osFormattedLine += std::string(nLeftPadding, ' ');
+                osFormattedLine += col;
+                osFormattedLine += std::string(
+                    anColSize[idxCol] - col.size() - nLeftPadding, ' ');
+            }
+            else if (!bLeftPadNumbers || !abIsNumbersOnly[idxCol])
+            {
+                osFormattedLine += col;
+                osFormattedLine +=
+                    std::string(anColSize[idxCol] - col.size(), ' ');
+            }
+            else
+            {
+                osFormattedLine +=
+                    std::string(anColSize[idxCol] - col.size(), ' ');
+                osFormattedLine += col;
+            }
+        }
+        AddLine(osFormattedLine);
+
+        if (idxLine == 0 && headerLineSeparator)
+        {
+            osFormattedLine = std::string(nIndentSpaces, ' ');
+            for (size_t idxCol = 0; idxCol < line.size(); ++idxCol)
+            {
+                if (idxCol > 0)
+                    osFormattedLine += "  ";
+                osFormattedLine += std::string(anColSize[idxCol], '-');
+            }
+            AddLine(osFormattedLine);
+        }
+    }
+}
+
+/************************************************************************/
+/*                            TypeToString()                            */
+/************************************************************************/
+
+static std::string TypeToString(const GDALExtendedDataType &dt,
+                                bool emitCompoundName = true)
+{
+    std::string ret;
+    switch (dt.GetClass())
+    {
+        case GEDTC_STRING:
+            ret = "String";
+            break;
+
+        case GEDTC_NUMERIC:
+            ret = GDALGetDataTypeName(dt.GetNumericDataType());
+            break;
+
+        case GEDTC_COMPOUND:
+        {
+            if (emitCompoundName && !dt.GetName().empty())
+            {
+                ret = dt.GetName();
+                ret += ": ";
+            }
+            ret += '{';
+            bool firstComp = true;
+            const auto &components = dt.GetComponents();
+            for (const auto &comp : components)
+            {
+                if (!firstComp)
+                    ret += ", ";
+                firstComp = false;
+                ret += comp->GetName();
+                ret += ": ";
+                ret += TypeToString(comp->GetType(), false);
+            }
+            ret += '}';
+            break;
+        }
+    }
+    return ret;
+}
+
+/************************************************************************/
+/*                           DumpAttributes()                           */
+/************************************************************************/
+
+void GDALMultiDimTextOutputDumper::DumpAttributes(
+    const std::vector<std::shared_ptr<GDALAttribute>> &apoAttrs,
+    int nIndentSpaces)
+{
+    if (!apoAttrs.empty())
+    {
+        AddLine();
+        AddLine(std::string(nIndentSpaces, ' ').append("Attributes:"));
+        TableType attrs;
+        attrs.push_back({"Name", "Type", "Value"});
+
+        for (const auto &poAttr : apoAttrs)
+        {
+            CPLJSonStreamingWriter serializer(nullptr, nullptr);
+            serializer.SetPrettyFormatting(false);
+            DumpAttrValue(poAttr, serializer);
+            std::string osAttrVal = serializer.GetString();
+            constexpr size_t MAX_COLS = 80;
+            if (osAttrVal.size() <= MAX_COLS)
+            {
+                attrs.push_back({poAttr->GetName(),
+                                 TypeToString(poAttr->GetDataType()),
+                                 osAttrVal});
+            }
+            else
+            {
+                bool bFirstLineAttr = true;
+                while (osAttrVal.size() > MAX_COLS)
+                {
+                    auto nLastBreak = osAttrVal.find_last_of(" ,\n", MAX_COLS);
+                    if (nLastBreak == std::string::npos)
+                        nLastBreak = osAttrVal.find_first_of(" ,\n");
+                    if (nLastBreak != std::string::npos)
+                    {
+                        auto osVal = osAttrVal.substr(0, nLastBreak);
+                        if (osAttrVal[nLastBreak] != ' ' &&
+                            osAttrVal[nLastBreak] != '\n')
+                            osVal += osAttrVal[nLastBreak];
+                        attrs.push_back(
+                            {bFirstLineAttr ? poAttr->GetName() : std::string(),
+                             bFirstLineAttr
+                                 ? TypeToString(poAttr->GetDataType())
+                                 : std::string(),
+                             osVal});
+                        osAttrVal = osAttrVal.substr(nLastBreak + 1);
+                    }
+                    else
+                    {
+                        break;
+                    }
+                    bFirstLineAttr = false;
+                }
+                attrs.push_back(
+                    {bFirstLineAttr ? poAttr->GetName() : std::string(),
+                     bFirstLineAttr ? TypeToString(poAttr->GetDataType())
+                                    : std::string(),
+                     osAttrVal});
+            }
+        }
+        DumpTable(attrs, nIndentSpaces + 2);
+    }
+}
+
+/************************************************************************/
+/*                         DimsToShapeString()                          */
+/************************************************************************/
+
+static std::string
+DimsToShapeString(const std::vector<std::shared_ptr<GDALDimension>> &dims)
+{
+    std::string s("[");
+    for (const auto &poDim : dims)
+    {
+        if (s.size() > 1)
+            s += ", ";
+        s += std::to_string(poDim->GetSize());
+    }
+    s += ']';
+    return s;
+}
+
+/************************************************************************/
+/*                            DimsToString()                            */
+/************************************************************************/
+
+static std::string
+DimsToString(const std::vector<std::shared_ptr<GDALDimension>> &dims,
+             const std::string &osSameDimGroup)
+{
+    std::string s("(");
+    for (const auto &poDim : dims)
+    {
+        if (s.size() > 1)
+            s += ", ";
+        else if (!osSameDimGroup.empty())
+        {
+            s += osSameDimGroup;
+            s += '/';
+        }
+        const std::string &osFullname = poDim->GetFullName();
+        if (!osFullname.empty())
+        {
+            s += osSameDimGroup.empty()
+                     ? osFullname
+                     : osFullname.substr(osSameDimGroup.size() + 1);
+        }
+        else
+        {
+            s += "(unnamed)";
+        }
+    }
+    s += ')';
+    return s;
+}
+
+/************************************************************************/
+/*                         DimsToSameDimGroup()                         */
+/************************************************************************/
+
+/** Return the prefix shared by all dimensions if there is one, or empty string
+ * otherwise.
+ */
+static std::string
+DimsToSameDimGroup(const std::vector<std::shared_ptr<GDALDimension>> &dims)
+{
+    std::string osSameDimGroup;
+    for (const auto &poDim : dims)
+    {
+        std::string osDimGroup = poDim->GetFullName();
+        const auto nPos = osDimGroup.rfind('/');
+        if (nPos != std::string::npos)
+        {
+            osDimGroup.resize(nPos);
+            if (osSameDimGroup.empty())
+            {
+                osSameDimGroup = osDimGroup;
+            }
+            else if (osSameDimGroup != osDimGroup)
+            {
+                return {};
+            }
+        }
+        else
+        {
+            return {};
+        }
+    }
+    return osSameDimGroup;
+}
+
+/************************************************************************/
+/*                         BlockSizeToString()                          */
+/************************************************************************/
+
+template <class T>
+static std::string BlockSizeToString(const std::vector<T> &anBlockSize,
+                                     bool *pbAllZero = nullptr)
+{
+    std::string s("[");
+    if (pbAllZero)
+        *pbAllZero = true;
+    for (const auto nSize : anBlockSize)
+    {
+        if (s.size() > 1)
+            s += ", ";
+        s += std::to_string(nSize);
+        if (pbAllZero)
+            *pbAllZero = *pbAllZero && nSize == 0;
+    }
+    s += ']';
+    return s;
+}
+
+/************************************************************************/
+/*                    WriteToStdoutWithSpaceIndent()                    */
+/************************************************************************/
+
+static void WriteToStdoutWithSpaceIndent(const char *pszText, void *pUserData)
+{
+    const int *pnIndent = static_cast<const int *>(pUserData);
+    printf("%s", pszText);
+    if (pszText[0] == '\n')
+        printf("%s", std::string(*pnIndent, ' ').c_str());
+}
+
+/************************************************************************/
+/*          GDALMultiDimTextOutputDumper::DumpStructuralInfo()          */
+/************************************************************************/
+
+void GDALMultiDimTextOutputDumper::DumpStructuralInfo(
+    CSLConstList papszStructuralInfo, int nIndentSpaces)
+{
+    AddLine();
+    AddLine(std::string(nIndentSpaces, ' ').append("Structural metadata:"));
+
+    TableType info;
+
+    int i = 1;
+    for (const auto &[pszKey, pszValue] :
+         cpl::IterateNameValue(papszStructuralInfo,
+                               /* bReturnNullKeyIfNotNameValue = */ true))
+    {
+        std::vector<std::string> line;
+        if (pszKey)
+        {
+            line.push_back(pszKey);
+        }
+        else
+        {
+            line.push_back(CPLSPrintf("metadata_%d", i));
+            ++i;
+        }
+        line.push_back(pszValue);
+        info.push_back(std::move(line));
+    }
+    DumpTable(info, nIndentSpaces + 2, {}, false);
+}
+
+/************************************************************************/
+/*              GDALMultiDimTextOutputDumper::DumpArray()               */
+/************************************************************************/
+
+void GDALMultiDimTextOutputDumper::DumpArray(
+    const std::shared_ptr<GDALMDArray> &poArray)
+{
+    AddLine();
+    AddLine("  - " + poArray->GetFullName() + ":");
+
+    constexpr int INDENT_LEVEL = 6;
+
+    TableType props;
+    const auto &dims = poArray->GetDimensions();
+    props.push_back(
+        {"Dimensions:", DimsToString(dims, DimsToSameDimGroup(dims))});
+    props.push_back({"Shape:", DimsToShapeString(dims)});
+    bool bAllZero = true;
+    std::string osChunkSize =
+        BlockSizeToString(poArray->GetBlockSize(), &bAllZero);
+    if (!bAllZero)
+        props.push_back({"Chunk size:", std::move(osChunkSize)});
+
+    const auto &dt = poArray->GetDataType();
+    props.push_back({"Type:", TypeToString(dt)});
+    const std::string &osUnit = poArray->GetUnit();
+    if (!osUnit.empty())
+        props.push_back({"Unit:", osUnit});
+
+    if (const auto nodata = poArray->GetRawNoDataValue())
+    {
+        CPLJSonStreamingWriter serializer(nullptr, nullptr);
+        serializer.SetPrettyFormatting(false);
+        DumpValue(serializer, static_cast<const GByte *>(nodata), dt);
+        props.push_back({"Nodata value:", serializer.GetString()});
+    }
+    DumpTable(props, INDENT_LEVEL, {},
+              /* headerLineSeparator =  */ false,
+              /* bLeftPadNumbers = */ false);
+
+    DumpAttributes(poArray->GetAttributes(), INDENT_LEVEL);
+
+    if (const auto poSRS = poArray->GetSpatialRef())
+    {
+        AddLine();
+        std::string osCRS;
+        EmitTextDisplayOfCRS(poSRS.get(), "AUTO", "Coordinate Reference System",
+                             [&osCRS](const std::string &s) { osCRS += s; });
+        const CPLStringList aosLines(
+            CSLTokenizeString2(osCRS.c_str(), "\n", 0));
+        for (const char *pszLine : aosLines)
+            AddLine(std::string(INDENT_LEVEL, ' ').append(pszLine));
+    }
+
+    if (CSLConstList papszStructuralInfo = poArray->GetStructuralInfo())
+    {
+        DumpStructuralInfo(papszStructuralInfo, INDENT_LEVEL);
+    }
+
+    if (m_sOptions.bStats)
+    {
+        double dfMin = 0.0;
+        double dfMax = 0.0;
+        double dfMean = 0.0;
+        double dfStdDev = 0.0;
+        GUInt64 nValidCount = 0;
+        if (poArray->GetStatistics(false, true, &dfMin, &dfMax, &dfMean,
+                                   &dfStdDev, &nValidCount, nullptr,
+                                   nullptr) == CE_None)
+        {
+            AddLine();
+            AddLine(std::string(INDENT_LEVEL, ' ').append("Statistics:"));
+
+            TableType stats;
+            if (nValidCount > 0)
+            {
+                stats.push_back({"min", std::to_string(dfMin)});
+                stats.push_back({"max", std::to_string(dfMax)});
+                stats.push_back({"mean", std::to_string(dfMean)});
+                stats.push_back({"stddev", std::to_string(dfStdDev)});
+            }
+            stats.push_back(
+                {"valid sample count", std::to_string(nValidCount)});
+
+            DumpTable(stats, INDENT_LEVEL + 2, {}, false);
+        }
+    }
+
+    if (m_sOptions.bDetailed)
+    {
+        if (dims.empty())
+        {
+            std::vector<GByte> abyTmp(dt.GetSize());
+            poArray->Read(nullptr, nullptr, nullptr, nullptr, dt, &abyTmp[0]);
+            CPLJSonStreamingWriter serializer(nullptr, nullptr);
+            DumpValue(serializer, &abyTmp[0], dt);
+
+            AddLine();
+            AddLine(std::string(INDENT_LEVEL, ' ')
+                        .append("Value: ")
+                        .append(serializer.GetString()));
+        }
+        else
+        {
+            AddLine();
+            AddLine(std::string(INDENT_LEVEL, ' ').append("Values:"));
+
+            int nIndent = INDENT_LEVEL;
+            CPLJSonStreamingWriter serializer(m_sOptions.bStdoutOutput
+                                                  ? WriteToStdoutWithSpaceIndent
+                                                  : nullptr,
+                                              &nIndent);
+            std::vector<GUInt64> startIdx(dims.size());
+            std::vector<GUInt64> dimSizes;
+            for (const auto &dim : dims)
+                dimSizes.emplace_back(dim->GetSize());
+            if (m_sOptions.bStdoutOutput)
+                printf("%s", std::string(INDENT_LEVEL, ' ').c_str());
+            DumpArrayRec(poArray, serializer, 0, dimSizes, startIdx,
+                         &m_sOptions);
+            if (!m_sOptions.bStdoutOutput)
+            {
+                AddLine(std::string(INDENT_LEVEL, ' ')
+                            .append(CPLString(serializer.GetString())
+                                        .replaceAll(
+                                            '\n', std::string("\n").append(
+                                                      std::string(INDENT_LEVEL,
+                                                                  ' ')))));
+            }
+            else
+            {
+                AddLine();
+            }
+        }
+    }
+}
+
+/************************************************************************/
+/*        GDALMultiDimTextOutputDumper:: DumpDimensionsSummary()        */
+/************************************************************************/
+
+std::set<std::string> GDALMultiDimTextOutputDumper::DumpDimensionsSummary(
+    const std::shared_ptr<GDALGroup> &group)
+{
+    std::set<std::string> oSetIndexingVariablePaths;
+
+    const auto dims = group->GetDimensionsRecursive();
+    if (!dims.empty())
+    {
+        AddLine();
+        AddLine("Dimensions:");
+        TableType lines;
+        lines.push_back({"Name (path)", "Size", "Type", "Direction"});
+        for (const auto &poDim : dims)
+        {
+            std::vector<std::string> line{
+                poDim->GetFullName(), std::to_string(poDim->GetSize()),
+                poDim->GetType(), poDim->GetDirection()};
+            lines.push_back(std::move(line));
+            const auto poIndexingVariable = poDim->GetIndexingVariable();
+            if (poIndexingVariable)
+            {
+                const auto &osIndexingVarPath =
+                    poIndexingVariable->GetFullName();
+                if (!osIndexingVarPath.empty() && osIndexingVarPath[0] == '/')
+                {
+                    oSetIndexingVariablePaths.insert(osIndexingVarPath);
+                }
+            }
+        }
+        DumpTable(lines);
+    }
+
+    return oSetIndexingVariablePaths;
+}
+
+/************************************************************************/
+/*          GDALMultiDimTextOutputDumper:: DumpArraysSummary()          */
+/************************************************************************/
+
+void GDALMultiDimTextOutputDumper::DumpArraysSummary(
+    const std::shared_ptr<GDALGroup> &group,
+    const std::vector<std::shared_ptr<GDALMDArray>> &apoArrays)
+{
+    const std::set<std::string> oSetIndexingVariablePaths =
+        DumpDimensionsSummary(group);
+
+    TableType linesCoordinateArrays;
+    TableType linesScalarArrays;
+    std::map<std::string, TableType> linesDataArrays;
+    for (const auto &poArray : apoArrays)
+    {
+        const auto &dims = poArray->GetDimensions();
+        if (cpl::contains(oSetIndexingVariablePaths, poArray->GetFullName()))
+        {
+            if (linesCoordinateArrays.empty())
+                linesCoordinateArrays.push_back(
+                    {"Name (path)", "Dimension", "Type", "Unit"});
+            std::string osDimension;
+            for (const auto &poDim : dims)
+            {
+                if (osDimension.empty())
+                    osDimension = '(';
+                else
+                    osDimension += ", ";
+                osDimension += poDim->GetName();
+            }
+            if (!osDimension.empty())
+                osDimension += ')';
+            std::vector<std::string> line{
+                poArray->GetFullName(), std::move(osDimension),
+                TypeToString(poArray->GetDataType()), poArray->GetUnit()};
+            linesCoordinateArrays.push_back(std::move(line));
+        }
+        else if (dims.empty())
+        {
+            if (linesScalarArrays.empty())
+                linesScalarArrays.push_back({"Name (path)", "Type", "Unit"});
+            std::vector<std::string> line{poArray->GetFullName(),
+                                          TypeToString(poArray->GetDataType()),
+                                          poArray->GetUnit()};
+            linesScalarArrays.push_back(std::move(line));
+        }
+        else
+        {
+            const std::string osSameDimGroup = DimsToSameDimGroup(dims);
+
+            bool bAllZero = true;
+            std::string osChunkSize =
+                BlockSizeToString(poArray->GetBlockSize(), &bAllZero);
+
+            std::vector<std::string> line{
+                poArray->GetFullName(), TypeToString(poArray->GetDataType()),
+                poArray->GetUnit(), DimsToShapeString(dims),
+                bAllZero ? std::string("(unknown)") : osChunkSize};
+            linesDataArrays[DimsToString(dims, osSameDimGroup)].push_back(
+                std::move(line));
+        }
+    }
+
+    if (!linesCoordinateArrays.empty())
+    {
+        AddLine();
+        AddLine("Coordinates (indexing variables):");
+        DumpTable(linesCoordinateArrays);
+    }
+
+    if (!linesDataArrays.empty())
+    {
+        AddLine();
+        AddLine("Data variables:");
+
+        TableType headerLine;
+        headerLine.push_back(
+            {"Name (path)", "Type", "Unit", "Shape", "Chunk size"});
+
+        std::vector<size_t> anColSizeDataVars;
+        anColSizeDataVars.resize(headerLine[0].size());
+        for (const auto [iCol, col] : cpl::enumerate(headerLine[0]))
+            anColSizeDataVars[iCol] = col.size();
+        for (const auto &[_, lines] : linesDataArrays)
+        {
+            for (const auto &line : lines)
+            {
+                for (const auto [iCol, col] : cpl::enumerate(line))
+                {
+                    anColSizeDataVars[iCol] =
+                        std::max(anColSizeDataVars[iCol], col.size());
+                }
+            }
+        }
+
+        DumpTable(headerLine, 2, anColSizeDataVars);
+        for (const auto &[path, lines] : linesDataArrays)
+        {
+            AddLine();
+            AddLine(" " + path + ":");
+            DumpTable(lines, 2, anColSizeDataVars, false);
+        }
+    }
+
+    if (!linesScalarArrays.empty())
+    {
+        AddLine();
+        AddLine("Scalar arrays:");
+        DumpTable(linesScalarArrays);
+    }
+}
+
+/************************************************************************/
+/*          GDALMultiDimTextOutputDumper::DrumpGroupsSummary()          */
+/************************************************************************/
+
+void GDALMultiDimTextOutputDumper::DrumpGroupsSummary(
+    const std::shared_ptr<GDALGroup> &group)
+{
+    const auto apoGroups = group->GetGroupsRecursive();
+    if (!apoGroups.empty())
+    {
+        AddLine();
+        AddLine("Groups:");
+        std::vector<std::vector<std::string>> groupNames;
+        for (auto &poGroup : apoGroups)
+            groupNames.push_back(CPLStringList(
+                CSLTokenizeString2(poGroup->GetFullName().c_str(), "/", 0)));
+        std::sort(groupNames.begin(), groupNames.end());
+        for (const auto &groupName : groupNames)
+        {
+            std::string osLine("  ");
+            for (const auto &part : groupName)
+            {
+                osLine += '/';
+                osLine += part;
+            }
+            AddLine(osLine);
+        }
+    }
+}
+
+/************************************************************************/
+/*                             DumpAsText()                             */
+/************************************************************************/
+
+static char *DumpAsText(const std::shared_ptr<GDALGroup> &group,
+                        const char *pszDriverName,
+                        const GDALMultiDimInfoOptions *psOptions)
+{
+    GDALMultiDimTextOutputDumper dumper(psOptions);
+
+    CPLStringList aosOptionsGetArray(psOptions->aosArrayOptions);
+    if (psOptions->bDetailed)
+        aosOptionsGetArray.SetNameValue("SHOW_ALL", "YES");
+
+    const auto apoArrays =
+        group->GetMDArraysRecursive(nullptr, aosOptionsGetArray.List());
+
+    if (psOptions->osArrayName.empty())
+    {
+        dumper.AddLine(
+            std::string("Driver: ")
+                .append(pszDriverName ? pszDriverName : "(unknown)"));
+
+        if (CSLConstList papszStructuralInfo = group->GetStructuralInfo())
+        {
+            dumper.DumpStructuralInfo(papszStructuralInfo, 0);
+        }
+
+        dumper.DumpArraysSummary(group, apoArrays);
+
+        dumper.DrumpGroupsSummary(group);
+    }
+
+    if ((!psOptions->bSummary || !psOptions->osArrayName.empty()) &&
+        !apoArrays.empty())
+    {
+        if (psOptions->osArrayName.empty())
+        {
+            dumper.DumpAttributes(group->GetAttributes(), 0);
+            dumper.AddLine();
+        }
+
+        dumper.AddLine("Arrays:");
+        for (const auto &poArray : apoArrays)
+        {
+            if (psOptions->osArrayName.empty() ||
+                poArray->GetName() == psOptions->osArrayName ||
+                poArray->GetFullName() == psOptions->osArrayName)
+            {
+                dumper.DumpArray(poArray);
+            }
+        }
+    }
+
+    if (psOptions->bStdoutOutput)
+    {
+        return VSIStrdup("ok");
+    }
+    else
+    {
+        return VSIStrdup(dumper.m_osOutput.c_str());
+    }
+}
+
+/************************************************************************/
 /*                           WriteToStdout()                            */
 /************************************************************************/
 
@@ -1203,6 +1999,10 @@ static void WriteToStdout(const char *pszText, void *)
 {
     printf("%s", pszText);
 }
+
+/************************************************************************/
+/*                GDALMultiDimInfoAppOptionsGetParser()                 */
+/************************************************************************/
 
 static std::unique_ptr<GDALArgumentParser> GDALMultiDimInfoAppOptionsGetParser(
     GDALMultiDimInfoOptions *psOptions,
@@ -1277,6 +2077,11 @@ static std::unique_ptr<GDALArgumentParser> GDALMultiDimInfoAppOptionsGetParser(
         .store_into(psOptions->bStats)
         .help(_("Read and display image statistics."));
 
+    argParser->add_argument("-format")
+        .hidden()
+        .store_into(psOptions->osFormat)
+        .help(_("Output format."));
+
     // Only used by gdalmdiminfo binary to write output to stdout instead of in a string, in JSON mode
     argParser->add_argument("-stdout").flag().hidden().store_into(
         psOptions->bStdoutOutput);
@@ -1349,60 +2154,70 @@ char *GDALMultiDimInfo(GDALDatasetH hDataset,
 
     std::set<std::string> alreadyDumpedDimensions;
     std::set<std::string> alreadyDumpedArrays;
+
     try
     {
-        if (psOptions->osArrayName.empty())
+        const char *pszDriverName = nullptr;
+        auto poDriver = poDS->GetDriver();
+        if (poDriver)
+            pszDriverName = poDriver->GetDescription();
+
+        if (psOptions->osFormat == "text")
         {
-            const char *pszDriverName = nullptr;
-            auto poDriver = poDS->GetDriver();
-            if (poDriver)
-                pszDriverName = poDriver->GetDescription();
-            DumpGroup(group, group, pszDriverName, serializer, psOptions,
-                      alreadyDumpedDimensions, alreadyDumpedArrays, true, true);
+            return DumpAsText(group, pszDriverName, psOptions);
         }
         else
         {
-            auto curGroup = group;
-            CPLStringList aosTokens(
-                CSLTokenizeString2(psOptions->osArrayName.c_str(), "/", 0));
-            for (int i = 0; i < aosTokens.size() - 1; i++)
+            if (psOptions->osArrayName.empty())
             {
-                auto curGroupNew = curGroup->OpenGroup(aosTokens[i]);
-                if (!curGroupNew)
+                DumpGroup(group, group, pszDriverName, serializer, psOptions,
+                          alreadyDumpedDimensions, alreadyDumpedArrays, true,
+                          true);
+            }
+            else
+            {
+                auto curGroup = group;
+                CPLStringList aosTokens(
+                    CSLTokenizeString2(psOptions->osArrayName.c_str(), "/", 0));
+                for (int i = 0; i < aosTokens.size() - 1; i++)
+                {
+                    auto curGroupNew = curGroup->OpenGroup(aosTokens[i]);
+                    if (!curGroupNew)
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Cannot find group %s", aosTokens[i]);
+                        return nullptr;
+                    }
+                    curGroup = std::move(curGroupNew);
+                }
+                const char *pszArrayName = aosTokens.back();
+                auto array(curGroup->OpenMDArray(pszArrayName));
+                if (!array)
                 {
                     CPLError(CE_Failure, CPLE_AppDefined,
-                             "Cannot find group %s", aosTokens[i]);
+                             "Cannot find array %s", pszArrayName);
                     return nullptr;
                 }
-                curGroup = std::move(curGroupNew);
+                DumpArray(group, array, serializer, psOptions,
+                          alreadyDumpedDimensions, alreadyDumpedArrays, true,
+                          true, true);
             }
-            const char *pszArrayName = aosTokens.back();
-            auto array(curGroup->OpenMDArray(pszArrayName));
-            if (!array)
+
+            if (psOptions->bStdoutOutput)
             {
-                CPLError(CE_Failure, CPLE_AppDefined, "Cannot find array %s",
-                         pszArrayName);
-                return nullptr;
+                printf("\n");
+                return VSIStrdup("ok");
             }
-            DumpArray(group, array, serializer, psOptions,
-                      alreadyDumpedDimensions, alreadyDumpedArrays, true, true,
-                      true);
+            else
+            {
+                return VSIStrdup(serializer.GetString().c_str());
+            }
         }
     }
     catch (const std::exception &e)
     {
         CPLError(CE_Failure, CPLE_AppDefined, "%s", e.what());
         return nullptr;
-    }
-
-    if (psOptions->bStdoutOutput)
-    {
-        printf("\n");
-        return VSIStrdup("ok");
-    }
-    else
-    {
-        return VSIStrdup(serializer.GetString().c_str());
     }
 }
 

--- a/autotest/utilities/test_gdalalg_mdim_info.py
+++ b/autotest/utilities/test_gdalalg_mdim_info.py
@@ -177,9 +177,11 @@ def test_gdalalg_mdim_info_all_options():
     }
 
 
-def test_gdalalg_mdim_info_binary(gdal_path):
+def test_gdalalg_mdim_info_binary_json(gdal_path):
 
-    out = gdaltest.runexternal(f"{gdal_path} mdim info ../gdrivers/data/netcdf/byte.nc")
+    out = gdaltest.runexternal(
+        f"{gdal_path} mdim info ../gdrivers/data/netcdf/byte.nc --format json"
+    )
     assert json.loads(out) == {
         "arrays": {
             "Band1": {
@@ -312,6 +314,421 @@ def test_gdalalg_mdim_info_binary(gdal_path):
         },
         "type": "group",
     }
+
+
+def test_gdalalg_mdim_info_text():
+
+    with gdal.alg.mdim.info(
+        input="../gdrivers/data/netcdf/byte.nc", format="text"
+    ) as alg:
+        out = alg.Output()
+
+    out = "\n".join([x.rstrip() for x in out.replace("\r\n", "\n").split("\n")])
+    assert out == """Driver: netCDF
+
+Structural metadata:
+  NC_FORMAT  CLASSIC
+
+Dimensions:
+  Name (path)  Size      Type      Direction
+  -----------  ----  ------------  ---------
+  /x             20  HORIZONTAL_X
+  /y             20  HORIZONTAL_Y
+
+Coordinates (indexing variables):
+  Name (path)  Dimension   Type    Unit
+  -----------  ---------  -------  ----
+  /x           (x)        Float64  m
+  /y           (y)        Float64  m
+
+Data variables:
+  Name (path)  Type  Unit   Shape    Chunk size
+  -----------  ----  ----  --------  ----------
+
+ (/y, /x):
+  /Band1       Byte        [20, 20]  (unknown)
+
+Attributes:
+         Name          Type                                  Value
+  ------------------  ------  -------------------------------------------------------------------
+  GDAL_AREA_OR_POINT  String  "Area"
+  Conventions         String  "CF-1.5"
+  GDAL                String  "GDAL 3.8.0dev-refs/heads-dirty, released 2023/10/09 (debug build)"
+  history             String  "Mon Oct 09 18:27:35 2023: GDAL CreateCopy( byte.nc, ... )"
+
+Arrays:
+
+  - /x:
+      Dimensions:  (/x)
+      Shape:       [20]
+      Type:        Float64
+      Unit:        m
+
+      Attributes:
+            Name        Type              Value
+        -------------  ------  ----------------------------
+        standard_name  String  "projection_x_coordinate"
+        long_name      String  "x coordinate of projection"
+
+  - /y:
+      Dimensions:  (/y)
+      Shape:       [20]
+      Type:        Float64
+      Unit:        m
+
+      Attributes:
+            Name        Type              Value
+        -------------  ------  ----------------------------
+        standard_name  String  "projection_y_coordinate"
+        long_name      String  "y coordinate of projection"
+
+  - /Band1:
+      Dimensions:  (/y, /x)
+      Shape:       [20, 20]
+      Type:        Byte
+
+      Attributes:
+           Name       Type          Value
+        -----------  ------  --------------------
+        long_name    String  "GDAL Band Number 1"
+        valid_range  UInt16  [0,255]
+
+      Coordinate Reference System:
+        - name: NAD27 / UTM zone 11N
+        - ID: EPSG:26711
+        - type: Projected
+        - projection type: UTM zone 11N, Transverse Mercator
+        - units: metre
+""", out
+
+
+def test_gdalalg_mdim_info_text_summary():
+
+    with gdal.alg.mdim.info(
+        input="../gdrivers/data/netcdf/byte.nc", summary=True, format="text"
+    ) as alg:
+        out = alg.Output()
+
+    out = "\n".join([x.rstrip() for x in out.replace("\r\n", "\n").split("\n")])
+    assert out == """Driver: netCDF
+
+Structural metadata:
+  NC_FORMAT  CLASSIC
+
+Dimensions:
+  Name (path)  Size      Type      Direction
+  -----------  ----  ------------  ---------
+  /x             20  HORIZONTAL_X
+  /y             20  HORIZONTAL_Y
+
+Coordinates (indexing variables):
+  Name (path)  Dimension   Type    Unit
+  -----------  ---------  -------  ----
+  /x           (x)        Float64  m
+  /y           (y)        Float64  m
+
+Data variables:
+  Name (path)  Type  Unit   Shape    Chunk size
+  -----------  ----  ----  --------  ----------
+
+ (/y, /x):
+  /Band1       Byte        [20, 20]  (unknown)
+""", out
+
+
+def test_gdalalg_mdim_info_text_array_detailed_stats():
+
+    with gdal.alg.mdim.info(
+        input="../gdrivers/data/netcdf/byte.nc",
+        detailed=True,
+        stats=True,
+        array="/Band1",
+        format="text",
+    ) as alg:
+        out = alg.Output()
+
+    out = "\n".join([x.rstrip() for x in out.replace("\r\n", "\n").split("\n")])
+    assert out == """Arrays:
+
+  - /Band1:
+      Dimensions:  (/y, /x)
+      Shape:       [20, 20]
+      Type:        Byte
+
+      Attributes:
+           Name       Type          Value
+        -----------  ------  --------------------
+        long_name    String  "GDAL Band Number 1"
+        valid_range  UInt16  [0,255]
+
+      Coordinate Reference System:
+        - name: NAD27 / UTM zone 11N
+        - ID: EPSG:26711
+        - type: Projected
+        - projection type: UTM zone 11N, Transverse Mercator
+        - units: metre
+
+      Statistics:
+        min                  74.000000
+        max                 255.000000
+        mean                126.765000
+        stddev               22.928471
+        valid sample count         400
+
+      Values:
+      [
+        [181, 181, 156, 148, 156, 156, 156, 181, 132, 148, 115, 132, 107, 107, 107, 107, 107, 115, 99, 107],
+        [173, 247, 255, 206, 132, 107, 140, 123, 148, 132, 165, 165, 148, 140, 132, 123, 107, 123, 107, 123],
+        [156, 181, 140, 173, 123, 132, 99, 115, 123, 74, 115, 99, 123, 140, 156, 132, 165, 140, 140, 99],
+        [189, 173, 140, 140, 165, 115, 132, 90, 99, 115, 90, 99, 99, 107, 99, 132, 99, 107, 132, 132],
+        [165, 148, 156, 123, 107, 107, 107, 115, 140, 99, 115, 99, 99, 107, 115, 132, 115, 90, 123, 115],
+        [140, 107, 140, 90, 107, 115, 107, 90, 99, 123, 115, 115, 115, 123, 123, 148, 115, 148, 99, 132],
+        [148, 132, 132, 107, 123, 99, 99, 115, 99, 132, 99, 140, 115, 148, 123, 99, 132, 123, 148, 140],
+        [173, 148, 99, 123, 123, 107, 123, 99, 107, 189, 173, 107, 115, 115, 107, 99, 140, 107, 173, 140],
+        [123, 123, 123, 107, 140, 123, 123, 115, 115, 90, 107, 173, 107, 107, 107, 107, 99, 132, 123, 115],
+        [132, 132, 132, 123, 99, 132, 123, 107, 148, 99, 115, 123, 140, 173, 123, 107, 123, 123, 123, 107],
+        [140, 140, 99, 140, 99, 115, 123, 107, 132, 107, 115, 107, 115, 123, 132, 123, 107, 123, 132, 132],
+        [123, 115, 132, 115, 123, 132, 115, 132, 132, 123, 123, 132, 99, 115, 99, 123, 132, 115, 115, 107],
+        [148, 123, 148, 115, 148, 123, 140, 123, 107, 115, 132, 115, 107, 115, 99, 123, 99, 181, 99, 107],
+        [197, 173, 148, 140, 140, 132, 99, 132, 123, 115, 140, 132, 132, 99, 132, 123, 132, 173, 123, 115],
+        [189, 173, 173, 148, 148, 115, 148, 123, 107, 132, 115, 132, 156, 99, 123, 115, 132, 132, 206, 107],
+        [132, 156, 132, 140, 132, 132, 115, 115, 115, 123, 148, 123, 165, 123, 132, 107, 107, 132, 156, 123],
+        [148, 132, 123, 123, 115, 132, 132, 123, 115, 123, 115, 123, 107, 115, 148, 107, 115, 140, 115, 132],
+        [115, 132, 140, 132, 123, 115, 140, 107, 140, 115, 132, 123, 107, 132, 132, 115, 115, 107, 115, 107],
+        [115, 132, 107, 123, 148, 115, 165, 115, 140, 107, 123, 123, 99, 132, 123, 132, 132, 132, 99, 156],
+        [107, 123, 132, 115, 132, 132, 140, 132, 132, 132, 107, 132, 107, 132, 132, 107, 123, 115, 156, 148]
+      ]
+""", out
+
+
+def test_gdalalg_mdim_info_text_structural_md_and_line_truncation():
+
+    with gdal.alg.mdim.info(
+        input="../gdrivers/data/hdf5/deflate.h5", format="text"
+    ) as alg:
+        out = alg.Output()
+
+    out = "\n".join([x.rstrip() for x in out.replace("\r\n", "\n").split("\n")])
+    assert out == """Driver: HDF5
+
+Dimensions:
+  Name (path)  Size  Type  Direction
+  -----------  ----  ----  ---------
+  /x             20
+  /y             20
+
+Data variables:
+  Name (path)  Type  Unit   Shape    Chunk size
+  -----------  ----  ----  --------  ----------
+
+ (/y, /x):
+  /Band1       Byte        [20, 20]  [1, 2]
+
+Scalar arrays:
+      Name (path)        Type   Unit
+  --------------------  ------  ----
+  /transverse_mercator  String
+
+Attributes:
+     Name       Type    Value
+  -----------  ------  --------
+  Conventions  String  "CF-1.6"
+
+Arrays:
+
+  - /Band1:
+      Dimensions:    (/y, /x)
+      Shape:         [20, 20]
+      Chunk size:    [1, 2]
+      Type:          Byte
+      Nodata value:  0
+
+      Attributes:
+            Name       Type           Value
+        ------------  ------  ---------------------
+        long_name     String  "GDAL Band Number 1"
+        valid_range   UInt16  [0,255]
+        grid_mapping  String  "transverse_mercator"
+
+      Structural metadata:
+        COMPRESSION  DEFLATE
+        FILTER       SHUFFLE
+
+  - /transverse_mercator:
+      Dimensions:  ()
+      Shape:       []
+      Type:        String
+
+      Attributes:
+                      Name                 Type                                         Value
+        --------------------------------  -------  -------------------------------------------------------------------------------
+        grid_mapping_name                 String   "transverse_mercator"
+        longitude_of_central_meridian     Float64  -117
+        false_easting                     Float64  500000
+        false_northing                    Float64  0
+        latitude_of_projection_origin     Float64  0
+        scale_factor_at_central_meridian  Float64  0.99960000000000004
+        long_name                         String   "CRS definition"
+        longitude_of_prime_meridian       Float64  0
+        semi_major_axis                   Float64  6378206.4000000004
+        inverse_flattening                Float64  294.97869821389821
+        crs_wkt                           String   "PROJCS[\\"NAD27 / UTM zone 11N\\",GEOGCS[\\"NAD27\\",
+                                                   DATUM[\\"North_American_Datum_1927\\",SPHEROID[\\"Clarke 1866\\",6378206.4,
+                                                   294.978698213898,AUTHORITY[\\"EPSG\\",\\"7008\\"]],AUTHORITY[\\"EPSG\\",\\"6267\\"]],
+                                                   PRIMEM[\\"Greenwich\\",0,AUTHORITY[\\"EPSG\\",\\"8901\\"]],UNIT[\\"degree\\",
+                                                   0.0174532925199433,AUTHORITY[\\"EPSG\\",\\"9122\\"]],AUTHORITY[\\"EPSG\\",\\"4267\\"]],
+                                                   PROJECTION[\\"Transverse_Mercator\\"],PARAMETER[\\"latitude_of_origin\\",0],
+                                                   PARAMETER[\\"central_meridian\\",-117],PARAMETER[\\"scale_factor\\",0.9996],
+                                                   PARAMETER[\\"false_easting\\",500000],PARAMETER[\\"false_northing\\",0],
+                                                   UNIT[\\"metre\\",1,AUTHORITY[\\"EPSG\\",\\"9001\\"]],AXIS[\\"Easting\\",EAST],
+                                                   AXIS[\\"Northing\\",NORTH],AUTHORITY[\\"EPSG\\",\\"26711\\"]]"
+        spatial_ref                       String   "PROJCS[\\"NAD27 / UTM zone 11N\\",GEOGCS[\\"NAD27\\",
+                                                   DATUM[\\"North_American_Datum_1927\\",SPHEROID[\\"Clarke 1866\\",6378206.4,
+                                                   294.978698213898,AUTHORITY[\\"EPSG\\",\\"7008\\"]],AUTHORITY[\\"EPSG\\",\\"6267\\"]],
+                                                   PRIMEM[\\"Greenwich\\",0,AUTHORITY[\\"EPSG\\",\\"8901\\"]],UNIT[\\"degree\\",
+                                                   0.0174532925199433,AUTHORITY[\\"EPSG\\",\\"9122\\"]],AUTHORITY[\\"EPSG\\",\\"4267\\"]],
+                                                   PROJECTION[\\"Transverse_Mercator\\"],PARAMETER[\\"latitude_of_origin\\",0],
+                                                   PARAMETER[\\"central_meridian\\",-117],PARAMETER[\\"scale_factor\\",0.9996],
+                                                   PARAMETER[\\"false_easting\\",500000],PARAMETER[\\"false_northing\\",0],
+                                                   UNIT[\\"metre\\",1,AUTHORITY[\\"EPSG\\",\\"9001\\"]],AXIS[\\"Easting\\",EAST],
+                                                   AXIS[\\"Northing\\",NORTH],AUTHORITY[\\"EPSG\\",\\"26711\\"]]"
+"""
+
+
+def test_gdalalg_mdim_info_binary_text(gdal_path):
+
+    out = gdaltest.runexternal(f"{gdal_path} mdim info ../gdrivers/data/netcdf/byte.nc")
+    out = "\n".join([x.rstrip() for x in out.replace("\r\n", "\n").split("\n")])
+    assert out == """Driver: netCDF
+
+Structural metadata:
+  NC_FORMAT  CLASSIC
+
+Dimensions:
+  Name (path)  Size      Type      Direction
+  -----------  ----  ------------  ---------
+  /x             20  HORIZONTAL_X
+  /y             20  HORIZONTAL_Y
+
+Coordinates (indexing variables):
+  Name (path)  Dimension   Type    Unit
+  -----------  ---------  -------  ----
+  /x           (x)        Float64  m
+  /y           (y)        Float64  m
+
+Data variables:
+  Name (path)  Type  Unit   Shape    Chunk size
+  -----------  ----  ----  --------  ----------
+
+ (/y, /x):
+  /Band1       Byte        [20, 20]  (unknown)
+
+Attributes:
+         Name          Type                                  Value
+  ------------------  ------  -------------------------------------------------------------------
+  GDAL_AREA_OR_POINT  String  "Area"
+  Conventions         String  "CF-1.5"
+  GDAL                String  "GDAL 3.8.0dev-refs/heads-dirty, released 2023/10/09 (debug build)"
+  history             String  "Mon Oct 09 18:27:35 2023: GDAL CreateCopy( byte.nc, ... )"
+
+Arrays:
+
+  - /x:
+      Dimensions:  (/x)
+      Shape:       [20]
+      Type:        Float64
+      Unit:        m
+
+      Attributes:
+            Name        Type              Value
+        -------------  ------  ----------------------------
+        standard_name  String  "projection_x_coordinate"
+        long_name      String  "x coordinate of projection"
+
+  - /y:
+      Dimensions:  (/y)
+      Shape:       [20]
+      Type:        Float64
+      Unit:        m
+
+      Attributes:
+            Name        Type              Value
+        -------------  ------  ----------------------------
+        standard_name  String  "projection_y_coordinate"
+        long_name      String  "y coordinate of projection"
+
+  - /Band1:
+      Dimensions:  (/y, /x)
+      Shape:       [20, 20]
+      Type:        Byte
+
+      Attributes:
+           Name       Type          Value
+        -----------  ------  --------------------
+        long_name    String  "GDAL Band Number 1"
+        valid_range  UInt16  [0,255]
+
+      Coordinate Reference System:
+        - name: NAD27 / UTM zone 11N
+        - ID: EPSG:26711
+        - type: Projected
+        - projection type: UTM zone 11N, Transverse Mercator
+        - units: metre
+""", out
+
+
+def test_gdalalg_mdim_info_binary_text_array_and_detailed(gdal_path):
+
+    out = gdaltest.runexternal(
+        f"{gdal_path} mdim info --array Band1 --detailed ../gdrivers/data/netcdf/byte.nc"
+    )
+    assert (
+        "\n".join([x.rstrip() for x in out.replace("\r\n", "\n").split("\n")])
+        == """Arrays:
+
+  - /Band1:
+      Dimensions:  (/y, /x)
+      Shape:       [20, 20]
+      Type:        Byte
+
+      Attributes:
+           Name       Type          Value
+        -----------  ------  --------------------
+        long_name    String  "GDAL Band Number 1"
+        valid_range  UInt16  [0,255]
+
+      Coordinate Reference System:
+        - name: NAD27 / UTM zone 11N
+        - ID: EPSG:26711
+        - type: Projected
+        - projection type: UTM zone 11N, Transverse Mercator
+        - units: metre
+
+      Values:
+      [
+        [181, 181, 156, 148, 156, 156, 156, 181, 132, 148, 115, 132, 107, 107, 107, 107, 107, 115, 99, 107],
+        [173, 247, 255, 206, 132, 107, 140, 123, 148, 132, 165, 165, 148, 140, 132, 123, 107, 123, 107, 123],
+        [156, 181, 140, 173, 123, 132, 99, 115, 123, 74, 115, 99, 123, 140, 156, 132, 165, 140, 140, 99],
+        [189, 173, 140, 140, 165, 115, 132, 90, 99, 115, 90, 99, 99, 107, 99, 132, 99, 107, 132, 132],
+        [165, 148, 156, 123, 107, 107, 107, 115, 140, 99, 115, 99, 99, 107, 115, 132, 115, 90, 123, 115],
+        [140, 107, 140, 90, 107, 115, 107, 90, 99, 123, 115, 115, 115, 123, 123, 148, 115, 148, 99, 132],
+        [148, 132, 132, 107, 123, 99, 99, 115, 99, 132, 99, 140, 115, 148, 123, 99, 132, 123, 148, 140],
+        [173, 148, 99, 123, 123, 107, 123, 99, 107, 189, 173, 107, 115, 115, 107, 99, 140, 107, 173, 140],
+        [123, 123, 123, 107, 140, 123, 123, 115, 115, 90, 107, 173, 107, 107, 107, 107, 99, 132, 123, 115],
+        [132, 132, 132, 123, 99, 132, 123, 107, 148, 99, 115, 123, 140, 173, 123, 107, 123, 123, 123, 107],
+        [140, 140, 99, 140, 99, 115, 123, 107, 132, 107, 115, 107, 115, 123, 132, 123, 107, 123, 132, 132],
+        [123, 115, 132, 115, 123, 132, 115, 132, 132, 123, 123, 132, 99, 115, 99, 123, 132, 115, 115, 107],
+        [148, 123, 148, 115, 148, 123, 140, 123, 107, 115, 132, 115, 107, 115, 99, 123, 99, 181, 99, 107],
+        [197, 173, 148, 140, 140, 132, 99, 132, 123, 115, 140, 132, 132, 99, 132, 123, 132, 173, 123, 115],
+        [189, 173, 173, 148, 148, 115, 148, 123, 107, 132, 115, 132, 156, 99, 123, 115, 132, 132, 206, 107],
+        [132, 156, 132, 140, 132, 132, 115, 115, 115, 123, 148, 123, 165, 123, 132, 107, 107, 132, 156, 123],
+        [148, 132, 123, 123, 115, 132, 132, 123, 115, 123, 115, 123, 107, 115, 148, 107, 115, 140, 115, 132],
+        [115, 132, 140, 132, 123, 115, 140, 107, 140, 115, 132, 123, 107, 132, 132, 115, 115, 107, 115, 107],
+        [115, 132, 107, 123, 148, 115, 165, 115, 140, 107, 123, 123, 99, 132, 123, 132, 132, 132, 99, 156],
+        [107, 123, 132, 115, 132, 132, 140, 132, 132, 132, 107, 132, 107, 132, 132, 107, 123, 115, 156, 148]
+      ]
+"""
+    ), out
 
 
 def test_gdalalg_mdim_info_completion_array_invalid_ds(gdal_path):

--- a/doc/source/programs/gdal_mdim_info.rst
+++ b/doc/source/programs/gdal_mdim_info.rst
@@ -46,8 +46,15 @@ step of a :ref:`gdal_mdim_pipeline`.
 
 The following options are available:
 
-Standard options
-++++++++++++++++
+Program-Specific Options
+------------------------
+
+.. option:: -f, --of, --format, --output-format json|text
+
+    .. versionadded:: 3.14
+
+    Which output format to use. Default is JSON, unless the program is invoked
+    from command line, in which case it is text.
 
 .. option:: --summary
 
@@ -108,11 +115,110 @@ Examples
 --------
 
 .. example::
-   :title: Getting information on the file :file:`netcdf-4d.nc` as JSON output
+   :title: Getting information on the file :file:`netcdf-4d.nc` as text output
 
    .. code-block:: console
 
        $ gdal mdim info netcdf-4d.nc
+
+   .. code-block::
+
+        Driver: netCDF
+
+        Structural metadata:
+          NC_FORMAT  CLASSIC
+
+        Dimensions:
+          Name (path)  Size      Type      Direction
+          -----------  ----  ------------  ---------
+          /levelist       2  VERTICAL
+          /longitude     10  HORIZONTAL_X  EAST
+          /latitude      10  HORIZONTAL_Y  NORTH
+          /time           4  TEMPORAL
+
+        Coordinates (indexing variables):
+          Name (path)   Dimension    Type                 Unit
+          -----------  -----------  -------  -------------------------------
+          /levelist    (levelist)   Int32    millibars
+          /longitude   (longitude)  Float32  degrees_east
+          /latitude    (latitude)   Float32  degrees_north
+          /time        (time)       Float64  hours since 1900-01-01 00:00:00
+
+        Data variables:
+          Name (path)  Type   Unit      Shape       Chunk size
+          -----------  -----  ----  --------------  ----------
+
+         (/time, /levelist, /latitude, /longitude):
+          /t           Int32        [4, 2, 10, 10]  (unknown)
+
+        Attributes:
+             Name       Type    Value
+          -----------  ------  --------
+          Conventions  String  "CF-1.5"
+
+        Arrays:
+
+          - /levelist:
+              Dimensions:  (/levelist)
+              Shape:       [2]
+              Type:        Int32
+              Unit:        millibars
+
+              Attributes:
+                  Name      Type        Value
+                ---------  ------  ----------------
+                long_name  String  "pressure_level"
+
+          - /longitude:
+              Dimensions:  (/longitude)
+              Shape:       [10]
+              Type:        Float32
+              Unit:        degrees_east
+
+              Attributes:
+                    Name        Type      Value
+                -------------  ------  -----------
+                standard_name  String  "longitude"
+                long_name      String  "longitude"
+                axis           String  "X"
+
+          - /latitude:
+              Dimensions:  (/latitude)
+              Shape:       [10]
+              Type:        Float32
+              Unit:        degrees_north
+
+              Attributes:
+                    Name        Type     Value
+                -------------  ------  ----------
+                standard_name  String  "latitude"
+                long_name      String  "latitude"
+                axis           String  "Y"
+
+          - /time:
+              Dimensions:  (/time)
+              Shape:       [4]
+              Type:        Float64
+              Unit:        hours since 1900-01-01 00:00:00
+
+              Attributes:
+                    Name        Type     Value
+                -------------  ------  ----------
+                standard_name  String  "time"
+                calendar       String  "standard"
+
+          - /t:
+              Dimensions:    (/time, /levelist, /latitude, /longitude)
+              Shape:         [4, 2, 10, 10]
+              Type:          Int32
+              Nodata value:  -32767
+
+.. example::
+   :title: Getting information on the file :file:`netcdf-4d.nc` as JSON output
+
+   .. code-block:: console
+
+       $ gdal mdim info --format json netcdf-4d.nc
 
    .. code-block:: json
 

--- a/gcore/multidim/gdal_multidim.h
+++ b/gcore/multidim/gdal_multidim.h
@@ -391,14 +391,33 @@ class CPL_DLL GDALGroup : public GDALIHasAttribute
                 CSLConstList papszOptions = nullptr) const;
 
     std::vector<std::string> GetMDArrayFullNamesRecursive(
-        CSLConstList papszGroupOptions = nullptr,
-        CSLConstList papszArrayOptions = nullptr) const;
+        CSLConstList papszGroupDiscoverOptions = nullptr,
+        CSLConstList papszArrayDiscoverOptions = nullptr,
+        CSLConstList papszGroupOpenOptions = nullptr) const;
+
+    std::vector<std::shared_ptr<GDALMDArray>>
+    GetMDArrays(CSLConstList papszDiscoverOptions = nullptr,
+                CSLConstList papszOpenOptions = nullptr) const;
+
+    std::vector<std::shared_ptr<GDALMDArray>>
+    GetMDArraysRecursive(CSLConstList papszGroupDiscoverOptions = nullptr,
+                         CSLConstList papszArrayDiscoverOptions = nullptr,
+                         CSLConstList papszGroupOpenOptions = nullptr,
+                         CSLConstList papszArrayOpenOptions = nullptr) const;
 
     virtual std::vector<std::string>
     GetGroupNames(CSLConstList papszOptions = nullptr) const;
     virtual std::shared_ptr<GDALGroup>
     OpenGroup(const std::string &osName,
               CSLConstList papszOptions = nullptr) const;
+
+    std::vector<std::shared_ptr<GDALGroup>>
+    GetGroups(CSLConstList papszDiscoverOptions = nullptr,
+              CSLConstList papszOpenOptions = nullptr) const;
+
+    std::vector<std::shared_ptr<GDALGroup>>
+    GetGroupsRecursive(CSLConstList papszDiscoverOptions = nullptr,
+                       CSLConstList papszOpenOptions = nullptr) const;
 
     virtual std::vector<std::string>
     GetVectorLayerNames(CSLConstList papszOptions = nullptr) const;
@@ -408,6 +427,13 @@ class CPL_DLL GDALGroup : public GDALIHasAttribute
 
     virtual std::vector<std::shared_ptr<GDALDimension>>
     GetDimensions(CSLConstList papszOptions = nullptr) const;
+
+    std::vector<std::shared_ptr<GDALDimension>>
+    GetDimensionsRecursive(CSLConstList papszDimensionDiscoverOptions = nullptr,
+                           CSLConstList papszGroupDiscoverOptions = nullptr,
+                           CSLConstList papszArrayDiscoverOptions = nullptr,
+                           CSLConstList papszGroupOpenOptions = nullptr,
+                           CSLConstList papszArrayOpenOptions = nullptr) const;
 
     virtual std::shared_ptr<GDALGroup>
     CreateGroup(const std::string &osName, CSLConstList papszOptions = nullptr);

--- a/gcore/multidim/gdalmultidim_group.cpp
+++ b/gcore/multidim/gdalmultidim_group.cpp
@@ -76,18 +76,21 @@ GDALGroup::GetMDArrayNames(CPL_UNUSED CSLConstList papszOptions) const
  *
  * This is the same as the C function GDALGroupGetMDArrayFullNamesRecursive().
  *
- * @param papszGroupOptions Driver specific options determining how groups
+ * @param papszGroupDiscoverOptions Driver specific options determining how groups
  * should be retrieved. Pass nullptr for default behavior.
- * @param papszArrayOptions Driver specific options determining how arrays
+ * @param papszArrayDiscoverOptions Driver specific options determining how arrays
  * should be retrieved. Pass nullptr for default behavior.
+ * @param papszGroupOpenOptions Driver specific options determining how a group should
+ * be opened.  Pass nullptr for default behavior.
  *
  * @return the array full names.
  *
  * @since 3.11
  */
-std::vector<std::string>
-GDALGroup::GetMDArrayFullNamesRecursive(CSLConstList papszGroupOptions,
-                                        CSLConstList papszArrayOptions) const
+std::vector<std::string> GDALGroup::GetMDArrayFullNamesRecursive(
+    CSLConstList papszGroupDiscoverOptions,
+    CSLConstList papszArrayDiscoverOptions,
+    CSLConstList papszGroupOpenOptions) const
 {
     std::vector<std::string> ret;
     std::list<std::shared_ptr<GDALGroup>> stackGroups;
@@ -98,7 +101,7 @@ GDALGroup::GetMDArrayFullNamesRecursive(CSLConstList papszGroupOptions,
         stackGroups.erase(stackGroups.begin());
         const GDALGroup *poCurGroup = groupPtr ? groupPtr.get() : this;
         for (const std::string &arrayName :
-             poCurGroup->GetMDArrayNames(papszArrayOptions))
+             poCurGroup->GetMDArrayNames(papszArrayDiscoverOptions))
         {
             std::string osFullName = poCurGroup->GetFullName();
             if (!osFullName.empty() && osFullName.back() != '/')
@@ -108,9 +111,10 @@ GDALGroup::GetMDArrayFullNamesRecursive(CSLConstList papszGroupOptions,
         }
         auto insertionPoint = stackGroups.begin();
         for (const auto &osSubGroup :
-             poCurGroup->GetGroupNames(papszGroupOptions))
+             poCurGroup->GetGroupNames(papszGroupDiscoverOptions))
         {
-            auto poSubGroup = poCurGroup->OpenGroup(osSubGroup);
+            auto poSubGroup =
+                poCurGroup->OpenGroup(osSubGroup, papszGroupOpenOptions);
             if (poSubGroup)
                 stackGroups.insert(insertionPoint, std::move(poSubGroup));
         }
@@ -143,6 +147,87 @@ GDALGroup::OpenMDArray(CPL_UNUSED const std::string &osName,
                        CPL_UNUSED CSLConstList papszOptions) const
 {
     return nullptr;
+}
+
+/************************************************************************/
+/*                            GetMDArrays()                             */
+/************************************************************************/
+
+/** Open and return all multidimensional arrays of this group.
+ *
+ * @param papszDiscoverOptions Driver specific options determining how arrays
+ * should be retrieved. Pass nullptr for default behavior.
+ * @param papszOpenOptions Driver specific options determining how an array should
+ * be opened.  Pass nullptr for default behavior.
+ *
+ * @return the arrays
+ * @since GDAL 3.14
+ */
+std::vector<std::shared_ptr<GDALMDArray>>
+GDALGroup::GetMDArrays(CSLConstList papszDiscoverOptions,
+                       CSLConstList papszOpenOptions) const
+{
+    std::vector<std::shared_ptr<GDALMDArray>> ret;
+    for (const auto &osName : GetMDArrayNames(papszDiscoverOptions))
+    {
+        if (auto poMDArray = OpenMDArray(osName, papszOpenOptions))
+            ret.push_back(std::move(poMDArray));
+    }
+    return ret;
+}
+
+/************************************************************************/
+/*                        GetMDArraysRecursive()                        */
+/************************************************************************/
+
+/** Open and return all multidimensional arrays of this group and its subgroups.
+ *
+ * @param papszGroupDiscoverOptions Driver specific options determining how groups
+ * should be retrieved. Pass nullptr for default behavior.
+ * @param papszArrayDiscoverOptions Driver specific options determining how arrays
+ * should be retrieved. Pass nullptr for default behavior.
+ * @param papszGroupOpenOptions Driver specific options determining how a group should
+ * be opened.  Pass nullptr for default behavior.
+ * @param papszArrayOpenOptions Driver specific options determining how an array should
+ * be opened.  Pass nullptr for default behavior.
+ *
+ * @return the arrays
+ * @since GDAL 3.14
+ */
+std::vector<std::shared_ptr<GDALMDArray>>
+GDALGroup::GetMDArraysRecursive(CSLConstList papszGroupDiscoverOptions,
+                                CSLConstList papszArrayDiscoverOptions,
+                                CSLConstList papszGroupOpenOptions,
+                                CSLConstList papszArrayOpenOptions) const
+{
+    std::vector<std::shared_ptr<GDALMDArray>> ret;
+    std::list<std::shared_ptr<GDALGroup>> stackGroups;
+    stackGroups.push_back(nullptr);  // nullptr means this
+    while (!stackGroups.empty())
+    {
+        std::shared_ptr<GDALGroup> groupPtr = std::move(stackGroups.front());
+        stackGroups.erase(stackGroups.begin());
+        const GDALGroup *poCurGroup = groupPtr ? groupPtr.get() : this;
+        for (const std::string &arrayName :
+             poCurGroup->GetMDArrayNames(papszArrayDiscoverOptions))
+        {
+            auto poArray =
+                poCurGroup->OpenMDArray(arrayName, papszArrayOpenOptions);
+            if (poArray)
+                ret.push_back(std::move(poArray));
+        }
+        auto insertionPoint = stackGroups.begin();
+        for (const auto &osSubGroup :
+             poCurGroup->GetGroupNames(papszGroupDiscoverOptions))
+        {
+            auto poSubGroup =
+                poCurGroup->OpenGroup(osSubGroup, papszGroupOpenOptions);
+            if (poSubGroup)
+                stackGroups.insert(insertionPoint, std::move(poSubGroup));
+        }
+    }
+
+    return ret;
 }
 
 /************************************************************************/
@@ -193,6 +278,76 @@ GDALGroup::OpenGroup(CPL_UNUSED const std::string &osName,
                      CPL_UNUSED CSLConstList papszOptions) const
 {
     return nullptr;
+}
+
+/************************************************************************/
+/*                             GetGroups()                              */
+/************************************************************************/
+
+/** Open and return all subgroups of this group.
+ *
+ * @param papszDiscoverOptions Driver specific options determining how subgroups
+ * should be retrieved. Pass nullptr for default behavior.
+ * @param papszOpenOptions Driver specific options determining how a subgroup should
+ * be opened. Pass nullptr for default behavior.
+ *
+ * @return the subgroups
+ * @since GDAL 3.14
+ */
+std::vector<std::shared_ptr<GDALGroup>>
+GDALGroup::GetGroups(CSLConstList papszDiscoverOptions,
+                     CSLConstList papszOpenOptions) const
+{
+    std::vector<std::shared_ptr<GDALGroup>> ret;
+    for (const auto &osName : GetGroupNames(papszDiscoverOptions))
+    {
+        if (auto poSubGroup = OpenGroup(osName, papszOpenOptions))
+            ret.push_back(std::move(poSubGroup));
+    }
+    return ret;
+}
+
+/************************************************************************/
+/*                    GetMDArrayFullNamesRecursive()                    */
+/************************************************************************/
+
+/** Open and return all subgroups of this group, in a recursive way.
+ *
+ * @param papszDiscoverOptions Driver specific options determining how subgroups
+ * should be retrieved. Pass nullptr for default behavior.
+ * @param papszOpenOptions Driver specific options determining how a subgroup should
+ * be opened. Pass nullptr for default behavior.
+ *
+ * @return the subgroups
+ * @since GDAL 3.14
+ */
+std::vector<std::shared_ptr<GDALGroup>>
+GDALGroup::GetGroupsRecursive(CSLConstList papszDiscoverOptions,
+                              CSLConstList papszOpenOptions) const
+{
+    std::vector<std::shared_ptr<GDALGroup>> ret;
+    std::list<std::shared_ptr<GDALGroup>> stackGroups;
+    stackGroups.push_back(nullptr);  // nullptr means this
+    while (!stackGroups.empty())
+    {
+        std::shared_ptr<GDALGroup> groupPtr = std::move(stackGroups.front());
+        stackGroups.erase(stackGroups.begin());
+        const GDALGroup *poCurGroup = groupPtr ? groupPtr.get() : this;
+        auto insertionPoint = stackGroups.begin();
+        for (const auto &osSubGroup :
+             poCurGroup->GetGroupNames(papszDiscoverOptions))
+        {
+            auto poSubGroup =
+                poCurGroup->OpenGroup(osSubGroup, papszOpenOptions);
+            if (poSubGroup)
+            {
+                ret.push_back(poSubGroup);
+                stackGroups.insert(insertionPoint, std::move(poSubGroup));
+            }
+        }
+    }
+
+    return ret;
 }
 
 /************************************************************************/
@@ -268,7 +423,7 @@ OGRLayer *GDALGroup::OpenVectorLayer(CPL_UNUSED const std::string &osName,
  *
  * This is the same as the C function GDALGroupGetDimensions().
  *
- * @param papszOptions Driver specific options determining how groups
+ * @param papszOptions Driver specific options determining how dimensions
  * should be retrieved. Pass nullptr for default behavior.
  *
  * @return the dimensions.
@@ -277,6 +432,82 @@ std::vector<std::shared_ptr<GDALDimension>>
 GDALGroup::GetDimensions(CPL_UNUSED CSLConstList papszOptions) const
 {
     return {};
+}
+
+/************************************************************************/
+/*                       GetDimensionsRecursive()                       */
+/************************************************************************/
+
+/** Return all dimensions arrays of this group, its arrays, its subgroups,
+ * in a recursive way
+ *
+ * @param papszDimensionDiscoverOptions Driver specific options determining how dimensions
+ * should be retrieved. Pass nullptr for default behavior.
+ * @param papszGroupDiscoverOptions Driver specific options determining how groups
+ * should be retrieved. Pass nullptr for default behavior.
+ * @param papszArrayDiscoverOptions Driver specific options determining how arrays
+ * should be retrieved. Pass nullptr for default behavior.
+ * @param papszGroupOpenOptions Driver specific options determining how a group should
+ * be opened.  Pass nullptr for default behavior.
+ * @param papszArrayOpenOptions Driver specific options determining how an array should
+ * be opened.  Pass nullptr for default behavior.
+ *
+ * @return the dimensions
+ * @since GDAL 3.14
+ */
+std::vector<std::shared_ptr<GDALDimension>>
+GDALGroup::GetDimensionsRecursive(CSLConstList papszDimensionDiscoverOptions,
+                                  CSLConstList papszGroupDiscoverOptions,
+                                  CSLConstList papszArrayDiscoverOptions,
+                                  CSLConstList papszGroupOpenOptions,
+                                  CSLConstList papszArrayOpenOptions) const
+{
+    std::set<std::string> setDimensionNames;
+    std::vector<std::shared_ptr<GDALDimension>> ret;
+
+    const auto AddDimensions =
+        [&setDimensionNames,
+         &ret](const std::vector<std::shared_ptr<GDALDimension>> &apoDims)
+    {
+        for (const auto &poDim : apoDims)
+        {
+            const std::string &osName = poDim->GetFullName();
+            if (osName.empty() || osName.front() != '/')
+                ret.push_back(poDim);
+            else if (setDimensionNames.insert(osName).second)
+                ret.push_back(poDim);
+        }
+    };
+
+    std::list<std::shared_ptr<GDALGroup>> stackGroups;
+    stackGroups.push_back(nullptr);  // nullptr means this
+    while (!stackGroups.empty())
+    {
+        std::shared_ptr<GDALGroup> groupPtr = std::move(stackGroups.front());
+        stackGroups.erase(stackGroups.begin());
+        const GDALGroup *poCurGroup = groupPtr ? groupPtr.get() : this;
+
+        AddDimensions(poCurGroup->GetDimensions(papszDimensionDiscoverOptions));
+
+        for (const std::string &arrayName :
+             poCurGroup->GetMDArrayNames(papszArrayDiscoverOptions))
+        {
+            if (auto poMDArray = OpenMDArray(arrayName, papszArrayOpenOptions))
+            {
+                AddDimensions(poMDArray->GetDimensions());
+            }
+        }
+        auto insertionPoint = stackGroups.begin();
+        for (const auto &osSubGroup :
+             poCurGroup->GetGroupNames(papszGroupDiscoverOptions))
+        {
+            auto poSubGroup =
+                poCurGroup->OpenGroup(osSubGroup, papszGroupOpenOptions);
+            if (poSubGroup)
+                stackGroups.insert(insertionPoint, std::move(poSubGroup));
+        }
+    }
+    return ret;
 }
 
 /************************************************************************/


### PR DESCRIPTION
Summary text output is strongly inspired from @mdsumner's jq style sheet: https://raw.githubusercontent.com/mdsumner/gdal-mdim-summary/refs/heads/main/mdim-summary.jq

Example:
```
Driver: netCDF

Structural metadata:
  NC_FORMAT  CLASSIC

Dimensions:
  Name (path)  Size      Type      Direction
  -----------  ----  ------------  ---------
  /levelist       2  VERTICAL
  /longitude     10  HORIZONTAL_X  EAST
  /latitude      10  HORIZONTAL_Y  NORTH
  /time           4  TEMPORAL

Coordinates (indexing variables):
  Name (path)   Dimension    Type                 Unit
  -----------  -----------  -------  -------------------------------
  /levelist    (levelist)   Int32    millibars
  /longitude   (longitude)  Float32  degrees_east
  /latitude    (latitude)   Float32  degrees_north
  /time        (time)       Float64  hours since 1900-01-01 00:00:00

Data variables:
  Name (path)  Type   Unit      Shape       Chunk size
  -----------  -----  ----  --------------  ----------

 (/time, /levelist, /latitude, /longitude):
  /t           Int32        [4, 2, 10, 10]  (unknown)

Attributes:
     Name       Type    Value
   -----------  ------  --------
   Conventions  String  "CF-1.5"

Arrays:

  - /levelist:
      Dimensions:  (/levelist)
      Shape:       [2]
      Type:        Int32
      Unit:        millibars

      Attributes:
          Name      Type        Value
        ---------  ------  ----------------
        long_name  String  "pressure_level"

  - /longitude:
      Dimensions:  (/longitude)
      Shape:       [10]
      Type:        Float32
      Unit:        degrees_east

      Attributes:
            Name        Type      Value
        -------------  ------  -----------
        standard_name  String  "longitude"
        long_name      String  "longitude"
        axis           String  "X"

  - /latitude:
      Dimensions:  (/latitude)
      Shape:       [10]
      Type:        Float32
      Unit:        degrees_north

      Attributes:
            Name        Type     Value
        -------------  ------  ----------
        standard_name  String  "latitude"
        long_name      String  "latitude"
        axis           String  "Y"

  - /time:
      Dimensions:  (/time)
      Shape:       [4]
      Type:        Float64
      Unit:        hours since 1900-01-01 00:00:00

      Attributes:
            Name        Type     Value
        -------------  ------  ----------
        standard_name  String  "time"
        calendar       String  "standard"

  - /t:
      Dimensions:    (/time, /levelist, /latitude, /longitude)
      Shape:         [4, 2, 10, 10]
      Type:          Int32
      Nodata value:  -32767
```
