### PR TITLE
[Backport release/3.13] SXF: fix out-of-bounds write from signed attribute length byte

### DIFF
--- a/autotest/ogr/ogr_sxf.py
+++ b/autotest/ogr/ogr_sxf.py
@@ -123,3 +123,29 @@ def test_ogr_sxf_4():
         actual_layer_names.append(lyr.GetName())
 
     assert actual_layer_names == lyr_names
+
+
+###############################################################################
+# Test that a string attribute whose length byte is 0xFF does not overflow.
+# The length byte (nScale) is a signed char; 0xFF used to sign-extend to -1 and
+# wrap the computed length to 0, bypassing the bounds check.
+
+
+@pytest.mark.parametrize("attr_type", [0, 126, 127])  # ASCIIZ_DOS, ANSI_WIN, UNICODE
+def test_ogr_sxf_attribute_length_overflow(tmp_path, attr_type):
+
+    data = bytearray(open("data/sxf/100_test.sxf", "rb").read())
+    # First feature record holds an ANSI_WIN attribute; nType at offset 744,
+    # nScale at offset 745. Force the length byte to 0xFF.
+    data[744] = attr_type
+    data[745] = 0xFF
+    sxf_name = str(tmp_path / "attr_overflow.sxf")
+    open(sxf_name, "wb").write(data)
+
+    with gdal.quiet_errors():
+        ds = ogr.Open(sxf_name)
+        assert ds is not None
+        for layer_n in range(ds.GetLayerCount()):
+            lyr = ds.GetLayer(layer_n)
+            for feat in lyr:
+                pass

--- a/ogr/ogrsf_frmts/sxf/ogrsxflayer.cpp
+++ b/ogr/ogrsf_frmts/sxf/ogrsxflayer.cpp
@@ -906,7 +906,8 @@ OGRFeature *OGRSXFLayer::GetNextRawFeature(long nFID)
                 {
                     case SXF_RAT_ASCIIZ_DOS:
                     {
-                        unsigned nLen = unsigned(stAttInfo.nScale) + 1;
+                        unsigned nLen =
+                            unsigned(static_cast<GByte>(stAttInfo.nScale)) + 1;
                         if (nLen > nSemanticsSize ||
                             nSemanticsSize - nLen < offset)
                         {
@@ -922,7 +923,7 @@ OGRFeature *OGRSXFLayer::GetNextRawFeature(long nFID)
                         CPLFree(pszRecoded);
                         CPLFree(value);
 
-                        offset += stAttInfo.nScale + 1;
+                        offset += nLen;
                         break;
                     }
                     case SXF_RAT_ONEBYTE:
@@ -997,7 +998,8 @@ OGRFeature *OGRSXFLayer::GetNextRawFeature(long nFID)
                     }
                     case SXF_RAT_ANSI_WIN:
                     {
-                        unsigned nLen = unsigned(stAttInfo.nScale) + 1;
+                        unsigned nLen =
+                            unsigned(static_cast<GByte>(stAttInfo.nScale)) + 1;
                         if (nLen > nSemanticsSize ||
                             nSemanticsSize - nLen < offset)
                         {
@@ -1019,9 +1021,12 @@ OGRFeature *OGRSXFLayer::GetNextRawFeature(long nFID)
                     case SXF_RAT_UNICODE:
                     {
                         uint64_t nLen64 =
-                            (static_cast<uint64_t>(stAttInfo.nScale) + 1) * 2;
+                            (static_cast<uint64_t>(
+                                 static_cast<GByte>(stAttInfo.nScale)) +
+                             1) *
+                            2;
                         unsigned nLen = static_cast<unsigned>(nLen64);
-                        if (/* nLen < 2 || */ nLen64 > nSemanticsSize ||
+                        if (nLen64 > nSemanticsSize ||
                             nSemanticsSize - nLen < offset)
                         {
                             nSemanticsSize = 0;

--- a/ogr/ogrsf_frmts/sxf/org_sxf_defs.h
+++ b/ogr/ogrsf_frmts/sxf/org_sxf_defs.h
@@ -278,7 +278,7 @@ typedef struct
 {
     GUInt16 nCode;  // type
     char nType;
-    char nScale;
+    signed char nScale;
 } SXFRecordAttributeInfo;
 
 enum SXFRecordAttributeType


### PR DESCRIPTION
Backport #14912
 **Authored by:** @saddamr3e