### PR TITLE
Support PROJ-string projections in USGS ISIS

### DIFF
--- a/autotest/gdrivers/isis.py
+++ b/autotest/gdrivers/isis.py
@@ -2392,3 +2392,98 @@ End
             "_type": "group",
             "Test/with/slash:and:colon": 1,
         }
+
+
+def _open_isis3_projstr(tmp_vsimem, mapping):
+    # Write a minimal detached ISIS3 label whose Mapping group is 'mapping',
+    # plus the tiny raw image it points at, and open it.
+    gdal.FileFromMemBuffer(
+        tmp_vsimem / "projstr.lbl",
+        f"""Object = IsisCube
+  Object = Core
+    StartByte = 1
+    ^Core     = projstr.cub
+    Format    = BandSequential
+    Group = Dimensions
+      Samples = 2
+      Lines   = 2
+      Bands   = 1
+    End_Group
+    Group = Pixels
+      Type       = UnsignedByte
+      ByteOrder  = Lsb
+      Base       = 0.0
+      Multiplier = 1.0
+    End_Group
+  End_Object
+  Group = Mapping
+{mapping}
+  End_Group
+End_Object
+End
+""",
+    )
+    gdal.FileFromMemBuffer(tmp_vsimem / "projstr.cub", b"\x00" * 4)
+    return gdal.Open(tmp_vsimem / "projstr.lbl")
+
+
+def test_isis3_projstr_read(tmp_vsimem):
+
+    # The ISIS IProj projection (ProjectionName = IProj) carries its
+    # definition in a ProjStr PROJ string, which may span two lines.
+    with _open_isis3_projstr(
+        tmp_vsimem,
+        """    ProjectionName   = IProj
+    TargetName       = Mars
+    PixelResolution  = 10.0 <meters/pixel>
+    UpperLeftCornerX = -1000.0 <meters>
+    UpperLeftCornerY = 2000.0 <meters>
+    ProjStr          = "+proj=eqc +lat_ts=0 +lat_0=0 +lon_0=0 +x_0=0 +y_0=0
+                        +a=3396190 +b=3396190 +units=m +no_defs +type=crs" """,
+    ) as ds:
+        srs = ds.GetSpatialRef()
+        assert srs is not None
+        assert srs.IsProjected()
+        assert srs.GetSemiMajor() == pytest.approx(3396190)
+        assert "+proj=eqc" in srs.ExportToProj4()
+        assert ds.GetGeoTransform() == pytest.approx(
+            [-1000.0, 10.0, 0.0, 2000.0, 0.0, -10.0]
+        )
+
+
+def test_isis3_projstr_takes_precedence(tmp_vsimem):
+
+    # When both a named projection and ProjStr are present, ProjStr wins.
+    with _open_isis3_projstr(
+        tmp_vsimem,
+        """    ProjectionName   = Equirectangular
+    TargetName       = Mars
+    EquatorialRadius = 3396190.0 <meters>
+    PolarRadius      = 3396190.0 <meters>
+    CenterLongitude  = 0.0
+    CenterLatitude   = 0.0
+    PixelResolution  = 10.0 <meters/pixel>
+    UpperLeftCornerX = -1000.0 <meters>
+    UpperLeftCornerY = 2000.0 <meters>
+    ProjStr          = "+proj=stere +lat_0=90 +lon_0=0 +k=1 +x_0=0 +y_0=0
+                        +a=3396190 +b=3396190 +units=m +no_defs +type=crs" """,
+    ) as ds:
+        assert "+proj=stere" in ds.GetSpatialRef().ExportToProj4()
+
+
+def test_isis3_projstr_invalid(tmp_vsimem):
+
+    # An unparseable ProjStr should warn and leave no spatial reference,
+    # rather than crash.
+    with gdal.quiet_errors():
+        ds = _open_isis3_projstr(
+            tmp_vsimem,
+            """    ProjectionName   = IProj
+    TargetName       = Mars
+    PixelResolution  = 10.0 <meters/pixel>
+    UpperLeftCornerX = -1000.0 <meters>
+    UpperLeftCornerY = 2000.0 <meters>
+    ProjStr          = "+proj=no_such_projection +a=3396190" """,
+        )
+    assert ds is not None
+    assert ds.GetSpatialRef() is None

--- a/frmts/pds/isis3dataset.cpp
+++ b/frmts/pds/isis3dataset.cpp
@@ -2041,7 +2041,7 @@ GDALDataset *ISIS3Dataset::Open(GDALOpenInfo *poOpenInfo)
                 osProjStr += *pszIter;
         }
 
-        if (oSRS.SetFromUserInput(osProjStr.c_str()) == OGRERR_NONE)
+        if (oSRS.importFromProj4(osProjStr.c_str()) == OGRERR_NONE)
         {
             oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
             poDS->m_oSRS = std::move(oSRS);

--- a/frmts/pds/isis3dataset.cpp
+++ b/frmts/pds/isis3dataset.cpp
@@ -2017,8 +2017,45 @@ GDALDataset *ISIS3Dataset::Open(GDALOpenInfo *poOpenInfo)
     OGRSpatialReference oSRS;
     bool bProjectionSet = true;
 
-    if ((EQUAL(map_proj_name, "Equirectangular")) ||
-        (EQUAL(map_proj_name, "SimpleCylindrical")))
+    // The ISIS IProj projection (ProjectionName = IProj) carries its full
+    // definition in a ProjStr PROJ string. When present, use it directly and
+    // skip the per-parameter reconstruction below.
+    const char *pszProjStr = poDS->GetKeyword("IsisCube.Mapping.ProjStr", "");
+    if (pszProjStr[0] != '\0')
+    {
+        // A ProjStr that spans several label lines comes back with the line
+        // breaks embedded as literal "\n" (plus indentation), or as real
+        // control characters. Turn those into spaces before handing it to PROJ.
+        std::string osProjStr;
+        for (const char *pszIter = pszProjStr; *pszIter; ++pszIter)
+        {
+            if (pszIter[0] == '\\' &&
+                (pszIter[1] == 'n' || pszIter[1] == 'r' || pszIter[1] == 't'))
+            {
+                osProjStr += ' ';
+                ++pszIter;
+            }
+            else if (*pszIter == '\n' || *pszIter == '\r' || *pszIter == '\t')
+                osProjStr += ' ';
+            else
+                osProjStr += *pszIter;
+        }
+
+        if (oSRS.SetFromUserInput(osProjStr.c_str()) == OGRERR_NONE)
+        {
+            oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+            poDS->m_oSRS = std::move(oSRS);
+        }
+        else
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Cannot parse ProjStr '%s' from ISIS3 Mapping group.",
+                     osProjStr.c_str());
+        }
+        bProjectionSet = false;
+    }
+    else if ((EQUAL(map_proj_name, "Equirectangular")) ||
+             (EQUAL(map_proj_name, "SimpleCylindrical")))
     {
         oSRS.SetEquirectangular2(0.0, center_lon, center_lat, 0, 0);
     }


### PR DESCRIPTION
## What does this PR do?

ISIS added support for PROJ-style projections in .cub files through a projection field named IProj. This stores a PROJ string, the analogue of a WKT or PROJ georeferencing header. 

This PR adds reading of ProjStr by the GDAL ISIS driver. The existing logic is now a fallback when ProjStr is absent. The geotransform is still taken from PixelResolution and the upper-left corner, as before. A ProjStr that spans several label lines is normalized before it is passed to PROJ.

## How this was tested

A unit test is added. It covers a multi-line ProjStr projection read, ProjStr taking precedence when a named projection is also present, and an unparseable ProjStr leaving no spatial reference rather than crashing. 

To test by hand, download [isis3_iproj_sample.cub.txt](https://github.com/user-attachments/files/29580202/isis3_iproj_sample.cub.txt) having the IProj field, remove the .txt extension, and run:

    gdal_translate in.cub out.tif

Before this fix, the out.tif file would not have the projection string. After, it would.

Built and tested locally on macOS arm64 with clang.

## Related

- Fixes #14557 (support the ISIS PROJ-string Mapping groups), raised by @acpaquette.
- Related to #14555 (a reusable ISIS-PVL-to-SRS entry point), also raised by @acpaquette. This PR does not close that one, that is follow-up work.
- Supports [DOI-USGS/ISIS3 pull request 6039](https://github.com/DOI-USGS/ISIS3/pull/6039) (write the projection to cam2map GeoTIFFs) and the goal of removing the duplicated conversion code there.

(cc @Kelvinrr)

## AI tool usage

 - [x] AI supported my development of this PR. The relevant GDAL policy was read. This code change was very thoroughly reviewed and tested with gdalinfo and gdal_translate, as outlined above.

## Tasklist

 - [x] Make sure code is correctly formatted (pre-commit)
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

* OS: macOS arm64
* Compiler: clang
