### PR TITLE
MRF: use CPLAtof()/CPLStrtod() to parse numbers from .mrf descriptor

### DIFF
--- a/frmts/mrf/LERC_band.cpp
+++ b/frmts/mrf/LERC_band.cpp
@@ -684,10 +684,10 @@ LERC_Band::LERC_Band(MRFDataset *pDS, const ILImage &image, int b, int level)
 
     // Pick 1/1000 for floats and 0.5 losless for integers.
     if (eDataType == GDT_Float32 || eDataType == GDT_Float64)
-        precision = strtod(GetOptionValue("LERC_PREC", ".001"), nullptr);
+        precision = CPLStrtod(GetOptionValue("LERC_PREC", ".001"), nullptr);
     else
-        precision =
-            std::max(0.5, strtod(GetOptionValue("LERC_PREC", ".5"), nullptr));
+        precision = std::max(
+            0.5, CPLStrtod(GetOptionValue("LERC_PREC", ".5"), nullptr));
 
     // Encode in V2 by default.
     version = GetOptlist().FetchBoolean("V1", FALSE) ? 1 : 2;

--- a/frmts/mrf/marfa_dataset.cpp
+++ b/frmts/mrf/marfa_dataset.cpp
@@ -298,10 +298,10 @@ CPLErr MRFDataset::IBuildOverviews(const char *pszResampling, int nOverviews,
 
                 // The scale value is the same as first overview
                 scale =
-                    strtod(CPLGetXMLValue(
-                               config, "Rsets.scale",
-                               CPLOPrintf("%d", panOverviewList[0]).c_str()),
-                           nullptr);
+                    CPLStrtod(CPLGetXMLValue(
+                                  config, "Rsets.scale",
+                                  CPLOPrintf("%d", panOverviewList[0]).c_str()),
+                              nullptr);
                 if (scale == 0.0)
                 {
                     CPLError(CE_Failure, CPLE_IllegalArg,
@@ -1451,10 +1451,10 @@ CPLErr MRFDataset::Initialize(CPLXMLNode *config)
     {
         double x0, x1, y0, y1;
 
-        x0 = atof(CPLGetXMLValue(bbox, "minx", "0"));
-        x1 = atof(CPLGetXMLValue(bbox, "maxx", "1"));
-        y1 = atof(CPLGetXMLValue(bbox, "maxy", "1"));
-        y0 = atof(CPLGetXMLValue(bbox, "miny", "0"));
+        x0 = CPLAtof(CPLGetXMLValue(bbox, "minx", "0"));
+        x1 = CPLAtof(CPLGetXMLValue(bbox, "maxx", "1"));
+        y1 = CPLAtof(CPLGetXMLValue(bbox, "maxy", "1"));
+        y0 = CPLAtof(CPLGetXMLValue(bbox, "miny", "0"));
 
         m_gt.xorig = x0;
         m_gt.xscale = (x1 - x0) / full.size.x;

--- a/frmts/mrf/mrf_util.cpp
+++ b/frmts/mrf/mrf_util.cpp
@@ -316,7 +316,7 @@ double getXMLNum(CPLXMLNode *node, const char *pszPath, double def)
 {
     const char *textval = CPLGetXMLValue(node, pszPath, nullptr);
     if (textval)
-        return atof(textval);
+        return CPLAtof(textval);
     return def;
 }
 


### PR DESCRIPTION
## What does this PR do?

The MRF driver parses decimal numbers from the `.mrf` XML descriptor with the locale-dependent `atof()`/`strtod()`:

    LC_NUMERIC set to a comma-decimal locale (e.g. de_DE.UTF-8),
    <GeoTags><BoundingBox minx="-180.5" .../>:
        atof("-180.5") -> -180      (parsing stops at '.')

`getXMLNum()` (the generic `.mrf` numeric helper), the `GeoTags.BoundingBox` corners and `Rsets.scale` in `MRFDataset`, and the `LERC_PREC` value read from the descriptor's `<Options>` all go through `atof()`/`strtod()`. Under a locale whose decimal separator is not `.`, the fractional part is dropped, so the geotransform, overview scale and LERC precision come out wrong from an otherwise valid file. Switch these reads to the locale-independent `CPLAtof()`/`CPLStrtod()` already used elsewhere for values read from files.

## What are related issues/pull requests?

None.

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
