### PR TITLE
netCDF: fail when config file parsing emits CE_Failure

### DIFF
--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -2759,6 +2759,147 @@ def test_netcdf_65(tmp_path):
 # from a config file
 
 
+@gdaltest.enable_exceptions()
+def test_netcdf_66_missing_config(tmp_path):
+
+    with pytest.raises(Exception, match="Cannot open file"):
+        gdal.VectorTranslate(
+            tmp_path / "out.nc",
+            "data/netcdf/profile.nc",
+            format="netCDF",
+            datasetCreationOptions=["CONFIG_FILE=not_existing"],
+        )
+
+
+@gdaltest.enable_exceptions()
+def test_netcdf_66_malformed_xml(tmp_path):
+
+    with pytest.raises(Exception, match="not all elements have been closed"):
+        gdal.VectorTranslate(
+            tmp_path / "out.nc",
+            "data/netcdf/profile.nc",
+            format="netCDF",
+            datasetCreationOptions=["CONFIG_FILE=<Configuration>"],
+        )
+
+
+@gdaltest.enable_exceptions()
+def test_netcdf_66_unrecognized_element(tmp_path):
+
+    myconfig = """<Configuration>
+    <unrecognized_elt/>
+</Configuration>
+"""
+
+    # unrecognized element is silently ignored
+    gdal.VectorTranslate(
+        tmp_path / "out.nc",
+        "data/netcdf/profile.nc",
+        format="netCDF",
+        datasetCreationOptions=["CONFIG_FILE=" + myconfig],
+    )
+
+    assert os.path.exists(tmp_path / "out.nc")
+
+
+@gdaltest.enable_exceptions()
+def test_netcdf_66_unsupported_attribute_type(tmp_path):
+
+    myconfig = """<Configuration>
+    <Attribute name="foo" value="bar" type="unsupported"/>
+</Configuration>
+"""
+
+    with pytest.raises(Exception, match="type='unsupported' unsupported"):
+        gdal.VectorTranslate(
+            tmp_path / "out.nc",
+            "data/netcdf/profile.nc",
+            format="netCDF",
+            datasetCreationOptions=["CONFIG_FILE=" + myconfig],
+        )
+
+
+@gdaltest.enable_exceptions()
+def test_netcdf_66_unsupported_layer_attribute_type(tmp_path):
+
+    myconfig = """<Configuration>
+    <Layer name="x">
+    <Attribute name="foo" value="bar" type="unsupported"/>
+    </Layer>
+</Configuration>
+"""
+
+    with pytest.raises(Exception, match="type='unsupported' unsupported"):
+        gdal.VectorTranslate(
+            tmp_path / "out.nc",
+            "data/netcdf/profile.nc",
+            format="netCDF",
+            datasetCreationOptions=["CONFIG_FILE=" + myconfig],
+        )
+
+
+@gdaltest.enable_exceptions()
+def test_netcdf_66_field_invalid_dim(tmp_path):
+
+    myconfig = """<Configuration>
+    <Field name="station" main_dim="non_existing"/>
+</Configuration>
+"""
+
+    with pytest.raises(Exception, match="Dimension 'non_existing' does not exist"):
+        gdal.VectorTranslate(
+            tmp_path / "out.nc",
+            "data/netcdf/profile.nc",
+            format="netCDF",
+            datasetCreationOptions=["CONFIG_FILE=" + myconfig, "GEOMETRY_ENCODING=WKT"],
+        )
+
+
+@pytest.mark.parametrize(
+    "element",
+    (
+        "<DatasetCreationOption />",
+        '<DatasetCreationOption name="x" />',
+        '<DatasetCreationOption value="x" />',
+        "<LayerCreationOption/>",
+        '<LayerCreationOption name="x" />',
+        '<LayerCreationOption value="x" />',
+        "<Attribute/>",
+        '<Attribute name="x" />',
+        '<Attribute value="x" />',
+        "<Field/>",
+        '<Field name="x"><Attribute name="x"/></Field>',
+        "<Layer/>",
+        '<Layer name="x"><LayerCreationOption/></Layer>',
+        '<Layer name="x"><LayerCreationOption name="x"/></Layer>',
+        '<Layer name="x"><LayerCreationOption value="x"/></Layer>',
+        '<Layer name="x"><Attribute/></Layer>',
+        '<Layer name="x"><Attribute name="x"/></Layer>',
+        '<Layer name="x"><Attribute value="x"/></Layer>',
+        '<Layer name="x"><Field/></Layer>',
+    ),
+)
+@gdaltest.enable_exceptions()
+def test_netcdf_66_incomplete_element(tmp_path, element):
+
+    myconfig = f"<Configuration>{element}</Configuration>"
+
+    if "Field" in element and "Attribute" not in element:
+        message = "Both name and netcdf_name are missing"
+    elif "Layer" in element:
+        message = "Missing name"
+    else:
+        message = "Missing name/value"
+
+    with pytest.raises(Exception, match=message):
+        gdal.VectorTranslate(
+            tmp_path / "out.nc",
+            "data/netcdf/profile.nc",
+            format="netCDF",
+            datasetCreationOptions=["CONFIG_FILE=" + myconfig],
+        )
+
+
 @pytest.mark.require_driver("CSV")
 def test_netcdf_66(tmp_path, tmp_vsimem):
 

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -9263,7 +9263,15 @@ netCDFDataset *netCDFDataset::CreateLL(const char *pszFilename, int nXSize,
 
     // process options.
     poDS->aosCreationOptions = CSLDuplicate(papszOptions);
-    poDS->ProcessCreationOptions();
+    if (!poDS->ProcessCreationOptions())
+    {
+        CPLReleaseMutex(hNCMutex);  // Release mutex otherwise we'll
+        // deadlock with GDALDataset own
+        // mutex.
+        delete poDS;
+        CPLAcquireMutex(hNCMutex, 1000.0);
+        return nullptr;
+    }
 
     if (poDS->eMultipleLayerBehavior == SEPARATE_FILES)
     {
@@ -10015,7 +10023,7 @@ netCDFDataset::CreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
 
 // Note: some logic depends on bIsProjected and bIsGeoGraphic.
 // May not be known when Create() is called, see AddProjectionVars().
-void netCDFDataset::ProcessCreationOptions()
+bool netCDFDataset::ProcessCreationOptions()
 {
     const char *pszConfig = aosCreationOptions.FetchNameValue("CONFIG_FILE");
     if (pszConfig != nullptr)
@@ -10028,6 +10036,10 @@ void netCDFDataset::ProcessCreationOptions()
             {
                 aosCreationOptions.SetNameValue(osName, osValue);
             }
+        }
+        else
+        {
+            return false;
         }
     }
 
@@ -10056,7 +10068,7 @@ void netCDFDataset::ProcessCreationOptions()
         }
         else
         {
-            CPLError(CE_Failure, CPLE_NotSupported,
+            CPLError(CE_Warning, CPLE_NotSupported,
                      "FORMAT=%s in not supported, using the default NC format.",
                      pszValue);
         }
@@ -10084,7 +10096,7 @@ void netCDFDataset::ProcessCreationOptions()
         }
         else
         {
-            CPLError(CE_Failure, CPLE_NotSupported,
+            CPLError(CE_Warning, CPLE_NotSupported,
                      "COMPRESS=%s is not supported.", pszValue);
         }
     }
@@ -10160,6 +10172,8 @@ void netCDFDataset::ProcessCreationOptions()
 
     CPLDebug("GDAL_netCDF", "file options: format=%d compress=%d zlevel=%d",
              eFormat, eCompress, nZLevel);
+
+    return true;
 }
 
 int netCDFDataset::DefVarDeflate(int nVarId, bool bChunkingArg) const

--- a/frmts/netcdf/netcdfdataset.h
+++ b/frmts/netcdf/netcdfdataset.h
@@ -477,7 +477,7 @@ class netCDFDataset final : public GDALPamDataset
                           const char *pszAttr) const;
     const char *FetchAttr(int nGroupId, int nVarId, const char *pszAttr) const;
 
-    void ProcessCreationOptions();
+    bool ProcessCreationOptions();
     int DefVarDeflate(int nVarId, bool bChunkingArg = true) const;
     CPLErr AddProjectionVars(bool bDefsOnly, GDALProgressFunc pfnProgress,
                              void *pProgressData);

--- a/frmts/netcdf/netcdflayer.cpp
+++ b/frmts/netcdf/netcdflayer.cpp
@@ -2500,6 +2500,7 @@ OGRErr netCDFLayer::CreateField(const OGRFieldDefn *poFieldDefn,
             CPLError(CE_Failure, CPLE_AppDefined,
                      "Dimension '%s' does not exist",
                      poConfig->m_osMainDim.c_str());
+            return OGRERR_FAILURE;
         }
     }
 

--- a/frmts/netcdf/netcdfwriterconfig.cpp
+++ b/frmts/netcdf/netcdfwriterconfig.cpp
@@ -42,32 +42,56 @@ bool netCDFWriterConfiguration::Parse(const char *pszFilename)
             continue;
         if (EQUAL(psIter->pszValue, "DatasetCreationOption"))
         {
-            SetNameValue(psIter, m_oDatasetCreationOptions);
+            if (!SetNameValue(psIter, m_oDatasetCreationOptions))
+            {
+                return false;
+            }
         }
         else if (EQUAL(psIter->pszValue, "LayerCreationOption"))
         {
-            SetNameValue(psIter, m_oLayerCreationOptions);
+            if (!SetNameValue(psIter, m_oLayerCreationOptions))
+            {
+                return false;
+            }
         }
         else if (EQUAL(psIter->pszValue, "Attribute"))
         {
             netCDFWriterConfigAttribute oAtt;
             if (oAtt.Parse(psIter))
+            {
                 m_aoAttributes.push_back(std::move(oAtt));
+            }
+            else
+            {
+                return false;
+            }
         }
         else if (EQUAL(psIter->pszValue, "Field"))
         {
             netCDFWriterConfigField oField;
             if (oField.Parse(psIter))
+            {
                 m_oFields[!oField.m_osName.empty()
                               ? oField.m_osName
                               : CPLString("__") + oField.m_osNetCDFName] =
                     oField;
+            }
+            else
+            {
+                return false;
+            }
         }
         else if (EQUAL(psIter->pszValue, "Layer"))
         {
             netCDFWriterConfigLayer oLayer;
             if (oLayer.Parse(psIter))
+            {
                 m_oLayers[oLayer.m_osName] = std::move(oLayer);
+            }
+            else
+            {
+                return false;
+            }
         }
         else
         {
@@ -111,7 +135,7 @@ bool netCDFWriterConfigField::Parse(CPLXMLNode *psNode)
     if (pszName == nullptr && pszNetCDFName == nullptr)
     {
         CPLError(CE_Failure, CPLE_IllegalArg,
-                 "Bot name and netcdf_name are missing");
+                 "Both name and netcdf_name are missing");
         return false;
     }
     if (pszName != nullptr)
@@ -130,7 +154,13 @@ bool netCDFWriterConfigField::Parse(CPLXMLNode *psNode)
         {
             netCDFWriterConfigAttribute oAtt;
             if (oAtt.Parse(psIter))
+            {
                 m_aoAttributes.push_back(std::move(oAtt));
+            }
+            else
+            {
+                return false;
+            }
         }
         else
         {
@@ -161,23 +191,38 @@ bool netCDFWriterConfigLayer::Parse(CPLXMLNode *psNode)
             continue;
         if (EQUAL(psIter->pszValue, "LayerCreationOption"))
         {
-            netCDFWriterConfiguration::SetNameValue(psIter,
-                                                    m_oLayerCreationOptions);
+            if (!netCDFWriterConfiguration::SetNameValue(
+                    psIter, m_oLayerCreationOptions))
+            {
+                return false;
+            }
         }
         else if (EQUAL(psIter->pszValue, "Attribute"))
         {
             netCDFWriterConfigAttribute oAtt;
             if (oAtt.Parse(psIter))
+            {
                 m_aoAttributes.push_back(std::move(oAtt));
+            }
+            else
+            {
+                return false;
+            }
         }
         else if (EQUAL(psIter->pszValue, "Field"))
         {
             netCDFWriterConfigField oField;
             if (oField.Parse(psIter))
+            {
                 m_oFields[!oField.m_osName.empty()
                               ? oField.m_osName
                               : CPLString("__") + oField.m_osNetCDFName] =
                     std::move(oField);
+            }
+            else
+            {
+                return false;
+            }
         }
         else
         {


### PR DESCRIPTION
The netCDF driver allows use of an XML config file to configure an output datasource. When parsing this file, errors of type `CE_Failure` may be raised, but they are not propagated and do not result in failure of the overall operation or emission of a Python exception. This PR propagates the `CE_Failure` errors.

Processing of the configuration options `FORMAT` and `COMPRESS` can also yield a non-failing `CE_Failure`. I changed these to `CE_Warning` because the error message suggests that failure is not intended.