### PR TITLE
SAR_CEOS: fix int overflow in CCP/PALSAR scanline buffer size

### DIFF
--- a/frmts/ceos2/sar_ceosdataset.cpp
+++ b/frmts/ceos2/sar_ceosdataset.cpp
@@ -391,20 +391,22 @@ CPLErr CCPRasterBand::IReadBlock(CPL_UNUSED int nBlockXOff, int nBlockYOff,
     /* -------------------------------------------------------------------- */
     /*      Load all the pixel data associated with this scanline.          */
     /* -------------------------------------------------------------------- */
-    const int nBytesToRead = ImageDesc->BytesPerPixel * nBlockXSize;
-
-    GByte *pabyRecord = (GByte *)CPLMalloc(nBytesToRead);
+    GByte *pabyRecord = static_cast<GByte *>(
+        VSI_MALLOC2_VERBOSE(ImageDesc->BytesPerPixel, nBlockXSize));
+    if (pabyRecord == nullptr)
+        return CE_Failure;
+    const size_t nBytesToRead =
+        static_cast<size_t>(ImageDesc->BytesPerPixel) * nBlockXSize;
 
     if (VSIFSeekL(poGDS->fpImage, offset, SEEK_SET) != 0 ||
-        (int)VSIFReadL(pabyRecord, 1, nBytesToRead, poGDS->fpImage) !=
-            nBytesToRead)
+        VSIFReadL(pabyRecord, 1, nBytesToRead, poGDS->fpImage) != nBytesToRead)
     {
         CPLError(CE_Failure, CPLE_FileIO,
-                 "Error reading %d bytes of CEOS record data at offset %" PRIu64
-                 ".\n"
+                 "Error reading %" PRIu64
+                 " bytes of CEOS record data at offset %" PRIu64 ".\n"
                  "Reading file %s failed.",
-                 nBytesToRead, static_cast<uint64_t>(offset),
-                 poGDS->GetDescription());
+                 static_cast<uint64_t>(nBytesToRead),
+                 static_cast<uint64_t>(offset), poGDS->GetDescription());
         CPLFree(pabyRecord);
         return CE_Failure;
     }
@@ -535,20 +537,22 @@ CPLErr PALSARRasterBand::IReadBlock(int /* nBlockXOff */, int nBlockYOff,
     /* -------------------------------------------------------------------- */
     /*      Load all the pixel data associated with this scanline.          */
     /* -------------------------------------------------------------------- */
-    const int nBytesToRead = ImageDesc->BytesPerPixel * nBlockXSize;
-
-    GByte *pabyRecord = (GByte *)CPLMalloc(nBytesToRead);
+    GByte *pabyRecord = static_cast<GByte *>(
+        VSI_MALLOC2_VERBOSE(ImageDesc->BytesPerPixel, nBlockXSize));
+    if (pabyRecord == nullptr)
+        return CE_Failure;
+    const size_t nBytesToRead =
+        static_cast<size_t>(ImageDesc->BytesPerPixel) * nBlockXSize;
 
     if (VSIFSeekL(poGDS->fpImage, offset, SEEK_SET) != 0 ||
-        (int)VSIFReadL(pabyRecord, 1, nBytesToRead, poGDS->fpImage) !=
-            nBytesToRead)
+        VSIFReadL(pabyRecord, 1, nBytesToRead, poGDS->fpImage) != nBytesToRead)
     {
         CPLError(CE_Failure, CPLE_FileIO,
-                 "Error reading %d bytes of CEOS record data at offset %" PRIu64
-                 ".\n"
+                 "Error reading %" PRIu64
+                 " bytes of CEOS record data at offset %" PRIu64 ".\n"
                  "Reading file %s failed.",
-                 nBytesToRead, static_cast<uint64_t>(offset),
-                 poGDS->GetDescription());
+                 static_cast<uint64_t>(nBytesToRead),
+                 static_cast<uint64_t>(offset), poGDS->GetDescription());
         CPLFree(pabyRecord);
         return CE_Failure;
     }


### PR DESCRIPTION
## What does this PR do?

1. `CCPRasterBand::IReadBlock()` and `PALSARRasterBand::IReadBlock()` size the scanline buffer as `int nBytesToRead = ImageDesc->BytesPerPixel * nBlockXSize`, where `BytesPerPixel` and the pixel count behind `nBlockXSize` (`PixelsPerLine + LeftBorderPixels + RightBorderPixels`) both come from the CEOS image descriptor, so the product overflows int. With `BytesPerPixel=64` and `nBlockXSize=67108865` it wraps to 64 (`clang -fsanitize=signed-integer-overflow`: `64 * 67108865 cannot be represented in type 'int'`).
2. `CPLMalloc()` then hands back a 64-byte buffer (or NULL on the silly-size path, which is not checked), while the copy loop / `GDALCopyWords` still reads `nBlockXSize` groups from it, so a crafted CEOS scene gives a heap out-of-bounds read.

Allocate both with `VSI_MALLOC2_VERBOSE()` plus a NULL check and keep the read length in `size_t`, matching `SAR_CEOSRasterBand::IReadBlock()` which already does this in the same file.

## What are related issues/pull requests?

None.

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

* OS: macOS
* Compiler: clang
