### PR TITLE
gdal vector set-geom-type: implement --auto

### DIFF
--- a/.github/workflows/ubuntu_26.04/reference_arg_names.txt
+++ b/.github/workflows/ubuntu_26.04/reference_arg_names.txt
@@ -22,6 +22,7 @@ array
 array-option
 ascii
 attribute-name
+auto
 aux-xml
 auxiliary
 azimuth

--- a/apps/gdalalg_vector_set_geom_type.cpp
+++ b/apps/gdalalg_vector_set_geom_type.cpp
@@ -39,6 +39,11 @@ GDALVectorSetGeomTypeAlgorithm::GDALVectorSetGeomTypeAlgorithm(
 
     AddGeometryTypeArg(&m_opts.m_type);
 
+    AddArg("auto", 0,
+           _("Automatically determines the most restrictive geometry type that "
+             "fits all features of a layer"),
+           &m_opts.m_auto);
+
     AddArg("multi", 0, _("Force geometries to MULTI geometry types"),
            &m_opts.m_multi)
         .SetMutualExclusionGroup("multi-single");
@@ -128,9 +133,55 @@ GDALVectorSetGeomTypeAlgorithmLayer::GDALVectorSetGeomTypeAlgorithmLayer(
           oSrcLayer, opts),
       m_poFeatureDefn(oSrcLayer.GetLayerDefn()->Clone())
 {
-    if (!m_opts.m_featureGeomOnly)
+    const int nGeomFieldCount = m_poFeatureDefn->GetGeomFieldCount();
+    if (m_opts.m_auto)
     {
-        for (int i = 0; i < m_poFeatureDefn->GetGeomFieldCount(); ++i)
+        std::vector<OGRwkbGeometryType> aeGeomTypes;
+        for (int i = 0; i < nGeomFieldCount; ++i)
+        {
+            aeGeomTypes.push_back(
+                m_poFeatureDefn->GetGeomFieldDefn(i)->GetType());
+        }
+        std::vector<bool> abGeomTypeInit(nGeomFieldCount, false);
+
+        // Iterate over all features to find the most "restricted" geometry type
+        // that can fit all their geometries.
+        for (auto &&poSrcFeature : oSrcLayer)
+        {
+            for (int i = 0; i < nGeomFieldCount; ++i)
+            {
+                if (IsSelectedGeomField(i))
+                {
+                    const auto poGeom = poSrcFeature->GetGeomFieldRef(i);
+                    if (poGeom)
+                    {
+                        if (!abGeomTypeInit[i])
+                        {
+                            aeGeomTypes[i] = poGeom->getGeometryType();
+                            abGeomTypeInit[i] = true;
+                        }
+                        else if (wkbFlatten(aeGeomTypes[i]) != wkbUnknown)
+                        {
+                            aeGeomTypes[i] = OGRMergeGeometryTypesEx(
+                                aeGeomTypes[i], poGeom->getGeometryType(),
+                                /* bAllowPromotingToCurves = */ true);
+                        }
+                    }
+                }
+            }
+        }
+        for (int i = 0; i < nGeomFieldCount; ++i)
+        {
+            if (IsSelectedGeomField(i))
+            {
+                auto poGeomFieldDefn = m_poFeatureDefn->GetGeomFieldDefn(i);
+                poGeomFieldDefn->SetType(aeGeomTypes[i]);
+            }
+        }
+    }
+    else if (!m_opts.m_featureGeomOnly)
+    {
+        for (int i = 0; i < nGeomFieldCount; ++i)
         {
             if (IsSelectedGeomField(i))
             {
@@ -263,6 +314,16 @@ GDALVectorSetGeomTypeAlgorithm::CreateAlgLayer(OGRLayer &srcLayer)
 
 bool GDALVectorSetGeomTypeAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
 {
+    if (m_opts.m_auto &&
+        (!m_opts.m_type.empty() || m_opts.m_multi || m_opts.m_single ||
+         m_opts.m_linear || m_opts.m_curve || !m_opts.m_dim.empty()))
+    {
+        ReportError(CE_Failure, CPLE_AppDefined,
+                    "--auto cannot be used with any of "
+                    "--geometry-type/multi/single/linear/multi/dim");
+        return false;
+    }
+
     if (!m_opts.m_type.empty())
     {
         if (m_opts.m_multi || m_opts.m_single || m_opts.m_linear ||

--- a/apps/gdalalg_vector_set_geom_type.h
+++ b/apps/gdalalg_vector_set_geom_type.h
@@ -53,6 +53,7 @@ class GDALVectorSetGeomTypeAlgorithm /* non final */
         bool m_curve = false;
         std::string m_dim{};
         bool m_skip = false;
+        bool m_auto = false;
 
         // Computed value from m_type
         OGRwkbGeometryType m_eType = wkbUnknown;

--- a/autotest/utilities/test_gdalalg_vector_set_geom_type.py
+++ b/autotest/utilities/test_gdalalg_vector_set_geom_type.py
@@ -339,3 +339,53 @@ def test_gdalalg_vector_set_geom_type_test_ogrsf(tmp_path):
     assert "INFO" in ret
     assert "ERROR" not in ret
     assert "FAILURE" not in ret
+
+
+@pytest.mark.parametrize(
+    "input_geoms,expected_geom_type",
+    [
+        [["POINT (1 2)"], ogr.wkbPoint],
+        [["POINT (1 2)", None, "POINT (3 4)"], ogr.wkbPoint],
+        [["POINT (1 2)", "LINESTRING (3 4,5 6)", "POINT (3 4)"], ogr.wkbUnknown],
+        [
+            ["POLYGON ((0 0,0 1,1 1,0 0))", "MULTIPOLYGON (((0 0,0 1,1 1,0 0)))"],
+            ogr.wkbMultiPolygon,
+        ],
+        [
+            ["MULTIPOLYGON (((0 0,0 1,1 1,0 0)))", "POLYGON ((0 0,0 1,1 1,0 0))"],
+            ogr.wkbMultiPolygon,
+        ],
+        [
+            ["POLYGON ((0 0,0 1,1 1,0 0))", "CURVEPOLYGON ((0 0,0 1,1 1,0 0))"],
+            ogr.wkbCurvePolygon,
+        ],
+        [
+            ["LINESTRING (0 0, 1 1)", "CIRCULARSTRING M (1 1 0, 2 2 1, 3 1 2)"],
+            ogr.wkbCompoundCurveM,
+        ],
+    ],
+)
+def test_gdalalg_vector_geom_auto(input_geoms, expected_geom_type):
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 0, 0, 0, gdal.GDT_Unknown)
+
+    src_lyr = src_ds.CreateLayer("layer", geom_type=ogr.wkbNone)
+    src_lyr.CreateGeomField(ogr.GeomFieldDefn("a"))
+
+    for wkt in input_geoms:
+        f = ogr.Feature(src_lyr.GetLayerDefn())
+        if wkt:
+            f.SetGeometry(ogr.CreateGeometryFromWkt(wkt))
+        src_lyr.CreateFeature(f)
+
+    alg = get_alg()
+    alg["input"] = src_ds
+    alg["output"] = ""
+    alg["output-format"] = "stream"
+    alg["auto"] = True
+
+    assert alg.Run()
+
+    out_ds = alg["output"].GetDataset()
+    lyr = out_ds.GetLayer(0)
+    assert lyr.GetGeomType() == expected_geom_type

--- a/doc/source/programs/gdal_vector_set_geom_type.rst
+++ b/doc/source/programs/gdal_vector_set_geom_type.rst
@@ -41,6 +41,18 @@ The following groups of options can be combined together:
 Program-Specific Options
 ------------------------
 
+.. option:: --auto
+
+   .. versionadded:: 3.14
+
+   Automatically determine the geometry type by inspecting all input feature geometries. The most
+   restrictive geometry type will be selected. For example, if there is a mix of
+   polygons and multipolygons, the result will be multipolygons. If a common
+   geometry type cannot be determined, the generic Geometry type will be selected.
+
+   This option is mutually exclusive with :option:`--multi`, :option:`--single`,
+   :option:`--linear`, :option:`--curve`, :option:`--dim` and :option:`--geometry-type`.
+
 .. option:: --curve
 
    Force geometries to curve geometry types. e.g. ``LINESTRING`` ==> ``COMPOUNDCURVE``
@@ -167,3 +179,10 @@ Examples
    .. code-block:: bash
 
         $ gdal vector set-geom-type --linear in.gpkg out.shp --overwrite
+
+.. example::
+   :title: Convert a CSV file that contains only a single type of geometry into a properly typed GeoPackage
+
+   .. code-block:: bash
+
+        $ gdal vector set-geom-type --auto in.csv out.gpkg

--- a/ogr/ogrgeometry.cpp
+++ b/ogr/ogrgeometry.cpp
@@ -3106,12 +3106,6 @@ OGRwkbGeometryType OGRMergeGeometryTypesEx(OGRwkbGeometryType eMain,
     {
         if (OGR_GT_IsCurve(eFMain) && OGR_GT_IsCurve(eFExtra))
             return OGR_GT_SetModifier(wkbCompoundCurve, bHasZ, bHasM);
-
-        if (OGR_GT_IsSubClassOf(eFMain, eFExtra))
-            return OGR_GT_SetModifier(eFExtra, bHasZ, bHasM);
-
-        if (OGR_GT_IsSubClassOf(eFExtra, eFMain))
-            return OGR_GT_SetModifier(eFMain, bHasZ, bHasM);
     }
 
     // One is subclass of the other one
@@ -3122,6 +3116,15 @@ OGRwkbGeometryType OGRMergeGeometryTypesEx(OGRwkbGeometryType eMain,
     else if (OGR_GT_IsSubClassOf(eFExtra, eFMain))
     {
         return OGR_GT_SetModifier(eFMain, bHasZ, bHasM);
+    }
+
+    if (OGR_GT_GetSingle(eFMain) == eFExtra)
+    {
+        return OGR_GT_SetModifier(eFMain, bHasZ, bHasM);
+    }
+    else if (OGR_GT_GetSingle(eFExtra) == eFMain)
+    {
+        return OGR_GT_SetModifier(eFExtra, bHasZ, bHasM);
     }
 
     // Nothing apparently in common.


### PR DESCRIPTION
```rst
.. option:: --auto

   .. versionadded:: 3.14

   Guess the geometry type by inspecting all input feature geometries. The most
   restrictive geometry type will be selected. For example. if there is a mix of
   polygons and multipolygons, the result will be multipolygons. If a common
   geometry type cannot be determined, the generic Geometry type will be selected.

   This option is mutually exclusive with :option:`--multi`, :option:`--single`,
   :option:`--linear`, :option:`--curve`, :option:`--dim` and :option:`--geometry-type`.
```

Fixes #14863
