### PR TITLE
GDALMDArray: add +, -, *, / operators on same-shape arrays. Map to C and SWIG

### DIFF
--- a/autotest/gcore/multidim.py
+++ b/autotest/gcore/multidim.py
@@ -15,19 +15,13 @@ import array
 import itertools
 import json
 import math
+import operator
 import struct
 
 import gdaltest
 import pytest
 
 from osgeo import gdal, osr
-
-
-###############################################################################
-@pytest.fixture(autouse=True, scope="module")
-def module_disable_exceptions():
-    with gdaltest.disable_exceptions():
-        yield
 
 
 @pytest.mark.parametrize("obj_name", ["dataset", "band"])
@@ -173,6 +167,7 @@ def test_multidim_getview_with_indexing_var():
         gdal.GRIORA_RMS,
     ],
 )
+@gdaltest.disable_exceptions()
 def test_multidim_getresampled(resampling):
 
     ds = gdal.Open("../gdrivers/data/small_world.tif")
@@ -234,6 +229,7 @@ def test_multidim_getresampled(resampling):
         [True, True, True, True],
     ],
 )
+@gdaltest.disable_exceptions()
 def test_multidim_getresampled_new_dims_with_variables(
     with_dim_x, with_var_x, with_dim_y, with_var_y
 ):
@@ -315,6 +311,7 @@ def test_multidim_getresampled_with_srs():
     assert ds2.GetGeoTransform() == pytest.approx(expected_ds.GetGeoTransform())
 
 
+@gdaltest.disable_exceptions()
 def test_multidim_getresampled_3d():
 
     ds = gdal.Open("../gdrivers/data/small_world.tif")
@@ -378,9 +375,8 @@ def test_multidim_getresampled_error_single_dim():
     rg = mem_ds.GetRootGroup()
     dimX = rg.CreateDimension("X", None, None, 3)
     ar = rg.CreateMDArray("ar", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_UInt8))
-    with gdal.quiet_errors():
-        resampled_ar = ar.GetResampled([None], gdal.GRIORA_NearestNeighbour, None)
-        assert resampled_ar is None
+    with pytest.raises(Exception, match="only supports 2 dimensions or more"):
+        ar.GetResampled([None], gdal.GRIORA_NearestNeighbour, None)
 
 
 def test_multidim_getresampled_error_too_large_y():
@@ -393,12 +389,9 @@ def test_multidim_getresampled_error_too_large_y():
     ar = rg.CreateMDArray(
         "ar", [dimY, dimX], gdal.ExtendedDataType.Create(gdal.GDT_UInt8)
     )
-    new_dimY = rg.CreateDimension("Y", None, None, 4 * 1000 * 1000 * 1000)
-    with gdal.quiet_errors():
-        resampled_ar = ar.GetResampled(
-            [new_dimY, None], gdal.GRIORA_NearestNeighbour, None
-        )
-        assert resampled_ar is None
+    new_dimY = rg.CreateDimension("Ynew", None, None, 4 * 1000 * 1000 * 1000)
+    with pytest.raises(Exception, match="Too big size for Y dimension"):
+        ar.GetResampled([new_dimY, None], gdal.GRIORA_NearestNeighbour, None)
 
 
 def test_multidim_getresampled_error_too_large_x():
@@ -411,12 +404,9 @@ def test_multidim_getresampled_error_too_large_x():
     ar = rg.CreateMDArray(
         "ar", [dimY, dimX], gdal.ExtendedDataType.Create(gdal.GDT_UInt8)
     )
-    new_dimX = rg.CreateDimension("Y", None, None, 4 * 1000 * 1000 * 1000)
-    with gdal.quiet_errors():
-        resampled_ar = ar.GetResampled(
-            [None, new_dimX], gdal.GRIORA_NearestNeighbour, None
-        )
-        assert resampled_ar is None
+    new_dimX = rg.CreateDimension("Xnew", None, None, 4 * 1000 * 1000 * 1000)
+    with pytest.raises(Exception, match="Too big size for X dimension"):
+        ar.GetResampled([None, new_dimX], gdal.GRIORA_NearestNeighbour, None)
 
 
 def test_multidim_getresampled_error_no_geotransform():
@@ -429,9 +419,8 @@ def test_multidim_getresampled_error_no_geotransform():
     ar = rg.CreateMDArray(
         "ar", [dimY, dimX], gdal.ExtendedDataType.Create(gdal.GDT_UInt8)
     )
-    with gdal.quiet_errors():
-        resampled_ar = ar.GetResampled([None, None], gdal.GRIORA_NearestNeighbour, None)
-        assert resampled_ar is None
+    with pytest.raises(Exception, match="Unable to compute a transformation"):
+        ar.GetResampled([None, None], gdal.GRIORA_NearestNeighbour, None)
 
 
 def test_multidim_getresampled_error_extra_dim_not_same():
@@ -450,11 +439,10 @@ def test_multidim_getresampled_error_extra_dim_not_same():
     )
 
     dimOtherNew = rg.CreateDimension("otherNew", None, None, 1)
-    with gdal.quiet_errors():
-        resampled_ar = ar.GetResampled(
-            [dimOtherNew, None, None], gdal.GRIORA_NearestNeighbour, None
-        )
-        assert resampled_ar is None
+    with pytest.raises(
+        Exception, match=r"apoNewDims\[0\] should be the same as its parent"
+    ):
+        ar.GetResampled([dimOtherNew, None, None], gdal.GRIORA_NearestNeighbour, None)
 
 
 def test_multidim_getresampled_bad_input_dim_count():
@@ -464,17 +452,18 @@ def test_multidim_getresampled_bad_input_dim_count():
     ar = band.AsMDArray()
     assert ar
 
-    with gdal.quiet_errors():
-        resampled_ar = ar.GetResampled([None], gdal.GRIORA_NearestNeighbour, None)
-        assert resampled_ar is None
+    with pytest.raises(
+        Exception, match="apoNewDims size should be the same as GetDimensionCount"
+    ):
+        ar.GetResampled([None], gdal.GRIORA_NearestNeighbour, None)
 
-    with gdal.quiet_errors():
-        resampled_ar = ar.GetResampled(
-            [None, None, None], gdal.GRIORA_NearestNeighbour, None
-        )
-        assert resampled_ar is None
+    with pytest.raises(
+        Exception, match="apoNewDims size should be the same as GetDimensionCount"
+    ):
+        ar.GetResampled([None, None, None], gdal.GRIORA_NearestNeighbour, None)
 
 
+@gdaltest.disable_exceptions()
 def test_multidim_getgridded():
 
     drv = gdal.GetDriverByName("MEM")
@@ -2042,9 +2031,9 @@ def test_multidim_guesstransform_regular_2d():
     assert gt == pytest.approx((89.1, -1.0, 0.0, -179.1, 0.0, 1.0))
     ## allowable, harmless
     assert ar.GuessGeoTransform(0, 0, False) is not None  # same dim twice
-    assert (
-        ar.GuessGeoTransform(2, 1, False) is None
-    )  # dim out of bounds, but safe in C api
+
+    with pytest.raises(Exception, match="Dimension index out of range"):
+        ar.GuessGeoTransform(2, 1, False)
 
 
 def test_multidim_guessgeotransform_irregular_2d():
@@ -2098,3 +2087,480 @@ def test_multidim_get_regular_spacing():
     assert ar.GetRegularSpacing() is None
     assert varX.GetRegularSpacing() == pytest.approx((-179.1, 1.0))
     assert varY.GetRegularSpacing() is None
+
+
+def _get_arithmetic_arrays():
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("")
+    rg = mem_ds.GetRootGroup()
+    dimX = rg.CreateDimension("X", None, None, 2)
+    dimY = rg.CreateDimension("Y", None, None, 3)
+
+    ar = rg.CreateMDArray(
+        "ar", [dimY, dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
+    )
+    ar_vals = [0, 10, 20, 30, 40, 50, 60]
+    ar.Write(array.array("B", ar_vals))
+    ar2 = rg.CreateMDArray(
+        "ar2", [dimY, dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
+    )
+    ar2_vals = [6, 5, 4, 3, 2, 1]
+    ar2.Write(array.array("B", ar2_vals))
+
+    return ar, ar_vals, ar2, ar2_vals
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        pytest.param(operator.add, id="add"),
+        pytest.param(operator.sub, id="sub"),
+        pytest.param(operator.mul, id="mul"),
+        pytest.param(operator.truediv, id="div"),
+    ],
+)
+def test_multidim_array_arithmetic_operator(op):
+
+    ar, ar_vals, ar2, ar2_vals = _get_arithmetic_arrays()
+    res_ar = op(ar, ar2)
+    assert [(x.GetName(), x.GetSize()) for x in res_ar.GetDimensions()] == [
+        (x.GetName(), x.GetSize()) for x in ar.GetDimensions()
+    ]
+    assert res_ar.GetNoDataValueAsRaw() is None
+    assert res_ar.GetUnit() == ""
+    assert res_ar.GetDataType().GetNumericDataType() == gdal.GDT_Float64
+    assert res_ar.GetSpatialRef() is None
+    assert len(res_ar.GetCoordinateVariables()) == 0
+    assert list(struct.unpack("d" * 6, res_ar.Read())) == [
+        op(x, y) for x, y in zip(ar_vals, ar2_vals)
+    ]
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        pytest.param(operator.add, id="add"),
+        pytest.param(operator.sub, id="sub"),
+        pytest.param(operator.mul, id="mul"),
+        pytest.param(operator.truediv, id="div"),
+    ],
+)
+def test_multidim_array_arithmetic_numpy_interop(op):
+
+    numpy = pytest.importorskip("numpy")
+    gdaltest.importorskip_gdal_array()
+
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("")
+    rg = mem_ds.GetRootGroup()
+    dimX = rg.CreateDimension("X", None, None, 2)
+    ar = rg.CreateMDArray("ar", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar.Write(array.array("B", [1, 2]))
+
+    numpy_ar = numpy.array([3, 4])
+
+    assert numpy.all(
+        op(ar, numpy_ar).ReadAsArray() == numpy.array([op(1, 3), op(2, 4)])
+    )
+    assert numpy.all(
+        op(numpy_ar, ar).ReadAsArray() == numpy.array([op(3, 1), op(4, 2)])
+    )
+
+
+def test_multidim_array_arithmetic_unit():
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("")
+    rg = mem_ds.GetRootGroup()
+    dimX = rg.CreateDimension("X", None, None, 2)
+    ar = rg.CreateMDArray("ar", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar.SetUnit("unit1")
+
+    ar2 = rg.CreateMDArray("ar2", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar2.SetUnit("unit2")
+
+    ar_unitless = rg.CreateMDArray(
+        "ar_unitless", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
+    )
+
+    assert (ar + ar).GetUnit() == "unit1"
+    assert (ar + ar2).GetUnit() == ""
+    assert (ar + ar_unitless).GetUnit() == ""
+
+    assert (ar - ar).GetUnit() == "unit1"
+    assert (ar - ar2).GetUnit() == ""
+    assert (ar + ar_unitless).GetUnit() == ""
+
+    assert (ar * ar2).GetUnit() == "unit1 * unit2"
+    assert (ar * ar_unitless).GetUnit() == ""
+    assert (ar_unitless * ar).GetUnit() == ""
+
+    assert (ar / ar2).GetUnit() == "unit1 / unit2"
+    assert (ar / ar_unitless).GetUnit() == ""
+    assert (ar_unitless / ar).GetUnit() == ""
+
+
+def test_multidim_array_arithmetic_srs():
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("")
+    rg = mem_ds.GetRootGroup()
+    dimX = rg.CreateDimension("X", None, None, 2)
+    ar = rg.CreateMDArray("ar", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar.SetSpatialRef(osr.SpatialReference(epsg=4326))
+
+    ar2 = rg.CreateMDArray("ar2", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar2.SetSpatialRef(osr.SpatialReference(epsg=4258))
+
+    ar_no_srs = rg.CreateMDArray(
+        "ar_no_srs", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
+    )
+
+    assert (ar + ar).GetSpatialRef().GetAuthorityCode() == "4326"
+    assert (ar + ar2).GetSpatialRef() is None
+    assert (ar + ar_no_srs).GetSpatialRef() is None
+    assert (ar_no_srs + ar).GetSpatialRef() is None
+
+
+@pytest.mark.parametrize("same_scale", [True, False])
+def test_multidim_array_arithmetic_offset_no_scale_or_same_scale(same_scale):
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("")
+    rg = mem_ds.GetRootGroup()
+    dimX = rg.CreateDimension("X", None, None, 2)
+    ar = rg.CreateMDArray("ar", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    if same_scale:
+        ar.SetScale(20)
+    ar.SetOffset(1)
+
+    ar2 = rg.CreateMDArray("ar2", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    if same_scale:
+        ar2.SetScale(20)
+    ar2.SetOffset(2)
+
+    ar_no_offset = rg.CreateMDArray(
+        "ar_no_offset", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
+    )
+
+    assert (ar + ar2).GetOffset() == 3
+    assert (ar + ar_no_offset).GetOffset() is None
+    assert (ar_no_offset + ar).GetOffset() is None
+
+    assert (ar - ar2).GetOffset() == -1
+    assert (ar - ar_no_offset).GetOffset() is None
+    assert (ar_no_offset - ar).GetOffset() is None
+
+    assert (ar * ar2).GetOffset() is None
+    assert (ar / ar2).GetOffset() is None
+
+
+def test_multidim_array_arithmetic_offset_different_scale():
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("")
+    rg = mem_ds.GetRootGroup()
+    dimX = rg.CreateDimension("X", None, None, 2)
+    ar = rg.CreateMDArray("ar", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar.SetOffset(1)
+    ar.SetScale(10)
+
+    ar2 = rg.CreateMDArray("ar2", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar2.SetOffset(2)
+    ar2.SetScale(20)
+
+    assert (ar + ar2).GetOffset() is None
+    assert (ar - ar2).GetOffset() is None
+    assert (ar * ar2).GetOffset() is None
+    assert (ar / ar2).GetOffset() is None
+
+
+def test_multidim_array_arithmetic_scale_same_and_zero_offset():
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("")
+    rg = mem_ds.GetRootGroup()
+    dimX = rg.CreateDimension("X", None, None, 2)
+    ar = rg.CreateMDArray("ar", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar.SetOffset(0)
+    ar.SetScale(10)
+
+    ar2 = rg.CreateMDArray("ar2", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar2.SetOffset(0)
+    ar2.SetScale(10)
+
+    assert (ar + ar2).GetScale() == 10
+    assert (ar - ar2).GetScale() == 10
+    assert (ar * ar2).GetScale() == 100
+    assert (ar / ar2).GetScale() == 1
+
+
+def test_multidim_array_arithmetic_scale_same_but_non_zero_offset():
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("")
+    rg = mem_ds.GetRootGroup()
+    dimX = rg.CreateDimension("X", None, None, 2)
+    ar = rg.CreateMDArray("ar", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar.SetOffset(1)
+    ar.SetScale(10)
+
+    ar2 = rg.CreateMDArray("ar2", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar2.SetOffset(0)
+    ar2.SetScale(10)
+
+    assert (ar + ar2).GetScale() is None
+    assert (ar - ar2).GetScale() is None
+    assert (ar * ar2).GetScale() is None
+    assert (ar / ar2).GetScale() is None
+
+
+@pytest.mark.require_driver("HDF5")
+def test_multidim_array_arithmetic_block_size():
+
+    ds = gdal.OpenEx("../gdrivers/data/hdf5/deflate.h5", gdal.OF_MULTIDIM_RASTER)
+    ar = ds.GetRootGroup().OpenMDArray("Band1")
+    assert (ar + ar).GetBlockSize() == [1, 2]
+
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("")
+    rg = mem_ds.GetRootGroup()
+    ar_no_block_size = rg.CreateMDArray(
+        "ar", ar.GetDimensions(), gdal.ExtendedDataType.Create(gdal.GDT_Byte)
+    )
+
+    assert (ar + ar_no_block_size).GetBlockSize() == [0, 0]
+    assert (ar_no_block_size + ar).GetBlockSize() == [0, 0]
+
+
+def _assert_equal_nan_aware(left, right):
+
+    assert len(left) == len(right)
+    for x, y in zip(left, right):
+        if math.isnan(x):
+            assert math.isnan(y)
+        else:
+            assert x == y
+
+
+def test_multidim_array_arithmetic_nodata_finite_same():
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("")
+    rg = mem_ds.GetRootGroup()
+    dimX = rg.CreateDimension("X", None, None, 3)
+    ar = rg.CreateMDArray("ar", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar.SetNoDataValueDouble(100)
+    ar.Write(array.array("B", [2, 100, 3]))
+
+    ar2 = rg.CreateMDArray("ar2", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar2.SetNoDataValueDouble(100)
+    ar2.Write(array.array("B", [3, 2, 100]))
+
+    assert (ar + ar2).GetNoDataValueAsDouble() == 100.0
+
+    _assert_equal_nan_aware(struct.unpack("d" * 3, (ar + ar2).Read()), (5, 100, 100))
+
+    _assert_equal_nan_aware(
+        struct.unpack("B" * 3, (ar + ar2).Read(buffer_datatype=ar.GetDataType())),
+        (5, 100, 100),
+    )
+
+    _assert_equal_nan_aware(struct.unpack("d" * 3, (ar - ar2).Read()), (-1, 100, 100))
+
+    _assert_equal_nan_aware(struct.unpack("d" * 3, (ar * ar2).Read()), (6, 100, 100))
+
+    _assert_equal_nan_aware(
+        struct.unpack("d" * 3, (ar / ar2).Read()), (2.0 / 3.0, 100, 100)
+    )
+
+
+def test_multidim_array_arithmetic_nodata_finite_left_only():
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("")
+    rg = mem_ds.GetRootGroup()
+    dimX = rg.CreateDimension("X", None, None, 3)
+    ar = rg.CreateMDArray("ar", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar.SetNoDataValueDouble(100)
+    ar.Write(array.array("B", [2, 100, 3]))
+
+    ar2 = rg.CreateMDArray("ar2", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar2.Write(array.array("B", [3, 2, 100]))
+
+    assert (ar + ar2).GetNoDataValueAsDouble() == 100.0
+
+    _assert_equal_nan_aware(struct.unpack("d" * 3, (ar + ar2).Read()), (5, 100, 103))
+
+    _assert_equal_nan_aware(struct.unpack("d" * 3, (ar - ar2).Read()), (-1, 100, -97))
+
+    _assert_equal_nan_aware(struct.unpack("d" * 3, (ar * ar2).Read()), (6, 100, 300))
+
+    _assert_equal_nan_aware(
+        struct.unpack("d" * 3, (ar / ar2).Read()), (2.0 / 3.0, 100, 3.0 / 100.0)
+    )
+
+
+def test_multidim_array_arithmetic_nodata_finite_right_only():
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("")
+    rg = mem_ds.GetRootGroup()
+    dimX = rg.CreateDimension("X", None, None, 3)
+    ar = rg.CreateMDArray("ar", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar.Write(array.array("B", [2, 100, 3]))
+
+    ar2 = rg.CreateMDArray("ar2", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar2.SetNoDataValueDouble(100)
+    ar2.Write(array.array("B", [3, 2, 100]))
+
+    assert (ar + ar2).GetNoDataValueAsDouble() == 100.0
+
+    _assert_equal_nan_aware(struct.unpack("d" * 3, (ar + ar2).Read()), (5, 102, 100))
+
+    _assert_equal_nan_aware(struct.unpack("d" * 3, (ar - ar2).Read()), (-1, 98, 100))
+
+    _assert_equal_nan_aware(struct.unpack("d" * 3, (ar * ar2).Read()), (6, 200, 100))
+
+    _assert_equal_nan_aware(
+        struct.unpack("d" * 3, (ar / ar2).Read()), (2.0 / 3.0, 50, 100)
+    )
+
+
+def test_multidim_array_arithmetic_nodata_finite_different():
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("")
+    rg = mem_ds.GetRootGroup()
+    dimX = rg.CreateDimension("X", None, None, 3)
+    ar = rg.CreateMDArray("ar", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar.SetNoDataValueDouble(100)
+    ar.Write(array.array("B", [2, 100, 3]))
+
+    ar2 = rg.CreateMDArray("ar2", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar2.SetNoDataValueDouble(200)
+    ar2.Write(array.array("B", [3, 2, 200]))
+
+    assert math.isnan((ar + ar2).GetNoDataValueAsDouble())
+
+    _assert_equal_nan_aware(
+        struct.unpack("d" * 3, (ar + ar2).Read()), (5, float("nan"), float("nan"))
+    )
+
+    _assert_equal_nan_aware(
+        struct.unpack("d" * 3, (ar - ar2).Read()), (-1, float("nan"), float("nan"))
+    )
+
+    _assert_equal_nan_aware(
+        struct.unpack("d" * 3, (ar * ar2).Read()), (6, float("nan"), float("nan"))
+    )
+
+    _assert_equal_nan_aware(
+        struct.unpack("d" * 3, (ar / ar2).Read()),
+        (2.0 / 3.0, float("nan"), float("nan")),
+    )
+
+
+def test_multidim_array_arithmetic_operations_error():
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("")
+    rg = mem_ds.GetRootGroup()
+    dimX = rg.CreateDimension("X", None, None, 2)
+    dimY = rg.CreateDimension("Y", None, None, 3)
+    ar = rg.CreateMDArray("ar", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar2 = rg.CreateMDArray("ar2", [dimY], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    string_ar = rg.CreateMDArray(
+        "string_ar", [dimX], gdal.ExtendedDataType.CreateString()
+    )
+
+    with pytest.raises(
+        Exception, match="Arrays /ar and /ar2 do not have the same shape"
+    ):
+        ar + ar2
+
+    with pytest.raises(
+        Exception, match="Arrays /ar and /ar2 do not have the same shape"
+    ):
+        ar - ar2
+
+    with pytest.raises(
+        Exception, match="Arrays /ar and /ar2 do not have the same shape"
+    ):
+        ar * ar2
+
+    with pytest.raises(
+        Exception, match="Arrays /ar and /ar2 do not have the same shape"
+    ):
+        ar / ar2
+
+    with pytest.raises(Exception, match="non-numeric buffer data type not supported"):
+        (ar + ar).Read(buffer_datatype=gdal.ExtendedDataType.CreateString())
+
+    with pytest.raises(Exception, match="Array /string_ar is not numeric"):
+        ar + string_ar
+
+    with pytest.raises(Exception, match="Array /string_ar is not numeric"):
+        string_ar + ar
+
+
+def test_multidim_array_arithmetic_scalar():
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("")
+    rg = mem_ds.GetRootGroup()
+    ar = rg.CreateMDArray("ar", [], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar.Write(array.array("B", [1]))
+    ar2 = rg.CreateMDArray("ar2", [], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar2.Write(array.array("B", [2]))
+
+    assert struct.unpack("d" * 1, (ar + ar2).Read()) == (1 + 2,)
+
+    assert struct.unpack(
+        "B" * 1, (ar + ar2).Read(buffer_datatype=ar.GetDataType())
+    ) == (1 + 2,)
+
+
+def test_multidim_array_optim_minus_self_integer_scalar():
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("")
+    rg = mem_ds.GetRootGroup()
+    ar = rg.CreateMDArray("ar", [], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+    ar.Write(array.array("B", [1]))
+
+    assert struct.unpack("d" * 1, (ar - ar).Read()) == (0,)
+
+
+def test_multidim_array_optim_minus_self_integer():
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("")
+    rg = mem_ds.GetRootGroup()
+    dimX = rg.CreateDimension("X", None, None, 2)
+    dimY = rg.CreateDimension("Y", None, None, 3)
+    ar = rg.CreateMDArray(
+        "ar", [dimX, dimY], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
+    )
+    ar.Write(array.array("B", [1, 2, 3, 4, 5, 6]))
+
+    assert struct.unpack("d" * 6, (ar - ar).Read()) == (0, 0, 0, 0, 0, 0)
+
+
+def test_multidim_array_arithmetic_write_error():
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("")
+    rg = mem_ds.GetRootGroup()
+    dimX = rg.CreateDimension("X", None, None, 1)
+    ar = rg.CreateMDArray("ar", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+
+    with pytest.raises(
+        Exception,
+        match="Write operation not permitted on dataset opened in read-only mode",
+    ):
+        (ar + ar).AsClassicDataset(0, 0).WriteRaster(0, 0, 1, 1, array.array("d", [1]))
+
+
+def test_multidim_array_arithmetic_coordinate_variables():
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("")
+    rg = mem_ds.GetRootGroup()
+    dimX = rg.CreateDimension("X", None, None, 2)
+    rg.CreateMDArray("varX", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Float64))
+    dimY = rg.CreateDimension("Y", None, None, 3)
+    rg.CreateMDArray("varY", [dimY], gdal.ExtendedDataType.Create(gdal.GDT_Float64))
+    ar = rg.CreateMDArray(
+        "ar", [dimX, dimY], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
+    )
+    coordinates = ar.CreateAttribute(
+        "coordinates", [], gdal.ExtendedDataType.CreateString()
+    )
+    assert coordinates.WriteString("varX varY") == 0
+
+    assert len((ar + ar).GetCoordinateVariables()) == 2

--- a/gcore/CMakeLists.txt
+++ b/gcore/CMakeLists.txt
@@ -65,6 +65,7 @@ target_sources(gcore PRIVATE
   multidim/gdalmultidim_array_gltorthorectification.cpp
   multidim/gdalmultidim_array_gridded.cpp
   multidim/gdalmultidim_array_mask.cpp
+  multidim/gdalmultidim_array_maths.cpp
   multidim/gdalmultidim_array_meshgrid.cpp
   multidim/gdalmultidim_array_regularly_spaced.cpp
   multidim/gdalmultidim_array_resampled.cpp

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -2971,6 +2971,10 @@ bool CPL_DLL GDALMDArrayGuessGeoTransform(GDALMDArrayH hArray, size_t nDimX,
 bool CPL_DLL GDALMDArrayIsRegularlySpaced(GDALMDArrayH hArray, double *pdfStart,
                                           double *pdfIncrement);
 
+GDALMDArrayH CPL_DLL GDALMDArrayBinaryOperation(
+    GDALMDArrayH hArrayLeft, GDALRasterAlgebraBinaryOperation eOp,
+    GDALMDArrayH hArrayRight) CPL_WARN_UNUSED_RESULT;
+
 #ifdef __cplusplus
 extern "C++"
 {

--- a/gcore/multidim/gdal_multidim.h
+++ b/gcore/multidim/gdal_multidim.h
@@ -1032,6 +1032,8 @@ class CPL_DLL GDALMDArray : virtual public GDALAbstractMDArray,
     virtual bool SetScale(double dfScale,
                           GDALDataType eStorageType = GDT_Unknown);
 
+    std::shared_ptr<GDALMDArray> GetSelf() const;
+
     std::shared_ptr<GDALMDArray> GetView(const std::string &viewExpr) const;
 
     std::shared_ptr<GDALMDArray> operator[](const std::string &fieldName) const;
@@ -1143,6 +1145,22 @@ class CPL_DLL GDALMDArray : virtual public GDALAbstractMDArray,
                                   GDALProgressFunc pfnProgress,
                                   void *pProgressData,
                                   CSLConstList papszOptions);
+
+    bool HasSameShapeAs(const GDALMDArray &other) const;
+
+    static void CopyContiguousBufferToBuffer(
+        const size_t nDims, const size_t *count, const void *pSrcBuffer,
+        const GDALExtendedDataType &srcType, void *pDstBuffer,
+        const GDALExtendedDataType &dstType, const GPtrDiff_t *dstStride);
+
+    std::shared_ptr<GDALMDArray> operator+(
+        const std::shared_ptr<GDALMDArray> &other) const CPL_WARN_UNUSED_RESULT;
+    std::shared_ptr<GDALMDArray> operator-(
+        const std::shared_ptr<GDALMDArray> &other) const CPL_WARN_UNUSED_RESULT;
+    std::shared_ptr<GDALMDArray> operator*(
+        const std::shared_ptr<GDALMDArray> &other) const CPL_WARN_UNUSED_RESULT;
+    std::shared_ptr<GDALMDArray> operator/(
+        const std::shared_ptr<GDALMDArray> &other) const CPL_WARN_UNUSED_RESULT;
 
     //! @cond Doxygen_Suppress
     static constexpr GUInt64 COPY_COST = 1000;

--- a/gcore/multidim/gdalmultidim_array.cpp
+++ b/gcore/multidim/gdalmultidim_array.cpp
@@ -1724,3 +1724,130 @@ GDALMDArray::GetCoordinateVariables() const
 {
     return {};
 }
+
+/************************************************************************/
+/*                              GetSelf()                               */
+/************************************************************************/
+
+/**
+ * \brief Return a shared_ptr on this array
+ *
+ * @return a a shared_ptr on this array, or nullptr if none can be constructed
+ *
+ * @since GDAL 3.14
+ */
+
+std::shared_ptr<GDALMDArray> GDALMDArray::GetSelf() const
+{
+    return std::dynamic_pointer_cast<GDALMDArray>(m_pSelf.lock());
+}
+
+/************************************************************************/
+/*                    CopyContiguousBufferToBuffer()                    */
+/************************************************************************/
+
+/**
+ * \brief Copy a contiguous buffer into a possibly non contiguous one.
+ *
+ * @param nDims Number of dimensions
+ * @param count Number of values along each dimension
+ * @param pSrcBuffer Pointer to source buffer. Can be nullptr for an all-zero source
+ * @param srcType Source data type
+ * @param pDstBuffer Pointer to destination buffer
+ * @param dstType Destination data type
+ * @param dstStride Destination stride along each dimension (in terms of
+ *                  number of data types, not bytes)
+ *
+ * @since GDAL 3.14
+ */
+
+/* static */
+void GDALMDArray::CopyContiguousBufferToBuffer(
+    const size_t nDims, const size_t *count, const void *pSrcBuffer,
+    const GDALExtendedDataType &srcType, void *pDstBuffer,
+    const GDALExtendedDataType &dstType, const GPtrDiff_t *dstStride)
+{
+    if (nDims == 0)
+    {
+        if (pSrcBuffer)
+        {
+            GDALExtendedDataType::CopyValue(pSrcBuffer, srcType, pDstBuffer,
+                                            dstType);
+        }
+        else
+        {
+            memset(pDstBuffer, 0, dstType.GetSize());
+        }
+        return;
+    }
+
+    // +1 just to make some gcc versions not emit -Wnull-dereference false positives
+    std::vector<GByte *> dstPtrStack(nDims + 1);
+    std::vector<size_t> dstStrideBytes(nDims + 1);
+    std::vector<size_t> anCurCount(nDims + 1);
+    const size_t nSrcDTSize = srcType.GetSize();
+    const size_t nDstDTSize = dstType.GetSize();
+    for (size_t i = 0; i < nDims; ++i)
+    {
+        anCurCount[i] = count[i];
+        dstStrideBytes[i] = dstStride[i] * nDstDTSize;
+    }
+
+    const GByte *pabySrc = static_cast<const GByte *>(pSrcBuffer);
+    dstPtrStack[0] = static_cast<GByte *>(pDstBuffer);
+
+    std::vector<GByte> abyZero(nDstDTSize);
+
+    const bool bLastDstStrideFitsOnInt =
+        dstStride[nDims - 1] >= INT_MIN / static_cast<GPtrDiff_t>(nDstDTSize) &&
+        dstStride[nDims - 1] <= INT_MAX / static_cast<GPtrDiff_t>(nDstDTSize);
+    const bool bZeroCopyWordsOptim =
+        dstType.GetClass() == GEDTC_NUMERIC && bLastDstStrideFitsOnInt;
+    const size_t nCountLastDim = anCurCount[nDims - 1];
+
+    size_t dimIdx = 0;
+lbl_next_depth:
+    if (dimIdx + 1 == nDims)
+    {
+        if (pabySrc)
+        {
+            GDALExtendedDataType::CopyValues(
+                pabySrc, srcType, 1, dstPtrStack[dimIdx], dstType,
+                dstStride[nDims - 1], nCountLastDim);
+            pabySrc += nCountLastDim * nSrcDTSize;
+        }
+        else if (bZeroCopyWordsOptim)
+        {
+            GDALCopyWords64(abyZero.data(), dstType.GetNumericDataType(), 0,
+                            dstPtrStack[dimIdx], dstType.GetNumericDataType(),
+                            static_cast<int>(dstStride[nDims - 1] * nDstDTSize),
+                            nCountLastDim);
+        }
+        else
+        {
+            GByte *pabyDst = dstPtrStack[dimIdx];
+            for (size_t i = 0; i < nCountLastDim; ++i)
+            {
+                memset(pabyDst, 0, nDstDTSize);
+                pabyDst += dstStride[nDims - 1];
+            }
+        }
+    }
+    else
+    {
+        anCurCount[dimIdx] = count[dimIdx];
+        while (true)
+        {
+            dimIdx++;
+            dstPtrStack[dimIdx] = dstPtrStack[dimIdx - 1];
+            goto lbl_next_depth;
+        lbl_return_to_caller:
+            dimIdx--;
+            if (--anCurCount[dimIdx] == 0)
+                break;
+            dstPtrStack[dimIdx] += dstStrideBytes[dimIdx];
+        }
+    }
+    if (dimIdx > 0)
+        goto lbl_return_to_caller;
+}

--- a/gcore/multidim/gdalmultidim_array_maths.cpp
+++ b/gcore/multidim/gdalmultidim_array_maths.cpp
@@ -1,0 +1,685 @@
+/******************************************************************************
+ *
+ * Name:     gdalmultidim_array_maths.cpp
+ * Project:  GDAL Core
+ * Purpose:  Mathematic operations on GDALMDArray
+ * Author:   Even Rouault <even.rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2019, Even Rouault <even.rouault at spatialys.com>
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#include "gdal_multidim.h"
+#include "gdal_pam_multidim.h"
+#include "ogr_spatialref.h"
+
+#include <cmath>
+#include <limits>
+
+/************************************************************************/
+/*                    GDALMDArray::HasSameShapeAs()                     */
+/************************************************************************/
+
+/** Returns true if both arrays have the same shape.
+ *
+ * That is to say the same number of dimensions and the size of corresponding
+ * dimensions is the same.
+ *
+ * @since 3.14
+ */
+bool GDALMDArray::HasSameShapeAs(const GDALMDArray &other) const
+{
+    bool bRet = (GetDimensionCount() == other.GetDimensionCount());
+    if (bRet)
+    {
+        const auto &apoThisDims = GetDimensions();
+        const auto &apoOtherDims = other.GetDimensions();
+        for (size_t i = 0; bRet && i < apoThisDims.size(); ++i)
+        {
+            bRet = (apoThisDims[i]->GetSize() == apoOtherDims[i]->GetSize());
+        }
+    }
+    return bRet;
+}
+
+/************************************************************************/
+/*                       GDALMathOperationMDArray                       */
+/************************************************************************/
+
+//! @cond Doxygen_Suppress
+
+class GDALMathOperationMDArray final : public GDALPamMDArray
+{
+  public:
+    enum class Operation
+    {
+        OP_ADD,
+        OP_SUBTRACT,
+        OP_MULTIPLY,
+        OP_DIVIDE,
+    };
+
+    static const char *OperationToString(Operation op)
+    {
+        switch (op)
+        {
+            case Operation::OP_ADD:
+                break;
+            case Operation::OP_SUBTRACT:
+                return "-";
+            case Operation::OP_MULTIPLY:
+                return "*";
+            case Operation::OP_DIVIDE:
+                return "/";
+        }
+        return "+";
+    }
+
+    static std::shared_ptr<GDALMathOperationMDArray>
+    Create(const std::shared_ptr<GDALMDArray> &arrayLeft,
+           const std::shared_ptr<GDALMDArray> &arrayRight, Operation op);
+
+  protected:
+    static std::string GetName(const std::shared_ptr<GDALMDArray> &arrayLeft,
+                               const std::shared_ptr<GDALMDArray> &arrayRight,
+                               Operation op)
+    {
+        return std::string(arrayLeft->GetFullName())
+            .append(" ")
+            .append(OperationToString(op))
+            .append(" ")
+            .append(arrayRight->GetFullName());
+    }
+
+    GDALMathOperationMDArray(const std::shared_ptr<GDALMDArray> &arrayLeft,
+                             const std::shared_ptr<GDALMDArray> &arrayRight,
+                             Operation op)
+        : GDALAbstractMDArray(std::string(),
+                              GetName(arrayLeft, arrayRight, op)),
+          GDALPamMDArray(std::string(), GetName(arrayLeft, arrayRight, op),
+                         // Arbitrary linking to arrayLeft for PAM purposes
+                         GDALPamMultiDim::GetPAM(arrayLeft),
+                         arrayLeft->GetContext()),
+          m_arrayLeft(arrayLeft), m_arrayRight(arrayRight), m_op(op),
+          m_dt(GDALExtendedDataType::Create(GDT_Float64)),
+          m_dfNoDataLeft(
+              m_arrayLeft->GetNoDataValueAsDouble(&m_bHasNoDataLeft)),
+          m_dfNoDataRight(
+              m_arrayRight->GetNoDataValueAsDouble(&m_bHasNoDataRight))
+    {
+        if (m_bHasNoDataLeft || m_bHasNoDataRight)
+        {
+            if (m_bHasNoDataLeft && m_bHasNoDataRight)
+            {
+                if (m_dfNoDataLeft == m_dfNoDataRight)
+                    m_dfNoData = m_dfNoDataLeft;
+            }
+            else if (m_bHasNoDataLeft)
+                m_dfNoData = m_dfNoDataLeft;
+            else
+                m_dfNoData = m_dfNoDataRight;
+            m_abyRawNoDataValue.resize(sizeof(double));
+            memcpy(m_abyRawNoDataValue.data(), &m_dfNoData, sizeof(m_dfNoData));
+        }
+
+        const auto &leftUnit = m_arrayLeft->GetUnit();
+        const auto &rightUnit = m_arrayRight->GetUnit();
+        switch (m_op)
+        {
+            case Operation::OP_ADD:
+            case Operation::OP_SUBTRACT:
+            {
+                if (leftUnit == rightUnit)
+                    m_osUnit = leftUnit;
+                break;
+            }
+            case Operation::OP_MULTIPLY:
+            case Operation::OP_DIVIDE:
+            {
+                if (!leftUnit.empty() && !rightUnit.empty())
+                {
+                    m_osUnit = leftUnit;
+                    m_osUnit += ' ';
+                    m_osUnit += OperationToString(m_op);
+                    m_osUnit += ' ';
+                    m_osUnit += rightUnit;
+                }
+                break;
+            }
+        }
+    }
+
+    bool IsWritable() const override
+    {
+        return false;
+    }
+
+    const std::string &GetFilename() const override
+    {
+        const auto &filename1 = m_arrayLeft->GetFilename();
+        const auto &filename2 = m_arrayRight->GetFilename();
+        if (filename1 == filename2)
+            return filename1;
+        static std::string emptyString;
+        return emptyString;
+    }
+
+    const std::vector<std::shared_ptr<GDALDimension>> &
+    GetDimensions() const override
+    {
+        return m_arrayLeft->GetDimensions();
+    }
+
+    std::vector<std::shared_ptr<GDALMDArray>>
+    GetCoordinateVariables() const override
+    {
+        auto left = m_arrayLeft->GetCoordinateVariables();
+        auto right = m_arrayRight->GetCoordinateVariables();
+        if (left == right)
+            return left;
+        return GDALMDArray::GetCoordinateVariables();
+    }
+
+    const GDALExtendedDataType &GetDataType() const override
+    {
+        return m_dt;
+    }
+
+    const void *GetRawNoDataValue() const override
+    {
+        return m_abyRawNoDataValue.empty() ? nullptr
+                                           : m_abyRawNoDataValue.data();
+    }
+
+    const std::string &GetUnit() const override
+    {
+        return m_osUnit;
+    }
+
+    std::shared_ptr<OGRSpatialReference> GetSpatialRef() const override
+    {
+        auto leftSRS = m_arrayLeft->GetSpatialRef();
+        auto rightSRS = m_arrayRight->GetSpatialRef();
+        if (!leftSRS || !rightSRS || !leftSRS->IsSame(rightSRS.get()))
+            return nullptr;
+        return leftSRS;
+    }
+
+    double GetOffset(bool *pbHasOffset,
+                     GDALDataType *peStorageType) const override
+    {
+        bool bHasLeftOffset = false;
+        GDALDataType leftStorageType = GDT_Unknown;
+        const double dfLeftOffset =
+            m_arrayLeft->GetOffset(&bHasLeftOffset, &leftStorageType);
+
+        bool bHasRightOffset = false;
+        GDALDataType rightStorageType = GDT_Unknown;
+        const double dfRightOffset =
+            m_arrayRight->GetOffset(&bHasRightOffset, &rightStorageType);
+
+        bool bHasLeftScale = false;
+        const double dfLeftScale = m_arrayLeft->GetScale(&bHasLeftScale);
+
+        bool bHasRightScale = false;
+        const double dfRightScale = m_arrayRight->GetScale(&bHasRightScale);
+
+        bool bRet = false;
+        double dfRes = 0.0;
+
+        switch (m_op)
+        {
+            case Operation::OP_ADD:
+            {
+                bRet = bHasLeftOffset && bHasRightOffset &&
+                       (bHasLeftScale == bHasRightScale &&
+                        (!bHasLeftScale || dfLeftScale == dfRightScale));
+                if (bRet)
+                    dfRes = dfLeftOffset + dfRightOffset;
+                break;
+            }
+
+            case Operation::OP_SUBTRACT:
+            {
+                bRet = bHasLeftOffset && bHasRightOffset &&
+                       (bHasLeftScale == bHasRightScale &&
+                        (!bHasLeftScale || dfLeftScale == dfRightScale));
+                if (bRet)
+                    dfRes = dfLeftOffset - dfRightOffset;
+                break;
+            }
+
+            case Operation::OP_MULTIPLY:
+            case Operation::OP_DIVIDE:
+                break;
+        }
+
+        if (pbHasOffset)
+            *pbHasOffset = bRet;
+        if (bRet && peStorageType)
+        {
+            *peStorageType =
+                GDALDataTypeUnion(leftStorageType, rightStorageType);
+        }
+
+        return dfRes;
+    }
+
+    double GetScale(bool *pbHasScale,
+                    GDALDataType *peStorageType) const override
+    {
+        bool bHasLeftOffset = false;
+        const double dfLeftOffset = m_arrayLeft->GetOffset(&bHasLeftOffset);
+
+        bool bHasRightOffset = false;
+        const double dfRightOffset = m_arrayRight->GetOffset(&bHasRightOffset);
+
+        bool bHasLeftScale = false;
+        GDALDataType leftStorageType = GDT_Unknown;
+        const double dfLeftScale =
+            m_arrayLeft->GetScale(&bHasLeftScale, &leftStorageType);
+
+        bool bHasRightScale = false;
+        GDALDataType rightStorageType = GDT_Unknown;
+        const double dfRightScale =
+            m_arrayRight->GetScale(&bHasRightScale, &rightStorageType);
+
+        bool bRet = false;
+        double dfRes = 1.0;
+
+        const bool bZeroOffset =
+            (bHasLeftOffset == bHasRightOffset &&
+             (!bHasLeftOffset ||
+              (dfLeftOffset == dfRightOffset && dfLeftOffset == 0)));
+
+        switch (m_op)
+        {
+            case Operation::OP_ADD:
+            case Operation::OP_SUBTRACT:
+            {
+                bRet = bZeroOffset &&
+                       (bHasLeftScale == bHasRightScale &&
+                        (!bHasLeftScale || dfLeftScale == dfRightScale));
+                if (bRet)
+                    dfRes = dfLeftScale;
+                break;
+            }
+
+            case Operation::OP_MULTIPLY:
+            {
+                bRet = bZeroOffset && bHasLeftScale && bHasRightScale;
+                if (bRet)
+                    dfRes = dfLeftScale * dfRightScale;
+                break;
+            }
+
+            case Operation::OP_DIVIDE:
+            {
+                bRet = bZeroOffset && bHasLeftScale && bHasRightScale;
+                if (bRet)
+                    dfRes = dfLeftScale / dfRightScale;
+                break;
+            }
+        }
+
+        if (pbHasScale)
+            *pbHasScale = bRet;
+        if (bRet && peStorageType)
+        {
+            *peStorageType =
+                GDALDataTypeUnion(leftStorageType, rightStorageType);
+        }
+
+        return dfRes;
+    }
+
+    std::vector<GUInt64> GetBlockSize() const override
+    {
+        const auto leftBlockSize = m_arrayLeft->GetBlockSize();
+        const auto rightBlockSize = m_arrayRight->GetBlockSize();
+        if (leftBlockSize != rightBlockSize)
+            return GDALMDArray::GetBlockSize();
+        return leftBlockSize;
+    }
+
+    bool IRead(const GUInt64 *arrayStartIdx, const size_t *count,
+               const GInt64 *arrayStep, const GPtrDiff_t *bufferStride,
+               const GDALExtendedDataType &bufferDataType,
+               void *pDstBuffer) const override;
+
+  private:
+    const std::shared_ptr<GDALMDArray> m_arrayLeft;
+    const std::shared_ptr<GDALMDArray> m_arrayRight;
+    const Operation m_op;
+    const GDALExtendedDataType m_dt;
+    bool m_bHasNoDataLeft = false;
+    bool m_bHasNoDataRight = false;
+    const double m_dfNoDataLeft;
+    const double m_dfNoDataRight;
+    double m_dfNoData = std::numeric_limits<double>::quiet_NaN();
+    std::vector<GByte> m_abyRawNoDataValue{};
+    std::string m_osUnit{};
+    mutable std::vector<double> m_leftValues{};
+    mutable std::vector<double> m_rightValues{};
+
+    inline bool IsInvalidTuple(double dfLeft, double dfRight) const
+    {
+        return std::isnan(dfLeft) ||
+               (m_bHasNoDataLeft && m_dfNoDataLeft == dfLeft) ||
+               std::isnan(dfRight) ||
+               (m_bHasNoDataRight && m_dfNoDataRight == dfRight);
+    }
+};
+
+/************************************************************************/
+/*                  GDALMathOperationMDArray::Create()                  */
+/************************************************************************/
+
+/* static */ std::shared_ptr<GDALMathOperationMDArray>
+GDALMathOperationMDArray::Create(const std::shared_ptr<GDALMDArray> &arrayLeft,
+                                 const std::shared_ptr<GDALMDArray> &arrayRight,
+                                 Operation op)
+{
+    if (!arrayLeft)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "arrayLeft is null");
+        return nullptr;
+    }
+
+    if (!arrayRight)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "arrayRight is null");
+        return nullptr;
+    }
+
+    if (!arrayLeft->HasSameShapeAs(*arrayRight))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "%s",
+                 ("Arrays " + arrayLeft->GetFullName() + " and " +
+                  arrayRight->GetFullName() + " do not have the same shape")
+                     .c_str());
+        return nullptr;
+    }
+
+    for (const auto &array : {arrayLeft, arrayRight})
+    {
+        if (array->GetDataType().GetClass() != GEDTC_NUMERIC)
+        {
+            CPLError(
+                CE_Failure, CPLE_AppDefined, "%s",
+                ("Array " + array->GetFullName() + " is not numeric").c_str());
+            return nullptr;
+        }
+    }
+
+    auto newAr(std::shared_ptr<GDALMathOperationMDArray>(
+        new GDALMathOperationMDArray(arrayLeft, arrayRight, op)));
+    newAr->SetSelf(newAr);
+    return newAr;
+}
+
+/************************************************************************/
+/*                  GDALMathOperationMDArray::IRead()                   */
+/************************************************************************/
+
+bool GDALMathOperationMDArray::IRead(const GUInt64 *arrayStartIdx,
+                                     const size_t *count,
+                                     const GInt64 *arrayStep,
+                                     const GPtrDiff_t *bufferStride,
+                                     const GDALExtendedDataType &bufferDataType,
+                                     void *pDstBuffer) const
+{
+    if (bufferDataType.GetClass() != GEDTC_NUMERIC)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "GDALMathOperationMDArray::IRead(): not supported with "
+                 "non-numeric buffer data type");
+        return false;
+    }
+
+    const auto &apoDims = GetDimensions();
+    const size_t nDims = apoDims.size();
+
+    const bool bIntegerAndAllValid =
+        m_abyRawNoDataValue.empty() &&
+        GDALDataTypeIsInteger(
+            m_arrayLeft->GetDataType().GetNumericDataType()) &&
+        GDALDataTypeIsInteger(m_arrayRight->GetDataType().GetNumericDataType());
+
+    if (bIntegerAndAllValid && m_op == Operation::OP_SUBTRACT &&
+        m_arrayLeft == m_arrayRight)
+    {
+        CopyContiguousBufferToBuffer(nDims, count, nullptr,
+                                     GDALExtendedDataType::Create(GDT_Unknown),
+                                     pDstBuffer, bufferDataType, bufferStride);
+        return true;
+    }
+
+    size_t nElts = 1;
+    bool bFullArrayRequested = true;
+    for (size_t i = 0; i < nDims; ++i)
+    {
+        nElts *= count[i];
+        if (bFullArrayRequested)
+            bFullArrayRequested = (count[i] == apoDims[i]->GetSize());
+    }
+    try
+    {
+        if (nElts > m_leftValues.size())
+            m_leftValues.resize(nElts);
+        if (nElts > m_rightValues.size())
+            m_rightValues.resize(nElts);
+    }
+    catch (const std::exception &)
+    {
+        CPLError(CE_Failure, CPLE_OutOfMemory,
+                 "GDALMathOperationMDArray::IRead(): out of memory");
+        return false;
+    }
+
+    const bool ret = m_arrayLeft->Read(arrayStartIdx, count, arrayStep, nullptr,
+                                       m_dt, m_leftValues.data()) &&
+                     m_arrayRight->Read(arrayStartIdx, count, arrayStep,
+                                        nullptr, m_dt, m_rightValues.data());
+    if (ret)
+    {
+        switch (m_op)
+        {
+            case Operation::OP_ADD:
+            {
+                if (bIntegerAndAllValid)
+                {
+                    for (size_t i = 0; i < nElts; ++i)
+                    {
+                        m_leftValues[i] += m_rightValues[i];
+                    }
+                }
+                else
+                {
+                    for (size_t i = 0; i < nElts; ++i)
+                    {
+                        if (IsInvalidTuple(m_leftValues[i], m_rightValues[i]))
+                            m_leftValues[i] = m_dfNoData;
+                        else
+                            m_leftValues[i] += m_rightValues[i];
+                    }
+                }
+                break;
+            }
+            case Operation::OP_SUBTRACT:
+            {
+                if (bIntegerAndAllValid)
+                {
+                    for (size_t i = 0; i < nElts; ++i)
+                    {
+                        m_leftValues[i] -= m_rightValues[i];
+                    }
+                }
+                else
+                {
+                    for (size_t i = 0; i < nElts; ++i)
+                    {
+                        if (IsInvalidTuple(m_leftValues[i], m_rightValues[i]))
+                            m_leftValues[i] = m_dfNoData;
+                        else
+                            m_leftValues[i] -= m_rightValues[i];
+                    }
+                }
+                break;
+            }
+            case Operation::OP_MULTIPLY:
+            {
+                if (bIntegerAndAllValid)
+                {
+                    for (size_t i = 0; i < nElts; ++i)
+                    {
+                        m_leftValues[i] *= m_rightValues[i];
+                    }
+                }
+                else
+                {
+                    for (size_t i = 0; i < nElts; ++i)
+                    {
+                        if (IsInvalidTuple(m_leftValues[i], m_rightValues[i]))
+                            m_leftValues[i] = m_dfNoData;
+                        else
+                            m_leftValues[i] *= m_rightValues[i];
+                    }
+                }
+                break;
+            }
+            case Operation::OP_DIVIDE:
+            {
+                if (bIntegerAndAllValid)
+                {
+                    for (size_t i = 0; i < nElts; ++i)
+                    {
+                        m_leftValues[i] /= m_rightValues[i];
+                    }
+                }
+                else
+                {
+                    for (size_t i = 0; i < nElts; ++i)
+                    {
+                        if (IsInvalidTuple(m_leftValues[i], m_rightValues[i]))
+                            m_leftValues[i] = m_dfNoData;
+                        else
+                            m_leftValues[i] /= m_rightValues[i];
+                    }
+                }
+                break;
+            }
+        }
+
+        CopyContiguousBufferToBuffer(nDims, count, m_leftValues.data(), m_dt,
+                                     pDstBuffer, bufferDataType, bufferStride);
+    }
+
+    if (bFullArrayRequested)
+    {
+        m_leftValues.clear();
+        m_rightValues.clear();
+    }
+
+    return ret;
+}
+
+//! @endcond
+
+/************************************************************************/
+/*                             operator+()                              */
+/************************************************************************/
+
+/** Add this array with another one of the same shape.
+ *
+ * The resulting array is lazy evaluated.
+ *
+ * The resulting array type is Float64.
+ *
+ * The operation is nodata-aware.
+ *
+ * This is the same as C function GDALMDArrayBinaryOperation().
+ *
+ * @since 3.14
+ * @return a new array, or nullptr in case of error
+ */
+std::shared_ptr<GDALMDArray>
+GDALMDArray::operator+(const std::shared_ptr<GDALMDArray> &other) const
+{
+    return GDALMathOperationMDArray::Create(
+        GetSelf(), other, GDALMathOperationMDArray::Operation::OP_ADD);
+}
+
+/************************************************************************/
+/*                             operator-()                              */
+/************************************************************************/
+
+/** Subtract this array with another one of the same shape.
+ *
+ * The resulting array is lazy evaluated.
+ *
+ * The resulting array type is Float64.
+ *
+ * The operation is nodata-aware.
+ *
+ * This is the same as C function GDALMDArrayBinaryOperation().
+ *
+ * @since 3.14
+ * @return a new array, or nullptr in case of error
+ */
+std::shared_ptr<GDALMDArray>
+GDALMDArray::operator-(const std::shared_ptr<GDALMDArray> &other) const
+{
+    return GDALMathOperationMDArray::Create(
+        GetSelf(), other, GDALMathOperationMDArray::Operation::OP_SUBTRACT);
+}
+
+/************************************************************************/
+/*                             operator*()                              */
+/************************************************************************/
+
+/** Multiply this array with another one of the same shape.
+ *
+ * The resulting array is lazy evaluated.
+ *
+ * The resulting array type is Float64.
+ *
+ * The operation is nodata-aware.
+ *
+ * This is the same as C function GDALMDArrayBinaryOperation().
+ *
+ * @since 3.14
+ * @return a new array, or nullptr in case of error
+ */
+std::shared_ptr<GDALMDArray>
+GDALMDArray::operator*(const std::shared_ptr<GDALMDArray> &other) const
+{
+    return GDALMathOperationMDArray::Create(
+        GetSelf(), other, GDALMathOperationMDArray::Operation::OP_MULTIPLY);
+}
+
+/************************************************************************/
+/*                             operator/()                              */
+/************************************************************************/
+
+/** Divide this array by another one of the same shape.
+ *
+ * The resulting array is lazy evaluated.
+ *
+ * The resulting array type is Float64.
+ *
+ * The operation is nodata-aware.
+ *
+ * This is the same as C function GDALMDArrayBinaryOperation().
+ *
+ * @since 3.14
+ * @return a new array, or nullptr in case of error
+ */
+std::shared_ptr<GDALMDArray>
+GDALMDArray::operator/(const std::shared_ptr<GDALMDArray> &other) const
+{
+    return GDALMathOperationMDArray::Create(
+        GetSelf(), other, GDALMathOperationMDArray::Operation::OP_DIVIDE);
+}

--- a/gcore/multidim/gdalmultidim_c_api_array.cpp
+++ b/gcore/multidim/gdalmultidim_c_api_array.cpp
@@ -1716,3 +1716,68 @@ bool GDALMDArrayIsRegularlySpaced(GDALMDArrayH hArray, double *pdfStart,
     VALIDATE_POINTER1(hArray, __func__, false);
     return hArray->m_poImpl->IsRegularlySpaced(*pdfStart, *pdfIncrement);
 }
+
+/************************************************************************/
+/*                     GDALMDArrayBinaryOperation()                     */
+/************************************************************************/
+
+/** Perform a binary operation between a left and right array.
+ *
+ * Currently only GRABO_ADD, GRABO_SUB, GRABO_MUL and GRABO_DIV are supported.
+ *
+ * The resulting array is lazy evaluated.
+ *
+ * The resulting array type is Float64.
+ *
+ * The operation is nodata-aware.
+ *
+ * This is the same as GDALMDArray::operator+(), GDALMDArray::operator-(),
+ * GDALMDArray::operator*() and GDALMDArray::operator/().
+ *
+ * @return a new GDALMDArray, or nullptr.
+ * Must be released with GDALMDArrayRelease()
+ *
+ * @since 3.14
+ */
+
+GDALMDArrayH GDALMDArrayBinaryOperation(GDALMDArrayH hArrayLeft,
+                                        GDALRasterAlgebraBinaryOperation eOp,
+                                        GDALMDArrayH hArrayRight)
+{
+    VALIDATE_POINTER1(hArrayLeft, __func__, nullptr);
+    VALIDATE_POINTER1(hArrayRight, __func__, nullptr);
+    std::shared_ptr<GDALMDArray> res;
+    switch (eOp)
+    {
+        case GRABO_ADD:
+            res = (*(hArrayLeft->m_poImpl)) + hArrayRight->m_poImpl;
+            break;
+
+        case GRABO_SUB:
+            res = (*(hArrayLeft->m_poImpl)) - hArrayRight->m_poImpl;
+            break;
+
+        case GRABO_MUL:
+            res = (*(hArrayLeft->m_poImpl)) * hArrayRight->m_poImpl;
+            break;
+
+        case GRABO_DIV:
+            res = (*(hArrayLeft->m_poImpl)) / hArrayRight->m_poImpl;
+            break;
+
+        case GRABO_POW:
+        case GRABO_GT:
+        case GRABO_GE:
+        case GRABO_LT:
+        case GRABO_LE:
+        case GRABO_EQ:
+        case GRABO_NE:
+        case GRABO_LOGICAL_AND:
+        case GRABO_LOGICAL_OR:
+            CPLError(CE_Failure, CPLE_NotSupported, "Operator not supported");
+            break;
+    }
+    if (!res)
+        return nullptr;
+    return new GDALMDArrayHS(res);
+}

--- a/swig/include/MultiDimensional.i
+++ b/swig/include/MultiDimensional.i
@@ -1328,6 +1328,14 @@ RETURN_NONE GetRegularSpacing(double argout[2]) {
 %clear (RETURN_NONE);
 #endif
 
+  %apply Pointer NONNULL {GDALMDArrayHS* other};
+  %newobject BinaryOpArray;
+  GDALMDArrayHS* BinaryOpArray(GDALRasterAlgebraBinaryOperation op, GDALMDArrayHS* other)
+  {
+      return GDALMDArrayBinaryOperation(self, op, other);
+  }
+  %clear GDALMDArrayHS* other;
+
 } /* extend */
 }; /* GDALMDArrayH */
 

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -3032,6 +3032,83 @@ def GetMDArrayNames(self, options = []) -> "list[str]":
         return _gdal.MDArray_SetNoDataValueUInt64(self, value)
 
     return _gdal.MDArray_SetNoDataValueDouble(self, value)
+
+  @staticmethod
+  def _get_as_mdarray_if_possible(o):
+        if hasattr(o, "shape") and not isinstance(o, MDArray):
+            from osgeo import gdal_array
+            ds = gdal_array.OpenMultiDimensionalNumPyArray(o)
+            return ds.GetRootGroup().OpenMDArray("array")
+        else:
+            return o
+
+  def __add__(self, other):
+      """Add this array to another array
+
+         The resulting array is lazily evaluated.
+      """
+      other = MDArray._get_as_mdarray_if_possible(other)
+      return _gdal.MDArray_BinaryOpArray(self, GRABO_ADD, other)
+
+  # Define __array_priority__ so that numpy doesn't just forward us the first
+  # value of the array
+  __array_priority__ = 1000
+
+  def __radd__(self, other):
+      """Add this array to another array
+
+         The resulting array is lazily evaluated.
+      """
+      other = MDArray._get_as_mdarray_if_possible(other)
+      return _gdal.MDArray_BinaryOpArray(other, GRABO_ADD, self)
+
+  def __sub__(self, other):
+      """Subtract this array with another array
+
+         The resulting array is lazily evaluated.
+      """
+      other = MDArray._get_as_mdarray_if_possible(other)
+      return _gdal.MDArray_BinaryOpArray(self, GRABO_SUB, other)
+
+  def __rsub__(self, other):
+      """Subtract this array with another array
+
+         The resulting array is lazily evaluated.
+      """
+      other = MDArray._get_as_mdarray_if_possible(other)
+      return _gdal.MDArray_BinaryOpArray(other, GRABO_SUB, self)
+
+  def __mul__(self, other):
+      """Multiply this array with another array
+
+         The resulting array is lazily evaluated.
+      """
+      other = MDArray._get_as_mdarray_if_possible(other)
+      return _gdal.MDArray_BinaryOpArray(self, GRABO_MUL, other)
+
+  def __rmul__(self, other):
+      """Multiply this array with another array
+
+         The resulting array is lazily evaluated.
+      """
+      other = MDArray._get_as_mdarray_if_possible(other)
+      return _gdal.MDArray_BinaryOpArray(other, GRABO_MUL, self)
+
+  def __truediv__(self, other):
+      """Divide this array by another array
+
+         The resulting array is lazily evaluated.
+      """
+      other = MDArray._get_as_mdarray_if_possible(other)
+      return _gdal.MDArray_BinaryOpArray(self, GRABO_DIV, other)
+
+  def __rtruediv__(self, other):
+      """Divide this array by another array
+
+         The resulting array is lazily evaluated.
+      """
+      other = MDArray._get_as_mdarray_if_possible(other)
+      return _gdal.MDArray_BinaryOpArray(other, GRABO_DIV, self)
 %}
 
 }


### PR DESCRIPTION
Result is lazy evaluated, with Float64 return type, and nodata-aware.

For Python, mixing MDArray and numpy.array is possible
