### PR TITLE
DGN: bound b-spline knot/weight array read to element size

### DIFF
--- a/ogr/ogrsf_frmts/dgn/dgnread.cpp
+++ b/ogr/ogrsf_frmts/dgn/dgnread.cpp
@@ -1077,7 +1077,8 @@ static DGNElemCore *DGNProcessElement(DGNInfo *psDGN, int nType, int nLevel)
             DGNParseCore(psDGN, psElement);
 
             // Read array
-            for (int i = 0; i < numelems; i++)
+            for (int i = 0; i < numelems && 36 + i * 4 + 4 <= psDGN->nElemBytes;
+                 i++)
             {
                 psArray->array[i] = static_cast<float>(
                     1.0 * DGN_INT32(psDGN->abyElem + 36 + i * 4) /


### PR DESCRIPTION
## What does this PR do?

1. numelems for the BSPLINE_KNOT/WEIGHT case is derived from the attribute-offset field at abyElem[30..31], so it is unrelated to the element size nElemBytes.
2. the read loop walks DGN_INT32(abyElem + 36 + i*4) up to numelems without the `36 + i*4 + 4 <= nElemBytes` bound the sibling multipoint (`DGNT_LINE_STRING`) and surface-boundary loops already have.

A crafted knot element with abyElem[30..31]=0xFF gives numelems=32766; on a 40-byte element the loop then reads to byte offset 131100, past both the element and the fixed 131077-byte abyElem buffer. Added the same bound the sibling loops use, so only knots that fit in the element are read.

## What are related issues/pull requests?

None.

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

* OS: macOS
* Compiler: clang
