### PR TITLE
gdal raster reclassify: add --keep-color-table

### DIFF
--- a/.github/workflows/ubuntu_26.04/reference_arg_names.txt
+++ b/.github/workflows/ubuntu_26.04/reference_arg_names.txt
@@ -138,6 +138,7 @@ interval
 invert
 invisible-value
 join-style
+keep-color-table
 keep-lower-dim
 keep-nested
 kernel

--- a/apps/gdalalg_raster_reclassify.cpp
+++ b/apps/gdalalg_raster_reclassify.cpp
@@ -40,6 +40,8 @@ GDALRasterReclassifyAlgorithm::GDALRasterReclassifyAlgorithm(
              "a file containing mappings"),
            &m_mapping)
         .SetRequired();
+    AddArg("keep-color-table", 0, _("Preserve the input color table"),
+           &m_keepColorTable);
     AddOutputDataTypeArg(&m_type);
 }
 
@@ -69,7 +71,7 @@ static bool GDALReclassifyValidateMappings(GDALDataset &input,
 
 static std::unique_ptr<GDALDataset>
 GDALReclassifyCreateVRTDerived(GDALDataset &input, const std::string &mappings,
-                               GDALDataType eDstType)
+                               GDALDataType eDstType, bool keepColorTable)
 {
     CPLXMLTreeCloser root(CPLCreateXMLNode(nullptr, CXT_Element, "VRTDataset"));
 
@@ -78,8 +80,8 @@ GDALReclassifyCreateVRTDerived(GDALDataset &input, const std::string &mappings,
 
     for (int iBand = 1; iBand <= input.GetRasterCount(); ++iBand)
     {
-        const GDALDataType srcType =
-            input.GetRasterBand(iBand)->GetRasterDataType();
+        GDALRasterBand *poSrcBand = input.GetRasterBand(iBand);
+        const GDALDataType srcType = poSrcBand->GetRasterDataType();
         const GDALDataType bandType =
             eDstType == GDT_Unknown ? srcType : eDstType;
         const GDALDataType xferType = GDALDataTypeUnion(srcType, bandType);
@@ -101,6 +103,28 @@ GDALReclassifyCreateVRTDerived(GDALDataset &input, const std::string &mappings,
             CPLCreateXMLNode(band, CXT_Element, "SourceTransferType");
         CPLCreateXMLNode(sourceTransferType, CXT_Text,
                          GDALGetDataTypeName(xferType));
+
+        if (const GDALColorTable *poTable =
+                keepColorTable ? poSrcBand->GetColorTable() : nullptr)
+        {
+            CPLXMLNode *colorTable =
+                CPLCreateXMLNode(band, CXT_Element, "ColorTable");
+            for (int i = 0; i < poTable->GetColorEntryCount(); ++i)
+            {
+                const GDALColorEntry *poSrcEntry = poTable->GetColorEntry(i);
+
+                CPLXMLNode *entry =
+                    CPLCreateXMLNode(colorTable, CXT_Element, "Entry");
+                CPLAddXMLAttributeAndValue(
+                    entry, "c1", std::to_string(poSrcEntry->c1).c_str());
+                CPLAddXMLAttributeAndValue(
+                    entry, "c2", std::to_string(poSrcEntry->c2).c_str());
+                CPLAddXMLAttributeAndValue(
+                    entry, "c3", std::to_string(poSrcEntry->c3).c_str());
+                CPLAddXMLAttributeAndValue(
+                    entry, "c4", std::to_string(poSrcEntry->c4).c_str());
+            }
+        }
     }
 
     auto ds = std::make_unique<VRTDataset>(nX, nY);
@@ -205,8 +229,8 @@ bool GDALRasterReclassifyAlgorithm::RunStep(GDALPipelineStepRunContext &)
             return false;
         }
 
-        m_outputDataset.Set(
-            GDALReclassifyCreateVRTDerived(*poSrcDS, m_mapping, eDstType));
+        m_outputDataset.Set(GDALReclassifyCreateVRTDerived(
+            *poSrcDS, m_mapping, eDstType, m_keepColorTable));
     }
     return m_outputDataset.GetDatasetRef() != nullptr;
 }

--- a/apps/gdalalg_raster_reclassify.h
+++ b/apps/gdalalg_raster_reclassify.h
@@ -37,6 +37,7 @@ class GDALRasterReclassifyAlgorithm : public GDALRasterPipelineStepAlgorithm
 
     std::string m_mapping{};
     std::string m_type{};
+    bool m_keepColorTable{false};
 };
 
 /************************************************************************/

--- a/autotest/utilities/test_gdalalg_raster_reclassify.py
+++ b/autotest/utilities/test_gdalalg_raster_reclassify.py
@@ -224,6 +224,43 @@ def test_gdalalg_raster_reclassify_multiple_bands(reclassify, tmp_vsimem):
             assert np.all(dst_val[np.where(src_val >= 128)] == 1)
 
 
+@pytest.mark.parametrize("keep_color_table", (True, False))
+def test_gdalalg_raster_reclassify_keep_color_table(
+    reclassify, tmp_vsimem, keep_color_table
+):
+
+    test_ct_data = [
+        (255, 0, 0, 255),
+        (0, 255, 0, 128),
+        (0, 0, 255, 0),
+        (255, 255, 255, 0),
+    ]
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    src_ct = gdal.ColorTable()
+    for i, color in enumerate(test_ct_data):
+        src_ct.SetColorEntry(i, color)
+    src_ds.GetRasterBand(1).SetColorTable(src_ct)
+
+    reclassify["input"] = src_ds
+    reclassify["mapping"] = "DEFAULT=PASS_THROUGH"
+    reclassify["output-format"] = "stream"
+    reclassify["keep-color-table"] = keep_color_table
+
+    assert reclassify.Run()
+
+    dst_ds = reclassify.Output()
+
+    dst_ct = dst_ds.GetRasterBand(1).GetColorTable()
+
+    if keep_color_table:
+        assert dst_ct.GetCount() == len(test_ct_data)
+        for i, color in enumerate(test_ct_data):
+            assert dst_ct.GetColorEntry(i) == color
+    else:
+        assert dst_ct is None
+
+
 def test_gdalalg_raster_reclassify_empty_mapping(reclassify, tmp_vsimem):
 
     infile = "../gcore/data/byte.tif"

--- a/doc/source/programs/gdal_raster_reclassify.rst
+++ b/doc/source/programs/gdal_raster_reclassify.rst
@@ -86,6 +86,12 @@ These pixels may be converted unto NoData (``DEFAULT = NO_DATA``), some other co
 Program-Specific Options
 ------------------------
 
+.. option:: --keep-color-table
+
+   Preserve the color table of the input raster bands in the output.
+
+   .. versionadded:: 3.14
+
 .. option:: -m, --mapping <MAPPING>
 
    A definition of mappings between input and output pixel values, as described above.

--- a/doc/source/programs/gdal_raster_reclassify.rst
+++ b/doc/source/programs/gdal_raster_reclassify.rst
@@ -88,9 +88,9 @@ Program-Specific Options
 
 .. option:: --keep-color-table
 
-   Preserve the color table of the input raster bands in the output.
-
    .. versionadded:: 3.14
+
+   Preserve the color table of the input raster bands in the output.
 
 .. option:: -m, --mapping <MAPPING>
 


### PR DESCRIPTION
Motivated by the following issue (QGIS, but could just as well be GDAL). A similar option would be useful for `gdal raster calc` -- I'm trying to figure out how that would work. Options to keep a RAT may also be useful.

<img width="820" height="908" alt="image" src="https://github.com/user-attachments/assets/9950f010-2c9d-4773-a5d5-fe9d1b195465" />
