### PR TITLE
DTED: avoid signed integer overflow when reading record checksum

### DIFF
--- a/frmts/dted/dted_api.c
+++ b/frmts/dted/dted_api.c
@@ -693,10 +693,11 @@ int DTEDReadProfileEx(DTEDInfo *psDInfo, int nColumnOffset, GInt16 *panData,
         for (i = 0; i < psDInfo->nYSize * 2 + 8; i++)
             nCheckSum += pabyRecord[i];
 
-        fileCheckSum = (pabyRecord[8 + psDInfo->nYSize * 2 + 0] << 24) |
-                       (pabyRecord[8 + psDInfo->nYSize * 2 + 1] << 16) |
-                       (pabyRecord[8 + psDInfo->nYSize * 2 + 2] << 8) |
-                       pabyRecord[8 + psDInfo->nYSize * 2 + 3];
+        fileCheckSum =
+            ((unsigned)pabyRecord[8 + psDInfo->nYSize * 2 + 0] << 24) |
+            (pabyRecord[8 + psDInfo->nYSize * 2 + 1] << 16) |
+            (pabyRecord[8 + psDInfo->nYSize * 2 + 2] << 8) |
+            pabyRecord[8 + psDInfo->nYSize * 2 + 3];
 
         if (fileCheckSum > 0xff * (8 + (unsigned int)psDInfo->nYSize * 2))
         {


### PR DESCRIPTION
## What does this PR do?

UBSan via `gdalinfo -checksum` on a crafted DTED with `DTED_VERIFY_CHECKSUM=YES`:

    dted_api.c:696:65: runtime error: left shift of 255 by 24 places cannot be represented in type 'int'
        #0 DTEDReadProfileEx dted_api.c:696
        #1 DTEDRasterBand::IReadBlock(int, int, void*) dteddataset.cpp:166

`DTEDReadProfileEx()` reads the 4-byte record checksum as `(pabyRecord[8 + nYSize*2 + 0] << 24) | ...`. `pabyRecord` is `GByte`, so the high byte promotes to `int` and the `<< 24` is undefined once it is `>= 0x80`. A valid checksum can never set that byte (its maximum is `0xff * (8 + 2*nYSize)`), so only a crafted record trailer reaches it, and the shift runs before the existing impossible-value check at `:701`. `frmts/ceos/ceosopen.c` already assembles such values with `(unsigned)abyHeader[0] << 24`; this puts the same cast on the high byte here.

Trips UBSan before the change and is clean after; valid DTED files read identically.

## What are related issues/pull requests?

None.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments

## Environment

* OS: macOS (arm64)
* Compiler: clang with `-fsanitize=undefined`