### PR TITLE
FAST: reject path traversal in band filename from header

### DIFF
--- a/frmts/raw/fastdataset.cpp
+++ b/frmts/raw/fastdataset.cpp
@@ -221,6 +221,12 @@ VSILFILE *FASTDataset::FOpenChannel(const char *pszBandname, int iBand,
         case LANDSAT:
             if (pszBandname && !EQUAL(pszBandname, ""))
             {
+                if (CPLHasPathTraversal(pszBandname))
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Path traversal detected in %s", pszBandname);
+                    return nullptr;
+                }
                 osChannelFilename =
                     CPLFormCIFilenameSafe(pszDirname, pszBandname, nullptr);
                 if (OpenChannel(osChannelFilename.c_str(), iBand))


### PR DESCRIPTION
## What does this PR do?

`FASTDataset::FOpenChannel()` takes the band file name from the `FILENAME =`
field of the administrative record and, for LANDSAT scenes, opens it relative
to the dataset directory without checking it:

    osChannelFilename = CPLFormCIFilenameSafe(pszDirname, pszBandname, nullptr);
    ...
    fpChannels[iBand] = VSIFOpenL(pszFilenameIn, "rb");

`pszBandname` comes straight from the header, so a `.fst` with
`SATELLITE = LANDSAT7` and `FILENAME = ../../../../etc/passwd` makes the driver
open a file outside the dataset directory.

Reject band names containing path traversal with `CPLHasPathTraversal()`, the
same guard already used in ers/ndf/pds/rcm/sentinel2/tsx/map.

## What are related issues/pull requests?

None.

## AI tool usage

 - [x] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

* OS: macOS
* Compiler: clang
