### PR TITLE
Envisat: fix heap overflow in ScanForGCPs_ASAR from unchecked NUM_DSR

### DIFF
--- a/autotest/gdrivers/envisat.py
+++ b/autotest/gdrivers/envisat.py
@@ -324,3 +324,83 @@ class TestEnvisatMERIS(EnvisatTestBase):
                 if float(ri) != pytest.approx(float(v[i]), abs=1e-10):
                     print(r)
                     pytest.fail("Wrong GCP coordinates.")
+
+
+def _build_minimal_asar(num_dsr, geo_ds_size, num_geo_records):
+    # Build a minimal ASAR product whose "GEOLOCATION GRID ADS" advertises
+    # NUM_DSR=num_dsr, exercising EnvisatDataset::ScanForGCPs_ASAR().
+    MPH_SIZE = 1247
+    DSD_SIZE = 280
+    REC = 521
+
+    def dsd(lines):
+        b = ("".join(line + "\n" for line in lines)).encode("ascii")
+        return b + b"\n" * (DSD_SIZE - len(b))
+
+    sph_kw = (
+        b"DATA_TYPE=UWORD\n"
+        b"SAMPLE_TYPE=DETECTED\n"
+        b"LINE_LENGTH=+00000000005<samples>\n"
+    )
+    sph_size = len(sph_kw) + 2 * DSD_SIZE
+    data_offset = MPH_SIZE + sph_size
+
+    dsd_mds = dsd(
+        [
+            'DS_NAME="MDS1                        "',
+            "DS_TYPE=M",
+            'FILENAME="%s"' % (" " * 62),
+            "DS_OFFSET=+%021d<bytes>" % data_offset,
+            "DS_SIZE=+000000000000000000010<bytes>",
+            "NUM_DSR=+0000000001",
+            "DSR_SIZE=+000000000010<bytes>",
+        ]
+    )
+    dsd_geo = dsd(
+        [
+            'DS_NAME="GEOLOCATION GRID ADS        "',
+            "DS_TYPE=A",
+            'FILENAME="NOT USED%s"' % (" " * 54),
+            "DS_OFFSET=+%021d<bytes>" % data_offset,
+            "DS_SIZE=+%021d<bytes>" % geo_ds_size,
+            "NUM_DSR=+%010d" % num_dsr,
+            "DSR_SIZE=+000000000521<bytes>",
+        ]
+    )
+    sph = sph_kw + dsd_mds + dsd_geo
+
+    mph = (
+        b'PRODUCT="ASA_APG_1PXPDE00000000_000000_000000000000_00000_00000_0000.N1"\n'
+        b"PROC_STAGE=N\n"
+        b"SPH_SIZE=+%010d<bytes>\n" % sph_size + b"NUM_DSD=+0000000002\n"
+        b"DSD_SIZE=+0000000280<bytes>\n"
+    )
+    mph = mph + b"\n" * (MPH_SIZE - len(mph))
+
+    data = (bytes(range(256)) * 8)[: num_geo_records * REC]
+    return mph + sph + data
+
+
+def test_envisat_asar_scanforgcps_num_dsr_overflow(tmp_vsimem):
+    # A crafted GEOLOCATION GRID ADS with a huge NUM_DSR used to overflow the
+    # (nNumDSR + 1) * 11 GCP array size computation in ScanForGCPs_ASAR() and
+    # write past the under-allocated array. It must now be rejected instead.
+    fname = tmp_vsimem / "asar_num_dsr_overflow.n1"
+    # (390451572 + 1) * 11 == 4294967303, i.e. 7 modulo 2**32.
+    gdal.FileFromMemBuffer(
+        fname, _build_minimal_asar(390451572, geo_ds_size=521, num_geo_records=1)
+    )
+    ds = gdal.Open(fname)
+    assert ds is not None
+    assert ds.GetGCPCount() == 0
+
+
+def test_envisat_asar_scanforgcps_valid(tmp_vsimem):
+    # A well-formed geolocation grid still yields GCPs (11 per record + 11).
+    fname = tmp_vsimem / "asar_geolocation.n1"
+    gdal.FileFromMemBuffer(
+        fname, _build_minimal_asar(2, geo_ds_size=2 * 521, num_geo_records=2)
+    )
+    ds = gdal.Open(fname)
+    assert ds is not None
+    assert ds.GetGCPCount() == 33

--- a/frmts/envisat/envisatdataset.cpp
+++ b/frmts/envisat/envisatdataset.cpp
@@ -292,13 +292,21 @@ void EnvisatDataset::ScanForGCPs_ASAR()
     if (nDatasetIndex == -1)
         return;
 
-    int nNumDSR, nDSRSize;
+    int nNumDSR, nDSRSize, nDSSize;
     if (EnvisatFile_GetDatasetInfo(hEnvisatFile, nDatasetIndex, nullptr,
-                                   nullptr, nullptr, nullptr, nullptr, &nNumDSR,
-                                   &nDSRSize) != SUCCESS)
+                                   nullptr, nullptr, nullptr, &nDSSize,
+                                   &nNumDSR, &nDSRSize) != SUCCESS)
         return;
 
     if (nNumDSR == 0 || nDSRSize != 521)
+        return;
+
+    // nNumDSR is taken verbatim from the dataset descriptor. Reject a record
+    // count that cannot fit the declared dataset size before using it to size
+    // the GCP array: (nNumDSR + 1) * 11 is otherwise evaluated as int and
+    // overflows for a large nNumDSR, under-allocating the array while the loop
+    // below still writes 11 GCPs per record (heap buffer overflow).
+    if (nNumDSR < 0 || nNumDSR > nDSSize / nDSRSize)
         return;
 
     /* -------------------------------------------------------------------- */
@@ -310,7 +318,8 @@ void EnvisatDataset::ScanForGCPs_ASAR()
     GUInt32 unValue;
 
     nGCPCount = 0;
-    pasGCPList = (GDAL_GCP *)CPLCalloc(sizeof(GDAL_GCP), (nNumDSR + 1) * 11);
+    pasGCPList = (GDAL_GCP *)CPLCalloc(sizeof(GDAL_GCP),
+                                       (static_cast<size_t>(nNumDSR) + 1) * 11);
 
     for (int iRecord = 0; iRecord < nNumDSR; iRecord++)
     {


### PR DESCRIPTION
## What does this PR do?

`EnvisatDataset::ScanForGCPs_ASAR()` sizes the GCP array from the `NUM_DSR` field of the GEOLOCATION GRID ADS descriptor:

```c
pasGCPList = (GDAL_GCP *)CPLCalloc(sizeof(GDAL_GCP), (nNumDSR + 1) * 11);
```

`nNumDSR` is taken verbatim from the dataset descriptor and `(nNumDSR + 1) * 11` is evaluated as `int`. A large declared count overflows: `(390451572 + 1) * 11` wraps to 7, so the array is under-allocated while the per-record loop keeps writing 11 GCPs per record through `GDALInitGCPs()` past the end of the buffer.

It triggers on a small crafted `.N1` with a single 521-byte geolocation record and `NUM_DSR=390451572`. With `-ftrapv` (GDAL Debug builds) the multiply traps; without it AddressSanitizer reports:

```
ERROR: AddressSanitizer: heap-buffer-overflow ... WRITE of size 56
    #1 GDALInitGCPs gdal_misc.cpp:1884
    #2 EnvisatDataset::ScanForGCPs_ASAR() envisatdataset.cpp:335
    #3 EnvisatDataset::Open(GDALOpenInfo*) envisatdataset.cpp:1140
0x... is located 0 bytes after 392-byte region
allocated by ... EnvisatDataset::ScanForGCPs_ASAR() envisatdataset.cpp:313
```

The fix stays in the callee: reject a `NUM_DSR` that cannot fit the declared dataset size, and compute the array size in `size_t`, the same way `ScanForGCPs_MERIS()` already does. Valid products read identically; the added test builds a well-formed geolocation grid that still yields 33 GCPs.

## What are related issues/pull requests?

None. Found by review of the GCP collection paths.

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

* OS: any
* Compiler: any
