### PR TITLE
Change 'step' to 'increment' in RegularlySpacedValues example

### DIFF
--- a/doc/source/drivers/raster/vrt_multidimensional.rst
+++ b/doc/source/drivers/raster/vrt_multidimensional.rst
@@ -115,7 +115,7 @@ or zero, one or several elements among *ConstantValue*, *InlineValues*, *InlineV
     <Array name="longitude">
         <DataType>Float64</DataType>
         <DimensionRef ref="longitude"/>
-        <RegularlySpacedValues start="-180" step="0.5"/>
+        <RegularlySpacedValues start="-180" increment="0.5"/>
     </Array>
 
 .. code-block:: xml


### PR DESCRIPTION
Small doc fix in Multidimensional VRT 

`step` should be `increment` as per https://github.com/OSGeo/gdal/blob/0af1ddd60de5a1c4e7645a257dca3cd17b5d00b8/frmts/vrt/data/gdalvrt.xsd#L733


## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
