### PR TITLE
Python bindings: when using setuptools >= 77, indicate python 3.9 as …

### DIFF
--- a/swig/python/pyproject.toml.setuptools_gte_77
+++ b/swig/python/pyproject.toml.setuptools_gte_77
@@ -1,8 +1,7 @@
 [build-system]
 requires = ["setuptools>=77.0.3",
             "wheel",
-            "oldest-supported-numpy; python_version=='3.8'",
-            "numpy >=2.0.0rc1; python_version>='3.9'"]
+            "numpy >=2.0.0rc1"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -31,7 +30,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: GIS",
     "Topic :: Scientific/Engineering :: Information Analysis",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 numpy = ['numpy>1.0.0']


### PR DESCRIPTION
…minimum version, since setuptools 77 doesn't support 3.8

Fixes #14852
