### PR TITLE
autotest: gate test_zarr_read_simple_sharding on netCDF driver

### DIFF
--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -6379,6 +6379,7 @@ def test_zarr_read_kerchunk_parquet_GetRawBlockInfo():
 # inner chunks, and whose inner chunk index is protected by CRC32C.
 
 
+@pytest.mark.require_driver("netCDF")
 @gdaltest.enable_exceptions()
 def test_zarr_read_simple_sharding(tmp_path):
 


### PR DESCRIPTION
## What does this PR do?

Disables this test on minimal builds. `open_with_cache_tile_presence_option()` depends on netCDF.

## What are related issues/pull requests?

https://github.com/NixOS/nixpkgs/issues/540609

## AI tool usage

 - [x] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

Claude Opus 4.8 used to debug the issue.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
