### PR TITLE
fix: use sqlite3_result_blob64() in ogr_deflate/ogr_inflate to avoid size_t truncation

### DIFF
--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitesqlfunctions.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitesqlfunctions.cpp
@@ -162,8 +162,8 @@ static void OGR2SQLITE_ogr_deflate(sqlite3_context *pContext, int argc,
     }
     if (pOut != nullptr)
     {
-        sqlite3_result_blob(pContext, pOut, static_cast<int>(nOutBytes),
-                            VSIFree);
+        sqlite3_result_blob64(pContext, pOut,
+                              static_cast<sqlite3_uint64>(nOutBytes), VSIFree);
     }
     else
     {
@@ -194,8 +194,8 @@ static void OGR2SQLITE_ogr_inflate(sqlite3_context *pContext, int argc,
 
     if (pOut != nullptr)
     {
-        sqlite3_result_blob(pContext, pOut, static_cast<int>(nOutBytes),
-                            VSIFree);
+        sqlite3_result_blob64(pContext, pOut,
+                              static_cast<sqlite3_uint64>(nOutBytes), VSIFree);
     }
     else
     {


### PR DESCRIPTION
In `OGR2SQLITE_ogr_deflate()` and `OGR2SQLITE_ogr_inflate()`, the decompressed
size `nOutBytes` (type `size_t`) is cast to `int` before being passed to
`sqlite3_result_blob()`:

    sqlite3_result_blob(pContext, pOut, static_cast<int>(nOutBytes), VSIFree);

On 64-bit platforms, if `nOutBytes > INT_MAX` (2,147,483,647), the cast produces
a negative value. In release builds (NDEBUG), `sqlite3VdbeMemSetStr()` then
receives `enc=0` (BLOB) with `n<0`, and falls into the UTF-16 length-scan branch,
reading past the end of the allocated buffer.

Fix: replace `sqlite3_result_blob()` with `sqlite3_result_blob64()`, which takes
`sqlite3_uint64` and handles large blobs correctly.

Trigger condition: `SELECT ogr_inflate(x'<zlib_bomb>')` via `ExecuteSQL()` with
SQLITE dialect, where the compressed blob decompresses to > 2 GB.