### PR TITLE
AIGrid: fix signed overflow in block size checks in gridlib.c

### DIFF
--- a/frmts/aigrid/gridlib.c
+++ b/frmts/aigrid/gridlib.c
@@ -35,7 +35,7 @@ static CPLErr AIGProcessRaw32BitFloatBlock(GByte *pabyCur, int nDataSize,
     int i;
 
     (void)nMin;
-    if (nDataSize < nBlockXSize * nBlockYSize * 4)
+    if (nDataSize < (GIntBig)nBlockXSize * nBlockYSize * 4)
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Block too small");
         return CE_Failure;
@@ -120,7 +120,7 @@ static CPLErr AIGProcessRaw32BitBlock(GByte *pabyCur, int nDataSize, int nMin,
 {
     int i;
 
-    if (nDataSize < nBlockXSize * nBlockYSize * 4)
+    if (nDataSize < (GIntBig)nBlockXSize * nBlockYSize * 4)
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Block too small");
         return CE_Failure;
@@ -153,7 +153,7 @@ static CPLErr AIGProcessRaw16BitBlock(GByte *pabyCur, int nDataSize, int nMin,
 {
     int i;
 
-    if (nDataSize < nBlockXSize * nBlockYSize * 2)
+    if (nDataSize < (GIntBig)nBlockXSize * nBlockYSize * 2)
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Block too small");
         return CE_Failure;
@@ -184,7 +184,7 @@ static CPLErr AIGProcessRaw4BitBlock(GByte *pabyCur, int nDataSize, int nMin,
 {
     int i;
 
-    if (nDataSize < (nBlockXSize * nBlockYSize + 1) / 2)
+    if (nDataSize < ((GIntBig)nBlockXSize * nBlockYSize + 1) / 2)
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Block too small");
         return CE_Failure;
@@ -217,7 +217,7 @@ static CPLErr AIGProcessRaw1BitBlock(GByte *pabyCur, int nDataSize, int nMin,
 {
     int i;
 
-    if (nDataSize < (nBlockXSize * nBlockYSize + 7) / 8)
+    if (nDataSize < ((GIntBig)nBlockXSize * nBlockYSize + 7) / 8)
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Block too small");
         return CE_Failure;
@@ -250,7 +250,7 @@ static CPLErr AIGProcessRawBlock(GByte *pabyCur, int nDataSize, int nMin,
 {
     int i;
 
-    if (nDataSize < nBlockXSize * nBlockYSize)
+    if (nDataSize < (GIntBig)nBlockXSize * nBlockYSize)
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Block too small");
         return CE_Failure;


### PR DESCRIPTION
## What does this PR do?

The block decoders in `frmts/aigrid/gridlib.c` size-check their reads with 32-bit int math, e.g. in `AIGProcessRaw32BitFloatBlock`:

    if (nDataSize < nBlockXSize * nBlockYSize * 4)

`nBlockXSize`/`nBlockYSize` come from `hdr.adf` and are only validated against `INT_MAX / nBlocksPerRow(Column)` in `AIGOpen`, so with `nBlocksPerRow=nBlocksPerColumn=1` each can reach ~`INT_MAX`. `clang -fsanitize=signed-integer-overflow` with `nBlockXSize=536870912, nBlockYSize=1`:

    runtime error: signed integer overflow: 536870912 * 4 cannot be represented in type 'int'

The product wraps negative, so `nDataSize < <negative>` is false, the guard passes, and the loop then reads `nBlockXSize*nBlockYSize` elements from `pabyCur`, whose backing buffer is only `nDataSize` bytes (`nBlockSize <= 65535*2`). Heap out-of-bounds read.

Compute the required size as `GIntBig` in the six raw decoders that guard a read this way (`AIGProcessRaw32BitFloatBlock`, `AIGProcessRaw32BitBlock`, `AIGProcessRaw16BitBlock`, `AIGProcessRaw4BitBlock`, `AIGProcessRaw1BitBlock`, `AIGProcessRawBlock`). Once the guard rejects oversized requests the surviving product is small (<= ~1M), so the int loop bounds stay in range.

## What are related issues/pull requests?

None.

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

* OS: macOS
* Compiler: clang
