### PR TITLE
liblerc: backport upstream fix for misaligned unsigned int access in Huffman coder

### DIFF
--- a/third_party/LercLib/Huffman.cpp
+++ b/third_party/LercLib/Huffman.cpp
@@ -447,8 +447,6 @@ bool Huffman::BitStuffCodes(Byte** ppByte, int i0, int i1) const
   if (!ppByte)
     return false;
 
-  unsigned int* arr = (unsigned int*)(*ppByte);
-  unsigned int* dstPtr = arr;
   int size = (int)m_codeTable.size();
   int bitPos = 0;
 
@@ -459,30 +457,15 @@ bool Huffman::BitStuffCodes(Byte** ppByte, int i0, int i1) const
     if (len > 0)
     {
       unsigned int val = m_codeTable[k].second;
-      if (32 - bitPos >= len)
-      {
-        if (bitPos == 0)
-          *dstPtr = 0;
 
-        *dstPtr |= val << (32 - bitPos - len);
-        bitPos += len;
-        if (bitPos == 32)
-        {
-          bitPos = 0;
-          dstPtr++;
-        }
-      }
-      else
-      {
-        bitPos += len - 32;
-        *dstPtr++ |= val >> bitPos;    // bitPos > 0
-        *dstPtr = val << (32 - bitPos);
-      }
+      if (!Huffman::PushValue(ppByte, bitPos, val, len))
+        return false;
     }
   }
 
-  size_t numUInts = dstPtr - arr + (bitPos > 0 ? 1 : 0);
+  size_t numUInts = (bitPos > 0 ? 1 : 0);
   *ppByte += numUInts * sizeof(unsigned int);
+
   return true;
 }
 
@@ -495,9 +478,10 @@ bool Huffman::BitUnStuffCodes(const Byte** ppByte, size_t& nBytesRemainingInOut,
 
   size_t nBytesRemaining = nBytesRemainingInOut;
 
-  const unsigned int* arr = (const unsigned int*)(*ppByte);
-  const unsigned int* srcPtr = arr;
-  const size_t sizeUInt = sizeof(*srcPtr);
+  const Byte* ptr0 = *ppByte;
+  const Byte* ptr = ptr0;
+
+  const size_t s4 = sizeof(unsigned int);
 
   int size = (int)m_codeTable.size();
   int bitPos = 0;
@@ -508,10 +492,12 @@ bool Huffman::BitUnStuffCodes(const Byte** ppByte, size_t& nBytesRemainingInOut,
     int len = m_codeTable[k].first;
     if (len > 0)
     {
-      if (nBytesRemaining < sizeUInt || len > 32)
+      if (nBytesRemaining < s4 || len > 32)
         return false;
 
-      m_codeTable[k].second = ((*srcPtr) << bitPos) >> (32 - len);
+      unsigned int temp(0);
+      memcpy(&temp, ptr, s4);
+      m_codeTable[k].second = (temp << bitPos) >> (32 - len);
 
       if (32 - bitPos >= len)
       {
@@ -519,26 +505,26 @@ bool Huffman::BitUnStuffCodes(const Byte** ppByte, size_t& nBytesRemainingInOut,
         if (bitPos == 32)
         {
           bitPos = 0;
-          srcPtr++;
-          nBytesRemaining -= sizeUInt;
+          ptr += s4;
+          nBytesRemaining -= s4;
         }
       }
       else
       {
         bitPos += len - 32;
-        srcPtr++;
-        nBytesRemaining -= sizeUInt;
+        ptr += s4;
+        nBytesRemaining -= s4;
 
-        if (nBytesRemaining < sizeUInt)
+        if (nBytesRemaining < s4)
           return false;
 
-        m_codeTable[k].second |= (*srcPtr) >> (32 - bitPos);    // bitPos > 0
+        memcpy(&temp, ptr, s4);
+        m_codeTable[k].second |= temp >> (32 - bitPos);    // bitPos > 0
       }
     }
   }
 
-  size_t numUInts = srcPtr - arr + (bitPos > 0 ? 1 : 0);
-  size_t len = numUInts * sizeUInt;
+  size_t len = (ptr - ptr0) + (bitPos > 0 ? s4 : 0);
 
   if (nBytesRemainingInOut < len)
     return false;
@@ -546,7 +532,8 @@ bool Huffman::BitUnStuffCodes(const Byte** ppByte, size_t& nBytesRemainingInOut,
   *ppByte += len;
   nBytesRemainingInOut -= len;
 
-  if (nBytesRemaining != nBytesRemainingInOut && nBytesRemaining != nBytesRemainingInOut + sizeUInt)    // the real check
+  if (nBytesRemaining != nBytesRemainingInOut
+    && nBytesRemaining != nBytesRemainingInOut + s4)    // the real check
     return false;
 
   return true;

--- a/third_party/LercLib/Lerc2.h
+++ b/third_party/LercLib/Lerc2.h
@@ -1793,9 +1793,6 @@ bool Lerc2::EncodeHuffman(const T* data, Byte** ppByte) const
   int height = m_headerInfo.nRows;
   int width = m_headerInfo.nCols;
   int nDim = m_headerInfo.nDim;
-
-  unsigned int* arr = (unsigned int*)(*ppByte);
-  unsigned int* dstPtr = arr;
   int bitPos = 0;
 
   if (m_imageEncodeMode == IEM_DeltaHuffman)
@@ -1831,25 +1828,8 @@ bool Lerc2::EncodeHuffman(const T* data, Byte** ppByte) const
 
             unsigned int code = m_huffmanCodes[kBin].second;
 
-            if (32 - bitPos >= len)
-            {
-              if (bitPos == 0)
-                *dstPtr = 0;
-
-              *dstPtr |= code << (32 - bitPos - len);
-              bitPos += len;
-              if (bitPos == 32)
-              {
-                bitPos = 0;
-                dstPtr++;
-              }
-            }
-            else
-            {
-              bitPos += len - 32;
-              *dstPtr++ |= code >> bitPos;
-              *dstPtr = code << (32 - bitPos);
-            }
+            if (!Huffman::PushValue(ppByte, bitPos, code, len))
+              return false;
           }
     }
   }
@@ -1871,33 +1851,17 @@ bool Lerc2::EncodeHuffman(const T* data, Byte** ppByte) const
 
             unsigned int code = m_huffmanCodes[kBin].second;
 
-            if (32 - bitPos >= len)
-            {
-              if (bitPos == 0)
-                *dstPtr = 0;
-
-              *dstPtr |= code << (32 - bitPos - len);
-              bitPos += len;
-              if (bitPos == 32)
-              {
-                bitPos = 0;
-                dstPtr++;
-              }
-            }
-            else
-            {
-              bitPos += len - 32;
-              *dstPtr++ |= code >> bitPos;
-              *dstPtr = code << (32 - bitPos);
-            }
+            if (!Huffman::PushValue(ppByte, bitPos, code, len))
+              return false;
           }
   }
 
   else
     return false;
 
-  size_t numUInts = dstPtr - arr + (bitPos > 0 ? 1 : 0) + 1;    // add one more as the decode LUT can read ahead
+  size_t numUInts = (bitPos > 0 ? 1 : 0) + 1;    // add one more as the decode LUT can read ahead
   *ppByte += numUInts * sizeof(unsigned int);
+
   return true;
 }
 
@@ -1922,8 +1886,9 @@ bool Lerc2::DecodeHuffman(const Byte** ppByte, size_t& nBytesRemainingInOut, T* 
   int width = m_headerInfo.nCols;
   int nDim = m_headerInfo.nDim;
 
-  const unsigned int* arr = (const unsigned int*)(*ppByte);
-  const unsigned int* srcPtr = arr;
+  const Byte* ptr0 = *ppByte;
+  const Byte* ptr = ptr0;
+
   int bitPos = 0;
   size_t nBytesRemaining = nBytesRemainingInOut;
 
@@ -1938,16 +1903,8 @@ bool Lerc2::DecodeHuffman(const Byte** ppByte, size_t& nBytesRemainingInOut, T* 
           for (int j = 0; j < width; j++, m += nDim)
           {
             int val = 0;
-            if (nBytesRemaining >= 4 * sizeof(unsigned int))
-            {
-              if (!huffman.DecodeOneValue_NoOverrunCheck(&srcPtr, nBytesRemaining, bitPos, numBitsLUT, val))
-                return false;
-            }
-            else
-            {
-              if (!huffman.DecodeOneValue(&srcPtr, nBytesRemaining, bitPos, numBitsLUT, val))
-                return false;
-            }
+            if (!huffman.DecodeOneValue(&ptr, nBytesRemaining, bitPos, numBitsLUT, val))
+              return false;
 
             T delta = (T)(val - offset);
 
@@ -1971,16 +1928,8 @@ bool Lerc2::DecodeHuffman(const Byte** ppByte, size_t& nBytesRemainingInOut, T* 
           for (int m = 0; m < nDim; m++)
           {
             int val = 0;
-            if (nBytesRemaining >= 4 * sizeof(unsigned int))
-            {
-              if (!huffman.DecodeOneValue_NoOverrunCheck(&srcPtr, nBytesRemaining, bitPos, numBitsLUT, val))
-                return false;
-            }
-            else
-            {
-              if (!huffman.DecodeOneValue(&srcPtr, nBytesRemaining, bitPos, numBitsLUT, val))
-                return false;
-            }
+            if (!huffman.DecodeOneValue(&ptr, nBytesRemaining, bitPos, numBitsLUT, val))
+              return false;
 
             data[m0 + m] = (T)(val - offset);
           }
@@ -2002,16 +1951,8 @@ bool Lerc2::DecodeHuffman(const Byte** ppByte, size_t& nBytesRemainingInOut, T* 
             if (m_bitMask.IsValid(k))
             {
               int val = 0;
-              if (nBytesRemaining >= 4 * sizeof(unsigned int))
-              {
-                if (!huffman.DecodeOneValue_NoOverrunCheck(&srcPtr, nBytesRemaining, bitPos, numBitsLUT, val))
-                  return false;
-              }
-              else
-              {
-                if (!huffman.DecodeOneValue(&srcPtr, nBytesRemaining, bitPos, numBitsLUT, val))
-                  return false;
-              }
+              if (!huffman.DecodeOneValue(&ptr, nBytesRemaining, bitPos, numBitsLUT, val))
+                return false;
 
               T delta = (T)(val - offset);
 
@@ -2040,16 +1981,8 @@ bool Lerc2::DecodeHuffman(const Byte** ppByte, size_t& nBytesRemainingInOut, T* 
             for (int m = 0; m < nDim; m++)
             {
               int val = 0;
-              if (nBytesRemaining >= 4 * sizeof(unsigned int))
-              {
-                if (!huffman.DecodeOneValue_NoOverrunCheck(&srcPtr, nBytesRemaining, bitPos, numBitsLUT, val))
-                  return false;
-              }
-              else
-              {
-                if (!huffman.DecodeOneValue(&srcPtr, nBytesRemaining, bitPos, numBitsLUT, val))
-                  return false;
-              }
+              if (!huffman.DecodeOneValue(&ptr, nBytesRemaining, bitPos, numBitsLUT, val))
+                return false;
 
               data[m0 + m] = (T)(val - offset);
             }
@@ -2059,8 +1992,8 @@ bool Lerc2::DecodeHuffman(const Byte** ppByte, size_t& nBytesRemainingInOut, T* 
       return false;
   }
 
-  size_t numUInts = srcPtr - arr + (bitPos > 0 ? 1 : 0) + 1;    // add one more as the decode LUT can read ahead
-  size_t len = numUInts * sizeof(unsigned int);
+  size_t numUInts = (bitPos > 0 ? 1 : 0) + 1;    // add one more as the decode LUT can read ahead
+  size_t len = (ptr - ptr0) + numUInts * sizeof(unsigned int);
 
   if (nBytesRemainingInOut < len)
     return false;


### PR DESCRIPTION
## What does this PR do?

The LERC Huffman coder reads and writes the compressed bit stream through `unsigned int*` casts of the incoming `Byte` pointer, which carries no alignment guarantee, so those accesses are misaligned (undefined behavior). Building with `-fsanitize=undefined` and reading any LERC-compressed raster reports it, and the committed test data reproduces it directly:

```
$ gdalinfo -checksum autotest/gcore/data/byte_lerc.tif
third_party/LercLib/Huffman.cpp:514:33: runtime error: load of misaligned address 0x... for type 'const unsigned int', which requires 4 byte alignment
```

(also `Huffman.cpp:535` and the inline decode in `Huffman.h`; it shows up on every LERC test raster, e.g. the `byte_LERC*` / `rgbsmall_LERC*` files).

Per the review comment: this is already fixed upstream in Esri/lerc c442e0e2602dabce1f594cae3519a088bb019401 ("avoid unaligned pointer casts", Aug 2022), and the copy in `third_party/LercLib` is a June 2018 snapshot (see README_GDAL.TXT) that predates it. This PR is now a backport of that upstream commit, restricted to the files GDAL vendors: the hunks for `Lerc1Decode/` and `fpl_*` are dropped, and the `Lerc2.cpp` changes apply to `Lerc2.h`, where the snapshot keeps the templates. Besides the decoder loads, this also picks up the upstream fix for the matching misaligned stores on the encode path (`BitStuffCodes` / `EncodeHuffman`, folded into `Huffman::PushValue`).

Verified with a `-fsanitize=undefined` build: all committed LERC rasters decode UBSan-clean with unchanged checksums (`byte_lerc.tif` still checksums to 4672), and LERC write+read roundtrips of `byte.tif` and `rgbsmall.tif` are UBSan-clean with checksums matching the source.

No new test is added because the committed LERC rasters already exercise this code and turn the warning into a hard error under the UBSan CI build.

## What are related issues/pull requests?

Fixed upstream in https://github.com/Esri/lerc/commit/c442e0e2602dabce1f594cae3519a088bb019401; this backports it. Found while running the raster autotest corpus under `-fsanitize=undefined`.

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (`third_party/LercLib/` is excluded from pre-commit; existing style preserved)
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

* OS: Linux / macOS
* Compiler: clang with `-fsanitize=undefined`
