### PR TITLE
SXF: fix out-of-bounds write from signed attribute length byte

### DIFF
--- a/autotest/ogr/ogr_sxf.py
+++ b/autotest/ogr/ogr_sxf.py
@@ -123,3 +123,29 @@ def test_ogr_sxf_4():
         actual_layer_names.append(lyr.GetName())
 
     assert actual_layer_names == lyr_names
+
+
+###############################################################################
+# Test that a string attribute whose length byte is 0xFF does not overflow.
+# The length byte (nScale) is a signed char; 0xFF used to sign-extend to -1 and
+# wrap the computed length to 0, bypassing the bounds check.
+
+
+@pytest.mark.parametrize("attr_type", [0, 126, 127])  # ASCIIZ_DOS, ANSI_WIN, UNICODE
+def test_ogr_sxf_attribute_length_overflow(tmp_path, attr_type):
+
+    data = bytearray(open("data/sxf/100_test.sxf", "rb").read())
+    # First feature record holds an ANSI_WIN attribute; nType at offset 744,
+    # nScale at offset 745. Force the length byte to 0xFF.
+    data[744] = attr_type
+    data[745] = 0xFF
+    sxf_name = str(tmp_path / "attr_overflow.sxf")
+    open(sxf_name, "wb").write(data)
+
+    with gdal.quiet_errors():
+        ds = ogr.Open(sxf_name)
+        assert ds is not None
+        for layer_n in range(ds.GetLayerCount()):
+            lyr = ds.GetLayer(layer_n)
+            for feat in lyr:
+                pass

--- a/ogr/ogrsf_frmts/sxf/ogrsxflayer.cpp
+++ b/ogr/ogrsf_frmts/sxf/ogrsxflayer.cpp
@@ -906,7 +906,8 @@ OGRFeature *OGRSXFLayer::GetNextRawFeature(long nFID)
                 {
                     case SXF_RAT_ASCIIZ_DOS:
                     {
-                        unsigned nLen = unsigned(stAttInfo.nScale) + 1;
+                        unsigned nLen =
+                            unsigned(static_cast<GByte>(stAttInfo.nScale)) + 1;
                         if (nLen > nSemanticsSize ||
                             nSemanticsSize - nLen < offset)
                         {
@@ -922,7 +923,7 @@ OGRFeature *OGRSXFLayer::GetNextRawFeature(long nFID)
                         CPLFree(pszRecoded);
                         CPLFree(value);
 
-                        offset += stAttInfo.nScale + 1;
+                        offset += nLen;
                         break;
                     }
                     case SXF_RAT_ONEBYTE:
@@ -997,7 +998,8 @@ OGRFeature *OGRSXFLayer::GetNextRawFeature(long nFID)
                     }
                     case SXF_RAT_ANSI_WIN:
                     {
-                        unsigned nLen = unsigned(stAttInfo.nScale) + 1;
+                        unsigned nLen =
+                            unsigned(static_cast<GByte>(stAttInfo.nScale)) + 1;
                         if (nLen > nSemanticsSize ||
                             nSemanticsSize - nLen < offset)
                         {
@@ -1019,9 +1021,12 @@ OGRFeature *OGRSXFLayer::GetNextRawFeature(long nFID)
                     case SXF_RAT_UNICODE:
                     {
                         uint64_t nLen64 =
-                            (static_cast<uint64_t>(stAttInfo.nScale) + 1) * 2;
+                            (static_cast<uint64_t>(
+                                 static_cast<GByte>(stAttInfo.nScale)) +
+                             1) *
+                            2;
                         unsigned nLen = static_cast<unsigned>(nLen64);
-                        if (/* nLen < 2 || */ nLen64 > nSemanticsSize ||
+                        if (nLen64 > nSemanticsSize ||
                             nSemanticsSize - nLen < offset)
                         {
                             nSemanticsSize = 0;

--- a/ogr/ogrsf_frmts/sxf/org_sxf_defs.h
+++ b/ogr/ogrsf_frmts/sxf/org_sxf_defs.h
@@ -278,7 +278,7 @@ typedef struct
 {
     GUInt16 nCode;  // type
     char nType;
-    char nScale;
+    signed char nScale;
 } SXFRecordAttributeInfo;
 
 enum SXFRecordAttributeType


### PR DESCRIPTION
## What does this PR do?

ASan/UBSan on a crafted .sxf, iterating features:

    ogrsxflayer.cpp:1009:25: runtime error: applying non-zero offset 4294967295 to null pointer
    AddressSanitizer: heap-buffer-overflow ogrsxflayer.cpp:1031 in OGRSXFLayer::GetNextRawFeature(long)

`GetNextRawFeature()` reads the value length of the string attribute types (`SXF_RAT_ASCIIZ_DOS`, `SXF_RAT_ANSI_WIN`, `SXF_RAT_UNICODE`) from `nScale`, which is declared `char` in `org_sxf_defs.h`. `unsigned(nScale) + 1` sign-extends a `0xFF` byte to `-1`, so the length wraps to `0` and slips through the `nLen > nSemanticsSize` / `nSemanticsSize - nLen < offset` check. `CPLMalloc(0)` returns `nullptr`, then `value[nLen - 1] = 0` writes at `nullptr + 0xFFFFFFFF`; the UNICODE case also does `memcpy(value, ..., nLen - 2)` with `nLen - 2 == 0xFFFFFFFE`.

Reading `nScale` as `GByte` before the length math keeps it in range (0..255 -> 1..256). Values 0..127 are unchanged, so valid files parse identically; 128..255 were previously rejected by the wrap and now decode correctly. The ASCIIZ case advanced `offset` by the signed `nScale` too, so it uses the corrected `nLen` like the sibling cases.

Trigger: any feature-record attribute with `nType` in {0, 126, 127} and the length byte set to `0xFF`.

## What are related issues/pull requests?

None.

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

* OS: Ubuntu / macOS
* Compiler: clang with -fsanitize=address,undefined
