### PR TITLE
gdal raster mosaic: include vertical component of CRS in mismatch error

### DIFF
--- a/apps/gdalbuildvrt_lib.cpp
+++ b/apps/gdalbuildvrt_lib.cpp
@@ -443,7 +443,8 @@ static CPLString GetProjectionName(const char *pszProjection)
     OGRSpatialReference oSRS;
     oSRS.SetFromUserInput(pszProjection);
 
-    return oSRS.GetName();
+    const char *pszName = oSRS.GetName();
+    return pszName ? pszName : "(null)";
 }
 
 /************************************************************************/

--- a/apps/gdalbuildvrt_lib.cpp
+++ b/apps/gdalbuildvrt_lib.cpp
@@ -442,12 +442,8 @@ static CPLString GetProjectionName(const char *pszProjection)
 
     OGRSpatialReference oSRS;
     oSRS.SetFromUserInput(pszProjection);
-    const char *pszRet = nullptr;
-    if (oSRS.IsProjected())
-        pszRet = oSRS.GetAttrValue("PROJCS");
-    else if (oSRS.IsGeographic())
-        pszRet = oSRS.GetAttrValue("GEOGCS");
-    return pszRet ? pszRet : "(null)";
+
+    return oSRS.GetName();
 }
 
 /************************************************************************/
@@ -847,7 +843,7 @@ std::string VRTBuilder::AnalyseRaster(GDALDatasetH hDS,
                 CPLString osGot = GetProjectionName(proj);
                 return m_osProgramName +
                        CPLSPrintf(" does not support heterogeneous "
-                                  "projection: expected %s, got %s.",
+                                  "projection: expected \"%s\", got \"%s\".",
                                   osExpected.c_str(), osGot.c_str());
             }
         }

--- a/autotest/utilities/test_gdalalg_raster_mosaic.py
+++ b/autotest/utilities/test_gdalalg_raster_mosaic.py
@@ -11,6 +11,8 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import re
+
 import gdaltest
 import pytest
 
@@ -407,16 +409,21 @@ def test_gdalalg_raster_mosaic_inconsistent_characteristics():
     src1_ds.SetGeoTransform([2, 1, 0, 49, 0, -1])
     src2_ds = gdal.GetDriverByName("MEM").Create("", 2, 2)
     src2_ds.SetGeoTransform([3, 0.5, 0, 49, 0, -0.5])
-    srs = osr.SpatialReference()
-    srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
-    srs.SetFromUserInput("WGS84")
-    src2_ds.SetSpatialRef(srs)
+
+    srs1 = osr.SpatialReference(epsg=2953)
+    src1_ds.SetSpatialRef(srs1)
+
+    srs2 = osr.SpatialReference("EPSG:2953+6647")
+    src2_ds.SetSpatialRef(srs2)
 
     alg = get_mosaic_alg()
     alg["input"] = [src1_ds, src2_ds]
     alg["output-format"] = "stream"
     with pytest.raises(
-        Exception, match="gdal raster mosaic does not support heterogeneous projection"
+        Exception,
+        match=re.escape(
+            'expected "NAD83(CSRS) / New Brunswick Stereographic", got "NAD83(CSRS) / New Brunswick Stereographic + CGVD2013(CGG2013) height"'
+        ),
     ):
         assert alg.Run()
 


### PR DESCRIPTION
Resolves #14887