### PR TITLE
FAST: cap band count at MAX_FILES when parsing BANDS PRESENT

### DIFF
--- a/autotest/gdrivers/fast.py
+++ b/autotest/gdrivers/fast.py
@@ -231,7 +231,7 @@ def test_fast_9():
 # used to walk past that array. Check the count is clamped to 7.
 
 
-def test_fast_bands_present_count():
+def test_fast_bands_present_count(tmp_vsimem):
 
     header = bytearray(b" " * 1600)
 
@@ -248,15 +248,12 @@ def test_fast_bands_present_count():
     put(440, "OUTPUT BITS PER PIXEL =8")
     put(500, "BIASES AND GAINS =" + "1.0 0.0 " * 8)
 
-    dirname = "/vsimem/test_fast_bands_present"
+    dirname = str(tmp_vsimem / "test_fast_bands_present")
     gdal.FileFromMemBuffer(dirname + "/hdr.fst", bytes(header))
     gdal.FileFromMemBuffer(dirname + "/IMAGERY2.DAT", b"\x00" * 4096)
-    try:
-        ds = gdal.Open(dirname + "/hdr.fst")
-        assert ds is not None
-        assert ds.RasterCount == 7
-    finally:
-        gdal.RmdirRecursive(dirname)
+    ds = gdal.Open(dirname + "/hdr.fst")
+    assert ds is not None
+    assert ds.RasterCount == 7
 
 
 ###############################################################################

--- a/autotest/gdrivers/fast.py
+++ b/autotest/gdrivers/fast.py
@@ -226,4 +226,38 @@ def test_fast_9():
 
 
 ###############################################################################
+# The IRS P6 "BANDS PRESENT" list drives one band-file open per digit into
+# fixed-size arrays capped at MAX_FILES (7). A header repeating a band digit
+# used to walk past that array. Check the count is clamped to 7.
+
+
+def test_fast_bands_present_count():
+
+    header = bytearray(b" " * 1600)
+
+    def put(offset, text):
+        header[offset : offset + len(text)] = text.encode("ascii")
+
+    put(52, "ACQUISITION DATE =2006/01/01")
+    put(120, "SATELLITE =IRS P6")
+    put(160, "SENSOR =LISS")
+    put(200, "GENERATING AGENCY =EUROMAP")
+    put(260, "BANDS PRESENT =" + "2" * 32)
+    put(360, "PIXELS PER LINE =4")
+    put(400, "LINES PER BAND =4")
+    put(440, "OUTPUT BITS PER PIXEL =8")
+    put(500, "BIASES AND GAINS =" + "1.0 0.0 " * 8)
+
+    dirname = "/vsimem/test_fast_bands_present"
+    gdal.FileFromMemBuffer(dirname + "/hdr.fst", bytes(header))
+    gdal.FileFromMemBuffer(dirname + "/IMAGERY2.DAT", b"\x00" * 4096)
+    try:
+        ds = gdal.Open(dirname + "/hdr.fst")
+        assert ds is not None
+        assert ds.RasterCount == 7
+    finally:
+        gdal.RmdirRecursive(dirname)
+
+
+###############################################################################
 #

--- a/frmts/raw/fastdataset.cpp
+++ b/frmts/raw/fastdataset.cpp
@@ -684,7 +684,8 @@ GDALDataset *FASTDataset::Open(GDALOpenInfo *poOpenInfo)
                                          BANDS_PRESENT_SIZE, TRUE);
                 if (pszTemp)
                 {
-                    for (int i = 0; pszTemp[i] != '\0'; i++)
+                    for (int i = 0; pszTemp[i] != '\0' && l_nBands < MAX_FILES;
+                         i++)
                     {
                         if (pszTemp[i] >= '2' && pszTemp[i] <= '5')
                         {


### PR DESCRIPTION
## What does this PR do?

For IRS P6 datasets the driver builds its band list from the `BANDS PRESENT` header field, opening one channel per digit and storing each handle in the fixed `fpChannels[MAX_FILES]` / `apoChannelFilenames[MAX_FILES]` arrays (`MAX_FILES` = 7). The loop increments `l_nBands` on every successful open but never checks it against `MAX_FILES`. `BANDS PRESENT` holds up to 32 characters, and a repeated band digit reopens the same sidecar each time, so `l_nBands` runs past 7 and `OpenChannel()` writes out of bounds.

Crafted `.fst` header (`SATELLITE =IRS P6`, `BANDS PRESENT =2222...`) plus one `IMAGERY2.DAT` sidecar, opened under UBSan/ASan:

    fastdataset.cpp:217:5: runtime error: index 7 out of bounds for type 'VSILFILE *[7]'
        #0 FASTDataset::FOpenChannel(char const*, int, int) fastdataset.cpp:217
        #1 FASTDataset::Open(GDALOpenInfo*) fastdataset.cpp:697
    ...
    SUMMARY: AddressSanitizer: SEGV cpl_vsil.cpp:2956 in VSIFCloseL

The sibling `FILENAME` fallback loop already bounds itself with `i < 7`; this caps `l_nBands` at `MAX_FILES` the same way.

## What are related issues/pull requests?

None.

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
