### PR TITLE
gdal vector reproject: add --like, --like-layer

### DIFF
--- a/apps/gdalalg_vector_reproject.cpp
+++ b/apps/gdalalg_vector_reproject.cpp
@@ -38,9 +38,16 @@ GDALVectorReprojectAlgorithm::GDALVectorReprojectAlgorithm(bool standaloneStep)
         .AddHiddenAlias("s_srs");
     AddArg(GDAL_ARG_NAME_OUTPUT_CRS, 'd', _("Output CRS"), &m_dstCrs)
         .SetIsCRSArg()
-        .SetRequired()
         .AddHiddenAlias("dst-crs")
-        .AddHiddenAlias("t_srs");
+        .AddHiddenAlias("t_srs")
+        .SetMutualExclusionGroup("output-crs");
+    AddArg("like", 0, _("Dataset from which an output CRS should be extracted"),
+           &m_likeDataset, GDAL_OF_RASTER | GDAL_OF_VECTOR)
+        .SetMetaVar("DATASET")
+        .SetMutualExclusionGroup("output-crs");
+    AddArg("like-layer", 0, ("Name of the layer of the 'like' dataset"),
+           &m_likeLayer)
+        .SetMetaVar("LAYER-NAME");
 }
 
 /************************************************************************/
@@ -64,8 +71,58 @@ bool GDALVectorReprojectAlgorithm::RunStep(GDALPipelineStepRunContext &)
     }
 
     OGRSpatialReference oDstCRS;
-    oDstCRS.SetFromUserInput(m_dstCrs.c_str());
-    oDstCRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+    if (!m_dstCrs.empty())
+    {
+        oDstCRS.SetFromUserInput(m_dstCrs.c_str());
+        oDstCRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+    }
+    else if (auto *poLikeDS = m_likeDataset.GetDatasetRef())
+    {
+        if (!m_likeLayer.empty())
+        {
+            const auto *poLikeLayer =
+                poLikeDS->GetLayerByName(m_likeLayer.c_str());
+            if (!poLikeLayer)
+            {
+                ReportError(CE_Failure, CPLE_AppDefined,
+                            "Specified layer '%s' not found.",
+                            m_likeLayer.c_str());
+                return false;
+            }
+            if (!poLikeLayer->GetSpatialRef())
+            {
+                ReportError(
+                    CE_Failure, CPLE_AppDefined,
+                    "Specified layer '%s' has no spatial reference system.",
+                    m_likeLayer.c_str());
+                return false;
+            }
+
+            oDstCRS = *poLikeLayer->GetSpatialRef();
+        }
+        else
+        {
+            const auto *poLikeCRS = poLikeDS->GetSpatialRef();
+
+            if (!poLikeCRS)
+            {
+                ReportError(
+                    CE_Failure, CPLE_AppDefined,
+                    "Dataset specified by --like has no spatial reference "
+                    "system, or has multiple layers with different spatial "
+                    "reference systems. An individual layer can be specified "
+                    "with --like-layer.");
+                return false;
+            }
+            oDstCRS = *poLikeCRS;
+        }
+    }
+    else
+    {
+        ReportError(CE_Failure, CPLE_AppDefined,
+                    "Must specify --output-crs or --like");
+        return false;
+    }
 
     auto reprojectedDataset =
         std::make_unique<GDALVectorPipelineOutputDataset>(*poSrcDS);

--- a/apps/gdalalg_vector_reproject.h
+++ b/apps/gdalalg_vector_reproject.h
@@ -38,6 +38,8 @@ class GDALVectorReprojectAlgorithm /* non final */
     std::string m_activeLayer{};
     std::string m_srcCrs{};
     std::string m_dstCrs{};
+    GDALArgDatasetValue m_likeDataset{};
+    std::string m_likeLayer{};
 };
 
 /************************************************************************/

--- a/autotest/utilities/test_gdalalg_vector_pipeline.py
+++ b/autotest/utilities/test_gdalalg_vector_pipeline.py
@@ -713,7 +713,7 @@ def test_gdalalg_vector_pipeline_reproject_no_arg(tmp_vsimem):
     pipeline = get_pipeline_alg()
     with pytest.raises(
         Exception,
-        match="reproject: Required argument 'output-crs' has not been specified",
+        match="reproject: Must specify --output-crs or --like",
     ):
         pipeline.ParseRunAndFinalize(
             [

--- a/autotest/utilities/test_gdalalg_vector_reproject.py
+++ b/autotest/utilities/test_gdalalg_vector_reproject.py
@@ -113,6 +113,89 @@ def test_gdalalg_vector_reproject_complete_dst_crs():
     assert "2193 --" not in out  # NZGD2000
 
 
+@pytest.mark.parametrize(
+    "like_layer,num_like_layers",
+    (
+        (None, 0),
+        (None, 1),
+        ("test", 2),
+        ("test2", 2),
+    ),
+)
+def test_gdalalg_vector_reproject_like_multiple_layers(like_layer, num_like_layers):
+
+    src_ds = gdal.GetDriverByName("MEM").CreateVector("")
+    src_lyr = src_ds.CreateLayer(
+        "points", srs=osr.SpatialReference(epsg=4326), geom_type=ogr.wkbPoint
+    )
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (-72.5802 44.2626)"))
+    src_lyr.CreateFeature(f)
+
+    like_ds = gdal.GetDriverByName("MEM").Create("", 10, 10, 1)
+    like_ds.SetSpatialRef(osr.SpatialReference(epsg=6589))
+    if num_like_layers > 0:
+        like_ds.CreateLayer("test", srs=osr.SpatialReference(epsg=32145))
+    if num_like_layers > 1:
+        like_ds.CreateLayer("test2", srs=osr.SpatialReference(epsg=5646))
+
+    alg = get_reproject_alg()
+    alg["input"] = src_ds
+    alg["like"] = like_ds
+    if like_layer:
+        alg["like-layer"] = like_layer
+    alg["output-format"] = "stream"
+
+    if like_layer is None and num_like_layers > 1:
+        with pytest.raises(Exception, match="multiple layers with different spatial"):
+            alg.Run()
+        return
+
+    assert alg.Run()
+
+    dst_ds = alg.Output()
+
+    if num_like_layers == 0:
+        like_srs = like_ds.GetSpatialRef()
+    else:
+        like_srs = like_ds.GetLayer(like_layer or 0).GetSpatialRef()
+
+    assert dst_ds.GetLayer(0).GetSpatialRef().IsSame(like_srs)
+
+
+def test_gdalalg_vector_reproject_like_invalid_dataset():
+
+    alg = get_reproject_alg()
+    alg["input"] = "../ogr/data/poly.shp"
+    alg["like"] = "/vsimem/does_not_exist"
+    alg["output-format"] = "stream"
+
+    with pytest.raises(Exception, match="No such file or directory"):
+        alg.Run()
+
+
+def test_gdalalg_vector_reproject_like_layer():
+
+    alg = get_reproject_alg()
+    alg["input"] = "../ogr/data/poly.shp"
+    alg["like"] = "../ogr/data/poly.shp"
+    alg["like-layer"] = "does_not_exist"
+    alg["output-format"] = "stream"
+
+    with pytest.raises(Exception, match="Specified layer .* not found"):
+        alg.Run()
+
+
+def test_gdalalg_vector_reproject_unspecified_dst_crs():
+
+    alg = get_reproject_alg()
+    alg["input"] = "../ogr/data/poly.shp"
+    alg["output-format"] = "stream"
+
+    with pytest.raises(Exception, match="Must specify --output-crs or --like"):
+        alg.Run()
+
+
 ###############################################################################
 # Test from a polar projected CRS to geographic
 

--- a/doc/source/programs/gdal_raster_zonal_stats.rst
+++ b/doc/source/programs/gdal_raster_zonal_stats.rst
@@ -269,3 +269,47 @@ Examples
             --output-crs EPSG:4326 ! \
           write out.gpkg
 
+.. example::
+   :title: Reproject zones to match raster
+
+   This example identifies the most command land use in each town in Chittenden County, Vermont.
+   Land cover is taken from an extract of the U.S. national land cover dataset for Vermont, and
+   town boundaries are taken from a TIGER shapefile. Both of these datasets can be accessed
+   remotely using GDAL virtual file systems.
+
+   Because the town boundaries are in a different spatial reference system from the land cover,
+   they must first be reprojected to match.
+
+   .. code-block:: console
+
+       $ gdal pipeline --config AWS_NO_SIGN_REQUEST=YES ! \
+             read /vsizip/vsicurl/https://www2.census.gov/geo/tiger/TIGER2025/COUSUB/tl_2025_50_cousub.zip ! \
+             filter --where "COUNTYFP='007'" ! \
+             reproject --like /vsis3/vtopendata-prd/Landcover/Annual_NLCD_LndCov_2024_Vermont.tif ! \
+             zonal-stats --input /vsis3/vtopendata-prd/Landcover/Annual_NLCD_LndCov_2024_Vermont.tif --zones _PIPE_ --include-field NAME  --stat mode ! \
+             write --output /vsistdout/ --output-format CSV
+
+       NAME,mode
+       Richmond,41
+       Underhill,41
+       Westford,41
+       Winooski,23
+       Buels,41
+       Essex,43
+       Colchester,11
+       St. George,43
+       Hinesburg,41
+       Huntington,41
+       Jericho,41
+       Bolton,41
+       Charlotte,81
+       Essex Junction,22
+       Milton,41
+       Burlington,11
+       Shelburne,11
+       South Burlington,11
+       Williston,81
+
+
+.. spelling:word-list::
+        Chittenden

--- a/doc/source/programs/gdal_vector_reproject.rst
+++ b/doc/source/programs/gdal_vector_reproject.rst
@@ -43,6 +43,20 @@ Program-Specific Options
 
     .. include:: gdal_options/srs_def_gdal_raster_reproject.rst
 
+.. option:: --like <DATASET>
+
+    .. versionadded:: 3.14
+
+    Set the output spatial reference to be the same as the provided raster or vector
+    dataset. If the dataset has layers with different spatial reference systems, a layer
+    can be specified using :option:`--like-layer`.
+
+.. option:: --like-layer <LAYER-NAME>
+
+    .. versionadded:: 3.14
+
+    Specify the name of the layer from which a spatial reference system should be read.
+
 .. option:: --output-crs, -d <OUTPUT-CRS>
 
     Set output spatial reference.


### PR DESCRIPTION
Includes motivating example from `gdal raster zonal-stats`.