### PR TITLE
netCDF: make CreateFeature() return failure if WKT cannot be written

### DIFF
--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -2281,9 +2281,10 @@ def test_netcdf_55(tmp_path):
 # Test truncation of bidimensional char variables and WKT in a vector NetCDF 3 file
 
 
+@gdaltest.disable_exceptions()
 def test_netcdf_56(tmp_path):
 
-    ofile = str(tmp_path / "out.nc")
+    ofile = tmp_path / "out.nc"
     ds = ogr.GetDriverByName("netCDF").CreateDataSource(
         ofile, options=["GEOMETRY_ENCODING=WKT"]
     )
@@ -2300,19 +2301,19 @@ def test_netcdf_56(tmp_path):
     lyr.CreateField(ogr.FieldDefn("txt"))
     f = ogr.Feature(lyr.GetLayerDefn())
     f["txt"] = "0123456789"
+
     f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (1 2)"))
-    with gdal.quiet_errors():
-        ret = lyr.CreateFeature(f)
-    assert ret == 0
+    with gdaltest.error_raised(gdal.CE_Failure, "Cannot write geometry as WKT"):
+        assert lyr.CreateFeature(f) != ogr.OGRERR_NONE
     ds = None
 
+    # Although CreateFeature raised an exception, the feature was still created.
     ds = gdal.Open(ofile, gdal.OF_VECTOR)
     lyr = ds.GetLayer(0)
     assert lyr.GetDataset().GetDescription() == ds.GetDescription()
     f = lyr.GetFeature(lyr.GetFeatureCount())
-    if f["txt"] != "01234" or f.GetGeometryRef() is not None:
-        f.DumpReadable()
-        pytest.fail()
+    assert f["txt"] == "01234"
+    assert f.GetGeometryRef() is None
     ds = None
 
 

--- a/frmts/netcdf/netcdflayer.cpp
+++ b/frmts/netcdf/netcdflayer.cpp
@@ -1975,12 +1975,14 @@ bool netCDFLayer::FillVarFromFeature(OGRFeature *poFeature, int nMainDimId,
     else if (m_poFeatureDefn->GetGeomType() != wkbNone && m_nWKTVarID >= 0 &&
              poGeom != nullptr && m_bLegacyCreateMode)
     {
-        char *pszWKT = nullptr;
-        poGeom->exportToWkt(&pszWKT, wkbVariantIso);
-        int status;
+        OGRWktOptions opts;
+        opts.variant = wkbVariantIso;
+
+        std::string osWKT = poGeom->exportToWkt(opts);
+        int status = NC_NOERR;
         if (m_nWKTNCDFType == NC_STRING)
         {
-            const char *pszWKTConst = pszWKT;
+            const char *pszWKTConst = osWKT.c_str();
             status = nc_put_var1_string(m_nLayerCDFId, m_nWKTVarID, anIndex,
                                         &pszWKTConst);
         }
@@ -1988,7 +1990,7 @@ bool netCDFLayer::FillVarFromFeature(OGRFeature *poFeature, int nMainDimId,
         {
             size_t anCount[2];
             anCount[0] = 1;
-            anCount[1] = strlen(pszWKT);
+            anCount[1] = osWKT.size();
             if (anCount[1] > static_cast<unsigned int>(m_nWKTMaxWidth))
             {
                 if (m_bAutoGrowStrings)
@@ -2005,7 +2007,7 @@ bool netCDFLayer::FillVarFromFeature(OGRFeature *poFeature, int nMainDimId,
                     m_nWKTMaxWidth = static_cast<int>(nNewSize);
 
                     status = nc_put_vara_text(m_nLayerCDFId, m_nWKTVarID,
-                                              anIndex, anCount, pszWKT);
+                                              anIndex, anCount, osWKT.c_str());
                 }
                 else
                 {
@@ -2013,16 +2015,16 @@ bool netCDFLayer::FillVarFromFeature(OGRFeature *poFeature, int nMainDimId,
                              "Cannot write geometry as WKT. Would require %d "
                              "characters but field width is %d",
                              static_cast<int>(anCount[1]), m_nWKTMaxWidth);
-                    status = NC_NOERR;
+                    status =
+                        NC_EEDGE;  // error that would be returned had we called nc_put_var_text
                 }
             }
             else
             {
                 status = nc_put_vara_text(m_nLayerCDFId, m_nWKTVarID, anIndex,
-                                          anCount, pszWKT);
+                                          anCount, osWKT.c_str());
             }
         }
-        CPLFree(pszWKT);
         NCDF_ERR(status);
         if (status != NC_NOERR)
         {


### PR DESCRIPTION
Before this PR, the code had an inconsistency where `CreateFeature` would return success (exceptions disabled) or throw an exception (exceptions enabled.)