### PR TITLE
Zarr classic dataset: make SetNoDataValue(), SetScale(), SetOffset() work on multi-band datasets

### DIFF
--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -9339,3 +9339,182 @@ def test_zarr_default_format_is_zarr_v3(tmp_vsimem):
 
     with gdal.VSIFile(tmp_vsimem / "test.zarr" / "zarr.json", "rb") as f:
         assert json.loads(f.read())["zarr_format"] == 3
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_setnodatavalue_multiband_ok(tmp_vsimem):
+
+    ds = gdal.GetDriverByName("Zarr").Create(
+        tmp_vsimem / "test.zarr", 1, 1, 2, gdal.GDT_Byte
+    )
+    assert ds.GetRasterBand(1).GetNoDataValue() is None
+    ds.GetRasterBand(1).SetNoDataValue(255)
+    assert ds.GetRasterBand(1).GetNoDataValue() == 255
+    ds.GetRasterBand(2).SetNoDataValue(255)
+    ds.Close()
+
+    ds = gdal.Open(tmp_vsimem / "test.zarr")
+    assert ds.GetRasterBand(1).GetNoDataValue() == 255
+    assert ds.GetRasterBand(2).GetNoDataValue() == 255
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_setnodatavalue_multiband_ok_nan(tmp_vsimem):
+
+    ds = gdal.GetDriverByName("Zarr").Create(
+        tmp_vsimem / "test.zarr", 1, 1, 2, gdal.GDT_Float32
+    )
+    ds.GetRasterBand(1).SetNoDataValue(float("nan"))
+    ds.GetRasterBand(2).SetNoDataValue(float("nan"))
+    ds.Close()
+
+    ds = gdal.Open(tmp_vsimem / "test.zarr")
+    assert math.isnan(ds.GetRasterBand(1).GetNoDataValue())
+    assert math.isnan(ds.GetRasterBand(2).GetNoDataValue())
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_setnodatavalue_multiband_only_one_set(tmp_vsimem):
+
+    ds = gdal.GetDriverByName("Zarr").Create(
+        tmp_vsimem / "test.zarr", 1, 1, 2, gdal.GDT_Byte
+    )
+    ds.GetRasterBand(1).SetNoDataValue(255)
+    with pytest.raises(Exception, match="Not all bands have the same nodata value"):
+        ds.Close()
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_setnodatavalue_multiband_different_non_nan(tmp_vsimem):
+
+    ds = gdal.GetDriverByName("Zarr").Create(
+        tmp_vsimem / "test.zarr", 1, 1, 2, gdal.GDT_Byte
+    )
+    ds.GetRasterBand(1).SetNoDataValue(255)
+    ds.GetRasterBand(2).SetNoDataValue(0)
+    with pytest.raises(Exception, match="Not all bands have the same nodata value"):
+        ds.Close()
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_setnodatavalue_multiband_different_nan(tmp_vsimem):
+
+    ds = gdal.GetDriverByName("Zarr").Create(
+        tmp_vsimem / "test.zarr", 1, 1, 2, gdal.GDT_Float32
+    )
+    ds.GetRasterBand(1).SetNoDataValue(float("nan"))
+    ds.GetRasterBand(2).SetNoDataValue(255)
+    with pytest.raises(Exception, match="Not all bands have the same nodata value"):
+        ds.Close()
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_setnodatavalue_int64_multiband_ok(tmp_vsimem):
+
+    ds = gdal.GetDriverByName("Zarr").Create(
+        tmp_vsimem / "test.zarr", 1, 1, 2, gdal.GDT_Int64
+    )
+    ds.GetRasterBand(1).SetNoDataValueAsInt64((1 << 63) - 1)
+    assert ds.GetRasterBand(1).GetNoDataValueAsInt64() == (1 << 63) - 1
+    ds.GetRasterBand(2).SetNoDataValueAsInt64((1 << 63) - 1)
+    ds.Close()
+
+    ds = gdal.Open(tmp_vsimem / "test.zarr")
+    assert ds.GetRasterBand(1).GetNoDataValueAsInt64() == (1 << 63) - 1
+    assert ds.GetRasterBand(2).GetNoDataValueAsInt64() == (1 << 63) - 1
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_setnodatavalue_int64_multiband_only_one_set(tmp_vsimem):
+
+    ds = gdal.GetDriverByName("Zarr").Create(
+        tmp_vsimem / "test.zarr", 1, 1, 2, gdal.GDT_Int64
+    )
+    ds.GetRasterBand(1).SetNoDataValueAsInt64(255)
+    with pytest.raises(Exception, match="Not all bands have the same nodata value"):
+        ds.Close()
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_setnodatavalue_int64_multiband_different(tmp_vsimem):
+
+    ds = gdal.GetDriverByName("Zarr").Create(
+        tmp_vsimem / "test.zarr", 1, 1, 2, gdal.GDT_Int64
+    )
+    ds.GetRasterBand(1).SetNoDataValueAsInt64(255)
+    ds.GetRasterBand(1).SetNoDataValueAsInt64(0)
+    with pytest.raises(Exception, match="Not all bands have the same nodata value"):
+        ds.Close()
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_setnodatavalue_uint64_multiband_ok(tmp_path):
+
+    ds = gdal.GetDriverByName("Zarr").Create(
+        tmp_path / "test.zarr", 1, 1, 2, gdal.GDT_UInt64
+    )
+    nv = (1 << 63) - 1
+    ds.GetRasterBand(1).SetNoDataValueAsUInt64(nv)
+    assert ds.GetRasterBand(1).GetNoDataValueAsUInt64() == nv
+    ds.GetRasterBand(2).SetNoDataValueAsUInt64(nv)
+    ds.Close()
+
+    ds = gdal.Open(tmp_path / "test.zarr")
+    assert ds.GetRasterBand(1).GetNoDataValueAsUInt64() == nv
+    assert ds.GetRasterBand(2).GetNoDataValueAsUInt64() == nv
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_setnodatavalue_uint64_multiband_only_one_set(tmp_vsimem):
+
+    ds = gdal.GetDriverByName("Zarr").Create(
+        tmp_vsimem / "test.zarr", 1, 1, 2, gdal.GDT_UInt64
+    )
+    ds.GetRasterBand(1).SetNoDataValueAsUInt64(255)
+    with pytest.raises(Exception, match="Not all bands have the same nodata value"):
+        ds.Close()
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_setnodatavalue_uint64_multiband_different(tmp_vsimem):
+
+    ds = gdal.GetDriverByName("Zarr").Create(
+        tmp_vsimem / "test.zarr", 1, 1, 2, gdal.GDT_UInt64
+    )
+    ds.GetRasterBand(1).SetNoDataValueAsUInt64(255)
+    ds.GetRasterBand(1).SetNoDataValueAsUInt64(0)
+    with pytest.raises(Exception, match="Not all bands have the same nodata value"):
+        ds.Close()

--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -9614,3 +9614,29 @@ def test_zarr_setoffset_multiband_different(tmp_vsimem):
     ds.GetRasterBand(1).SetOffset(1)
     with pytest.raises(Exception, match="Not all bands have the same offset value"):
         ds.Close()
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_setspatialref_multiband(tmp_vsimem):
+
+    ds = gdal.GetDriverByName("Zarr").Create(
+        tmp_vsimem / "test.zarr", 1, 1, 2, gdal.GDT_Byte
+    )
+    ds.SetSpatialRef(osr.SpatialReference(epsg=4326))
+    assert ds.GetSpatialRef().GetAuthorityCode() == "4326"
+    ds.Close()
+
+    assert set(gdal.ReadDirRecursive(tmp_vsimem)) == set(
+        [
+            "test.zarr/",
+            "test.zarr/test/",
+            "test.zarr/test/zarr.json",
+            "test.zarr/zarr.json",
+        ]
+    )
+
+    ds = gdal.Open(tmp_vsimem / "test.zarr")
+    assert ds.GetSpatialRef().GetAuthorityCode() == "4326"

--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -9518,3 +9518,99 @@ def test_zarr_setnodatavalue_uint64_multiband_different(tmp_vsimem):
     ds.GetRasterBand(1).SetNoDataValueAsUInt64(0)
     with pytest.raises(Exception, match="Not all bands have the same nodata value"):
         ds.Close()
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_setscale_multiband_ok(tmp_path):
+
+    ds = gdal.GetDriverByName("Zarr").Create(
+        tmp_path / "test.zarr", 1, 1, 2, gdal.GDT_Byte
+    )
+    ds.GetRasterBand(1).SetScale(0.5)
+    assert ds.GetRasterBand(1).GetScale() == 0.5
+    ds.GetRasterBand(2).SetScale(0.5)
+    ds.Close()
+
+    ds = gdal.Open(tmp_path / "test.zarr")
+    assert ds.GetRasterBand(1).GetScale() == 0.5
+    assert ds.GetRasterBand(2).GetScale() == 0.5
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_setscale_multiband_only_one_set(tmp_vsimem):
+
+    ds = gdal.GetDriverByName("Zarr").Create(
+        tmp_vsimem / "test.zarr", 1, 1, 2, gdal.GDT_Byte
+    )
+    ds.GetRasterBand(1).SetScale(0.5)
+    with pytest.raises(Exception, match="Not all bands have the same scale value"):
+        ds.Close()
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_setscale_multiband_different(tmp_vsimem):
+
+    ds = gdal.GetDriverByName("Zarr").Create(
+        tmp_vsimem / "test.zarr", 1, 1, 2, gdal.GDT_Byte
+    )
+    ds.GetRasterBand(1).SetScale(0.5)
+    ds.GetRasterBand(1).SetScale(1)
+    with pytest.raises(Exception, match="Not all bands have the same scale value"):
+        ds.Close()
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_setoffset_multiband_ok(tmp_path):
+
+    ds = gdal.GetDriverByName("Zarr").Create(
+        tmp_path / "test.zarr", 1, 1, 2, gdal.GDT_Byte
+    )
+    ds.GetRasterBand(1).SetOffset(0.5)
+    assert ds.GetRasterBand(1).GetOffset() == 0.5
+    ds.GetRasterBand(2).SetOffset(0.5)
+    ds.Close()
+
+    ds = gdal.Open(tmp_path / "test.zarr")
+    assert ds.GetRasterBand(1).GetOffset() == 0.5
+    assert ds.GetRasterBand(2).GetOffset() == 0.5
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_setoffset_multiband_only_one_set(tmp_vsimem):
+
+    ds = gdal.GetDriverByName("Zarr").Create(
+        tmp_vsimem / "test.zarr", 1, 1, 2, gdal.GDT_Byte
+    )
+    ds.GetRasterBand(1).SetOffset(0.5)
+    with pytest.raises(Exception, match="Not all bands have the same offset value"):
+        ds.Close()
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_setoffset_multiband_different(tmp_vsimem):
+
+    ds = gdal.GetDriverByName("Zarr").Create(
+        tmp_vsimem / "test.zarr", 1, 1, 2, gdal.GDT_Byte
+    )
+    ds.GetRasterBand(1).SetOffset(0.5)
+    ds.GetRasterBand(1).SetOffset(1)
+    with pytest.raises(Exception, match="Not all bands have the same offset value"):
+        ds.Close()

--- a/frmts/zarr/zarr.h
+++ b/frmts/zarr/zarr.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <mutex>
 #include <numeric>
+#include <optional>
 #include <set>
 
 #define ZARR_DEBUG_KEY "ZARR"
@@ -132,6 +133,9 @@ class ZarrRasterBand final : public GDALRasterBand
 
     std::shared_ptr<GDALMDArray> m_poArray;
     GDALColorInterp m_eColorInterp = GCI_Undefined;
+    std::optional<double> m_dfNoData{};
+    std::optional<uint64_t> m_nNoDataUInt64{};
+    std::optional<int64_t> m_nNoDataInt64{};
 
   protected:
     CPLErr IReadBlock(int nBlockXOff, int nBlockYOff, void *pData) override;

--- a/frmts/zarr/zarr.h
+++ b/frmts/zarr/zarr.h
@@ -136,6 +136,8 @@ class ZarrRasterBand final : public GDALRasterBand
     std::optional<double> m_dfNoData{};
     std::optional<uint64_t> m_nNoDataUInt64{};
     std::optional<int64_t> m_nNoDataInt64{};
+    std::optional<double> m_dfOffset{};
+    std::optional<double> m_dfScale{};
 
   protected:
     CPLErr IReadBlock(int nBlockXOff, int nBlockYOff, void *pData) override;
@@ -1142,9 +1144,11 @@ class ZarrArray CPL_NON_FINAL : public GDALPamMDArray
     double GetScale(bool *pbHasScale,
                     GDALDataType *peStorageType) const override;
 
-    bool SetOffset(double dfOffset, GDALDataType eStorageType) override;
+    bool SetOffset(double dfOffset,
+                   GDALDataType eStorageType = GDT_Unknown) override;
 
-    bool SetScale(double dfScale, GDALDataType eStorageType) override;
+    bool SetScale(double dfScale,
+                  GDALDataType eStorageType = GDT_Unknown) override;
 
     std::vector<std::shared_ptr<GDALMDArray>>
     GetCoordinateVariables() const override;

--- a/frmts/zarr/zarr_v2_array.cpp
+++ b/frmts/zarr/zarr_v2_array.cpp
@@ -1936,15 +1936,11 @@ ZarrV2Group::LoadArray(const std::string &osArrayName,
                 GDALCopyWords(&nNoDataValue, GDT_Int64, 0, &abyNoData[0],
                               oType.GetNumericDataType(), 0, 1);
             }
-            else if (oType.GetNumericDataType() == GDT_UInt64 &&
-                     /* we can't really deal with nodata value between */
-                     /* int64::max and uint64::max due to json-c limitations */
-                     dfNoDataValue >= 0)
+            else if (oType.GetNumericDataType() == GDT_UInt64)
             {
-                const int64_t nNoDataValue =
-                    static_cast<int64_t>(oFillValue.ToLong());
+                const uint64_t nNoDataValue = oFillValue.ToUInt64();
                 abyNoData.resize(oType.GetSize());
-                GDALCopyWords(&nNoDataValue, GDT_Int64, 0, &abyNoData[0],
+                GDALCopyWords(&nNoDataValue, GDT_UInt64, 0, &abyNoData[0],
                               oType.GetNumericDataType(), 0, 1);
             }
             else

--- a/frmts/zarr/zarr_v3_array.cpp
+++ b/frmts/zarr/zarr_v3_array.cpp
@@ -2526,15 +2526,11 @@ ZarrV3Group::LoadArray(const std::string &osArrayName,
             GDALCopyWords(&nNoDataValue, GDT_Int64, 0, &abyNoData[0],
                           oType.GetNumericDataType(), 0, 1);
         }
-        else if (oType.GetNumericDataType() == GDT_UInt64 &&
-                 /* we can't really deal with nodata value between */
-                 /* int64::max and uint64::max due to json-c limitations */
-                 dfNoDataValue >= 0)
+        else if (oType.GetNumericDataType() == GDT_UInt64)
         {
-            const int64_t nNoDataValue =
-                static_cast<int64_t>(oFillValue.ToLong());
+            const uint64_t nNoDataValue = oFillValue.ToUInt64();
             abyNoData.resize(oType.GetSize());
-            GDALCopyWords(&nNoDataValue, GDT_Int64, 0, &abyNoData[0],
+            GDALCopyWords(&nNoDataValue, GDT_UInt64, 0, &abyNoData[0],
                           oType.GetNumericDataType(), 0, 1);
         }
         else

--- a/frmts/zarr/zarrdriver.cpp
+++ b/frmts/zarr/zarrdriver.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cinttypes>
+#include <cmath>
 #include <limits>
 #include <future>
 #include <mutex>
@@ -1520,13 +1521,90 @@ CPLErr ZarrDataset::FlushCache(bool bAtClosing)
 
     if (bAtClosing && m_poSingleArray)
     {
-        bool bFound = false;
+        auto poFirstBand = cpl::down_cast<ZarrRasterBand *>(papoBands[0]);
+        if (poFirstBand->m_dfNoData.has_value())
+        {
+            bool bSameNoDataValue = true;
+            for (int i = 1; bSameNoDataValue && i < nBands; ++i)
+            {
+                auto poBand = cpl::down_cast<ZarrRasterBand *>(papoBands[i]);
+                bSameNoDataValue =
+                    poBand->m_dfNoData.has_value() &&
+                    ((std::isnan(poFirstBand->m_dfNoData.value()) &&
+                      std::isnan(poBand->m_dfNoData.value())) ||
+                     (poFirstBand->m_dfNoData.value() ==
+                      poBand->m_dfNoData.value()));
+            }
+            if (!bSameNoDataValue)
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "Not all bands have the same nodata value. It will be "
+                         "ignored as the array can only have a single nodata "
+                         "value for all bands.");
+                eErr = CE_Failure;
+            }
+            else
+            {
+                m_poSingleArray->SetNoDataValue(
+                    poFirstBand->m_dfNoData.value());
+            }
+        }
+        else if (poFirstBand->m_nNoDataInt64.has_value())
+        {
+            bool bSameNoDataValue = true;
+            for (int i = 1; bSameNoDataValue && i < nBands; ++i)
+            {
+                auto poBand = cpl::down_cast<ZarrRasterBand *>(papoBands[i]);
+                bSameNoDataValue = poBand->m_nNoDataInt64.has_value() &&
+                                   poFirstBand->m_nNoDataInt64.value() ==
+                                       poBand->m_nNoDataInt64.value();
+            }
+            if (!bSameNoDataValue)
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "Not all bands have the same nodata value. It will be "
+                         "ignored as the array can only have a single nodata "
+                         "value for all bands.");
+                eErr = CE_Failure;
+            }
+            else
+            {
+                m_poSingleArray->SetNoDataValue(
+                    poFirstBand->m_nNoDataInt64.value());
+            }
+        }
+        else if (poFirstBand->m_nNoDataUInt64.has_value())
+        {
+            bool bSameNoDataValue = true;
+            for (int i = 1; bSameNoDataValue && i < nBands; ++i)
+            {
+                auto poBand = cpl::down_cast<ZarrRasterBand *>(papoBands[i]);
+                bSameNoDataValue = poBand->m_nNoDataUInt64.has_value() &&
+                                   poFirstBand->m_nNoDataUInt64.value() ==
+                                       poBand->m_nNoDataUInt64.value();
+            }
+            if (!bSameNoDataValue)
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "Not all bands have the same nodata value. It will be "
+                         "ignored as the array can only have a single nodata "
+                         "value for all bands.");
+                eErr = CE_Failure;
+            }
+            else
+            {
+                m_poSingleArray->SetNoDataValue(
+                    poFirstBand->m_nNoDataUInt64.value());
+            }
+        }
+
+        bool bFoundColorInterp = false;
         for (int i = 0; i < nBands; ++i)
         {
             if (papoBands[i]->GetColorInterpretation() != GCI_Undefined)
-                bFound = true;
+                bFoundColorInterp = true;
         }
-        if (bFound)
+        if (bFoundColorInterp)
         {
             const auto oStringDT = GDALExtendedDataType::CreateString();
             auto poAttr = m_poSingleArray->GetAttribute("COLOR_INTERPRETATION");
@@ -1805,6 +1883,12 @@ ZarrRasterBand::ZarrRasterBand(const std::shared_ptr<GDALMDArray> &poArray)
 
 double ZarrRasterBand::GetNoDataValue(int *pbHasNoData)
 {
+    if (m_dfNoData.has_value())
+    {
+        if (pbHasNoData)
+            *pbHasNoData = true;
+        return m_dfNoData.value();
+    }
     bool bHasNodata = false;
     const auto res = m_poArray->GetNoDataValueAsDouble(&bHasNodata);
     if (pbHasNoData)
@@ -1818,6 +1902,12 @@ double ZarrRasterBand::GetNoDataValue(int *pbHasNoData)
 
 int64_t ZarrRasterBand::GetNoDataValueAsInt64(int *pbHasNoData)
 {
+    if (m_nNoDataInt64.has_value())
+    {
+        if (pbHasNoData)
+            *pbHasNoData = true;
+        return m_nNoDataInt64.value();
+    }
     bool bHasNodata = false;
     const auto res = m_poArray->GetNoDataValueAsInt64(&bHasNodata);
     if (pbHasNoData)
@@ -1831,6 +1921,12 @@ int64_t ZarrRasterBand::GetNoDataValueAsInt64(int *pbHasNoData)
 
 uint64_t ZarrRasterBand::GetNoDataValueAsUInt64(int *pbHasNoData)
 {
+    if (m_nNoDataUInt64.has_value())
+    {
+        if (pbHasNoData)
+            *pbHasNoData = true;
+        return m_nNoDataUInt64.value();
+    }
     bool bHasNodata = false;
     const auto res = m_poArray->GetNoDataValueAsUInt64(&bHasNodata);
     if (pbHasNoData)
@@ -1844,7 +1940,13 @@ uint64_t ZarrRasterBand::GetNoDataValueAsUInt64(int *pbHasNoData)
 
 CPLErr ZarrRasterBand::SetNoDataValue(double dfNoData)
 {
-    return m_poArray->SetNoDataValue(dfNoData) ? CE_None : CE_Failure;
+    auto poGDS = cpl::down_cast<ZarrDataset *>(poDS);
+    if (!poGDS->m_poSingleArray)
+    {
+        return m_poArray->SetNoDataValue(dfNoData) ? CE_None : CE_Failure;
+    }
+    m_dfNoData = dfNoData;
+    return CE_None;
 }
 
 /************************************************************************/
@@ -1853,7 +1955,13 @@ CPLErr ZarrRasterBand::SetNoDataValue(double dfNoData)
 
 CPLErr ZarrRasterBand::SetNoDataValueAsInt64(int64_t nNoData)
 {
-    return m_poArray->SetNoDataValue(nNoData) ? CE_None : CE_Failure;
+    auto poGDS = cpl::down_cast<ZarrDataset *>(poDS);
+    if (!poGDS->m_poSingleArray)
+    {
+        return m_poArray->SetNoDataValue(nNoData) ? CE_None : CE_Failure;
+    }
+    m_nNoDataInt64 = nNoData;
+    return CE_None;
 }
 
 /************************************************************************/
@@ -1862,7 +1970,13 @@ CPLErr ZarrRasterBand::SetNoDataValueAsInt64(int64_t nNoData)
 
 CPLErr ZarrRasterBand::SetNoDataValueAsUInt64(uint64_t nNoData)
 {
-    return m_poArray->SetNoDataValue(nNoData) ? CE_None : CE_Failure;
+    auto poGDS = cpl::down_cast<ZarrDataset *>(poDS);
+    if (!poGDS->m_poSingleArray)
+    {
+        return m_poArray->SetNoDataValue(nNoData) ? CE_None : CE_Failure;
+    }
+    m_nNoDataUInt64 = nNoData;
+    return CE_None;
 }
 
 /************************************************************************/

--- a/frmts/zarr/zarrdriver.cpp
+++ b/frmts/zarr/zarrdriver.cpp
@@ -1711,11 +1711,20 @@ std::shared_ptr<GDALGroup> ZarrDataset::GetRootGroup() const
 
 const OGRSpatialReference *ZarrDataset::GetSpatialRef() const
 {
-    if (nBands >= 1)
+    if (m_poSingleArray)
+    {
+        return m_poSingleArray->GetSpatialRef().get();
+    }
+    else if (nBands >= 1)
+    {
         return cpl::down_cast<ZarrRasterBand *>(papoBands[0])
             ->m_poArray->GetSpatialRef()
             .get();
-    return nullptr;
+    }
+    else
+    {
+        return nullptr;
+    }
 }
 
 /************************************************************************/
@@ -1724,10 +1733,17 @@ const OGRSpatialReference *ZarrDataset::GetSpatialRef() const
 
 CPLErr ZarrDataset::SetSpatialRef(const OGRSpatialReference *poSRS)
 {
-    for (int i = 0; i < nBands; ++i)
+    if (m_poSingleArray)
     {
-        cpl::down_cast<ZarrRasterBand *>(papoBands[i])
-            ->m_poArray->SetSpatialRef(poSRS);
+        m_poSingleArray->SetSpatialRef(poSRS);
+    }
+    else
+    {
+        for (int i = 0; i < nBands; ++i)
+        {
+            cpl::down_cast<ZarrRasterBand *>(papoBands[i])
+                ->m_poArray->SetSpatialRef(poSRS);
+        }
     }
     return CE_None;
 }

--- a/frmts/zarr/zarrdriver.cpp
+++ b/frmts/zarr/zarrdriver.cpp
@@ -1524,18 +1524,17 @@ CPLErr ZarrDataset::FlushCache(bool bAtClosing)
         auto poFirstBand = cpl::down_cast<ZarrRasterBand *>(papoBands[0]);
         if (poFirstBand->m_dfNoData.has_value())
         {
-            bool bSameNoDataValue = true;
-            for (int i = 1; bSameNoDataValue && i < nBands; ++i)
+            bool bSameValue = true;
+            for (int i = 1; bSameValue && i < nBands; ++i)
             {
                 auto poBand = cpl::down_cast<ZarrRasterBand *>(papoBands[i]);
-                bSameNoDataValue =
-                    poBand->m_dfNoData.has_value() &&
-                    ((std::isnan(poFirstBand->m_dfNoData.value()) &&
-                      std::isnan(poBand->m_dfNoData.value())) ||
-                     (poFirstBand->m_dfNoData.value() ==
-                      poBand->m_dfNoData.value()));
+                bSameValue = poBand->m_dfNoData.has_value() &&
+                             ((std::isnan(poFirstBand->m_dfNoData.value()) &&
+                               std::isnan(poBand->m_dfNoData.value())) ||
+                              (poFirstBand->m_dfNoData.value() ==
+                               poBand->m_dfNoData.value()));
             }
-            if (!bSameNoDataValue)
+            if (!bSameValue)
             {
                 CPLError(CE_Failure, CPLE_NotSupported,
                          "Not all bands have the same nodata value. It will be "
@@ -1551,15 +1550,15 @@ CPLErr ZarrDataset::FlushCache(bool bAtClosing)
         }
         else if (poFirstBand->m_nNoDataInt64.has_value())
         {
-            bool bSameNoDataValue = true;
-            for (int i = 1; bSameNoDataValue && i < nBands; ++i)
+            bool bSameValue = true;
+            for (int i = 1; bSameValue && i < nBands; ++i)
             {
                 auto poBand = cpl::down_cast<ZarrRasterBand *>(papoBands[i]);
-                bSameNoDataValue = poBand->m_nNoDataInt64.has_value() &&
-                                   poFirstBand->m_nNoDataInt64.value() ==
-                                       poBand->m_nNoDataInt64.value();
+                bSameValue = poBand->m_nNoDataInt64.has_value() &&
+                             poFirstBand->m_nNoDataInt64.value() ==
+                                 poBand->m_nNoDataInt64.value();
             }
-            if (!bSameNoDataValue)
+            if (!bSameValue)
             {
                 CPLError(CE_Failure, CPLE_NotSupported,
                          "Not all bands have the same nodata value. It will be "
@@ -1575,15 +1574,15 @@ CPLErr ZarrDataset::FlushCache(bool bAtClosing)
         }
         else if (poFirstBand->m_nNoDataUInt64.has_value())
         {
-            bool bSameNoDataValue = true;
-            for (int i = 1; bSameNoDataValue && i < nBands; ++i)
+            bool bSameValue = true;
+            for (int i = 1; bSameValue && i < nBands; ++i)
             {
                 auto poBand = cpl::down_cast<ZarrRasterBand *>(papoBands[i]);
-                bSameNoDataValue = poBand->m_nNoDataUInt64.has_value() &&
-                                   poFirstBand->m_nNoDataUInt64.value() ==
-                                       poBand->m_nNoDataUInt64.value();
+                bSameValue = poBand->m_nNoDataUInt64.has_value() &&
+                             poFirstBand->m_nNoDataUInt64.value() ==
+                                 poBand->m_nNoDataUInt64.value();
             }
-            if (!bSameNoDataValue)
+            if (!bSameValue)
             {
                 CPLError(CE_Failure, CPLE_NotSupported,
                          "Not all bands have the same nodata value. It will be "
@@ -1595,6 +1594,54 @@ CPLErr ZarrDataset::FlushCache(bool bAtClosing)
             {
                 m_poSingleArray->SetNoDataValue(
                     poFirstBand->m_nNoDataUInt64.value());
+            }
+        }
+
+        if (poFirstBand->m_dfOffset.has_value())
+        {
+            bool bSameValue = true;
+            for (int i = 1; bSameValue && i < nBands; ++i)
+            {
+                auto poBand = cpl::down_cast<ZarrRasterBand *>(papoBands[i]);
+                bSameValue = poBand->m_dfOffset.has_value() &&
+                             poFirstBand->m_dfOffset.value() ==
+                                 poBand->m_dfOffset.value();
+            }
+            if (!bSameValue)
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "Not all bands have the same offset value. It will be "
+                         "ignored as the array can only have a single offset "
+                         "value for all bands.");
+                eErr = CE_Failure;
+            }
+            else
+            {
+                m_poSingleArray->SetOffset(poFirstBand->m_dfOffset.value());
+            }
+        }
+
+        if (poFirstBand->m_dfScale.has_value())
+        {
+            bool bSameValue = true;
+            for (int i = 1; bSameValue && i < nBands; ++i)
+            {
+                auto poBand = cpl::down_cast<ZarrRasterBand *>(papoBands[i]);
+                bSameValue =
+                    poBand->m_dfScale.has_value() &&
+                    poFirstBand->m_dfScale.value() == poBand->m_dfScale.value();
+            }
+            if (!bSameValue)
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "Not all bands have the same scale value. It will be "
+                         "ignored as the array can only have a single scale "
+                         "value for all bands.");
+                eErr = CE_Failure;
+            }
+            else
+            {
+                m_poSingleArray->SetScale(poFirstBand->m_dfScale.value());
             }
         }
 
@@ -1985,6 +2032,12 @@ CPLErr ZarrRasterBand::SetNoDataValueAsUInt64(uint64_t nNoData)
 
 double ZarrRasterBand::GetOffset(int *pbSuccess)
 {
+    if (m_dfOffset.has_value())
+    {
+        if (pbSuccess)
+            *pbSuccess = true;
+        return m_dfOffset.value();
+    }
     bool bHasValue = false;
     double dfRet = m_poArray->GetOffset(&bHasValue);
     if (pbSuccess)
@@ -1998,7 +2051,13 @@ double ZarrRasterBand::GetOffset(int *pbSuccess)
 
 CPLErr ZarrRasterBand::SetOffset(double dfNewOffset)
 {
-    return m_poArray->SetOffset(dfNewOffset) ? CE_None : CE_Failure;
+    auto poGDS = cpl::down_cast<ZarrDataset *>(poDS);
+    if (!poGDS->m_poSingleArray)
+    {
+        return m_poArray->SetOffset(dfNewOffset) ? CE_None : CE_Failure;
+    }
+    m_dfOffset = dfNewOffset;
+    return CE_None;
 }
 
 /************************************************************************/
@@ -2007,6 +2066,12 @@ CPLErr ZarrRasterBand::SetOffset(double dfNewOffset)
 
 double ZarrRasterBand::GetScale(int *pbSuccess)
 {
+    if (m_dfScale.has_value())
+    {
+        if (pbSuccess)
+            *pbSuccess = true;
+        return m_dfScale.value();
+    }
     bool bHasValue = false;
     double dfRet = m_poArray->GetScale(&bHasValue);
     if (pbSuccess)
@@ -2020,7 +2085,13 @@ double ZarrRasterBand::GetScale(int *pbSuccess)
 
 CPLErr ZarrRasterBand::SetScale(double dfNewScale)
 {
-    return m_poArray->SetScale(dfNewScale) ? CE_None : CE_Failure;
+    auto poGDS = cpl::down_cast<ZarrDataset *>(poDS);
+    if (!poGDS->m_poSingleArray)
+    {
+        return m_poArray->SetScale(dfNewScale) ? CE_None : CE_Failure;
+    }
+    m_dfScale = dfNewScale;
+    return CE_None;
 }
 
 /************************************************************************/

--- a/port/cpl_json.cpp
+++ b/port/cpl_json.cpp
@@ -1166,6 +1166,50 @@ GInt64 CPLJSONObject::ToLong(GInt64 nDefault) const
 /**
  * Get value by key.
  * @param  osName    Key name.
+ * @param  nDefault   Default value.
+ * @return            uint64_t value.
+ *
+ */
+uint64_t CPLJSONObject::GetUInt64(const std::string &osName,
+                                  uint64_t nDefault) const
+{
+    if (!m_osKeyForSet.empty())
+        return nDefault;
+    CPLJSONObject object = GetObj(osName);
+    return object.ToUInt64(nDefault);
+}
+
+/**
+ * Get value.
+ * @param  nDefault   Default value.
+ * @return            uint64_t value.
+ *
+ */
+uint64_t CPLJSONObject::ToUInt64(uint64_t nDefault) const
+{
+    if (!m_osKeyForSet.empty())
+        return nDefault;
+    if( m_poJsonObject /*&& json_object_get_type( TO_JSONOBJ(m_poJsonObject) ) ==
+            json_type_int*/ )
+    {
+#if (!defined(JSON_C_VERSION_NUM)) || (JSON_C_VERSION_NUM < JSON_C_VER_014)
+        // We can't do much better without json_object_get_uint64
+        const double v = json_object_get_double(TO_JSONOBJ(m_poJsonObject));
+        if (v > 0)
+        {
+            return static_cast<uint64_t>(
+                json_object_get_int64(TO_JSONOBJ(m_poJsonObject)));
+        }
+#else
+        return json_object_get_uint64(TO_JSONOBJ(m_poJsonObject));
+#endif
+    }
+    return nDefault;
+}
+
+/**
+ * Get value by key.
+ * @param  osName    Key name.
  * @param  bDefault   Default value.
  * @return            Boolean value.
  *

--- a/port/cpl_json.h
+++ b/port/cpl_json.h
@@ -181,11 +181,13 @@ class CPL_DLL CPLJSONObject
     double GetDouble(const std::string &osName, double dfDefault = 0.0) const;
     int GetInteger(const std::string &osName, int nDefault = 0) const;
     GInt64 GetLong(const std::string &osName, GInt64 nDefault = 0) const;
+    uint64_t GetUInt64(const std::string &osName, uint64_t nDefault = 0) const;
     bool GetBool(const std::string &osName, bool bDefault = false) const;
     std::string ToString(const std::string &osDefault = "") const;
     double ToDouble(double dfDefault = 0.0) const;
     int ToInteger(int nDefault = 0) const;
     GInt64 ToLong(GInt64 nDefault = 0) const;
+    uint64_t ToUInt64(uint64_t nDefault = 0) const;
     bool ToBool(bool bDefault = false) const;
     CPLJSONArray ToArray() const;
     std::string Format(PrettyFormat eFormat) const;


### PR DESCRIPTION
provided the same value is set on all bands
    
Fixes #14952
    
also fixes reading uint64 nodata values in the [INT64_MAX, UINT64_MAX] range
