### PR TITLE
JP2Grok: upgrade to true single threaded support

### DIFF
--- a/.github/workflows/ubuntu_26.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_26.04/Dockerfile.ci
@@ -234,7 +234,7 @@ RUN curl -LO -fsS https://github.com/apache/arrow/archive/refs/heads/main.zip \
     && rm -rf arrow-main
 
 # Build Grok JPEG 2000 library
-ARG GROK_VERSION=v20.3.4
+ARG GROK_VERSION=v20.3.5
 
 RUN git clone --recursive --depth 1 --branch ${GROK_VERSION} \
     https://github.com/GrokImageCompression/grok.git grok-git && \

--- a/autotest/gdrivers/jp2grok.py
+++ b/autotest/gdrivers/jp2grok.py
@@ -1673,6 +1673,38 @@ def test_jp2grok_statistics_16bit_multi_tile():
     gdal.Unlink(out)
 
 
+def _jp2grok_checksums_in_subprocess(src, num_threads):
+    # The driver resolves Grok's thread count once per process (std::call_once),
+    # so single-threaded mode must be exercised in a fresh process
+    import subprocess
+
+    code = (
+        "import sys; from osgeo import gdal; gdal.UseExceptions();"
+        "ds = gdal.OpenEx(sys.argv[1], allowed_drivers=['JP2Grok']);"
+        "print(' '.join(str(ds.GetRasterBand(b + 1).Checksum())"
+        " for b in range(ds.RasterCount)))"
+    )
+    env = dict(os.environ)
+    env["GDAL_NUM_THREADS"] = str(num_threads)
+    out = subprocess.check_output(
+        [sys.executable, "-c", code, os.path.abspath(src)], env=env
+    )
+    return out.decode().strip()
+
+
+@pytest.mark.parametrize(
+    "src", ["data/jpeg2000/byte.jp2", "data/jpeg2000/tile_size_16.jp2"]
+)
+def test_jp2grok_single_threaded_matches_multi(src):
+    # GDAL_NUM_THREADS=1 runs Grok fully single-threaded
+    # output must match multi-threaded decode.
+    if not os.path.exists(src):
+        pytest.skip(f"{src} not available")
+    st = _jp2grok_checksums_in_subprocess(src, 1)
+    mt = _jp2grok_checksums_in_subprocess(src, 8)
+    assert st == mt
+
+
 def test_jp2grok_reuse_dataset_consecutive_reads():
     # Two reads on the same dataset instance must both be correct: the
     # single-shot codec is rebuilt for the second operation.

--- a/cmake/helpers/CheckDependentLibrariesGrok.cmake
+++ b/cmake/helpers/CheckDependentLibrariesGrok.cmake
@@ -2,4 +2,4 @@ gdal_check_package(Grok "Enable JPEG2000 support with Grok library"
                    CONFIG
                    CAN_DISABLE
                    TARGETS GROK::grokj2k
-                   VERSION 20.3.4)
+                   VERSION 20.3.5)


### PR DESCRIPTION
## What does this PR do?

This PR upgrades driver to grok version 20.3.5 and adds two unit tests to compare single and multi threaded decompression output.

Previous versions of grok in single threaded mode would have a single worker thread AND a calling thread, totaling two threads. Grok 20.3.5 is truly single threaded; using this version will avoid thread over subscription due to doubling in older version.

## What are related issues/pull requests?

#14814

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
