### PR TITLE
use MEM driver instead of deprecated Memory in the GNM

### DIFF
--- a/gnm/gnmgenericnetwork.cpp
+++ b/gnm/gnmgenericnetwork.cpp
@@ -777,10 +777,10 @@ OGRLayer *GNMGenericNetwork::GetPath(GNMGFID nStartFID, GNMGFID nEndFID,
     }
 
     GDALDriver *poMEMDrv =
-        OGRSFDriverRegistrar::GetRegistrar()->GetDriverByName("Memory");
+        OGRSFDriverRegistrar::GetRegistrar()->GetDriverByName("MEM");
     if (poMEMDrv == nullptr)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Cannot load 'Memory' driver");
+        CPLError(CE_Failure, CPLE_AppDefined, "Cannot load 'MEM' driver");
         return nullptr;
     }
 


### PR DESCRIPTION
## What does this PR do?

The `gnmanalyse` tool prints deprecation warning related to use of "Memory" driver. Use "MEM" driver instead to remove that warning.

## What are related issues/pull requests?

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

