### PR TITLE
PCIDSK: fix heap overflow on tiled channel pixel type mismatch

### DIFF
--- a/autotest/gdrivers/pcidsk.py
+++ b/autotest/gdrivers/pcidsk.py
@@ -771,3 +771,33 @@ def test_pcidsk_web_mercator(tmp_path):
     expected_srs = osr.SpatialReference()
     expected_srs.ImportFromEPSG(3857)
     assert ds.GetSpatialRef().IsSame(expected_srs)
+
+
+###############################################################################
+# Test that a tiled channel whose image header pixel type disagrees with the
+# tile layer data type is rejected instead of overflowing the block buffer.
+
+
+def test_pcidsk_tiled_type_mismatch(tmp_path):
+
+    filename = str(tmp_path / "mismatch.pix")
+    gdal.Translate(
+        filename,
+        "data/byte.tif",
+        options="-of PCIDSK -ot Float32 -co INTERLEAVING=TILED -co TILESIZE=16",
+    )
+
+    # The pixel type is stored in the image band header as an 8-byte field at
+    # offset 160, and independently as the tile layer data type. Change only the
+    # image header type from 32R (Float32, 4 bytes) to 8U (Byte, 1 byte); the
+    # block buffer is then sized for 1 byte per pixel while the tile still holds
+    # 4 bytes per pixel.
+    data = bytearray(open(filename, "rb").read())
+    assert data.count(b"32R     ") == 1
+    pos = data.index(b"32R     ")
+    data[pos : pos + 8] = b"8U      "
+    open(filename, "wb").write(data)
+
+    with gdal.quiet_errors():
+        ds = gdal.Open(filename)
+    assert ds is None

--- a/autotest/gdrivers/pcidsk.py
+++ b/autotest/gdrivers/pcidsk.py
@@ -778,6 +778,7 @@ def test_pcidsk_web_mercator(tmp_path):
 # tile layer data type is rejected instead of overflowing the block buffer.
 
 
+@gdaltest.enable_exceptions()
 def test_pcidsk_tiled_type_mismatch(tmp_path):
 
     filename = str(tmp_path / "mismatch.pix")
@@ -798,6 +799,8 @@ def test_pcidsk_tiled_type_mismatch(tmp_path):
     data[pos : pos + 8] = b"8U      "
     open(filename, "wb").write(data)
 
-    with gdal.quiet_errors():
-        ds = gdal.Open(filename)
-    assert ds is None
+    with pytest.raises(
+        Exception,
+        match=r"Tiled channel .* data type .* does not match image header pixel type",
+    ):
+        gdal.Open(filename)

--- a/frmts/pcidsk/sdk/channel/ctiledchannel.cpp
+++ b/frmts/pcidsk/sdk/channel/ctiledchannel.cpp
@@ -91,8 +91,20 @@ void CTiledChannel::EstablishAccess() const
 
     const char * pszDataType = mpoTileLayer->GetDataType();
 
-    if (GetDataTypeFromName(pszDataType) == CHN_UNKNOWN)
+    eChanType nLayerType = GetDataTypeFromName(pszDataType);
+
+    if (nLayerType == CHN_UNKNOWN)
         return ThrowPCIDSKException("Unknown channel type: %s", pszDataType);
+
+    // The read buffer is sized by the caller from the image band header pixel
+    // type, while the amount copied per tile comes from the tile layer data
+    // type. If they disagree a wider tile can be written into a buffer sized
+    // for a narrower type, so reject the mismatch here.
+    if (pixel_type != CHN_UNKNOWN && pixel_type != nLayerType)
+        return ThrowPCIDSKException(
+            "Tiled channel %d data type (%s) does not match image header "
+            "pixel type (%s).",
+            image, pszDataType, DataTypeName(pixel_type));
 }
 
 /************************************************************************/


### PR DESCRIPTION
## What does this PR do?

A tiled PCIDSK channel stores its pixel type in two independent places. `CTiledChannel` sizes the GDAL block buffer from the channel pixel type in the image band header (offset 160), but copies `GetTileSize()` bytes per tile, and `GetTileSize()` is computed from the tile layer data type held separately in the tile directory. Nothing checks that the two agree. A file whose image header declares `8U` (1 byte) while the tile layer declares `32R` (4 bytes) makes `CTiledChannel::ReadTile`/`ReadBlock` write a full 4-byte-per-pixel tile into a buffer allocated for 1 byte per pixel. On a 16x16 tile that is a 1024 byte write into a 256 byte block, and ASan reports a heap-buffer-overflow write reached from a plain `gdalinfo`. `EstablishAccess()` is the single point both the compressed and uncompressed read paths pass through, so the tile layer type is now checked against the image header pixel type there and a mismatch is rejected before any tile is read. Valid files are unaffected because the writer always stores the same type in both locations.

Repro:

```
gdal_translate -of PCIDSK -ot Float32 -co INTERLEAVING=TILED -co TILESIZE=16 in.tif t.pix
# patch the 8-byte pixel-type field at image-header offset 160 from "32R     " to "8U      "
gdalinfo -checksum t.pix
```

Before: `AddressSanitizer: heap-buffer-overflow WRITE of size 1024` in `BlockTileLayer::ReadTile` via `CTiledChannel::ReadBlock`.
After: `ERROR 1: Tiled channel 0 data type (32R) does not match image header pixel type (8U).` and no overflow.

## What are related issues/pull requests?

None. Found while auditing the PCIDSK tiled channel read path. Covered by a new regression test that crafts the mismatch from `data/byte.tif`.

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
