### PR TITLE
gdal vector rasterize: add --like

### DIFF
--- a/apps/gdalalg_vector_rasterize.cpp
+++ b/apps/gdalalg_vector_rasterize.cpp
@@ -79,6 +79,10 @@ GDALVectorRasterizeAlgorithm::GDALVectorRasterizeAlgorithm(bool bStandaloneStep)
            &m_nodata);
     AddArg("init", 0, _("Pre-initialize output bands with specified value"),
            &m_initValues);
+    AddArg("like", 0,
+           _("Dataset to use as a template for bounds, CRS and resolution"),
+           &m_likeDataset, GDAL_OF_RASTER | GDAL_OF_VECTOR)
+        .SetMetaVar("DATASET");
     AddArg("crs", 0, _("Override the projection for the output file"), &m_srs)
         .AddHiddenAlias("srs")
         .SetIsCRSArg(/*noneAllowed=*/false);
@@ -133,6 +137,20 @@ GDALVectorRasterizeAlgorithm::GDALVectorRasterizeAlgorithm(bool bStandaloneStep)
                 return true;
             });
     }
+
+    AddValidationAction(
+        [this]()
+        {
+            if (m_likeDataset.GetDatasetRef() &&
+                (!m_targetExtent.empty() || !m_srs.empty()))
+            {
+                ReportError(
+                    CE_Failure, CPLE_AppDefined,
+                    "--like is mutually exclusive with --extent and --crs");
+                return false;
+            }
+            return true;
+        });
 }
 
 /************************************************************************/
@@ -265,17 +283,75 @@ bool GDALVectorRasterizeAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
         }
     }
 
-    if (!m_srs.empty())
+    if (auto *poLikeDS = m_likeDataset.GetDatasetRef())
     {
-        if (m_update)
+        OGREnvelope sExtent;
+        if (poLikeDS->GetExtent(&sExtent) != CE_None)
         {
-            ReportError(
-                CE_Failure, CPLE_AppDefined,
-                "Cannot specify --crs when updating an existing raster.");
+            ReportError(CE_Failure, CPLE_AppDefined,
+                        "Cannot get extent of '%s'",
+                        poLikeDS->GetDescription());
             return false;
         }
-        aosOptions.AddString("-a_srs");
-        aosOptions.AddString(m_srs.c_str());
+        aosOptions.AddString("-te");
+        aosOptions.AddString(CPLSPrintf("%.17g", sExtent.MinX));
+        aosOptions.AddString(CPLSPrintf("%.17g", sExtent.MinY));
+        aosOptions.AddString(CPLSPrintf("%.17g", sExtent.MaxX));
+        aosOptions.AddString(CPLSPrintf("%.17g", sExtent.MaxY));
+
+        const auto poSRS = poLikeDS->GetSpatialRef();
+        if (poSRS)
+        {
+            const char *const options[] = {"FORMAT=WKT2_2019", nullptr};
+            const std::string osCRS = poSRS->exportToWkt(options);
+            aosOptions.AddString("-a_srs");
+            aosOptions.AddString(osCRS.c_str());
+        }
+
+        if (m_targetResolution.empty() && m_targetSize.empty())
+        {
+            GDALGeoTransform gt;
+            if (poLikeDS->GetGeoTransform(gt) == CE_None)
+            {
+                if (gt.xrot != 0 || gt.yrot != 0)
+                {
+                    ReportError(CE_Failure, CPLE_NotSupported,
+                                "Geotransform matrix of '%s' has non-zero "
+                                "rotation terms",
+                                poLikeDS->GetDescription());
+                    return false;
+                }
+                aosOptions.AddString("-ts");
+                aosOptions.AddString(
+                    CPLSPrintf("%d", poLikeDS->GetRasterXSize()));
+                aosOptions.AddString(
+                    CPLSPrintf("%d", poLikeDS->GetRasterYSize()));
+            }
+        }
+    }
+    else
+    {
+        if (m_targetExtent.size())
+        {
+            aosOptions.AddString("-te");
+            for (double targetExtent : m_targetExtent)
+            {
+                aosOptions.AddString(CPLSPrintf("%.17g", targetExtent));
+            }
+        }
+
+        if (!m_srs.empty())
+        {
+            if (m_update)
+            {
+                ReportError(
+                    CE_Failure, CPLE_AppDefined,
+                    "Cannot specify --crs when updating an existing raster.");
+                return false;
+            }
+            aosOptions.AddString("-a_srs");
+            aosOptions.AddString(m_srs.c_str());
+        }
     }
 
     if (m_transformerOption.size())
@@ -284,15 +360,6 @@ bool GDALVectorRasterizeAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
         {
             aosOptions.AddString("-to");
             aosOptions.AddString(to.c_str());
-        }
-    }
-
-    if (m_targetExtent.size())
-    {
-        aosOptions.AddString("-te");
-        for (double targetExtent : m_targetExtent)
-        {
-            aosOptions.AddString(CPLSPrintf("%.17g", targetExtent));
         }
     }
 
@@ -331,7 +398,7 @@ bool GDALVectorRasterizeAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
             aosOptions.AddString(CPLSPrintf("%d", targetSize));
         }
     }
-    else if (m_outputDataset.GetDatasetRef() == nullptr)
+    else if (!m_likeDataset.GetDatasetRef() && !m_outputDataset.GetDatasetRef())
     {
         ReportError(
             CE_Failure, CPLE_AppDefined,

--- a/apps/gdalalg_vector_rasterize.h
+++ b/apps/gdalalg_vector_rasterize.h
@@ -68,6 +68,7 @@ class GDALVectorRasterizeAlgorithm /* non final */
     std::string m_dialect{};
     double m_nodata = std::numeric_limits<double>::quiet_NaN();
     std::vector<double> m_initValues{};
+    GDALArgDatasetValue m_likeDataset{};
     std::string m_srs{};
     std::vector<std::string> m_transformerOption{};
     std::vector<double> m_targetExtent{};

--- a/autotest/utilities/test_gdalalg_vector_rasterize.py
+++ b/autotest/utilities/test_gdalalg_vector_rasterize.py
@@ -16,7 +16,7 @@ import contextlib
 import gdaltest
 import pytest
 
-from osgeo import gdal
+from osgeo import gdal, osr
 
 
 def get_rasterize_alg():
@@ -821,3 +821,50 @@ def test_gdalalg_vector_rasterize_tap_depends_resolution():
             output_format="MEM",
             tap=True,
         )
+
+
+@pytest.mark.require_driver("CSV")
+def test_gdalalg_vector_rasterize_like(tmp_vsimem):
+
+    input_csv = str(tmp_vsimem / "cutline.csv")
+    like_tif = str(tmp_vsimem / "like.tif")
+    output_tif = str(tmp_vsimem / "out.tif")
+
+    # Create a template dataset
+    with gdal.GetDriverByName("GTiff").Create(
+        like_tif, 12, 10, 1, gdal.GDT_UInt8
+    ) as like_ds:
+        like_ds.SetGeoTransform((0, 1, 0, 12, 0, -1))
+        like_ds.SetSpatialRef(osr.SpatialReference(epsg=32630))
+
+    with temp_cutline(input_csv):
+
+        gdal.alg.vector.rasterize(input=input_csv, output=output_tif, like=like_tif)
+        with gdal.Open(output_tif) as target_ds:
+            assert target_ds.RasterXSize == 12
+            assert target_ds.RasterYSize == 10
+            assert target_ds.GetGeoTransform() == (0, 1, 0, 12, 0, -1)
+            assert target_ds.GetSpatialRef().GetAuthorityCode() == "32630"
+
+
+@pytest.mark.require_driver("CSV")
+def test_gdalalg_vector_rasterize_like_error(tmp_vsimem):
+
+    input_csv = str(tmp_vsimem / "cutline.csv")
+    like_tif = str(tmp_vsimem / "like.tif")
+    output_tif = str(tmp_vsimem / "out.tif")
+
+    # Create a template dataset
+    with gdal.GetDriverByName("GTiff").Create(
+        like_tif, 12, 10, 1, gdal.GDT_UInt8
+    ) as like_ds:
+        like_ds.SetGeoTransform((0, 1, 0, 12, 0, -1))
+        like_ds.SetSpatialRef(osr.SpatialReference(epsg=32630))
+
+    with temp_cutline(input_csv):
+        with pytest.raises(
+            Exception, match="--like is mutually exclusive with --extent and --crs"
+        ):
+            gdal.alg.vector.rasterize(
+                input=input_csv, output=output_tif, like=like_tif, extent=[0, 1, 2, 3]
+            )

--- a/doc/source/programs/gdal_vector_rasterize.rst
+++ b/doc/source/programs/gdal_vector_rasterize.rst
@@ -98,6 +98,14 @@ Program-Specific Options
 
     Burn value. May be repeated.
 
+.. option:: --like <DATASET>
+
+    .. versionadded:: 3.14
+
+    Vector or raster dataset to use as a template for bounds, CRS, and when it
+    is a raster dataset, for dimension/resolution.
+    Mutually exclusive with :option:`--crs` and :option:`--extent`.
+
 .. option:: --crs <CRS>
 
     Override the projection for the output file. If not specified, the projection of the input vector file will be used if available. When using this option, no reprojection of features from the CRS of the input vector to the specified CRS of the output raster, so use only this option to correct an invalid source CRS. The ``<CRS>`` may be any of the usual GDAL/OGR forms, complete WKT, PROJ.4, EPSG:n or a file containing the WKT.


### PR DESCRIPTION
    Vector or raster dataset to use as a template for bounds, CRS, and when it
    is a raster dataset, for dimension/resolution.
    Mutually exclusive with :option:`--crs` and :option:`--extent`.

Fixes #14936
