### PR TITLE
Update -a_srs option description in ogr2ogr.rst

### DIFF
--- a/doc/source/programs/ogr2ogr.rst
+++ b/doc/source/programs/ogr2ogr.rst
@@ -210,7 +210,7 @@ output coordinate system or even reprojecting the features during translation.
 .. option:: -a_srs <srs_def>
 
     Assign an output SRS, but without reprojecting (use :option:`-t_srs`
-    to reproject)
+    to reproject). Use ``-a_srs None`` to make the SRS unknown.
 
     .. include:: options/srs_def.rst
 


### PR DESCRIPTION
Clarify usage of -a_srs option to indicate how to make the SRS unknown.

Else the user has no way to strip out all SRS's.

Tested with ogrinfo -al and it works.

e.g., x=8888 y=9999 on my checkered tile floor board, has no known SRS.

I hope I got the quoting right.

And my choice of words could be better perhaps.

E.g, "to strip all SRS, use..."