### PR TITLE
USGSDEM: avoid undefined behavior in float to int dimension cast

### DIFF
--- a/frmts/usgsdem/usgsdemdataset.cpp
+++ b/frmts/usgsdem/usgsdemdataset.cpp
@@ -804,8 +804,12 @@ int USGSDEMDataset::LoadFromFile(VSILFILE *InDem)
         /* njunk = */ ReadInt(InDem);
         const double dxStart = DConvert(InDem, 24);
 
-        nRasterYSize =
-            static_cast<int>((extent_max.y - extent_min.y) / dydelta + 1.5);
+        const double dfRasterYSize =
+            (extent_max.y - extent_min.y) / dydelta + 1.5;
+        if (dfRasterYSize <= INT_MIN || dfRasterYSize >= INT_MAX ||
+            !std::isfinite(dfRasterYSize))
+            return FALSE;
+        nRasterYSize = static_cast<int>(dfRasterYSize);
         nRasterXSize = nProfiles;
 
         m_gt.xorig = dxStart - dxdelta / 2.0;
@@ -820,8 +824,12 @@ int USGSDEMDataset::LoadFromFile(VSILFILE *InDem)
     /* -------------------------------------------------------------------- */
     else
     {
-        nRasterYSize =
-            static_cast<int>((extent_max.y - extent_min.y) / dydelta + 1.5);
+        const double dfRasterYSize =
+            (extent_max.y - extent_min.y) / dydelta + 1.5;
+        if (dfRasterYSize <= INT_MIN || dfRasterYSize >= INT_MAX ||
+            !std::isfinite(dfRasterYSize))
+            return FALSE;
+        nRasterYSize = static_cast<int>(dfRasterYSize);
         nRasterXSize = nProfiles;
 
         // Translate extents from arc-seconds to decimal degrees.


### PR DESCRIPTION
## What does this PR do?

UBSan via `gdalinfo` on a crafted DEM:

    usgsdemdataset.cpp:824:30: runtime error: inf is outside the range of representable values of type 'int'
        #0 USGSDEMDataset::LoadFromFile(VSIVirtualHandle*) usgsdemdataset.cpp:824
        #1 USGSDEMDataset::Open(GDALOpenInfo*) usgsdemdataset.cpp:913

`LoadFromFile()` sets `nRasterYSize` from `static_cast<int>((extent_max.y - extent_min.y) / dydelta + 1.5)` in both the projected and the geographic branch. The corner coordinates behind `extent_*` and `dydelta` come straight from the header via `DConvert()`, so a crafted file can push that double to `inf` or far past the `int` range, and the narrowing cast is undefined. A second malformed sample hits the same cast at `:808` with `1.84547e+23`.

`IReadBlock()` already guards its analogous `dygap` cast with `dygap <= INT_MIN || dygap >= INT_MAX || !std::isfinite(dygap)`; this puts the same check on the two `LoadFromFile` casts and bails out via the existing `return FALSE` path. Both sites trip UBSan before the change and are clean after; valid DEMs read identically.

## What are related issues/pull requests?

None.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments

## Environment

* OS: macOS (arm64)
* Compiler: clang with `-fsanitize=undefined`
