### PR TITLE
mdim mosaic propagate CF units  (#14881)

### DIFF
--- a/apps/gdalalg_mdim_mosaic.cpp
+++ b/apps/gdalalg_mdim_mosaic.cpp
@@ -90,7 +90,10 @@ GDALMdimMosaicAlgorithm::GetDimensionDesc(
     desc.osDirection = poDim->GetDirection();
     const auto nSize = poDim->GetSize();
     if (poVar)
+    {
         desc.attributes = poVar->GetAttributes();
+        desc.osUnit = poVar->GetUnit();
+    }
     CPLAssert(nSize > 0);
     desc.nSize = nSize;
     desc.bHasIndexingVar = poVar != nullptr;
@@ -757,6 +760,8 @@ bool GDALMdimMosaicAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
                                 dstAttr->Write(raw.data(), raw.size()));
                         }
                     }
+                    if (!desc.osUnit.empty())
+                        var->SetUnit(desc.osUnit);
 
                     if (desc.aaValues.empty())
                     {

--- a/apps/gdalalg_mdim_mosaic.cpp
+++ b/apps/gdalalg_mdim_mosaic.cpp
@@ -761,7 +761,10 @@ bool GDALMdimMosaicAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
                         }
                     }
                     if (!desc.osUnit.empty())
+                    {
+                        CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
                         var->SetUnit(desc.osUnit);
+                    }
 
                     if (desc.aaValues.empty())
                     {

--- a/apps/gdalalg_mdim_mosaic.h
+++ b/apps/gdalalg_mdim_mosaic.h
@@ -58,7 +58,8 @@ class GDALMdimMosaicAlgorithm /* non final*/
         uint64_t nSize = 0;
         uint64_t nBlockSize = 0;
         std::vector<std::shared_ptr<GDALAttribute>> attributes{};
-
+        // indexing variable unit (e.g. CF 'units')
+        std::string osUnit{};
         bool bHasIndexingVar = false;
 
         // Used for dimensions with irregular spaced labels

--- a/autotest/utilities/test_gdalalg_mdim_mosaic.py
+++ b/autotest/utilities/test_gdalalg_mdim_mosaic.py
@@ -1221,7 +1221,6 @@ def test_gdalalg_mdim_mosaic_preserves_indexing_var_unit(tmp_path):
             .GetDimensions()[0]
             .GetIndexingVariable()
         )
-        # did not work in gdal mdim mosaic 14881
         assert idx.GetUnit() == UNIT
         # plain attributes
         assert "long_name" in [a.GetName() for a in idx.GetAttributes()]

--- a/autotest/utilities/test_gdalalg_mdim_mosaic.py
+++ b/autotest/utilities/test_gdalalg_mdim_mosaic.py
@@ -1205,17 +1205,6 @@ def test_gdalalg_mdim_mosaic_preserves_indexing_var_unit(tmp_path):
             ar.Write(array.array("B", [4]))
 
     create_sources()
-    # convert
-    with gdal.Run(
-        "mdim",
-        "convert",
-        input=tmp_path / "test1.nc",
-        output=tmp_path / "c.vrt",
-        output_format="VRT",
-    ) as alg:
-        z = alg.Output().GetRootGroup().OpenMDArray("z")
-        assert z.GetUnit() == UNIT
-
     # mosaic
     with gdal.Run(
         "mdim",

--- a/autotest/utilities/test_gdalalg_mdim_mosaic.py
+++ b/autotest/utilities/test_gdalalg_mdim_mosaic.py
@@ -1162,3 +1162,77 @@ def test_gdalalg_mdim_mosaic_pipeline(tmp_path):
         pass
     with gdal.Open(tmp_path / "out.nc", gdal.OF_MULTIDIM_RASTER) as ds:
         assert ds.GetRootGroup().OpenMDArray("Band1")
+
+
+def test_gdalalg_mdim_mosaic_preserves_indexing_var_unit(tmp_path):
+    UNIT = "days since 2000-01-01 00:00:00"
+
+    def create_sources():
+        with gdal.GetDriverByName("netCDF").CreateMultiDimensional(
+            tmp_path / "test1.nc"
+        ) as ds:
+            rg = ds.GetRootGroup()
+            z = rg.CreateDimension("z", "TEMPORAL", "", 1)
+            z_ar = rg.CreateMDArray(
+                "z", [z], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+            )
+            z_ar.SetUnit(UNIT)
+            z_ar.CreateAttribute(
+                "long_name", [1], gdal.ExtendedDataType.CreateString()
+            ).WriteString("time")
+            z_ar.Write([10.0])
+            ar = rg.CreateMDArray(
+                "test", [z], gdal.ExtendedDataType.Create(gdal.GDT_UInt8)
+            )
+            ar.Write(array.array("B", [3]))
+
+        with gdal.GetDriverByName("netCDF").CreateMultiDimensional(
+            tmp_path / "test2.nc"
+        ) as ds:
+            rg = ds.GetRootGroup()
+            z = rg.CreateDimension("z", "TEMPORAL", "", 1)
+            z_ar = rg.CreateMDArray(
+                "z", [z], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+            )
+            z_ar.SetUnit(UNIT)
+            z_ar.CreateAttribute(
+                "long_name", [1], gdal.ExtendedDataType.CreateString()
+            ).WriteString("time")
+            z_ar.Write([20.0])
+            ar = rg.CreateMDArray(
+                "test", [z], gdal.ExtendedDataType.Create(gdal.GDT_UInt8)
+            )
+            ar.Write(array.array("B", [4]))
+
+    create_sources()
+    # convert
+    with gdal.Run(
+        "mdim",
+        "convert",
+        input=tmp_path / "test1.nc",
+        output=tmp_path / "c.vrt",
+        output_format="VRT",
+    ) as alg:
+        z = alg.Output().GetRootGroup().OpenMDArray("z")
+        assert z.GetUnit() == UNIT
+
+    # mosaic
+    with gdal.Run(
+        "mdim",
+        "mosaic",
+        input=tmp_path / "test*.nc",
+        output=tmp_path / "m.vrt",
+        array="test",
+        output_format="VRT",
+    ) as alg:
+        idx = (
+            alg.Output()
+            .GetRootGroup()
+            .OpenMDArray("test")
+            .GetDimensions()[0]
+            .GetIndexingVariable()
+        )
+        # did not work in gdal mdim mosaic 14881
+        assert idx.GetUnit() == UNIT
+        # plain attributes
+        assert "long_name" in [a.GetName() for a in idx.GetAttributes()]


### PR DESCRIPTION

Modify `mdim mosaic` to propagate `Unit` for each dimension's indexing variable. 

## What are related issues/pull requests?

Fixes #14881 

## AI tool usage

 - [x] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 
## Motivating example

(downloads to 2x 8Mb netcdf)

```bash
dsn="/vsicurl/https://www.ncei.noaa.gov/data/sea-surface-temperature-optimum-interpolation/v2.1/access/avhrr/198109/oisst-avhrr-v02r01.19810901.nc" 
gdal mdim convert $dsn /tmp/ctest.nc --overwrite
gdal mdim mosaic  $dsn /tmp/mtest.nc --overwrite


gdal mdim info /tmp/ctest.nc

# Driver: netCDF
# 
# Structural metadata:
#   NC_FORMAT  NETCDF4
# 
# Dimensions:
#   Name (path)  Size      Type      Direction
#   -----------  ----  ------------  ---------
#   /time           1  TEMPORAL
#   /zlev           1  VERTICAL      DOWN
#   /lat          720  HORIZONTAL_Y  NORTH
#   /lon         1440  HORIZONTAL_X  EAST
# 
# Coordinates (indexing variables):
#   Name (path)  Dimension   Type                 Unit
#   -----------  ---------  -------  ------------------------------
#   /lat         (lat)      Float32  degrees_north
#   /lon         (lon)      Float32  degrees_east
#   /time        (time)     Float32  days since 1978-01-01 12:00:00
#   /zlev        (zlev)     Float32  meters
# 
```


before this fix, `mtest.nc` has unit-less time

```bash
gdal mdim info /tmp/mtest.nc

# Driver: netCDF
# 
# Structural metadata:
#   NC_FORMAT  NETCDF4
# 
# Dimensions:
#   Name (path)  Size      Type      Direction
#   -----------  ----  ------------  ---------
#   /lat          720  HORIZONTAL_Y
#   /lon         1440  HORIZONTAL_X
#   /time           1
#   /zlev           1  VERTICAL      DOWN
# 
# Coordinates (indexing variables):
#   Name (path)  Dimension   Type    Unit
#   -----------  ---------  -------  ----
#   /time        (time)     Float64
#   /zlev        (zlev)     Float64
#   /lat         (lat)      Float64
#   /lon         (lon)      Float64
# 
# # 


```