### PR TITLE
autotest netCDF: enable exceptions

### DIFF
--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -31,9 +31,12 @@ pytestmark = pytest.mark.require_driver("netCDF")
 
 
 ###############################################################################
-@pytest.fixture(autouse=True, scope="module")
-def module_disable_exceptions():
-    with gdaltest.disable_exceptions():
+
+
+@pytest.fixture(autouse=True)
+def fail_on_warnings():
+
+    with gdaltest.error_raised(gdal.CE_None):
         yield
 
 
@@ -280,9 +283,7 @@ def test_netcdf_1():
         "NetCDF", 'NETCDF:"data/netcdf/bug636.nc":tas', 1, 31621, filename_absolute=1
     )
 
-    # We don't want to gum up the test stream output with the
-    # 'Warning 1: No UNIDATA NC_GLOBAL:Conventions attribute' message.
-    with gdal.quiet_errors():
+    with gdaltest.error_raised(gdal.CE_Warning, "Latitude grid not spaced evenly"):
         tst.testOpen()
 
 
@@ -337,7 +338,7 @@ def test_netcdf_2(tmp_path):
 
 def test_netcdf_3():
 
-    ds = gdal.Open("data/netcdf/sombrero.grd")
+    ds = gdal.Open("data/netcdf/sombrero.grd", gdal.OF_RASTER)
     bnd = ds.GetRasterBand(1)
     minmax = bnd.ComputeRasterMinMax()
 
@@ -363,9 +364,9 @@ def test_netcdf_4():
         filename_absolute=1,
     )
 
-    # We don't want to gum up the test stream output with the
-    # 'Warning 1: No UNIDATA NC_GLOBAL:Conventions attribute' message.
-    with gdal.quiet_errors():
+    with gdaltest.error_raised(
+        gdal.CE_Warning, "No 1D variable is indexed by dimension x"
+    ):
         # don't test for checksum (see bug #4284)
         tst.testOpen(skip_checksum=True)
 
@@ -385,9 +386,9 @@ def test_netcdf_5():
         filename_absolute=1,
     )
 
-    # We don't want to gum up the test stream output with the
-    # 'Warning 1: No UNIDATA NC_GLOBAL:Conventions attribute' message.
-    with gdal.quiet_errors():
+    with gdaltest.error_raised(
+        gdal.CE_Warning, "No 1D variable is indexed by dimension x"
+    ):
         # don't test for checksum (see bug #4284)
         tst.testOpen(skip_checksum=True)
 
@@ -578,7 +579,7 @@ def test_netcdf_cf_lon_lat_with_coordinates_no_crs():
 
 def test_netcdf_longitude_latitude():
 
-    ds = gdal.Open("data/netcdf/longitude_latitude.nc")
+    ds = gdal.Open("data/netcdf/longitude_latitude.nc", gdal.OF_RASTER)
 
     gt = ds.GetGeoTransform()
     assert gt == pytest.approx(
@@ -600,7 +601,7 @@ def test_netcdf_longitude_latitude():
 
 def test_netcdf_12(tmp_path):
 
-    ds = gdal.Open("data/netcdf/scale_offset.nc")
+    ds = gdal.Open("data/netcdf/scale_offset.nc", gdal.OF_RASTER)
 
     scale = ds.GetRasterBand(1).GetScale()
     offset = ds.GetRasterBand(1).GetOffset()
@@ -627,7 +628,7 @@ def test_netcdf_12(tmp_path):
 
 def test_netcdf_13():
 
-    ds = gdal.Open("data/netcdf/no_scale_offset.nc")
+    ds = gdal.Open("data/netcdf/no_scale_offset.nc", gdal.OF_RASTER)
 
     scale = ds.GetRasterBand(1).GetScale()
     offset = ds.GetRasterBand(1).GetOffset()
@@ -643,7 +644,7 @@ def test_netcdf_13():
 
 def test_netcdf_two_vars_as_subdatasets():
 
-    ds = gdal.Open("NETCDF:data/netcdf/two_vars_scale_offset.nc:z")
+    ds = gdal.Open("NETCDF:data/netcdf/two_vars_scale_offset.nc:z", gdal.OF_RASTER)
 
     scale = ds.GetRasterBand(1).GetScale()
     offset = ds.GetRasterBand(1).GetOffset()
@@ -655,7 +656,7 @@ def test_netcdf_two_vars_as_subdatasets():
 
     ds = None
 
-    ds = gdal.Open("NETCDF:data/netcdf/two_vars_scale_offset.nc:q")
+    ds = gdal.Open("NETCDF:data/netcdf/two_vars_scale_offset.nc:q", gdal.OF_RASTER)
 
     scale = ds.GetRasterBand(1).GetScale()
     offset = ds.GetRasterBand(1).GetOffset()
@@ -674,7 +675,9 @@ def test_netcdf_two_vars_as_subdatasets():
 def test_netcdf_two_vars_as_multiple_bands():
 
     ds = gdal.Open(
-        "data/netcdf/two_vars_scale_offset.nc", open_options=["VARIABLES_AS_BANDS=YES"]
+        "data/netcdf/two_vars_scale_offset.nc",
+        gdal.OF_RASTER,
+        open_options=["VARIABLES_AS_BANDS=YES"],
     )
     assert ds.RasterCount == 2
 
@@ -856,14 +859,11 @@ def test_netcdf_22():
 
     ifile = "data/hdf4/hdifftst2.hdf"
 
-    # suppress warning
+    # the following warning is emitted, but only on some configurations:
+    # NetCDF driver detected file type=6, but libnetcdf detected type=3
     with gdal.quiet_errors():
         ds = gdal.Open("NETCDF:" + ifile)
-
-    if ds is None:
-        pytest.fail("netcdf driver did not open hdf4 file")
-    else:
-        ds = None
+    assert ds is not None
 
 
 ###############################################################################
@@ -1021,7 +1021,7 @@ def netcdf_25_nc4(tmp_path):
 
 def test_netcdf_float_valid_range():
 
-    ds = gdal.Open("data/netcdf/float_valid_range.nc")
+    ds = gdal.Open("data/netcdf/float_valid_range.nc", gdal.OF_RASTER)
     assert ds.GetRasterBand(1).ComputeRasterMinMax() == pytest.approx(
         (0.1, 0.9), abs=1e-6
     )
@@ -1033,7 +1033,7 @@ def test_netcdf_float_valid_range():
 
 def test_netcdf_float_valid_min_max():
 
-    ds = gdal.Open("data/netcdf/float_valid_min_max.nc")
+    ds = gdal.Open("data/netcdf/float_valid_min_max.nc", gdal.OF_RASTER)
     assert ds.GetRasterBand(1).ComputeRasterMinMax() == pytest.approx(
         (0.1, 0.9), abs=1e-6
     )
@@ -1049,8 +1049,7 @@ def test_netcdf_26():
 
     # test default config
     test = gdaltest.GDALTest("NETCDF", "netcdf/int16-nogeo.nc", 1, 4672)
-    with gdal.quiet_errors():
-        test.testCreateCopy(check_gt=0, check_srs=0, check_minmax=0)
+    test.testCreateCopy(check_gt=0, check_srs=0, check_minmax=0)
 
     # test WRITE_BOTTOMUP=NO
     test = gdaltest.GDALTest(
@@ -1221,8 +1220,7 @@ def test_netcdf_30():
 
     # We don't want to gum up the test stream output with the
     # 'Warning 1: No UNIDATA NC_GLOBAL:Conventions attribute' message.
-    with gdal.quiet_errors():
-        tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -1387,7 +1385,7 @@ def test_netcdf_37():
 
     ifile = "data/netcdf/reduce-cgcms.nc"
 
-    with gdal.quiet_errors():
+    with gdaltest.error_raised(gdal.CE_Warning, "Latitude grid not spaced evenly"):
         ds = gdal.Open(ifile)
     assert ds is not None, "open failed"
 
@@ -1417,7 +1415,7 @@ def test_netcdf_38():
 
     ifile = "data/netcdf/bug5118.nc"
 
-    with gdal.quiet_errors():
+    with gdaltest.error_raised(gdal.CE_Warning, "no such variable exists"):
         ds = gdal.Open(ifile)
     assert ds is not None, "open failed"
 
@@ -1448,7 +1446,7 @@ def test_netcdf_38():
 def test_netcdf_39():
 
     shutil.copy("data/netcdf/two_vars_scale_offset.nc", "tmp")
-    src_ds = gdal.Open("NETCDF:tmp/two_vars_scale_offset.nc:z")
+    src_ds = gdal.Open("NETCDF:tmp/two_vars_scale_offset.nc:z", gdal.OF_RASTER)
     out_ds = gdal.GetDriverByName("VRT").CreateCopy("tmp/netcdf_39.vrt", src_ds)
     del out_ds
     src_ds = None
@@ -1462,7 +1460,7 @@ def test_netcdf_39():
     assert cs == 65463
 
     shutil.copy("data/netcdf/two_vars_scale_offset.nc", "tmp")
-    src_ds = gdal.Open('NETCDF:"tmp/two_vars_scale_offset.nc":z')
+    src_ds = gdal.Open('NETCDF:"tmp/two_vars_scale_offset.nc":z', gdal.OF_RASTER)
     out_ds = gdal.GetDriverByName("VRT").CreateCopy("tmp/netcdf_39.vrt", src_ds)
     del out_ds
     src_ds = None
@@ -1483,15 +1481,21 @@ def test_netcdf_39():
 def test_netcdf_39_absolute():
 
     if (
-        gdal.Open("%s/data/netcdf/two_vars_scale_offset.nc" % os.getcwd()) is None
-        and gdal.Open("data/netcdf/two_vars_scale_offset.nc") is not None
+        gdal.Open(
+            "%s/data/netcdf/two_vars_scale_offset.nc" % os.getcwd(), gdal.OF_RASTER
+        )
+        is None
+        and gdal.Open("data/netcdf/two_vars_scale_offset.nc", gdal.OF_RASTER)
+        is not None
     ):
         pytest.skip(
             "netcdf library can't handle absolute paths. Known to happen with some versions of msys mingw-w64-x86_64-netcdf package"
         )
 
     shutil.copy("data/netcdf/two_vars_scale_offset.nc", "tmp")
-    src_ds = gdal.Open('NETCDF:"%s/tmp/two_vars_scale_offset.nc":z' % os.getcwd())
+    src_ds = gdal.Open(
+        'NETCDF:"%s/tmp/two_vars_scale_offset.nc":z' % os.getcwd(), gdal.OF_RASTER
+    )
     out_ds = gdal.GetDriverByName("VRT").CreateCopy(
         "%s/tmp/netcdf_39.vrt" % os.getcwd(), src_ds
     )
@@ -1507,7 +1511,8 @@ def test_netcdf_39_absolute():
     assert cs == 65463
 
     src_ds = gdal.Open(
-        'NETCDF:"%s/data/netcdf/two_vars_scale_offset.nc":z' % os.getcwd()
+        'NETCDF:"%s/data/netcdf/two_vars_scale_offset.nc":z' % os.getcwd(),
+        gdal.OF_RASTER,
     )
     out_ds = gdal.GetDriverByName("VRT").CreateCopy("tmp/netcdf_39.vrt", src_ds)
     del out_ds
@@ -1537,8 +1542,7 @@ def test_netcdf_40(tmp_path):
 
 def test_netcdf_41():
 
-    with gdal.quiet_errors():
-        ds = gdal.Open("data/netcdf/byte_no_cf.nc")
+    ds = gdal.Open("data/netcdf/byte_no_cf.nc")
     assert ds.GetGeoTransform() == (440720, 60, 0, 3751320, 0, -60)
     assert ds.GetProjectionRef().find("26711") >= 0, ds.GetGeoTransform()
 
@@ -1740,9 +1744,13 @@ def test_netcdf_43(tmp_path):
 @pytest.mark.parametrize(
     "f,md5", [("data/netcdf/ushort.nc", 18), ("data/netcdf/uint.nc", 10)]
 )
+@gdaltest.error_raised(
+    gdal.CE_Warning,
+    "GeoTransform read from attribute of transverse_mercator variable differs",
+)  # these files happen to have an incorrect GeoTransform attribute
 def test_netcdf_44(tmp_path, f, md5):
 
-    ofile = str(tmp_path / "out.nc")
+    ofile = tmp_path / "out.nc"
     netcdf_test_copy(f, 1, md5, ofile, ["FORMAT=NC4"])
 
 
@@ -1754,12 +1762,12 @@ def test_netcdf_44(tmp_path, f, md5):
 def test_netcdf_45(tmp_vsimem):
 
     # Test that a vector cannot be opened in raster-only mode
-    ds = gdal.Open("data/netcdf/test_ogr_nc3.nc", gdal.OF_RASTER)
-    assert ds is None
+    with pytest.raises(Exception, match="not recognized"):
+        gdal.Open("data/netcdf/test_ogr_nc3.nc", gdal.OF_RASTER)
 
     # Test that a raster cannot be opened in vector-only mode
-    ds = gdal.Open("data/netcdf/cf-bug636.nc", gdal.OF_VECTOR)
-    assert ds is None
+    with pytest.raises(Exception, match="not recognized"):
+        gdal.Open("data/netcdf/cf-bug636.nc", gdal.OF_VECTOR)
 
     ds = gdal.Open("data/netcdf/test_ogr_nc3.nc", gdal.OF_VECTOR)
     lyr = ds.GetLayer(0)
@@ -1767,18 +1775,17 @@ def test_netcdf_45(tmp_vsimem):
     assert lyr.GetLayerDefn().GetFieldDefn(0).GetAlternativeName() == ""
     assert lyr.GetLayerDefn().GetFieldDefn(0).GetComment() == ""
 
-    with gdal.quiet_errors():
-        gdal.VectorTranslate(
-            tmp_vsimem / "netcdf_45.csv",
-            ds,
-            format="CSV",
-            layerCreationOptions=[
-                "LINEFORMAT=LF",
-                "CREATE_CSVT=YES",
-                "GEOMETRY=AS_WKT",
-                "STRING_QUOTING=IF_NEEDED",
-            ],
-        )
+    gdal.VectorTranslate(
+        tmp_vsimem / "netcdf_45.csv",
+        ds,
+        format="CSV",
+        layerCreationOptions=[
+            "LINEFORMAT=LF",
+            "CREATE_CSVT=YES",
+            "GEOMETRY=AS_WKT",
+            "STRING_QUOTING=IF_NEEDED",
+        ],
+    )
 
     fp = gdal.VSIFOpenL(tmp_vsimem / "netcdf_45.csv", "rb")
     if fp is not None:
@@ -1824,24 +1831,22 @@ def test_netcdf_46():
 def test_netcdf_47(tmp_vsimem):
 
     # Test that a vector cannot be opened in raster-only mode
-    with gdal.quiet_errors():
-        ds = gdal.Open("data/netcdf/test_ogr_nc4.nc", gdal.OF_RASTER)
-    assert ds is None
+    with pytest.raises(Exception, match="not recognized"):
+        gdal.Open("data/netcdf/test_ogr_nc4.nc", gdal.OF_RASTER)
 
     ds = gdal.Open("data/netcdf/test_ogr_nc4.nc", gdal.OF_VECTOR)
 
-    with gdal.quiet_errors():
-        gdal.VectorTranslate(
-            tmp_vsimem / "netcdf_47.csv",
-            ds,
-            format="CSV",
-            layerCreationOptions=[
-                "LINEFORMAT=LF",
-                "CREATE_CSVT=YES",
-                "GEOMETRY=AS_WKT",
-                "STRING_QUOTING=IF_NEEDED",
-            ],
-        )
+    gdal.VectorTranslate(
+        tmp_vsimem / "netcdf_47.csv",
+        ds,
+        format="CSV",
+        layerCreationOptions=[
+            "LINEFORMAT=LF",
+            "CREATE_CSVT=YES",
+            "GEOMETRY=AS_WKT",
+            "STRING_QUOTING=IF_NEEDED",
+        ],
+    )
 
     fp = gdal.VSIFOpenL(tmp_vsimem / "netcdf_47.csv", "rb")
     if fp is not None:
@@ -1869,8 +1874,7 @@ def test_netcdf_47(tmp_vsimem):
 
 def test_netcdf_48():
 
-    with gdal.quiet_errors():
-        ds = gdal.Open("data/netcdf/test_ogr_no_xyz_var.nc", gdal.OF_VECTOR)
+    ds = gdal.Open("data/netcdf/test_ogr_no_xyz_var.nc", gdal.OF_VECTOR)
     lyr = ds.GetLayer(0)
     assert lyr.GetGeomType() == ogr.wkbNone
     f = lyr.GetNextFeature()
@@ -1884,18 +1888,17 @@ def test_netcdf_48():
 @pytest.mark.require_driver("CSV")
 def test_netcdf_49(tmp_vsimem):
 
-    with gdal.quiet_errors():
-        ds = gdal.Open("data/netcdf/test_ogr_xyz_float.nc", gdal.OF_VECTOR)
-        gdal.VectorTranslate(
-            tmp_vsimem / "netcdf_49.csv",
-            ds,
-            format="CSV",
-            layerCreationOptions=[
-                "LINEFORMAT=LF",
-                "GEOMETRY=AS_WKT",
-                "STRING_QUOTING=IF_NEEDED",
-            ],
-        )
+    ds = gdal.Open("data/netcdf/test_ogr_xyz_float.nc", gdal.OF_VECTOR)
+    gdal.VectorTranslate(
+        tmp_vsimem / "netcdf_49.csv",
+        ds,
+        format="CSV",
+        layerCreationOptions=[
+            "LINEFORMAT=LF",
+            "GEOMETRY=AS_WKT",
+            "STRING_QUOTING=IF_NEEDED",
+        ],
+    )
 
     fp = gdal.VSIFOpenL(tmp_vsimem / "netcdf_49.csv", "rb")
     if fp is not None:
@@ -1983,21 +1986,19 @@ def test_netcdf_51(tmp_path, tmp_vsimem):
         datasetCreationOptions=["GEOMETRY_ENCODING=WKT"],
     )
 
-    with gdal.quiet_errors():
-        ds = gdal.Open(ofile, gdal.OF_VECTOR)
-        gdal.VectorTranslate(
-            tmp_vsimem / "netcdf_51.csv",
-            ds,
-            format="CSV",
-            layerCreationOptions=[
-                "LINEFORMAT=LF",
-                "CREATE_CSVT=YES",
-                "GEOMETRY=AS_WKT",
-                "STRING_QUOTING=IF_NEEDED",
-            ],
-            datasetCreationOptions=["GEOMETRY_ENCODING=WKT"],
-        )
-        ds = None
+    ds = gdal.Open(ofile, gdal.OF_VECTOR)
+    gdal.VectorTranslate(
+        tmp_vsimem / "netcdf_51.csv",
+        ds,
+        format="CSV",
+        layerCreationOptions=[
+            "LINEFORMAT=LF",
+            "CREATE_CSVT=YES",
+            "GEOMETRY=AS_WKT",
+            "STRING_QUOTING=IF_NEEDED",
+        ],
+    )
+    ds = None
 
     fp = gdal.VSIFOpenL(tmp_vsimem / "netcdf_51.csv", "rb")
     if fp is not None:
@@ -2058,20 +2059,19 @@ def test_netcdf_51_no_gdal_tags(tmp_path, tmp_vsimem):
         datasetCreationOptions=["WRITE_GDAL_TAGS=NO", "GEOMETRY_ENCODING=WKT"],
     )
 
-    with gdal.quiet_errors():
-        ds = gdal.Open(ofile, gdal.OF_VECTOR)
-        gdal.VectorTranslate(
-            tmp_vsimem / "netcdf_51_no_gdal_tags.csv",
-            ds,
-            format="CSV",
-            layerCreationOptions=[
-                "LINEFORMAT=LF",
-                "CREATE_CSVT=YES",
-                "GEOMETRY=AS_WKT",
-                "STRING_QUOTING=IF_NEEDED",
-            ],
-        )
-        ds = None
+    ds = gdal.Open(ofile, gdal.OF_VECTOR)
+    gdal.VectorTranslate(
+        tmp_vsimem / "netcdf_51_no_gdal_tags.csv",
+        ds,
+        format="CSV",
+        layerCreationOptions=[
+            "LINEFORMAT=LF",
+            "CREATE_CSVT=YES",
+            "GEOMETRY=AS_WKT",
+            "STRING_QUOTING=IF_NEEDED",
+        ],
+    )
+    ds = None
 
     fp = gdal.VSIFOpenL(tmp_vsimem / "netcdf_51_no_gdal_tags.csv", "rb")
     if fp is not None:
@@ -2114,20 +2114,19 @@ def test_netcdf_52(tmp_path, tmp_vsimem):
         datasetCreationOptions=["FORMAT=NC4", "GEOMETRY_ENCODING=WKT"],
     )
 
-    with gdal.quiet_errors():
-        ds = gdal.Open(ofile, gdal.OF_VECTOR)
-        gdal.VectorTranslate(
-            tmp_vsimem / "netcdf_52.csv",
-            ds,
-            format="CSV",
-            layerCreationOptions=[
-                "LINEFORMAT=LF",
-                "CREATE_CSVT=YES",
-                "GEOMETRY=AS_WKT",
-                "STRING_QUOTING=IF_NEEDED",
-            ],
-        )
-        ds = None
+    ds = gdal.Open(ofile, gdal.OF_VECTOR)
+    gdal.VectorTranslate(
+        tmp_vsimem / "netcdf_52.csv",
+        ds,
+        format="CSV",
+        layerCreationOptions=[
+            "LINEFORMAT=LF",
+            "CREATE_CSVT=YES",
+            "GEOMETRY=AS_WKT",
+            "STRING_QUOTING=IF_NEEDED",
+        ],
+    )
+    ds = None
 
     fp = gdal.VSIFOpenL(tmp_vsimem / "netcdf_52.csv", "rb")
     if fp is not None:
@@ -2380,14 +2379,13 @@ def test_netcdf_ogr_field_alternative_name_comment(tmp_path):
 
 def test_netcdf_57(tmp_path):
 
-    with gdal.quiet_errors():
-        ds = ogr.GetDriverByName("netCDF").CreateDataSource(
+    with pytest.raises(Exception, match="Cannot create .* directory"):
+        ogr.GetDriverByName("netCDF").CreateDataSource(
             "/not_existing_dir/invalid_subdir",
             options=["MULTIPLE_LAYERS=SEPARATE_FILES", "GEOMETRY_ENCODING=WKT"],
         )
-    assert ds is None
 
-    ofile = str(tmp_path / "out")
+    ofile = tmp_path / "out"
     ds = ogr.GetDriverByName("netCDF").CreateDataSource(
         ofile,
         options=["MULTIPLE_LAYERS=SEPARATE_FILES", "GEOMETRY_ENCODING=WKT"],
@@ -2412,7 +2410,6 @@ def test_netcdf_57(tmp_path):
 # Test one layer per file creation
 
 
-@gdaltest.enable_exceptions()
 def test_netcdf_one_layer_per_file_failure(tmp_path):
 
     ds = ogr.GetDriverByName("netCDF").CreateDataSource(
@@ -2467,7 +2464,7 @@ def test_netcdf_58(tmp_path):
 def test_netcdf_59():
 
     # get
-    ds = gdal.Open("data/netcdf/unittype.nc")
+    ds = gdal.Open("data/netcdf/unittype.nc", gdal.OF_RASTER)
 
     unit = ds.GetRasterBand(1).GetUnitType()
 
@@ -2490,23 +2487,22 @@ def test_netcdf_59():
 def test_netcdf_60(tmp_vsimem):
 
     # Test that a vector cannot be opened in raster-only mode
-    ds = gdal.Open("data/netcdf/profile.nc", gdal.OF_RASTER)
-    assert ds is None
+    with pytest.raises(Exception, match="not recognized"):
+        gdal.Open("data/netcdf/profile.nc", gdal.OF_RASTER)
 
     ds = gdal.Open("data/netcdf/profile.nc", gdal.OF_VECTOR)
     assert ds is not None
 
-    with gdal.quiet_errors():
-        gdal.VectorTranslate(
-            tmp_vsimem / "netcdf_60.csv",
-            ds,
-            format="CSV",
-            layerCreationOptions=[
-                "LINEFORMAT=LF",
-                "GEOMETRY=AS_WKT",
-                "STRING_QUOTING=IF_NEEDED",
-            ],
-        )
+    gdal.VectorTranslate(
+        tmp_vsimem / "netcdf_60.csv",
+        ds,
+        format="CSV",
+        layerCreationOptions=[
+            "LINEFORMAT=LF",
+            "GEOMETRY=AS_WKT",
+            "STRING_QUOTING=IF_NEEDED",
+        ],
+    )
 
     fp = gdal.VSIFOpenL(tmp_vsimem / "netcdf_60.csv", "rb")
     if fp is not None:
@@ -2698,7 +2694,6 @@ def test_netcdf_64(tmp_path, tmp_vsimem):
             "FEATURE_TYPE=PROFILE",
             "PROFILE_DIM_NAME=profile_dim",
             "PROFILE_DIM_INIT_SIZE=1",
-            "LEGACY=WKT",
         ],
         datasetCreationOptions=["GEOMETRY_ENCODING=WKT"],
     )
@@ -2759,7 +2754,6 @@ def test_netcdf_65(tmp_path):
 # from a config file
 
 
-@gdaltest.enable_exceptions()
 def test_netcdf_66_missing_config(tmp_path):
 
     with pytest.raises(Exception, match="Cannot open file"):
@@ -2771,7 +2765,6 @@ def test_netcdf_66_missing_config(tmp_path):
         )
 
 
-@gdaltest.enable_exceptions()
 def test_netcdf_66_malformed_xml(tmp_path):
 
     with pytest.raises(Exception, match="not all elements have been closed"):
@@ -2783,7 +2776,6 @@ def test_netcdf_66_malformed_xml(tmp_path):
         )
 
 
-@gdaltest.enable_exceptions()
 def test_netcdf_66_unrecognized_element(tmp_path):
 
     myconfig = """<Configuration>
@@ -2802,7 +2794,6 @@ def test_netcdf_66_unrecognized_element(tmp_path):
     assert os.path.exists(tmp_path / "out.nc")
 
 
-@gdaltest.enable_exceptions()
 def test_netcdf_66_unsupported_attribute_type(tmp_path):
 
     myconfig = """<Configuration>
@@ -2819,7 +2810,6 @@ def test_netcdf_66_unsupported_attribute_type(tmp_path):
         )
 
 
-@gdaltest.enable_exceptions()
 def test_netcdf_66_unsupported_layer_attribute_type(tmp_path):
 
     myconfig = """<Configuration>
@@ -2838,7 +2828,6 @@ def test_netcdf_66_unsupported_layer_attribute_type(tmp_path):
         )
 
 
-@gdaltest.enable_exceptions()
 def test_netcdf_66_field_invalid_dim(tmp_path):
 
     myconfig = """<Configuration>
@@ -2879,7 +2868,6 @@ def test_netcdf_66_field_invalid_dim(tmp_path):
         '<Layer name="x"><Field/></Layer>',
     ),
 )
-@gdaltest.enable_exceptions()
 def test_netcdf_66_incomplete_element(tmp_path, element):
 
     myconfig = f"<Configuration>{element}</Configuration>"
@@ -2905,68 +2893,6 @@ def test_netcdf_66(tmp_path, tmp_vsimem):
 
     ofile = tmp_path / "out.nc"
 
-    # First trying with no so good configs
-
-    with gdal.quiet_errors():
-        gdal.VectorTranslate(
-            ofile,
-            "data/netcdf/profile.nc",
-            format="netCDF",
-            datasetCreationOptions=["CONFIG_FILE=not_existing"],
-        )
-
-    with gdal.quiet_errors():
-        gdal.VectorTranslate(
-            ofile,
-            "data/netcdf/profile.nc",
-            format="netCDF",
-            datasetCreationOptions=["CONFIG_FILE=<Configuration>"],
-        )
-
-    myconfig = """<Configuration>
-    <!-- comment -->
-    <unrecognized_elt/>
-    <DatasetCreationOption/>
-    <DatasetCreationOption name="x"/>
-    <DatasetCreationOption value="x"/>
-    <LayerCreationOption/>
-    <LayerCreationOption name="x"/>
-    <LayerCreationOption value="x"/>
-    <Attribute/>
-    <Attribute name="foo"/>
-    <Attribute value="foo"/>
-    <Attribute name="foo" value="bar" type="unsupported"/>
-    <Field/>
-    <Field name="x">
-        <!-- comment -->
-        <unrecognized_elt/>
-    </Field>
-    <Field name="station" main_dim="non_existing"/>
-    <Layer/>
-    <Layer name="x">
-        <!-- comment -->
-        <unrecognized_elt/>
-        <LayerCreationOption/>
-        <LayerCreationOption name="x"/>
-        <LayerCreationOption value="x"/>
-        <Attribute/>
-        <Attribute name="foo"/>
-        <Attribute value="foo"/>
-        <Attribute name="foo" value="bar" type="unsupported"/>
-        <Field/>
-    </Layer>
-</Configuration>
-"""
-
-    with gdal.quiet_errors():
-        gdal.VectorTranslate(
-            ofile,
-            "data/netcdf/profile.nc",
-            format="netCDF",
-            datasetCreationOptions=["CONFIG_FILE=" + myconfig, "GEOMETRY_ENCODING=WKT"],
-        )
-
-    # Now with a correct configuration
     myconfig = """<Configuration>
     <DatasetCreationOption name="WRITE_GDAL_TAGS" value="NO"/>
     <LayerCreationOption name="STRING_DEFAULT_WIDTH" value="1"/>
@@ -3051,7 +2977,9 @@ def test_netcdf_67():
         #    tst = gdaltest.GDALTest( 'NetCDF', 'partial_block_ticket5950.nc', 1, 45 )
         #    result = tst.testOpen( check_stat=(1, 9, 5, 2.582) )
         # so for the moment compare the full image
-        ds = gdal.Open("data/netcdf/partial_block_ticket5950.nc", gdal.GA_ReadOnly)
+        ds = gdal.Open(
+            "data/netcdf/partial_block_ticket5950.nc", gdal.GA_ReadOnly | gdal.OF_RASTER
+        )
         ref = numpy.arange(1, 10).reshape((3, 3))
         if not numpy.array_equal(ds.GetRasterBand(1).ReadAsArray(), ref):
             pytest.fail()
@@ -3126,6 +3054,7 @@ def test_netcdf_72():
 # test geostationary with radian units (https://github.com/OSGeo/gdal/pull/220)
 
 
+@gdaltest.error_raised(gdal.CE_Warning, "Unhandled X/Y axis unit rad")
 def test_netcdf_73():
 
     ds = gdal.Open("data/netcdf/geos_rad.nc")
@@ -3145,6 +3074,7 @@ def test_netcdf_73():
 # test geostationary with microradian units (https://github.com/OSGeo/gdal/pull/220)
 
 
+@gdaltest.error_raised(gdal.CE_Warning, "Unhandled X/Y axis unit microradian")
 def test_netcdf_74():
 
     ds = gdal.Open("data/netcdf/geos_microradian.nc")
@@ -3421,8 +3351,11 @@ def test_netcdf_write_rotated_pole_from_method_grib(tmp_path):
 @pytest.mark.require_driver("CSV")
 def test_netcdf_82():
 
-    with gdal.quiet_errors():
-        ds = gdal.Open("data/netcdf/oddly_indexed_extra_dims.nc")
+    with gdaltest.error_raised(
+        gdal.CE_Warning,
+        "No 1D variable is indexed by dimension extra_dim_without_variable",
+    ):
+        ds = gdal.Open("data/netcdf/oddly_indexed_extra_dims.nc", gdal.OF_RASTER)
     md = ds.GetMetadata()
     expected_md = {
         "NETCDF_DIM_extra_dim_with_var_of_different_name_VALUES": "{100,200}",
@@ -3450,7 +3383,7 @@ def test_netcdf_82():
 
 def test_netcdf_83():
 
-    ds = gdal.Open("data/netcdf/complex.nc")
+    ds = gdal.Open("data/netcdf/complex.nc", gdal.OF_RASTER)
     sds_list = ds.GetMetadata("SUBDATASETS")
 
     assert len(sds_list) == 6, "Did not get expected complex subdataset count."
@@ -3474,7 +3407,7 @@ def test_netcdf_83():
 
 def test_netcdf_84():
 
-    ds = gdal.Open('NETCDF:"data/netcdf/complex.nc":f32')
+    ds = gdal.Open('NETCDF:"data/netcdf/complex.nc":f32', gdal.OF_RASTER)
     assert ds.GetRasterBand(1).DataType == gdal.GDT_CFloat32
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -3486,7 +3419,7 @@ def test_netcdf_84():
 
 def test_netcdf_85():
 
-    ds = gdal.Open('NETCDF:"data/netcdf/complex.nc":f64')
+    ds = gdal.Open('NETCDF:"data/netcdf/complex.nc":f64', gdal.OF_RASTER)
     assert ds.GetRasterBand(1).DataType == gdal.GDT_CFloat64
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -3498,7 +3431,7 @@ def test_netcdf_85():
 
 def test_netcdf_86():
 
-    ds = gdal.Open('NETCDF:"data/netcdf/complex.nc":/group/fmul')
+    ds = gdal.Open('NETCDF:"data/netcdf/complex.nc":/group/fmul', gdal.OF_RASTER)
     assert ds.GetRasterBand(1).DataType == gdal.GDT_CFloat32
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -3512,6 +3445,8 @@ def test_netcdf_86():
 
 
 ###############################################################################
+
+
 def test_netcdf_uffd():
 
     if uffd_compare("netcdf/orog_CRCM1.nc") is None:
@@ -3525,8 +3460,9 @@ def test_netcdf_uffd():
         "rotated_pole.nc",
         "reduce-cgcms.nc",
     ]
-    for netcdf_file in netcdf_files:
-        assert uffd_compare("netcdf/" + netcdf_file) is True
+    with gdaltest.error_raised(gdal.CE_Warning, "grid not spaced evenly"):
+        for netcdf_file in netcdf_files:
+            assert uffd_compare("netcdf/" + netcdf_file) is True
 
 
 ###############################################################################
@@ -3595,6 +3531,7 @@ def test_netcdf_huge_block_size(tmp_path):
 # geoloc arrays reflect the georeferencing correctly
 
 
+@gdal.quiet_warnings()
 def test_netcdf_swapped_x_y_dimension():
 
     ds = gdal.Open("data/netcdf/swapedxy.nc")
@@ -3784,25 +3721,27 @@ def test_netcdf_functions_2(filename, checksum, options, testfunction):
 
 
 #  basic tests
-def test_bad_cf1_8():
-    # basic resilience test, make sure it can exit "gracefully"
-    # if not it will abort all tests
-    bad_geometry = ogr.Open("data/netcdf-sg/no_geometry_type.nc")
-    bad_feature = ogr.Open("data/netcdf-sg/bad_feature_test.nc")
-    missing_node_counts_test = ogr.Open("data/netcdf-sg/missing_node_counts_test.nc")
-    uneq_x_y = ogr.Open("data/netcdf-sg/unequal_xy.nc")
-    corrupt_poly_1 = ogr.Open("data/netcdf-sg/corrupted_polygon_ncpncir.nc")
-    corrupt_poly_2 = ogr.Open("data/netcdf-sg/corrupted_polygon_pnc.nc")
-    corrupt_poly_3 = ogr.Open("data/netcdf-sg/corrupted_polygon_ir.nc")
+@pytest.mark.parametrize(
+    "fname,expected_warning",
+    (
+        ("no_geometry_type", "geometry_type is missing"),
+        ("bad_feature_test", "unrecognized feature type"),
+        ("missing_node_counts_test", "node_count is missing"),
+        ("unequal_xy", "coordinate axes do not match"),
+        ("corrupted_polygon_ncpncir", "node_count values may not be negative"),
+        ("corrupted_polygon_pnc", "part_not_count values may not be negative"),
+        ("corrupted_polygon_ir", "interior_ring values must be 0 or 1"),
+    ),
+)
+def test_bad_cf1_8(fname, expected_warning):
 
-    # error IS fatal
-    assert bad_geometry is None
-    assert bad_feature is None
-    assert missing_node_counts_test is None
-    assert corrupt_poly_1 is None
-    assert corrupt_poly_2 is None
-    assert corrupt_poly_3 is None
-    assert uneq_x_y is None
+    # basic resilience test, make sure it can exit "gracefully"
+    fpath = f"data/netcdf-sg/{fname}.nc"
+    assert os.path.exists(fpath)
+
+    with pytest.raises(Exception, match="not recognized"):
+        with gdaltest.error_raised(gdal.CE_Warning, expected_warning):
+            gdal.OpenEx(fpath, gdal.OF_VECTOR)
 
 
 def test_point_read():
@@ -4637,7 +4576,8 @@ def test_polygon3D_no_ir_write(tmp_path):
     assert src.GetLayerCount() == 1
 
     ofile = str(tmp_path / "out.nc")
-    gdal.VectorTranslate(ofile, src, format="netCDF")
+    with gdaltest.error_raised(gdal.CE_Warning, "Non closed ring"):
+        gdal.VectorTranslate(ofile, src, format="netCDF")
 
     nc_tsrc = ogr.Open(ofile)
     assert src is not None
@@ -4675,7 +4615,8 @@ def test_polygon3D_write(tmp_path):
     assert src.GetLayerCount() == 1
 
     ofile = str(tmp_path / "out.nc")
-    gdal.VectorTranslate(ofile, src, format="netCDF")
+    with gdaltest.error_raised(gdal.CE_Warning, "Non closed ring detected"):
+        gdal.VectorTranslate(ofile, src, format="netCDF")
 
     nc_tsrc = ogr.Open(ofile)
     assert src is not None
@@ -5006,7 +4947,8 @@ def test_multipolygon3D_with_no_ir_write(tmp_path):
     assert src.GetLayerCount() == 1
 
     ofile = str(tmp_path / "out.nc")
-    gdal.VectorTranslate(ofile, src, format="netCDF")
+    with gdaltest.error_raised(gdal.CE_Warning, "Non closed ring"):
+        gdal.VectorTranslate(ofile, src, format="netCDF")
 
     nc_tsrc = ogr.Open(ofile)
     assert nc_tsrc is not None
@@ -5222,7 +5164,9 @@ def test_netcdf_dimension_labels_with_null():
     ) or gdaltest.netcdf_drv_version.startswith("4.1."):
         pytest.skip("Test crashes with this libnetcdf version")
 
-    with gdal.quiet_errors():
+    with gdaltest.error_raised(
+        gdal.CE_Warning, "No 1D variable is indexed by dimension phony_dim_0"
+    ):
         assert gdal.Open("data/netcdf/dimension_labels_with_null.nc")
 
 
@@ -5656,10 +5600,10 @@ def test_netcdf_uint16_netcdf4_without_fill():
 
 def test_netcdf_sen3_sral_mwr_fake_standard_measurement():
 
-    ds = gdal.Open(
-        "data/netcdf/sen3_sral_mwr_fake_standard_measurement.nc", gdal.OF_RASTER
-    )
-    assert not ds
+    with pytest.raises(Exception, match="not recognized"):
+        gdal.Open(
+            "data/netcdf/sen3_sral_mwr_fake_standard_measurement.nc", gdal.OF_RASTER
+        )
 
     ds = gdal.Open(
         "data/netcdf/sen3_sral_mwr_fake_standard_measurement.nc", gdal.OF_VECTOR
@@ -5859,7 +5803,7 @@ def test_netcdf_metadata_sentinel5():
 
 def test_netcdf_modis_array():
 
-    ds = gdal.Open("data/netcdf/MODIS_ARRAY.nc")
+    ds = gdal.Open("data/netcdf/MODIS_ARRAY.nc", gdal.OF_RASTER)
     assert ds.GetGeoTransform(can_return_null=True) is not None
     assert ds.GetSpatialRef() is not None
 
@@ -5918,6 +5862,7 @@ def has_working_userfaultfd():
     )
 
 
+@gdaltest.disable_exceptions()
 def test_netcdf_open_userfaultfd(tmp_path):
 
     ofile = str(tmp_path / "out.zip")
@@ -6036,7 +5981,7 @@ def test_netcdf_read_gmt_file():
     """Test reading a GMT generated file that doesn't completely follow
     netCDF CF conventions regarding axis naming"""
 
-    ds = gdal.Open("data/netcdf/gmt_file.nc")
+    ds = gdal.Open("data/netcdf/gmt_file.nc", gdal.OF_RASTER)
     gt = ds.GetGeoTransform()
     assert gt == pytest.approx(
         (-34.6671666666667, 0.001, 0.0, 35.58483333333329, 0.0, -0.001)
@@ -6048,7 +5993,7 @@ def test_netcdf_read_gmt_file():
 
 def test_netcdf_read_int64():
 
-    ds = gdal.Open("data/netcdf/int64.nc")
+    ds = gdal.Open("data/netcdf/int64.nc", gdal.OF_RASTER)
     assert ds.GetRasterBand(1).DataType == gdal.GDT_Int64
     assert struct.unpack("q" * 4, ds.ReadRaster()) == (
         10000000001,
@@ -6063,7 +6008,7 @@ def test_netcdf_read_int64():
 
 def test_netcdf_write_int64(tmp_path):
 
-    src_ds = gdal.Open("data/netcdf/int64.nc")
+    src_ds = gdal.Open("data/netcdf/int64.nc", gdal.OF_RASTER)
     tmpfilename = str(tmp_path / "out.nc")
     gdaltest.netcdf_drv.CreateCopy(tmpfilename, src_ds)
     ds = gdal.Open(tmpfilename)
@@ -6082,7 +6027,7 @@ def test_netcdf_write_int64(tmp_path):
 
 def test_netcdf_read_uint64():
 
-    ds = gdal.Open("data/netcdf/uint64.nc")
+    ds = gdal.Open("data/netcdf/uint64.nc", gdal.OF_RASTER)
     assert ds.GetRasterBand(1).DataType == gdal.GDT_UInt64
     assert struct.unpack("Q" * 4, ds.ReadRaster()) == (10000000001, 1, 0, 10000000000)
 
@@ -6092,7 +6037,7 @@ def test_netcdf_read_uint64():
 
 def test_netcdf_write_uint64(tmp_path):
 
-    src_ds = gdal.Open("data/netcdf/uint64.nc")
+    src_ds = gdal.Open("data/netcdf/uint64.nc", gdal.OF_RASTER)
     tmpfilename = str(tmp_path / "out.nc")
     gdaltest.netcdf_drv.CreateCopy(tmpfilename, src_ds)
     ds = gdal.Open(tmpfilename)
@@ -6288,12 +6233,11 @@ def test_netcdf_read_cf_xy_latlon_crs_wkt():
 def test_netcdf_warning_get_metadata_item_PIXELTYPE():
 
     ds = gdal.Open("data/netcdf/byte_no_cf.nc")
-    with gdal.quiet_errors():
+    with gdaltest.error_raised(
+        gdal.CE_Warning,
+        "Starting with GDAL 3.7, PIXELTYPE=SIGNEDBYTE is no longer used to signal signed 8-bit raster. Change your code to test for the new GDT_Int8 data type instead.",
+    ):
         ds.GetRasterBand(1).GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE")
-    assert (
-        gdal.GetLastErrorMsg()
-        == "Starting with GDAL 3.7, PIXELTYPE=SIGNEDBYTE is no longer used to signal signed 8-bit raster. Change your code to test for the new GDT_Int8 data type instead."
-    )
 
 
 ###############################################################################
@@ -6355,10 +6299,10 @@ def test_netcdf_read_lon_lat_indexed_irregularly_spaced():
 
 def test_netcdf_read_invalid_valid_min_valid_max():
 
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
+    with gdaltest.error_raised(
+        gdal.CE_Warning, "contains floating-point values, whereas data type is integer"
+    ):
         ds = gdal.Open("data/netcdf/invalid_valid_min_valid_max.nc")
-    assert gdal.GetLastErrorType() == gdal.CE_Warning
     assert struct.unpack("i" * 4, ds.ReadRaster()) == (-9999, 0, 1, 2)
 
 
@@ -6370,6 +6314,7 @@ def test_netcdf_read_invalid_valid_min_valid_max():
 # Generation satellites.
 
 
+@gdaltest.error_raised(gdal.CE_Warning, "Unhandled X/Y axis unit radian")
 def test_netcdf_resolve_var_name():
     ds = gdal.Open(
         'NETCDF:data/netcdf/resolve_var_name.nc:/data/vis_08/measured/effective_radiance"'
@@ -6625,7 +6570,6 @@ def test_gdal_subdataset_bogus(bogus):
     gdal.GetSubdatasetInfo(bogus)
 
 
-@gdaltest.enable_exceptions()
 def test_band_names_creation_option(tmp_path):
 
     fname = tmp_path / "twobands.nc"
@@ -6649,7 +6593,6 @@ def test_band_names_creation_option(tmp_path):
         assert gdal.GetSubdatasetInfo(sds_names[1]).GetSubdatasetComponent() == "prate"
 
 
-@gdaltest.enable_exceptions()
 def test_band_names_creation_option_createcopy(tmp_path):
 
     fname = tmp_path / "out.nc"
@@ -6675,7 +6618,6 @@ def test_band_names_creation_option_createcopy(tmp_path):
         assert gdal.GetSubdatasetInfo(sds_names[1]).GetSubdatasetComponent() == "prate"
 
 
-@gdaltest.enable_exceptions()
 def test_netcdf_create_metadata_with_equal_sign(tmp_path):
 
     fname = tmp_path / "test_netcdf_create_metadata_with_equal_sign.nc"
@@ -6812,6 +6754,7 @@ def test_netcdf_var_extra_dim_unlimited():
 
 @pytest.mark.require_curl()
 @pytest.mark.skipif(sys.platform != "linux", reason="Incorrect platform")
+@gdaltest.disable_exceptions()
 def test_netcdf_var_extra_dim_unlimited_network():
 
     import webserver

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -396,7 +396,7 @@ class GDALTest:
                 wrk_filename, gdal.OF_RASTER, open_options=self.open_options
             )
         else:
-            src_ds = gdal.Open(wrk_filename, gdal.GA_ReadOnly)
+            src_ds = gdal.Open(wrk_filename, gdal.OF_RASTER)
 
         if self.band > 0:
             minmax = src_ds.GetRasterBand(self.band).ComputeRasterMinMax()
@@ -478,7 +478,7 @@ class GDALTest:
                 new_filename, gdal.OF_RASTER, open_options=dest_open_options
             )
         else:
-            new_ds = gdal.Open(new_filename)
+            new_ds = gdal.Open(new_filename, gdal.OF_RASTER)
         assert new_ds is not None, "Failed to open dataset: " + new_filename
 
         if self.band > 0:
@@ -580,7 +580,7 @@ class GDALTest:
                 wrk_filename, gdal.OF_RASTER, open_options=self.open_options
             )
         else:
-            src_ds = gdal.Open(wrk_filename, gdal.GA_ReadOnly)
+            src_ds = gdal.Open(wrk_filename, gdal.OF_RASTER)
 
         xsize = src_ds.RasterXSize
         ysize = src_ds.RasterYSize
@@ -636,7 +636,7 @@ class GDALTest:
                 new_filename, gdal.OF_RASTER, open_options=dest_open_options
             )
         else:
-            new_ds = gdal.Open(new_filename)
+            new_ds = gdal.Open(new_filename, gdal.OF_RASTER)
         assert new_ds is not None, "Failed to open dataset: " + new_filename
 
         for band in range(1, out_bands + 1):
@@ -669,7 +669,7 @@ class GDALTest:
                 wrk_filename, gdal.OF_RASTER, open_options=self.open_options
             )
         else:
-            src_ds = gdal.Open(wrk_filename, gdal.GA_ReadOnly)
+            src_ds = gdal.Open(wrk_filename, gdal.OF_RASTER)
 
         xsize = src_ds.RasterXSize
         ysize = src_ds.RasterYSize
@@ -695,7 +695,7 @@ class GDALTest:
         src_ds = None
         new_ds = None
 
-        new_ds = gdal.Open(new_filename)
+        new_ds = gdal.Open(new_filename, gdal.OF_RASTER)
         assert new_ds is not None, "Failed to open dataset: " + new_filename
 
         eps = 0.00000001
@@ -727,7 +727,7 @@ class GDALTest:
                 wrk_filename, gdal.OF_RASTER, open_options=self.open_options
             )
         else:
-            src_ds = gdal.Open(wrk_filename, gdal.GA_ReadOnly)
+            src_ds = gdal.Open(wrk_filename, gdal.OF_RASTER)
 
         xsize = src_ds.RasterXSize
         ysize = src_ds.RasterYSize
@@ -761,7 +761,7 @@ class GDALTest:
         src_ds = None
         new_ds = None
 
-        new_ds = gdal.Open(new_filename)
+        new_ds = gdal.Open(new_filename, gdal.OF_RASTER)
         assert new_ds is not None, "Failed to open dataset: " + new_filename
 
         expected_osr = osr.SpatialReference()
@@ -793,7 +793,7 @@ class GDALTest:
                 wrk_filename, gdal.OF_RASTER, open_options=self.open_options
             )
         else:
-            src_ds = gdal.Open(wrk_filename, gdal.GA_ReadOnly)
+            src_ds = gdal.Open(wrk_filename, gdal.OF_RASTER)
 
         xsize = src_ds.RasterXSize
         ysize = src_ds.RasterYSize
@@ -844,7 +844,7 @@ class GDALTest:
                 wrk_filename, gdal.OF_RASTER, open_options=self.open_options
             )
         else:
-            src_ds = gdal.Open(wrk_filename, gdal.GA_ReadOnly)
+            src_ds = gdal.Open(wrk_filename, gdal.OF_RASTER)
 
         xsize = src_ds.RasterXSize
         ysize = src_ds.RasterYSize
@@ -877,9 +877,9 @@ class GDALTest:
         new_ds = None
 
         if delete:
-            mode = gdal.GA_Update
+            mode = gdal.OF_RASTER | gdal.OF_UPDATE
         else:
-            mode = gdal.GA_ReadOnly
+            mode = gdal.OF_RASTER
         new_ds = gdal.Open(new_filename, mode)
         assert new_ds is not None, "Failed to open dataset: " + new_filename
 
@@ -895,7 +895,7 @@ class GDALTest:
         new_ds = None
 
         if delete:
-            new_ds = gdal.Open(new_filename)
+            new_ds = gdal.Open(new_filename, gdal.OF_RASTER)
             assert (
                 new_ds.GetRasterBand(1).GetNoDataValue() is None
             ), "Got nodata value whereas none was expected"
@@ -916,7 +916,7 @@ class GDALTest:
                 wrk_filename, gdal.OF_RASTER, open_options=self.open_options
             )
         else:
-            src_ds = gdal.Open(wrk_filename, gdal.GA_ReadOnly)
+            src_ds = gdal.Open(wrk_filename, gdal.OF_RASTER)
 
         xsize = src_ds.RasterXSize
         ysize = src_ds.RasterYSize
@@ -940,7 +940,7 @@ class GDALTest:
         src_ds = None
         new_ds = None
 
-        new_ds = gdal.Open(new_filename)
+        new_ds = gdal.Open(new_filename, gdal.OF_RASTER)
         assert new_ds is not None, "Failed to open dataset: " + new_filename
 
         assert (
@@ -961,7 +961,7 @@ class GDALTest:
                 wrk_filename, gdal.OF_RASTER, open_options=self.open_options
             )
         else:
-            src_ds = gdal.Open(wrk_filename, gdal.GA_ReadOnly)
+            src_ds = gdal.Open(wrk_filename, gdal.OF_RASTER)
 
         xsize = src_ds.RasterXSize
         ysize = src_ds.RasterYSize
@@ -987,7 +987,7 @@ class GDALTest:
         src_ds = None
         new_ds = None
 
-        new_ds = gdal.Open(new_filename)
+        new_ds = gdal.Open(new_filename, gdal.OF_RASTER)
         assert new_ds is not None, "Failed to open dataset: " + new_filename
 
         new_unit = new_ds.GetRasterBand(1).GetUnitType()

--- a/ogr/ogr_srs_cf1.cpp
+++ b/ogr/ogr_srs_cf1.cpp
@@ -754,7 +754,8 @@ OGRErr OGRSpatialReference::importFromCF1(CSLConstList papszKeyValues,
     else if (pszUnits != nullptr && !EQUAL(pszUnits, "") && !bRotatedPole)
     {
         if (EQUAL(pszUnits, "m") || EQUAL(pszUnits, "metre") ||
-            EQUAL(pszUnits, "meter"))
+            EQUAL(pszUnits, "meter") || EQUAL(pszUnits, "meters") ||
+            EQUAL(pszUnits, "metres"))
         {
             SetLinearUnits("metre", 1.0);
             SetAuthority("PROJCS|UNIT", "EPSG", 9001);


### PR DESCRIPTION
Also replace most non-specific `gdal.quiet_errors()` constructs.

References #14632 