### PR TITLE
Update virtual_file_systems.rst with layer name info

### DIFF
--- a/doc/source/user/virtual_file_systems.rst
+++ b/doc/source/user/virtual_file_systems.rst
@@ -1320,6 +1320,13 @@ read a file within a potentially big ZIP file streamed to gdal_translate:
 
     cat file.tif.zip | gdal_translate /vsizip/{/vsistdin?buffer_limit=-1}/path/to/some.tif out.tif
 
+We observe the layer name in effect is when using /vsistdin/ is just "layer",
+
+::
+
+    $ echo | ogrinfo -if CSV /vsistdin/ -al -q
+    Layer name: layer
+
 
 .. _vsistdout:
 


### PR DESCRIPTION
Finally document the layer name behavior when using /vsistdin/ .
