### PR TITLE
GDALRasterBand: fix inexact integer NoData checks in histogram, min/max calculations

### DIFF
--- a/autotest/gcore/gdal_stats.py
+++ b/autotest/gcore/gdal_stats.py
@@ -1405,6 +1405,26 @@ def test_stats_minmax_all_invalid_mask(datatype):
 ###############################################################################
 
 
+def test_stats_minmax_integer_nodata_comparison_exact():
+
+    gdaltest.importorskip_gdal_array()
+    np = pytest.importorskip("numpy")
+
+    data = np.array([[0, 4000000005], [4000000010, 4000000030]], dtype=np.uint32)
+
+    ds = gdal.GetDriverByName("MEM").Create("", 2, 2, 1, gdal.GDT_UInt32)
+    ds.GetRasterBand(1).WriteArray(data)
+    ds.GetRasterBand(1).SetNoDataValue(4000000000)
+
+    rmin, rmax = ds.GetRasterBand(1).ComputeRasterMinMax()
+
+    assert rmin == 0
+    assert rmax == 4000000030
+
+
+###############################################################################
+
+
 def test_stats_GetInterBandCovarianceMatrix(tmp_vsimem):
 
     gdal.FileFromMemBuffer(

--- a/autotest/gcore/histogram.py
+++ b/autotest/gcore/histogram.py
@@ -19,6 +19,7 @@ import shutil
 import struct
 import sys
 
+import gdaltest
 import pytest
 
 from osgeo import gdal
@@ -762,3 +763,23 @@ def test_histogram_min_equal_max():
 
     ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 1, gdal.GDT_Int16)
     assert ds.GetRasterBand(1).GetDefaultHistogram() == (-0.5, 0.5, 1, [1])
+
+
+###############################################################################
+
+
+def test_histogram_int_large_nodata():
+
+    gdaltest.importorskip_gdal_array()
+    np = pytest.importorskip("numpy")
+
+    data = np.array([[0, 4000000005], [4000000000, 4000000030]])
+
+    ds = gdal.GetDriverByName("MEM").Create("", 2, 2, 1, gdal.GDT_UInt32)
+    ds.GetRasterBand(1).WriteArray(data)
+    ds.GetRasterBand(1).SetNoDataValue(4000000000)
+
+    hist = ds.GetRasterBand(1).GetDefaultHistogram()
+
+    # raster has 3 valid pixels
+    assert np.array(hist[3]).sum() == 3

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -6488,7 +6488,9 @@ static inline double GetPixelValue(GDALDataType eDataType, bool bSignedByte,
     }
 
     if (sNoDataValues.bGotNoDataValue &&
-        ARE_REAL_EQUAL(dfValue, sNoDataValues.dfNoDataValue))
+        (GDALDataTypeIsInteger(eDataType)
+             ? dfValue == sNoDataValues.dfNoDataValue
+             : ARE_REAL_EQUAL(dfValue, sNoDataValues.dfNoDataValue)))
     {
         bValid = false;
         return 0.0;

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -4502,7 +4502,10 @@ CPLErr GDALRasterBand::GetHistogram(double dfMin, double dfMax, int nBuckets,
 
                 if (eDataType != GDT_Float16 && eDataType != GDT_Float32 &&
                     sNoDataValues.bGotNoDataValue &&
-                    ARE_REAL_EQUAL(dfValue, sNoDataValues.dfNoDataValue))
+                    (GDALDataTypeIsInteger(eDataType)
+                         ? dfValue == sNoDataValues.dfNoDataValue
+                         : ARE_REAL_EQUAL(dfValue,
+                                          sNoDataValues.dfNoDataValue)))
                     continue;
 
                 // Given that dfValue and dfMin are not NaN, and dfScale > 0 and
@@ -4771,7 +4774,10 @@ CPLErr GDALRasterBand::GetHistogram(double dfMin, double dfMax, int nBuckets,
 
                     if (eDataType != GDT_Float16 && eDataType != GDT_Float32 &&
                         sNoDataValues.bGotNoDataValue &&
-                        ARE_REAL_EQUAL(dfValue, sNoDataValues.dfNoDataValue))
+                        (GDALDataTypeIsInteger(eDataType)
+                             ? dfValue == sNoDataValues.dfNoDataValue
+                             : ARE_REAL_EQUAL(dfValue,
+                                              sNoDataValues.dfNoDataValue)))
                         continue;
 
                     // Given that dfValue and dfMin are not NaN, and dfScale > 0


### PR DESCRIPTION
I originally noticed the min/max case when enabling exceptions for netCDF tests. Without this PR, the values 4000000005, 4000000010, and 4000000030 all compare as equal to the NoData value of 4000000000.