### PR TITLE
[Backport release/3.13] gdal raster reproject: avoid old CLI arguments in warning messages

### DIFF
--- a/apps/gdalalg_raster_reproject.cpp
+++ b/apps/gdalalg_raster_reproject.cpp
@@ -220,6 +220,8 @@ bool GDALRasterReprojectAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
     CPLStringList aosOptions;
     std::string outputFilename;
 
+    aosOptions.AddString("--invoked-from-gdal-algorithm");
+
     // --like provide defaults: override if not explicitly set
     if (auto poLikeDS = m_likeDataset.GetDatasetRef())
     {

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -239,6 +239,9 @@ struct GDALWarpAppOptions
 
     /*! Used when using a temporary TIFF file while warping */
     bool bDeleteOutputFileOnceCreated = false;
+
+    /*! set to true to customize error messages when called from "new" (GDAL 3.11) CLI or Algorithm API */
+    bool bInvokedFromGdalAlgorithm = false;
 };
 
 static CPLErr
@@ -919,9 +922,14 @@ static bool DealWithCOGOptions(CPLStringList &aosCreateOptions, int nSrcCount,
             oSRS2.SetFromUserInput(osTargetSRS.c_str());
             if (!oSRS1.IsSame(&oSRS2))
             {
+                const char *pszOutputArg = psOptions->bInvokedFromGdalAlgorithm
+                                               ? "--output-crs"
+                                               : "-t_srs";
+
                 CPLError(CE_Failure, CPLE_AppDefined,
                          "Target SRS implied by COG creation options is not "
-                         "the same as the one specified by -t_srs");
+                         "the same as the one specified by %s",
+                         pszOutputArg);
                 return false;
             }
         }
@@ -4777,13 +4785,24 @@ static GDALDatasetH GDALWarpCreateOutput(
                     if (OGRProjCTDifferentOperationsUsed(
                             psRTI->poReverseTransform))
                     {
+                        const char *pszTransformOption =
+                            psOptions->bInvokedFromGdalAlgorithm
+                                ? "--transform-option"
+                                : "-to";
+                        const char *pszCoordinateOperation =
+                            psOptions->bInvokedFromGdalAlgorithm
+                                ? ""
+                                : ", or specify a particular coordinate "
+                                  "operation with -ct";
+
                         CPLError(
                             CE_Warning, CPLE_AppDefined,
                             "Several coordinate operations are going to be "
                             "used. Artifacts may appear. You may consider "
-                            "using the -to ALLOW_BALLPARK=NO and/or "
-                            "-to ONLY_BEST=YES transform options, or specify "
-                            "a particular coordinate operation with -ct");
+                            "using the %s ALLOW_BALLPARK=NO and/or "
+                            "%s ONLY_BEST=YES transform options%s",
+                            pszTransformOption, pszTransformOption,
+                            pszCoordinateOperation);
                     }
 
                     // Stop recording
@@ -6038,6 +6057,11 @@ GDALWarpAppOptionsGetParser(GDALWarpAppOptions *psOptions,
         .append()
         .store_into(psOptions->anDstBands)
         .help(_("Specify the output band number in which to warp."));
+
+    // Undocumented option used by gdal vector * algorithms
+    argParser->add_argument("--invoked-from-gdal-algorithm")
+        .store_into(psOptions->bInvokedFromGdalAlgorithm)
+        .hidden();
 
     if (psOptionsForBinary)
     {

--- a/autotest/utilities/test_gdalalg_raster_reproject.py
+++ b/autotest/utilities/test_gdalalg_raster_reproject.py
@@ -463,3 +463,20 @@ def test_gdalalg_raster_reproject_hidden_alias_dst_crs():
     ) as alg:
         ds = alg.Output()
         assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
+
+
+@pytest.mark.require_proj(9, 1)
+def test_gdalalg_raster_reproject_warn_different_coordinate_operations():
+    src_ds = gdal.GetDriverByName("MEM").Create("", 10, 10)
+    srs = osr.SpatialReference(epsg=4267)  # NAD27
+    srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+    src_ds.SetSpatialRef(srs)
+    src_ds.SetGeoTransform([-100, 2, 0, 60, 0, -2])
+
+    with gdaltest.error_raised(
+        gdal.CE_Warning,
+        "Several coordinate operations are going to be used. Artifacts may appear. You may consider using the --transform-option ALLOW_BALLPARK=NO and/or --transform-option ONLY_BEST=YES transform options",
+    ):
+        gdal.alg.raster.reproject(
+            input=src_ds, output="", output_format="MEM", output_crs="EPSG:4326"
+        )


### PR DESCRIPTION
Backport #14891
 **Authored by:** @dbaston