### PR TITLE
Two fixes related to 'gdal' top-level program

### DIFF
--- a/apps/gdalalg_main.cpp
+++ b/apps/gdalalg_main.cpp
@@ -71,6 +71,8 @@ bool GDALMainAlgorithm::ParseCommandLineArguments(
             GDALGlobalAlgorithmRegistry::GetSingleton().Instantiate("pipeline");
         if (m_subAlg)
         {
+            if (IsCalledFromCommandLine())
+                m_subAlg->SetCalledFromCommandLine();
             bool ret = m_subAlg->ParseCommandLineArguments(args);
             if (ret)
             {
@@ -88,7 +90,7 @@ bool GDALMainAlgorithm::ParseCommandLineArguments(
             }
         }
 
-        return GDALAlgorithm::ParseCommandLineArguments(args);
+        return false;
     }
     else if (args.size() == 1 && args[0].size() >= 2 && args[0][0] == '-' &&
              args[0][1] == '-')

--- a/apps/gdalalg_main.cpp
+++ b/apps/gdalalg_main.cpp
@@ -14,6 +14,10 @@
 
 #include "gdal_priv.h"
 
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
+
 //! @cond Doxygen_Suppress
 
 #ifndef _
@@ -110,9 +114,15 @@ bool GDALMainAlgorithm::ParseCommandLineArguments(
     // where "read" is omitted: "gdal in.tif"
     {
         VSIStatBufL sStat;
+        std::vector<char> osResolvedFilename(2048);
         for (const auto &arg : args)
         {
-            if (VSIStatL(arg.c_str(), &sStat) == 0)
+            if (VSIStatL(arg.c_str(), &sStat) == 0
+#if !defined(_WIN32)
+                || readlink(arg.c_str(), osResolvedFilename.data(),
+                            osResolvedFilename.size()) != -1
+#endif
+            )
             {
                 m_subAlg =
                     GDALGlobalAlgorithmRegistry::GetSingleton().Instantiate(

--- a/autotest/utilities/test_gdal.py
+++ b/autotest/utilities/test_gdal.py
@@ -939,3 +939,11 @@ def test_gdal_symlink(gdal_path, tmp_path):
     out, err = gdaltest.runexternal_out_and_err(f"{gdal_path} {tmp_path}/symlink.tif")
     assert out.startswith("Driver: GTiff/GeoTIFF")
     assert err == ""
+
+
+def test_gdal_implicit_pipeline_must_have_two_steps(gdal_path):
+
+    _, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} read ../gcore/data/byte.tif"
+    )
+    assert "pipeline: At least 2 steps must be provided" in err

--- a/autotest/utilities/test_gdal.py
+++ b/autotest/utilities/test_gdal.py
@@ -922,3 +922,20 @@ done
             assert x in output
     except FileNotFoundError:
         pytest.skip(f"{shell} not available")
+
+
+###############################################################################
+# Test that we can open a symlink whose pointed filename isn't a real
+# file, but a filename that GDAL recognizes
+
+
+def test_gdal_symlink(gdal_path, tmp_path):
+
+    if not gdaltest.support_symlink():
+        pytest.skip()
+
+    os.symlink("GTIFF_DIR:1:../gcore/data/byte.tif", tmp_path / "symlink.tif")
+
+    out, err = gdaltest.runexternal_out_and_err(f"{gdal_path} {tmp_path}/symlink.tif")
+    assert out.startswith("Driver: GTiff/GeoTIFF")
+    assert err == ""


### PR DESCRIPTION
- gdal: fix 'gdal some_symlink_that_is_not_a_file'
- gdal: make sure 'gdal read something' results in proper error message instead of progress bar
