### PR TITLE
Simplify NotifyOtherComponentsConfigOptionChanged

### DIFF
--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -1941,13 +1941,10 @@ static void NotifyOtherComponentsConfigOptionChanged(const char *pszKey,
         VSICurlAuthParametersChanged();
     }
 
-    if (!gSetConfigOptionSubscribers.empty())
+    for (const auto &[pfnCallback, pUserData] : gSetConfigOptionSubscribers)
     {
-        for (const auto &iter : gSetConfigOptionSubscribers)
-        {
-            if (iter.first)
-                iter.first(pszKey, pszValue, bThreadLocal, iter.second);
-        }
+        if (pfnCallback)
+            pfnCallback(pszKey, pszValue, bThreadLocal, pUserData);
     }
 }
 


### PR DESCRIPTION
Small simplification of `NotifyOtherComponentsConfigOptionChanged` (came across this during debugging):
- the `empty` check is not netecesary, as the loop is doing nothing in case the list is empty
- use structured binding to increase readability