### PR TITLE
Make `gdal_contour -p` fast…like, really fast

### DIFF
--- a/alg/contour.cpp
+++ b/alg/contour.cpp
@@ -832,7 +832,12 @@ CPLErr GDALContourGenerateEx(GDALRasterBandH hBand, void *hLayer,
 
             PolygonContourWriter w(&oCWI, dfMinimum);
             typedef PolygonRingAppender<PolygonContourWriter> RingAppender;
-            RingAppender appender(w);
+            // Ring coordinates reach the appender in raster space (the
+            // writer applies the geotransform), so the spatial index's
+            // domain is the raster extent plus the border cells.
+            RingAppender appender(w, -1.0, -1.0,
+                                  GDALGetRasterBandXSize(hBand) + 1.0,
+                                  GDALGetRasterBandYSize(hBand) + 1.0);
 
             if (expBase > 0.0)
             {

--- a/alg/marching_squares/polygon_ring_appender.h
+++ b/alg/marching_squares/polygon_ring_appender.h
@@ -18,6 +18,10 @@
 #include <deque>
 #include <cassert>
 #include <iterator>
+#include <cmath>
+#include <unordered_map>
+#include <functional>
+#include <algorithm>
 
 #include "point.h"
 #include "ogr_geometry.h"
@@ -38,8 +42,41 @@ template <typename PolygonWriter> class PolygonRingAppender
 
         Ring(const Ring &other) = default;
         Ring &operator=(const Ring &other) = default;
+        // Declaring the copy operations above suppresses the
+        // implicit move operations, so vector reshuffles and reallocations
+        // deep-copied entire ring subtrees. Restore them.
+        Ring(Ring &&other) = default;
+        Ring &operator=(Ring &&other) = default;
 
         LineString points;
+
+        // Bounding box, computed once when the ring is complete;
+        // gives isIn() an O(1) reject so parent search stops being
+        // O(rings * vertices) per insertion.
+        double bbXMin = 0, bbYMin = 0, bbXMax = 0, bbYMax = 0;
+
+        void computeBBox()
+        {
+            bool first = true;
+            for (const auto &pt : points)
+            {
+                if (first)
+                {
+                    bbXMin = bbXMax = pt.x;
+                    bbYMin = bbYMax = pt.y;
+                    first = false;
+                    continue;
+                }
+                if (pt.x < bbXMin)
+                    bbXMin = pt.x;
+                if (pt.x > bbXMax)
+                    bbXMax = pt.x;
+                if (pt.y < bbYMin)
+                    bbYMin = pt.y;
+                if (pt.y > bbYMax)
+                    bbYMax = pt.y;
+            }
+        }
 
         mutable std::vector<Ring> interiorRings;
 
@@ -49,6 +86,13 @@ template <typename PolygonWriter> class PolygonRingAppender
         {
             // Check if this is inside other using the winding number algorithm
             auto checkPoint = this->points.front();
+            // A point outside the candidate ring's bounding box
+            // cannot be inside the ring.
+            if (checkPoint.x < other.bbXMin || checkPoint.x > other.bbXMax ||
+                checkPoint.y < other.bbYMin || checkPoint.y > other.bbYMax)
+            {
+                return false;
+            }
             int windingNum = 0;
             auto otherIter = other.points.begin();
             // p1 and p2 define each segment of the ring other that will be
@@ -126,6 +170,171 @@ template <typename PolygonWriter> class PolygonRingAppender
     // level -> rings
     std::map<double, std::vector<Ring>> rings_;
 
+    // Per-level spatial index over TOP-LEVEL rings. Maps grid
+    // cell -> slot indices into the level's ring vector. Slots whose ring has
+    // been captured as an interior ring are tombstoned (empty points), never
+    // erased, so indices remain stable. Rings overlapping too many cells go
+    // to a small linear overflow list.
+    // Point-in-polygon accelerator for one target ring. The
+    // capture step tests MANY points against the SAME ring (pathological
+    // case: a domain-spanning ring with millions of vertices capturing tens
+    // of thousands of earlier rings) — bucketing the ring's segments by y
+    // makes each test O(segments-in-bucket) instead of O(all vertices).
+    struct RingPIPIndex
+    {
+        double yMin = 0, yMax = 0, inv = 0;
+        std::vector<std::vector<std::pair<Point, Point>>> buckets;
+
+        void build(const Ring &r)
+        {
+            yMin = r.bbYMin;
+            yMax = r.bbYMax;
+            const size_t nSeg = r.points.size();
+            const size_t nBuckets =
+                std::max<size_t>(64, std::min<size_t>(nSeg / 32, 65536));
+            buckets.assign(nBuckets, {});
+            inv = (yMax > yMin) ? nBuckets / (yMax - yMin) : 0;
+            auto it = r.points.begin();
+            auto p1 = *it;
+            for (++it; it != r.points.end(); ++it)
+            {
+                auto p2 = *it;
+                double lo = std::min(p1.y, p2.y), hi = std::max(p1.y, p2.y);
+                size_t b0 = bucketOf(lo), b1 = bucketOf(hi);
+                for (size_t b = b0; b <= b1; b++)
+                    buckets[b].emplace_back(p1, p2);
+                p1 = p2;
+            }
+        }
+
+        size_t bucketOf(double y) const
+        {
+            if (y <= yMin)
+                return 0;
+            if (y >= yMax)
+                return buckets.size() - 1;
+            size_t b = static_cast<size_t>((y - yMin) * inv);
+            return b >= buckets.size() ? buckets.size() - 1 : b;
+        }
+
+        // identical winding-number semantics to Ring::isIn
+        bool contains(const Point &checkPoint) const
+        {
+            int windingNum = 0;
+            for (const auto &seg : buckets[bucketOf(checkPoint.y)])
+            {
+                const auto &p1 = seg.first;
+                const auto &p2 = seg.second;
+                if (p1.y <= checkPoint.y)
+                {
+                    if (p2.y > checkPoint.y)
+                    {
+                        if (isLeft(p1, p2, checkPoint))
+                            ++windingNum;
+                    }
+                }
+                else
+                {
+                    if (p2.y <= checkPoint.y)
+                    {
+                        if (!isLeft(p1, p2, checkPoint))
+                            --windingNum;
+                    }
+                }
+            }
+            return windingNum != 0;
+        }
+    };
+
+    struct LevelIndex
+    {
+        // Ring coordinates are raster pixel units here (the georeferencing
+        // transform is applied downstream by the writer), so a fixed cell a
+        // few tens of pixels wide keeps small rings in O(1) cells while the
+        // overflow list bounds domain-spanning rings.
+        static constexpr double cell = 32.0;
+        static constexpr size_t maxCells = 4096;
+
+        struct CellHash
+        {
+            size_t operator()(const std::pair<long long, long long> &c) const
+            {
+                return std::hash<long long>()(
+                    c.first * 2654435761LL ^ (c.second << 21 | c.second >> 43));
+            }
+        };
+
+        std::unordered_map<std::pair<long long, long long>, std::vector<size_t>,
+                           CellHash>
+            cells;
+        std::vector<size_t> large;
+
+        static long long cellOf(double v)
+        {
+            return static_cast<long long>(std::floor(v / cell));
+        }
+
+        void insert(const Ring &r, size_t idx)
+        {
+            const long long x0 = cellOf(r.bbXMin), x1 = cellOf(r.bbXMax);
+            const long long y0 = cellOf(r.bbYMin), y1 = cellOf(r.bbYMax);
+            const size_t nCells = static_cast<size_t>(x1 - x0 + 1) *
+                                  static_cast<size_t>(y1 - y0 + 1);
+            if (nCells > maxCells)
+            {
+                large.push_back(idx);
+                return;
+            }
+            for (long long cx = x0; cx <= x1; cx++)
+                for (long long cy = y0; cy <= y1; cy++)
+                    cells[{cx, cy}].push_back(idx);
+        }
+
+        // Collect candidate slots whose bbox may contain point (px, py).
+        template <typename F> void forPoint(double px, double py, F f) const
+        {
+            auto it = cells.find({cellOf(px), cellOf(py)});
+            if (it != cells.end())
+                for (size_t idx : it->second)
+                    f(idx);
+            for (size_t idx : large)
+                f(idx);
+        }
+
+        // Collect candidate slots whose bbox may intersect the given bbox.
+        template <typename F>
+        void forBox(double xmin, double ymin, double xmax, double ymax,
+                    F f) const
+        {
+            const long long x0 = cellOf(xmin), x1 = cellOf(xmax);
+            const long long y0 = cellOf(ymin), y1 = cellOf(ymax);
+            if (static_cast<size_t>(x1 - x0 + 1) *
+                    static_cast<size_t>(y1 - y0 + 1) >
+                maxCells)
+            {
+                // huge query box: fall back to scanning every cell entry
+                for (const auto &kv : cells)
+                    for (size_t idx : kv.second)
+                        f(idx);
+            }
+            else
+            {
+                for (long long cx = x0; cx <= x1; cx++)
+                    for (long long cy = y0; cy <= y1; cy++)
+                    {
+                        auto it = cells.find({cx, cy});
+                        if (it != cells.end())
+                            for (size_t idx : it->second)
+                                f(idx);
+                    }
+            }
+            for (size_t idx : large)
+                f(idx);
+        }
+    };
+
+    std::map<double, LevelIndex> index_;
+
     PolygonWriter &writer_;
 
   public:
@@ -138,6 +347,7 @@ template <typename PolygonWriter> class PolygonRingAppender
     void addLine(double level, LineString &ls, bool)
     {
         auto &levelRings = rings_[level];
+        auto &levelIndex = index_[level];
         if (ls.empty())
         {
             return;
@@ -145,53 +355,102 @@ template <typename PolygonWriter> class PolygonRingAppender
         // Create a new ring from the LineString
         Ring newRing;
         newRing.points.swap(ls);
-        // This queue holds the rings to be checked
-        std::deque<Ring *> queue;
-        std::transform(levelRings.begin(), levelRings.end(),
-                       std::back_inserter(queue), [](Ring &r) { return &r; });
+        newRing.computeBBox();
+        // Find the top-level parent (if any) through the grid
+        // index instead of scanning every top-level ring, then descend the
+        // (short) nested sibling lists exactly as before.
         Ring *parentRing = nullptr;
-        while (!queue.empty())
         {
-            Ring *curRing = queue.front();
-            queue.pop_front();
-            if (newRing.isIn(*curRing))
+            Ring *top = nullptr;
+            levelIndex.forPoint(
+                newRing.points.front().x, newRing.points.front().y,
+                [&](size_t idx)
+                {
+                    Ring &cand = levelRings[idx];
+                    if (top == nullptr && !cand.points.empty() &&
+                        newRing.isIn(cand))
+                        top = &cand;
+                });
+            if (top != nullptr)
             {
-                // We know that there should only be one ring per level that we
-                // should fit in, so we can discard the rest of the queue and
-                // try again with the children of this ring
-                parentRing = curRing;
-                queue.clear();
-                std::transform(curRing->interiorRings.begin(),
-                               curRing->interiorRings.end(),
-                               std::back_inserter(queue),
-                               [](Ring &r) { return &r; });
+                parentRing = top;
+                // descend into nested rings (sibling lists are short)
+                std::deque<Ring *> queue;
+                std::transform(
+                    top->interiorRings.begin(), top->interiorRings.end(),
+                    std::back_inserter(queue), [](Ring &r) { return &r; });
+                while (!queue.empty())
+                {
+                    Ring *curRing = queue.front();
+                    queue.pop_front();
+                    if (newRing.isIn(*curRing))
+                    {
+                        parentRing = curRing;
+                        queue.clear();
+                        std::transform(curRing->interiorRings.begin(),
+                                       curRing->interiorRings.end(),
+                                       std::back_inserter(queue),
+                                       [](Ring &r) { return &r; });
+                    }
+                }
             }
         }
-        // Get a pointer to the list we need to check for rings to include in
-        // this ring
-        std::vector<Ring> *parentRingList;
         if (parentRing == nullptr)
         {
-            parentRingList = &levelRings;
+            // Top-level insertion: capture existing top-level rings that lie
+            // inside the new ring, via the index. Build a per-target PIP
+            // index lazily so a huge ring capturing many candidates costs
+            // O(V + R * V/B), not O(R * V).
+            std::vector<size_t> captured;
+            RingPIPIndex pip;
+            bool pipBuilt = false;
+            size_t nCandidates = 0;
+            levelIndex.forBox(
+                newRing.bbXMin, newRing.bbYMin, newRing.bbXMax, newRing.bbYMax,
+                [&](size_t idx)
+                {
+                    Ring &cand = levelRings[idx];
+                    if (cand.points.empty())
+                        return;
+                    const auto &fp = cand.points.front();
+                    if (fp.x < newRing.bbXMin || fp.x > newRing.bbXMax ||
+                        fp.y < newRing.bbYMin || fp.y > newRing.bbYMax)
+                        return;
+                    if (!pipBuilt && ++nCandidates > 16 &&
+                        newRing.points.size() > 512)
+                    {
+                        pip.build(newRing);
+                        pipBuilt = true;
+                    }
+                    const bool inside =
+                        pipBuilt ? pip.contains(fp) : cand.isIn(newRing);
+                    if (inside)
+                        captured.push_back(idx);
+                });
+            std::sort(captured.begin(), captured.end());
+            captured.erase(std::unique(captured.begin(), captured.end()),
+                           captured.end());
+            for (size_t idx : captured)
+            {
+                newRing.interiorRings.push_back(std::move(levelRings[idx]));
+                levelRings[idx].points.clear();  // tombstone the slot
+            }
+            levelRings.push_back(std::move(newRing));
+            levelIndex.insert(levelRings.back(), levelRings.size() - 1);
         }
         else
         {
-            parentRingList = &(parentRing->interiorRings);
+            // Nested insertion: identical to the original algorithm on the
+            // parent's (short) child list.
+            std::vector<Ring> *parentRingList = &(parentRing->interiorRings);
+            auto trueGroupIt = std::partition(
+                parentRingList->begin(), parentRingList->end(),
+                [&newRing](Ring &pRing) { return !pRing.isIn(newRing); });
+            std::move(trueGroupIt, parentRingList->end(),
+                      std::back_inserter(newRing.interiorRings));
+            parentRingList->erase(trueGroupIt, parentRingList->end());
+            parentRingList->push_back(std::move(newRing));
         }
-        // We found a valid parent, so we need to:
-        // 1. Find all the inner rings of the parent that are inside the new
-        // ring
-        auto trueGroupIt = std::partition(
-            parentRingList->begin(), parentRingList->end(),
-            [newRing](Ring &pRing) { return !pRing.isIn(newRing); });
-        // 2. Move those rings out of the parent and into the new ring's
-        // interior rings
-        std::move(trueGroupIt, parentRingList->end(),
-                  std::back_inserter(newRing.interiorRings));
-        // 3. Get rid of the moved-from elements in the parent's interior rings
-        parentRingList->erase(trueGroupIt, parentRingList->end());
-        // 4. Add the new ring to the parent's interior rings
-        parentRingList->push_back(newRing);
     }
 
     ~PolygonRingAppender()
@@ -203,10 +462,17 @@ template <typename PolygonWriter> class PolygonRingAppender
         // Traverse tree of rings
         for (auto &r : rings_)
         {
+            // Drop tombstoned slots (rings captured as interior
+            // rings of later-arriving parents) before traversal.
+            std::vector<Ring> live;
+            live.reserve(r.second.size());
+            for (auto &ring : r.second)
+                if (!ring.points.empty())
+                    live.push_back(std::move(ring));
             // For each level, create a multipolygon by traversing the tree of
             // rings and adding a part for every other level
             writer_.startPolygon(r.first);
-            processTree(r.second, 0);
+            processTree(live, 0);
             writer_.endPolygon();
         }
     }

--- a/alg/marching_squares/polygon_ring_appender.h
+++ b/alg/marching_squares/polygon_ring_appender.h
@@ -38,7 +38,7 @@ template <typename PolygonWriter> class PolygonRingAppender
   private:
     struct Ring
     {
-        Ring() : points(), interiorRings()
+        Ring() : points(), bbox(), interiorRings()
         {
         }
 
@@ -167,6 +167,10 @@ template <typename PolygonWriter> class PolygonRingAppender
     // winding test.
     struct PreparedRing
     {
+        PreparedRing() : poly(), prep()
+        {
+        }
+
         OGRPolygon poly;
         OGRPreparedGeometryUniquePtr prep;
 
@@ -231,7 +235,7 @@ template <typename PolygonWriter> class PolygonRingAppender
 
     PolygonRingAppender(PolygonWriter &writer, double minX, double minY,
                         double maxX, double maxY)
-        : domain_{minX, minY, maxX, maxY}, writer_(writer)
+        : rings_(), index_(), domain_{minX, minY, maxX, maxY}, writer_(writer)
     {
     }
 

--- a/alg/marching_squares/polygon_ring_appender.h
+++ b/alg/marching_squares/polygon_ring_appender.h
@@ -18,7 +18,6 @@
 #include <deque>
 #include <cassert>
 #include <iterator>
-#include <cstdint>
 #include <memory>
 #include <algorithm>
 
@@ -59,6 +58,7 @@ template <typename PolygonWriter> class PolygonRingAppender
 
         void computeBBox()
         {
+            bbox = OGREnvelope();
             for (const auto &pt : points)
                 bbox.Merge(pt.x, pt.y);
         }
@@ -176,6 +176,8 @@ template <typename PolygonWriter> class PolygonRingAppender
 
         bool build(const Ring &r)
         {
+            poly.empty();
+            prep.reset();
             auto ring = std::make_unique<OGRLinearRing>();
             ring->setNumPoints(static_cast<int>(r.points.size()));
             int i = 0;
@@ -196,11 +198,12 @@ template <typename PolygonWriter> class PolygonRingAppender
     };
 
     // Per-level spatial index over TOP-LEVEL rings: a CPLQuadTree over ring
-    // bounding boxes. Stored features are slot indices into the level's ring
-    // vector (encoded in the pointer value, never dereferenced), so vector
-    // reallocation is harmless. Rings captured as interior rings of a later
-    // ring are removed from the tree and their slot tombstoned (points
-    // cleared) rather than erased, keeping the remaining indices stable.
+    // bounding boxes. Each stored feature points at the ring's slot index in
+    // the level's ring vector, held in a std::deque so the pointer survives
+    // growth; vector reallocation of the rings themselves is harmless. Rings
+    // captured as interior rings of a later ring are removed from the tree
+    // and their slot tombstoned (points cleared) rather than erased, keeping
+    // the remaining indices stable.
     struct QuadTreeDestroyer
     {
         void operator()(CPLQuadTree *t) const
@@ -210,17 +213,12 @@ template <typename PolygonWriter> class PolygonRingAppender
     };
 
     std::map<double, std::unique_ptr<CPLQuadTree, QuadTreeDestroyer>> index_;
+    std::map<double, std::deque<std::size_t>> slots_;
     CPLRectObj domain_;
 
-    static void *slotFeature(std::size_t idx)
+    static std::size_t featureSlot(const void *f)
     {
-        return reinterpret_cast<void *>(static_cast<std::uintptr_t>(idx + 1));
-    }
-
-    static std::size_t featureSlot(void *f)
-    {
-        return static_cast<std::size_t>(reinterpret_cast<std::uintptr_t>(f)) -
-               1;
+        return *static_cast<const std::size_t *>(f);
     }
 
     static CPLRectObj ringRect(const Ring &r)
@@ -235,7 +233,8 @@ template <typename PolygonWriter> class PolygonRingAppender
 
     PolygonRingAppender(PolygonWriter &writer, double minX, double minY,
                         double maxX, double maxY)
-        : rings_(), index_(), domain_{minX, minY, maxX, maxY}, writer_(writer)
+        : rings_(), index_(), slots_(), domain_{minX, minY, maxX, maxY},
+          writer_(writer)
     {
     }
 
@@ -243,6 +242,7 @@ template <typename PolygonWriter> class PolygonRingAppender
     {
         auto &levelRings = rings_[level];
         auto &levelTree = index_[level];
+        auto &levelSlots = slots_[level];
         if (!levelTree)
             levelTree.reset(CPLQuadTreeCreate(&domain_, nullptr));
         if (ls.empty())
@@ -344,14 +344,15 @@ template <typename PolygonWriter> class PolygonRingAppender
             for (std::size_t idx : captured)
             {
                 CPLRectObj rb = ringRect(levelRings[idx]);
-                CPLQuadTreeRemove(levelTree.get(), slotFeature(idx), &rb);
+                CPLQuadTreeRemove(levelTree.get(), &levelSlots[idx], &rb);
                 newRing.interiorRings.push_back(std::move(levelRings[idx]));
                 levelRings[idx].points.clear();  // tombstone the slot
             }
             levelRings.push_back(std::move(newRing));
+            levelSlots.push_back(levelRings.size() - 1);
             CPLRectObj nb = ringRect(levelRings.back());
-            CPLQuadTreeInsertWithBounds(
-                levelTree.get(), slotFeature(levelRings.size() - 1), &nb);
+            CPLQuadTreeInsertWithBounds(levelTree.get(), &levelSlots.back(),
+                                        &nb);
         }
         else
         {

--- a/alg/marching_squares/polygon_ring_appender.h
+++ b/alg/marching_squares/polygon_ring_appender.h
@@ -20,9 +20,10 @@
 #include <iterator>
 #include <cmath>
 #include <cstdint>
-#include <unordered_map>
-#include <functional>
+#include <memory>
 #include <algorithm>
+
+#include "cpl_quad_tree.h"
 
 #include "point.h"
 #include "ogr_geometry.h"
@@ -54,29 +55,12 @@ template <typename PolygonWriter> class PolygonRingAppender
         // Bounding box, computed once when the ring is complete;
         // gives isIn() an O(1) reject so parent search stops being
         // O(rings * vertices) per insertion.
-        double bbXMin = 0, bbYMin = 0, bbXMax = 0, bbYMax = 0;
+        OGREnvelope bbox;
 
         void computeBBox()
         {
-            bool first = true;
             for (const auto &pt : points)
-            {
-                if (first)
-                {
-                    bbXMin = bbXMax = pt.x;
-                    bbYMin = bbYMax = pt.y;
-                    first = false;
-                    continue;
-                }
-                if (pt.x < bbXMin)
-                    bbXMin = pt.x;
-                if (pt.x > bbXMax)
-                    bbXMax = pt.x;
-                if (pt.y < bbYMin)
-                    bbYMin = pt.y;
-                if (pt.y > bbYMax)
-                    bbYMax = pt.y;
-            }
+                bbox.Merge(pt.x, pt.y);
         }
 
         mutable std::vector<Ring> interiorRings;
@@ -89,8 +73,10 @@ template <typename PolygonWriter> class PolygonRingAppender
             auto checkPoint = this->points.front();
             // A point outside the candidate ring's bounding box
             // cannot be inside the ring.
-            if (checkPoint.x < other.bbXMin || checkPoint.x > other.bbXMax ||
-                checkPoint.y < other.bbYMin || checkPoint.y > other.bbYMax)
+            if (checkPoint.x < other.bbox.MinX ||
+                checkPoint.x > other.bbox.MaxX ||
+                checkPoint.y < other.bbox.MinY ||
+                checkPoint.y > other.bbox.MaxY)
             {
                 return false;
             }
@@ -171,16 +157,14 @@ template <typename PolygonWriter> class PolygonRingAppender
     // level -> rings
     std::map<double, std::vector<Ring>> rings_;
 
-    // Per-level spatial index over TOP-LEVEL rings. Maps grid
-    // cell -> slot indices into the level's ring vector. Slots whose ring has
-    // been captured as an interior ring are tombstoned (empty points), never
-    // erased, so indices remain stable. Rings overlapping too many cells go
-    // to a small linear overflow list.
-    // Point-in-polygon accelerator for one target ring. The
-    // capture step tests MANY points against the SAME ring (pathological
-    // case: a domain-spanning ring with millions of vertices capturing tens
-    // of thousands of earlier rings) — bucketing the ring's segments by y
-    // makes each test O(segments-in-bucket) instead of O(all vertices).
+    // Point-in-polygon accelerator for one target ring. The capture step
+    // tests MANY points against the SAME ring (pathological case: a
+    // domain-spanning ring with millions of vertices capturing tens of
+    // thousands of earlier rings) — bucketing the ring's segments by y makes
+    // each test O(segments-in-bucket) instead of O(all vertices). GEOS has
+    // the natural structure for this (IndexedPointInAreaLocator), but GEOS
+    // is an optional dependency and contouring must work without it; GDAL
+    // core has no indexed point-in-polygon type.
     struct RingPIPIndex
     {
         double yMin = 0, yMax = 0, inv = 0;
@@ -188,8 +172,8 @@ template <typename PolygonWriter> class PolygonRingAppender
 
         void build(const Ring &r)
         {
-            yMin = r.bbYMin;
-            yMax = r.bbYMax;
+            yMin = r.bbox.MinY;
+            yMax = r.bbox.MaxY;
             const size_t nSeg = r.points.size();
             // A segment spanning dy is copied into about
             // dy * nBuckets / (yMax - yMin) + 1 buckets, so the total stored
@@ -274,112 +258,56 @@ template <typename PolygonWriter> class PolygonRingAppender
         }
     };
 
-    struct LevelIndex
+    // Per-level spatial index over TOP-LEVEL rings: a CPLQuadTree over ring
+    // bounding boxes. Stored features are slot indices into the level's ring
+    // vector (encoded in the pointer value, never dereferenced), so vector
+    // reallocation is harmless. Rings captured as interior rings of a later
+    // ring are removed from the tree and their slot tombstoned (points
+    // cleared) rather than erased, keeping the remaining indices stable.
+    struct QuadTreeDestroyer
     {
-        // Ring coordinates are raster pixel units here (the georeferencing
-        // transform is applied downstream by the writer), so a fixed cell a
-        // few tens of pixels wide keeps small rings in O(1) cells while the
-        // overflow list bounds domain-spanning rings.
-        static constexpr double cell = 32.0;
-        static constexpr size_t maxCells = 4096;
-
-        struct CellHash
+        void operator()(CPLQuadTree *t) const
         {
-            size_t operator()(const std::pair<long long, long long> &c) const
-            {
-                // Unsigned arithmetic: cells can be negative, and signed
-                // overflow / shifting negative values is undefined behavior.
-                const auto x = static_cast<std::uint64_t>(c.first);
-                const auto y = static_cast<std::uint64_t>(c.second);
-                return std::hash<std::uint64_t>()(x * 2654435761ULL ^
-                                                  (y << 21 | y >> 43));
-            }
-        };
-
-        std::unordered_map<std::pair<long long, long long>, std::vector<size_t>,
-                           CellHash>
-            cells;
-        std::vector<size_t> large;
-
-        static long long cellOf(double v)
-        {
-            return static_cast<long long>(std::floor(v / cell));
-        }
-
-        void insert(const Ring &r, size_t idx)
-        {
-            const long long x0 = cellOf(r.bbXMin), x1 = cellOf(r.bbXMax);
-            const long long y0 = cellOf(r.bbYMin), y1 = cellOf(r.bbYMax);
-            const size_t nCells = static_cast<size_t>(x1 - x0 + 1) *
-                                  static_cast<size_t>(y1 - y0 + 1);
-            if (nCells > maxCells)
-            {
-                large.push_back(idx);
-                return;
-            }
-            for (long long cx = x0; cx <= x1; cx++)
-                for (long long cy = y0; cy <= y1; cy++)
-                    cells[{cx, cy}].push_back(idx);
-        }
-
-        // Collect candidate slots whose bbox may contain point (px, py).
-        template <typename F> void forPoint(double px, double py, F f) const
-        {
-            auto it = cells.find({cellOf(px), cellOf(py)});
-            if (it != cells.end())
-                for (size_t idx : it->second)
-                    f(idx);
-            for (size_t idx : large)
-                f(idx);
-        }
-
-        // Collect candidate slots whose bbox may intersect the given bbox.
-        template <typename F>
-        void forBox(double xmin, double ymin, double xmax, double ymax,
-                    F f) const
-        {
-            const long long x0 = cellOf(xmin), x1 = cellOf(xmax);
-            const long long y0 = cellOf(ymin), y1 = cellOf(ymax);
-            if (static_cast<size_t>(x1 - x0 + 1) *
-                    static_cast<size_t>(y1 - y0 + 1) >
-                maxCells)
-            {
-                // huge query box: fall back to scanning every cell entry
-                for (const auto &kv : cells)
-                    for (size_t idx : kv.second)
-                        f(idx);
-            }
-            else
-            {
-                for (long long cx = x0; cx <= x1; cx++)
-                    for (long long cy = y0; cy <= y1; cy++)
-                    {
-                        auto it = cells.find({cx, cy});
-                        if (it != cells.end())
-                            for (size_t idx : it->second)
-                                f(idx);
-                    }
-            }
-            for (size_t idx : large)
-                f(idx);
+            CPLQuadTreeDestroy(t);
         }
     };
 
-    std::map<double, LevelIndex> index_;
+    std::map<double, std::unique_ptr<CPLQuadTree, QuadTreeDestroyer>> index_;
+    CPLRectObj domain_;
+
+    static void *slotFeature(std::size_t idx)
+    {
+        return reinterpret_cast<void *>(static_cast<std::uintptr_t>(idx + 1));
+    }
+
+    static std::size_t featureSlot(void *f)
+    {
+        return static_cast<std::size_t>(reinterpret_cast<std::uintptr_t>(f)) -
+               1;
+    }
+
+    static CPLRectObj ringRect(const Ring &r)
+    {
+        return CPLRectObj{r.bbox.MinX, r.bbox.MinY, r.bbox.MaxX, r.bbox.MaxY};
+    }
 
     PolygonWriter &writer_;
 
   public:
     const bool polygonize = true;
 
-    PolygonRingAppender(PolygonWriter &writer) : rings_(), writer_(writer)
+    PolygonRingAppender(PolygonWriter &writer, double minX, double minY,
+                        double maxX, double maxY)
+        : domain_{minX, minY, maxX, maxY}, writer_(writer)
     {
     }
 
     void addLine(double level, LineString &ls, bool)
     {
         auto &levelRings = rings_[level];
-        auto &levelIndex = index_[level];
+        auto &levelTree = index_[level];
+        if (!levelTree)
+            levelTree.reset(CPLQuadTreeCreate(&domain_, nullptr));
         if (ls.empty())
         {
             return;
@@ -388,21 +316,23 @@ template <typename PolygonWriter> class PolygonRingAppender
         Ring newRing;
         newRing.points.swap(ls);
         newRing.computeBBox();
-        // Find the top-level parent (if any) through the grid
-        // index instead of scanning every top-level ring, then descend the
-        // (short) nested sibling lists exactly as before.
+        // Find the top-level parent (if any) through the index instead of
+        // scanning every top-level ring, then descend the (short) nested
+        // sibling lists exactly as before.
         Ring *parentRing = nullptr;
         {
             Ring *top = nullptr;
-            levelIndex.forPoint(
-                newRing.points.front().x, newRing.points.front().y,
-                [&](size_t idx)
-                {
-                    Ring &cand = levelRings[idx];
-                    if (top == nullptr && !cand.points.empty() &&
-                        newRing.isIn(cand))
-                        top = &cand;
-                });
+            const auto &fp0 = newRing.points.front();
+            CPLRectObj aoi{fp0.x, fp0.y, fp0.x, fp0.y};
+            int nHits = 0;
+            void **hits = CPLQuadTreeSearch(levelTree.get(), &aoi, &nHits);
+            for (int h = 0; h < nHits && top == nullptr; h++)
+            {
+                Ring &cand = levelRings[featureSlot(hits[h])];
+                if (!cand.points.empty() && newRing.isIn(cand))
+                    top = &cand;
+            }
+            CPLFree(hits);
             if (top != nullptr)
             {
                 parentRing = top;
@@ -433,21 +363,24 @@ template <typename PolygonWriter> class PolygonRingAppender
             // inside the new ring, via the index. Build a per-target PIP
             // index lazily so a huge ring capturing many candidates costs
             // O(V + R * V/B), not O(R * V).
-            std::vector<size_t> captured;
+            std::vector<std::size_t> captured;
             RingPIPIndex pip;
             bool pipBuilt = false;
-            size_t nCandidates = 0;
-            levelIndex.forBox(
-                newRing.bbXMin, newRing.bbYMin, newRing.bbXMax, newRing.bbYMax,
-                [&](size_t idx)
+            std::size_t nCandidates = 0;
+            {
+                CPLRectObj aoi = ringRect(newRing);
+                int nHits = 0;
+                void **hits = CPLQuadTreeSearch(levelTree.get(), &aoi, &nHits);
+                for (int h = 0; h < nHits; h++)
                 {
+                    const std::size_t idx = featureSlot(hits[h]);
                     Ring &cand = levelRings[idx];
                     if (cand.points.empty())
-                        return;
+                        continue;
                     const auto &fp = cand.points.front();
-                    if (fp.x < newRing.bbXMin || fp.x > newRing.bbXMax ||
-                        fp.y < newRing.bbYMin || fp.y > newRing.bbYMax)
-                        return;
+                    if (fp.x < newRing.bbox.MinX || fp.x > newRing.bbox.MaxX ||
+                        fp.y < newRing.bbox.MinY || fp.y > newRing.bbox.MaxY)
+                        continue;
                     if (!pipBuilt && ++nCandidates > 16 &&
                         newRing.points.size() > 512)
                     {
@@ -458,17 +391,23 @@ template <typename PolygonWriter> class PolygonRingAppender
                         pipBuilt ? pip.contains(fp) : cand.isIn(newRing);
                     if (inside)
                         captured.push_back(idx);
-                });
+                }
+                CPLFree(hits);
+            }
             std::sort(captured.begin(), captured.end());
             captured.erase(std::unique(captured.begin(), captured.end()),
                            captured.end());
-            for (size_t idx : captured)
+            for (std::size_t idx : captured)
             {
+                CPLRectObj rb = ringRect(levelRings[idx]);
+                CPLQuadTreeRemove(levelTree.get(), slotFeature(idx), &rb);
                 newRing.interiorRings.push_back(std::move(levelRings[idx]));
                 levelRings[idx].points.clear();  // tombstone the slot
             }
             levelRings.push_back(std::move(newRing));
-            levelIndex.insert(levelRings.back(), levelRings.size() - 1);
+            CPLRectObj nb = ringRect(levelRings.back());
+            CPLQuadTreeInsertWithBounds(
+                levelTree.get(), slotFeature(levelRings.size() - 1), &nb);
         }
         else
         {

--- a/alg/marching_squares/polygon_ring_appender.h
+++ b/alg/marching_squares/polygon_ring_appender.h
@@ -19,6 +19,7 @@
 #include <cassert>
 #include <iterator>
 #include <cmath>
+#include <cstdint>
 #include <unordered_map>
 #include <functional>
 #include <algorithm>
@@ -190,8 +191,35 @@ template <typename PolygonWriter> class PolygonRingAppender
             yMin = r.bbYMin;
             yMax = r.bbYMax;
             const size_t nSeg = r.points.size();
-            const size_t nBuckets =
+            // A segment spanning dy is copied into about
+            // dy * nBuckets / (yMax - yMin) + 1 buckets, so the total stored
+            // copies is nSeg + sumSpan * nBuckets / (yMax - yMin). Cap
+            // nBuckets so that total stays O(nSeg): rings whose segments keep
+            // crossing most of the y-range (sawtooth or near-flat rings)
+            // would otherwise blow up quadratically.
+            double sumSpan = 0;
+            {
+                auto spanIt = r.points.begin();
+                auto prev = *spanIt;
+                for (++spanIt; spanIt != r.points.end(); ++spanIt)
+                {
+                    sumSpan += std::abs(spanIt->y - prev.y);
+                    prev = *spanIt;
+                }
+            }
+            size_t nBuckets =
                 std::max<size_t>(64, std::min<size_t>(nSeg / 32, 65536));
+            if (yMax > yMin && sumSpan > 0)
+            {
+                const double cap = 4.0 * nSeg * (yMax - yMin) / sumSpan;
+                if (cap < static_cast<double>(nBuckets))
+                    nBuckets = std::max<size_t>(1, static_cast<size_t>(cap));
+            }
+            else
+            {
+                // Degenerate flat ring: every segment would span all buckets.
+                nBuckets = 1;
+            }
             buckets.assign(nBuckets, {});
             inv = (yMax > yMin) ? nBuckets / (yMax - yMin) : 0;
             auto it = r.points.begin();
@@ -259,8 +287,12 @@ template <typename PolygonWriter> class PolygonRingAppender
         {
             size_t operator()(const std::pair<long long, long long> &c) const
             {
-                return std::hash<long long>()(
-                    c.first * 2654435761LL ^ (c.second << 21 | c.second >> 43));
+                // Unsigned arithmetic: cells can be negative, and signed
+                // overflow / shifting negative values is undefined behavior.
+                const auto x = static_cast<std::uint64_t>(c.first);
+                const auto y = static_cast<std::uint64_t>(c.second);
+                return std::hash<std::uint64_t>()(x * 2654435761ULL ^
+                                                  (y << 21 | y >> 43));
             }
         };
 

--- a/alg/marching_squares/polygon_ring_appender.h
+++ b/alg/marching_squares/polygon_ring_appender.h
@@ -269,7 +269,7 @@ template <typename PolygonWriter> class PolygonRingAppender
             if (top != nullptr)
             {
                 parentRing = top;
-                // descend into nested rings (sibling lists are short)
+                // This queue holds the rings to be checked
                 std::deque<Ring *> queue;
                 std::transform(
                     top->interiorRings.begin(), top->interiorRings.end(),
@@ -280,6 +280,10 @@ template <typename PolygonWriter> class PolygonRingAppender
                     queue.pop_front();
                     if (newRing.isIn(*curRing))
                     {
+                        // We know that there should only be one ring per
+                        // level that we should fit in, so we can discard the
+                        // rest of the queue and try again with the children
+                        // of this ring
                         parentRing = curRing;
                         queue.clear();
                         std::transform(curRing->interiorRings.begin(),
@@ -347,15 +351,23 @@ template <typename PolygonWriter> class PolygonRingAppender
         }
         else
         {
-            // Nested insertion: identical to the original algorithm on the
-            // parent's (short) child list.
+            // Get a pointer to the list we need to check for rings to include
+            // in this ring
             std::vector<Ring> *parentRingList = &(parentRing->interiorRings);
+            // We found a valid parent, so we need to:
+            // 1. Find all the inner rings of the parent that are inside the new
+            // ring
             auto trueGroupIt = std::partition(
                 parentRingList->begin(), parentRingList->end(),
                 [&newRing](Ring &pRing) { return !pRing.isIn(newRing); });
+            // 2. Move those rings out of the parent and into the new ring's
+            // interior rings
             std::move(trueGroupIt, parentRingList->end(),
                       std::back_inserter(newRing.interiorRings));
+            // 3. Get rid of the moved-from elements in the parent's interior
+            // rings
             parentRingList->erase(trueGroupIt, parentRingList->end());
+            // 4. Add the new ring to the parent's interior rings
             parentRingList->push_back(std::move(newRing));
         }
     }

--- a/alg/marching_squares/polygon_ring_appender.h
+++ b/alg/marching_squares/polygon_ring_appender.h
@@ -18,7 +18,6 @@
 #include <deque>
 #include <cassert>
 #include <iterator>
-#include <cmath>
 #include <cstdint>
 #include <memory>
 #include <algorithm>
@@ -26,6 +25,7 @@
 #include "cpl_quad_tree.h"
 
 #include "point.h"
+#include "ogr_api.h"
 #include "ogr_geometry.h"
 
 namespace marching_squares
@@ -157,104 +157,37 @@ template <typename PolygonWriter> class PolygonRingAppender
     // level -> rings
     std::map<double, std::vector<Ring>> rings_;
 
-    // Point-in-polygon accelerator for one target ring. The capture step
-    // tests MANY points against the SAME ring (pathological case: a
-    // domain-spanning ring with millions of vertices capturing tens of
-    // thousands of earlier rings) — bucketing the ring's segments by y makes
-    // each test O(segments-in-bucket) instead of O(all vertices). GEOS has
-    // the natural structure for this (IndexedPointInAreaLocator), but GEOS
-    // is an optional dependency and contouring must work without it; GDAL
-    // core has no indexed point-in-polygon type.
-    struct RingPIPIndex
+    // Point-in-polygon accelerator for one target ring: an
+    // OGRPreparedGeometry (GEOS indexed point-in-area locator) over the
+    // ring, built lazily when a ring turns out to capture many candidates.
+    // The pathological case is a domain-spanning ring with millions of
+    // vertices capturing tens of thousands of earlier rings; testing each
+    // candidate against the raw ring is O(candidates * vertices). In builds
+    // without GEOS support the capture step falls back to the linear
+    // winding test.
+    struct PreparedRing
     {
-        double yMin = 0, yMax = 0, inv = 0;
-        std::vector<std::vector<std::pair<Point, Point>>> buckets;
+        OGRPolygon poly;
+        OGRPreparedGeometryUniquePtr prep;
 
-        void build(const Ring &r)
+        bool build(const Ring &r)
         {
-            yMin = r.bbox.MinY;
-            yMax = r.bbox.MaxY;
-            const size_t nSeg = r.points.size();
-            // A segment spanning dy is copied into about
-            // dy * nBuckets / (yMax - yMin) + 1 buckets, so the total stored
-            // copies is nSeg + sumSpan * nBuckets / (yMax - yMin). Cap
-            // nBuckets so that total stays O(nSeg): rings whose segments keep
-            // crossing most of the y-range (sawtooth or near-flat rings)
-            // would otherwise blow up quadratically.
-            double sumSpan = 0;
-            {
-                auto spanIt = r.points.begin();
-                auto prev = *spanIt;
-                for (++spanIt; spanIt != r.points.end(); ++spanIt)
-                {
-                    sumSpan += std::abs(spanIt->y - prev.y);
-                    prev = *spanIt;
-                }
-            }
-            size_t nBuckets =
-                std::max<size_t>(64, std::min<size_t>(nSeg / 32, 65536));
-            if (yMax > yMin && sumSpan > 0)
-            {
-                const double cap = 4.0 * nSeg * (yMax - yMin) / sumSpan;
-                if (cap < static_cast<double>(nBuckets))
-                    nBuckets = std::max<size_t>(1, static_cast<size_t>(cap));
-            }
-            else
-            {
-                // Degenerate flat ring: every segment would span all buckets.
-                nBuckets = 1;
-            }
-            buckets.assign(nBuckets, {});
-            inv = (yMax > yMin) ? nBuckets / (yMax - yMin) : 0;
-            auto it = r.points.begin();
-            auto p1 = *it;
-            for (++it; it != r.points.end(); ++it)
-            {
-                auto p2 = *it;
-                double lo = std::min(p1.y, p2.y), hi = std::max(p1.y, p2.y);
-                size_t b0 = bucketOf(lo), b1 = bucketOf(hi);
-                for (size_t b = b0; b <= b1; b++)
-                    buckets[b].emplace_back(p1, p2);
-                p1 = p2;
-            }
+            auto ring = std::make_unique<OGRLinearRing>();
+            ring->setNumPoints(static_cast<int>(r.points.size()));
+            int i = 0;
+            for (const auto &pt : r.points)
+                ring->setPoint(i++, pt.x, pt.y);
+            poly.addRingDirectly(ring.release());
+            poly.closeRings();
+            prep.reset(OGRCreatePreparedGeometry(OGRGeometry::ToHandle(&poly)));
+            return prep != nullptr;
         }
 
-        size_t bucketOf(double y) const
+        bool contains(const Point &p) const
         {
-            if (y <= yMin)
-                return 0;
-            if (y >= yMax)
-                return buckets.size() - 1;
-            size_t b = static_cast<size_t>((y - yMin) * inv);
-            return b >= buckets.size() ? buckets.size() - 1 : b;
-        }
-
-        // identical winding-number semantics to Ring::isIn
-        bool contains(const Point &checkPoint) const
-        {
-            int windingNum = 0;
-            for (const auto &seg : buckets[bucketOf(checkPoint.y)])
-            {
-                const auto &p1 = seg.first;
-                const auto &p2 = seg.second;
-                if (p1.y <= checkPoint.y)
-                {
-                    if (p2.y > checkPoint.y)
-                    {
-                        if (isLeft(p1, p2, checkPoint))
-                            ++windingNum;
-                    }
-                }
-                else
-                {
-                    if (p2.y <= checkPoint.y)
-                    {
-                        if (!isLeft(p1, p2, checkPoint))
-                            --windingNum;
-                    }
-                }
-            }
-            return windingNum != 0;
+            OGRPoint pt(p.x, p.y);
+            return CPL_TO_BOOL(OGRPreparedGeometryContains(
+                prep.get(), OGRGeometry::ToHandle(&pt)));
         }
     };
 
@@ -364,7 +297,8 @@ template <typename PolygonWriter> class PolygonRingAppender
             // index lazily so a huge ring capturing many candidates costs
             // O(V + R * V/B), not O(R * V).
             std::vector<std::size_t> captured;
-            RingPIPIndex pip;
+            PreparedRing pip;
+            bool pipTried = false;
             bool pipBuilt = false;
             std::size_t nCandidates = 0;
             {
@@ -381,11 +315,11 @@ template <typename PolygonWriter> class PolygonRingAppender
                     if (fp.x < newRing.bbox.MinX || fp.x > newRing.bbox.MaxX ||
                         fp.y < newRing.bbox.MinY || fp.y > newRing.bbox.MaxY)
                         continue;
-                    if (!pipBuilt && ++nCandidates > 16 &&
+                    if (!pipTried && ++nCandidates > 16 &&
                         newRing.points.size() > 512)
                     {
-                        pip.build(newRing);
-                        pipBuilt = true;
+                        pipTried = true;
+                        pipBuilt = pip.build(newRing);
                     }
                     const bool inside =
                         pipBuilt ? pip.contains(fp) : cand.isIn(newRing);
@@ -394,6 +328,8 @@ template <typename PolygonWriter> class PolygonRingAppender
                 }
                 CPLFree(hits);
             }
+            // Sorting by slot restores insertion order, so captured rings
+            // nest in the same order the original linear scan produced.
             std::sort(captured.begin(), captured.end());
             captured.erase(std::unique(captured.begin(), captured.end()),
                            captured.end());

--- a/autotest/alg/contour.py
+++ b/autotest/alg/contour.py
@@ -649,7 +649,8 @@ def test_contour_polygonize_many_disjoint_rings():
     ogr_lyr.SetAttributeFilter("elevMin = -2")
     below = ogr_lyr.GetNextFeature()
     geom = below.GetGeometryRef()
-    assert geom.IsValid()
+    if ogrtest.have_geos():
+        assert geom.IsValid()
     assert geom.GetGeometryCount() == 1  # one polygon: the big region
     poly = geom.GetGeometryRef(0)
     # exterior + the 36 captured pond holes
@@ -658,19 +659,15 @@ def test_contour_polygonize_many_disjoint_rings():
     ogr_lyr.SetAttributeFilter("elevMax = 2")
     above = ogr_lyr.GetNextFeature()
     geom = above.GetGeometryRef()
-    assert geom.IsValid()
+    if ogrtest.have_geos():
+        assert geom.IsValid()
     # the domain polygon (with the big region as hole) + 36 pond islands
     assert geom.GetGeometryCount() == 37
-    ring_counts = sorted(
-        geom.GetGeometryRef(i).GetGeometryCount() for i in range(37)
-    )
+    ring_counts = sorted(geom.GetGeometryRef(i).GetGeometryCount() for i in range(37))
     assert ring_counts == [1] * 36 + [2]
 
     # the two bands partition the domain
-    total = sum(
-        f.GetGeometryRef().GetArea()
-        for f in (below, above)
-    )
+    total = sum(f.GetGeometryRef().GetArea() for f in (below, above))
     assert total == pytest.approx(512 * 512, rel=0.02)
 
 
@@ -719,7 +716,8 @@ def test_contour_polygonize_sawtooth_ring():
     ogr_lyr.SetAttributeFilter("elevMin = -2")
     below = ogr_lyr.GetNextFeature()
     geom = below.GetGeometryRef()
-    assert geom.IsValid()
+    if ogrtest.have_geos():
+        assert geom.IsValid()
     assert geom.GetGeometryCount() == 1  # one polygon: the whole comb
     poly = geom.GetGeometryRef(0)
     assert poly.GetGeometryCount() == 1 + n_ponds  # exterior + pond holes
@@ -727,7 +725,8 @@ def test_contour_polygonize_sawtooth_ring():
     ogr_lyr.SetAttributeFilter("elevMax = 2")
     above = ogr_lyr.GetNextFeature()
     geom = above.GetGeometryRef()
-    assert geom.IsValid()
+    if ogrtest.have_geos():
+        assert geom.IsValid()
     # the domain polygon (comb as hole) + one island per pond
     assert geom.GetGeometryCount() == 1 + n_ponds
 

--- a/autotest/alg/contour.py
+++ b/autotest/alg/contour.py
@@ -603,3 +603,72 @@ cellsize     1
             elev_values.append((f["ELEV_MIN"], f["ELEV_MAX"]))
 
         assert elev_values == expected_elev_values, (elev_values, expected_elev_values)
+
+
+def test_contour_polygonize_many_disjoint_rings():
+    """Many disjoint rings at one level, enclosed by a large late-closing ring:
+    the pattern that made polygon ring attachment quadratic (#1750, #2241). The
+    big ring closes after the small ones and must capture all of them as
+    interior rings; the small rings must survive as islands of the outer band."""
+
+    numpy = pytest.importorskip("numpy")
+
+    drv = gdal.GetDriverByName("MEM")
+    ds = drv.Create("", 512, 512, 1, gdal.GDT_Float32)
+    ds.SetGeoTransform([0, 1, 0, 512, 0, -1])
+
+    data = numpy.full((512, 512), 1.0, dtype=numpy.float32)
+    # large below-level region: ring perimeter ~1648 vertices
+    data[50:462, 50:462] = -1.0
+    # 36 above-level ponds inside it: 36 disjoint hole rings
+    for py in range(6):
+        for px in range(6):
+            y0 = 76 + py * 64
+            x0 = 76 + px * 64
+            data[y0 : y0 + 7, x0 : x0 + 7] = 1.0
+    ds.GetRasterBand(1).WriteArray(data)
+
+    ogr_ds = ogr.GetDriverByName("MEM").CreateDataSource("")
+    ogr_lyr = ogr_ds.CreateLayer("contour", geom_type=ogr.wkbMultiPolygon)
+    ogr_lyr.CreateField(ogr.FieldDefn("elevMin", ogr.OFTReal))
+    ogr_lyr.CreateField(ogr.FieldDefn("elevMax", ogr.OFTReal))
+
+    gdal.ContourGenerateEx(
+        ds.GetRasterBand(1),
+        ogr_lyr,
+        options=[
+            "FIXED_LEVELS=-2,0,2",
+            "ELEV_FIELD_MIN=0",
+            "ELEV_FIELD_MAX=1",
+            "POLYGONIZE=TRUE",
+        ],
+    )
+
+    assert ogr_lyr.GetFeatureCount() == 2
+
+    ogr_lyr.SetAttributeFilter("elevMin = -2")
+    below = ogr_lyr.GetNextFeature()
+    geom = below.GetGeometryRef()
+    assert geom.IsValid()
+    assert geom.GetGeometryCount() == 1  # one polygon: the big region
+    poly = geom.GetGeometryRef(0)
+    # exterior + the 36 captured pond holes
+    assert poly.GetGeometryCount() == 37
+
+    ogr_lyr.SetAttributeFilter("elevMax = 2")
+    above = ogr_lyr.GetNextFeature()
+    geom = above.GetGeometryRef()
+    assert geom.IsValid()
+    # the domain polygon (with the big region as hole) + 36 pond islands
+    assert geom.GetGeometryCount() == 37
+    ring_counts = sorted(
+        geom.GetGeometryRef(i).GetGeometryCount() for i in range(37)
+    )
+    assert ring_counts == [1] * 36 + [2]
+
+    # the two bands partition the domain
+    total = sum(
+        f.GetGeometryRef().GetArea()
+        for f in (below, above)
+    )
+    assert total == pytest.approx(512 * 512, rel=0.02)

--- a/autotest/alg/contour.py
+++ b/autotest/alg/contour.py
@@ -679,6 +679,7 @@ def test_contour_polygonize_sawtooth_ring():
     for the ring; that index must not grow with the vertical extent of each
     segment."""
 
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     width, height = 16384, 16

--- a/autotest/alg/contour.py
+++ b/autotest/alg/contour.py
@@ -672,3 +672,64 @@ def test_contour_polygonize_many_disjoint_rings():
         for f in (below, above)
     )
     assert total == pytest.approx(512 * 512, rel=0.02)
+
+
+def test_contour_polygonize_sawtooth_ring():
+    """A comb-shaped region whose boundary ring is almost entirely vertical
+    segments. Bucketing such a ring's segments by y must not copy each segment
+    into a large fraction of the buckets, which made RingPIPIndex::build()
+    quadratic in memory. The ponds in the comb's base force the capture path
+    that builds the index."""
+
+    numpy = pytest.importorskip("numpy")
+
+    width, height = 16384, 16
+    drv = gdal.GetDriverByName("MEM")
+    ds = drv.Create("", width, height, 1, gdal.GDT_Float32)
+    ds.SetGeoTransform([0, 1, 0, height, 0, -1])
+
+    data = numpy.full((height, width), 1.0, dtype=numpy.float32)
+    # comb base: a solid below-level band
+    data[10:14, 2 : width - 2] = -1.0
+    # comb teeth: 1px-wide columns every 2px, nearly full height
+    data[1:10, 2 : width - 2 : 2] = -1.0
+    # ponds in the base: enough that the capture step builds the PIP index
+    data[12, 256 : width - 256 : 256] = 1.0
+    ds.GetRasterBand(1).WriteArray(data)
+    n_ponds = len(range(256, width - 256, 256))
+
+    ogr_ds = ogr.GetDriverByName("MEM").CreateDataSource("")
+    ogr_lyr = ogr_ds.CreateLayer("contour", geom_type=ogr.wkbMultiPolygon)
+    ogr_lyr.CreateField(ogr.FieldDefn("elevMin", ogr.OFTReal))
+    ogr_lyr.CreateField(ogr.FieldDefn("elevMax", ogr.OFTReal))
+
+    gdal.ContourGenerateEx(
+        ds.GetRasterBand(1),
+        ogr_lyr,
+        options=[
+            "FIXED_LEVELS=-2,0,2",
+            "ELEV_FIELD_MIN=0",
+            "ELEV_FIELD_MAX=1",
+            "POLYGONIZE=TRUE",
+        ],
+    )
+
+    assert ogr_lyr.GetFeatureCount() == 2
+
+    ogr_lyr.SetAttributeFilter("elevMin = -2")
+    below = ogr_lyr.GetNextFeature()
+    geom = below.GetGeometryRef()
+    assert geom.IsValid()
+    assert geom.GetGeometryCount() == 1  # one polygon: the whole comb
+    poly = geom.GetGeometryRef(0)
+    assert poly.GetGeometryCount() == 1 + n_ponds  # exterior + pond holes
+
+    ogr_lyr.SetAttributeFilter("elevMax = 2")
+    above = ogr_lyr.GetNextFeature()
+    geom = above.GetGeometryRef()
+    assert geom.IsValid()
+    # the domain polygon (comb as hole) + one island per pond
+    assert geom.GetGeometryCount() == 1 + n_ponds
+
+    total = sum(f.GetGeometryRef().GetArea() for f in (below, above))
+    assert total == pytest.approx(width * height, rel=0.02)

--- a/autotest/alg/contour.py
+++ b/autotest/alg/contour.py
@@ -673,10 +673,10 @@ def test_contour_polygonize_many_disjoint_rings():
 
 def test_contour_polygonize_sawtooth_ring():
     """A comb-shaped region whose boundary ring is almost entirely vertical
-    segments. Bucketing such a ring's segments by y must not copy each segment
-    into a large fraction of the buckets, which made RingPIPIndex::build()
-    quadratic in memory. The ponds in the comb's base force the capture path
-    that builds the index."""
+    segments, each spanning nearly the full raster height. The ponds in the
+    comb's base force the capture path that builds the point-in-polygon index
+    for the ring; that index must not grow with the vertical extent of each
+    segment."""
 
     numpy = pytest.importorskip("numpy")
 

--- a/autotest/alg/contour.py
+++ b/autotest/alg/contour.py
@@ -611,6 +611,7 @@ def test_contour_polygonize_many_disjoint_rings():
     big ring closes after the small ones and must capture all of them as
     interior rings; the small rings must survive as islands of the outer band."""
 
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     drv = gdal.GetDriverByName("MEM")

--- a/autotest/cpp/test_marching_squares_polygon.cpp
+++ b/autotest/cpp/test_marching_squares_polygon.cpp
@@ -155,7 +155,8 @@ TEST_F(test_ms_polygon, dummy)
     std::vector<double> data = {2.0};
     TestPolygonWriter w;
     {
-        PolygonRingAppender<TestPolygonWriter> appender(w);
+        PolygonRingAppender<TestPolygonWriter> appender(w, -100, -100, 100,
+                                                        100);
         IntervalLevelRangeIterator levels(
             0.0, 10.0, -std::numeric_limits<double>::infinity());
         SegmentMerger<PolygonRingAppender<TestPolygonWriter>,
@@ -219,7 +220,8 @@ TEST_F(test_ms_polygon, four_pixels)
     std::vector<double> data = {5.0, 10.0, 10.0, 5.0};
     TestPolygonWriter w;
     {
-        PolygonRingAppender<TestPolygonWriter> appender(w);
+        PolygonRingAppender<TestPolygonWriter> appender(w, -100, -100, 100,
+                                                        100);
         IntervalLevelRangeIterator levels(
             0.0, 10.0, -std::numeric_limits<double>::infinity());
         SegmentMerger<PolygonRingAppender<TestPolygonWriter>,
@@ -290,7 +292,8 @@ TEST_F(test_ms_polygon, four_pixels_2)
     {
         TestPolygonWriter w;
         {
-            PolygonRingAppender<TestPolygonWriter> appender(w);
+            PolygonRingAppender<TestPolygonWriter> appender(w, -100, -100, 100,
+                                                            100);
             const double levels[] = {155.0};
             FixedLevelRangeIterator levelGenerator(
                 levels, 1, -std::numeric_limits<double>::infinity(),
@@ -328,7 +331,8 @@ TEST_F(test_ms_polygon, four_pixels_2)
     {
         TestPolygonWriter w;
         {
-            PolygonRingAppender<TestPolygonWriter> appender(w);
+            PolygonRingAppender<TestPolygonWriter> appender(w, -100, -100, 100,
+                                                            100);
             const double levels[] = {155.0};
             FixedLevelRangeIterator levelGenerator(
                 levels, 1, -std::numeric_limits<double>::infinity(),
@@ -428,7 +432,8 @@ TEST_F(test_ms_polygon, nine_pixels)
     std::vector<double> data = {0.0, 4.0, 0.0, 4.0, 12.0, 4.0, 0.0, 4.0, 0.0};
     TestPolygonWriter w;
     {
-        PolygonRingAppender<TestPolygonWriter> appender(w);
+        PolygonRingAppender<TestPolygonWriter> appender(w, -100, -100, 100,
+                                                        100);
         IntervalLevelRangeIterator levels(
             1.0, 10.0, -std::numeric_limits<double>::infinity());
         SegmentMerger<PolygonRingAppender<TestPolygonWriter>,
@@ -481,7 +486,8 @@ TEST_F(test_ms_polygon, three_nested_rings)
                                 4, 2, 2, 4, 4, 4, 2, 2, 2, 2, 2, 2};
     TestPolygonWriter w;
     {
-        PolygonRingAppender<TestPolygonWriter> appender(w);
+        PolygonRingAppender<TestPolygonWriter> appender(w, -100, -100, 100,
+                                                        100);
         IntervalLevelRangeIterator levels(
             1.0, 2.0, -std::numeric_limits<double>::infinity());
         SegmentMerger<PolygonRingAppender<TestPolygonWriter>,


### PR DESCRIPTION
## What does this PR do?

Makes `gdal_contour -p` fast. For example, on rasters where a level crosses speckled terrain such as high-resolution coastal wetlands, a single polygon pass for [Seascape](https://github.com/openwatersio/seascape) that used to take 80 minutes now takes 2 minutes with identical output. It accomplishes this by making ring attachment near-linear in ring count.

`PolygonRingAppender::addLine` has three compounding costs:

1. Each new ring is containment-tested against **every** existing top-level ring at its level, each test a full winding-number walk over the candidate's vertices; no bbox rejection, no spatial index.
2. `std::partition` then re-tests every sibling to find rings the new ring encloses, with the lambda capturing the new ring **by value**, copying its `std::list` of points once per insertion.
3. `Ring` declares defaulted copy operations, which suppresses the implicit moves, so vector reallocations and partition reshuffles deep-copy whole ring subtrees.

Plus a one-shot O(R × V) spike when a large ring closes last and every existing ring is winding-tested against its full vertex list.

This is the case that survived #2908: that PR replaced the post-sort with incremental tree insertion, which fixed hole attachment against a few large rings; the flat many-disjoint-rings case stayed quadratic (and is, I believe, the hang in #2241).

Changes, in `alg/marching_squares/polygon_ring_appender.h` (plus the appender's new domain arguments in `alg/contour.cpp` and the C++ test):

- restore `Ring` move semantics;
- cache each ring's bbox, with an O(1) reject in `isIn`;
- a per-level `CPLQuadTree` over top-level ring bounding boxes for parent search and enclosed-ring capture (captured rings tombstone their vector slot so slot indices stay stable);
- a lazily built `OGRPreparedGeometry` (GEOS indexed point-in-area locator) over a ring that turns out to capture many candidates, for the large-ring spike; builds without GEOS fall back to the linear winding test.

Ring coordinates at this layer are raster pixel units (the geotransform is applied downstream by the writer), so the quad tree's domain is the raster extent plus the border cells, passed in by `GDALContourGenerateEx`.

## Reproduction

```
python3 -c "
import numpy as np
from osgeo import gdal
n, blob = 2048, 4
rng = np.random.default_rng(7)
a = np.where(rng.random(((n//blob)+1, (n//blob)+1)) < 0.25, -0.5, 0.5)
a = np.kron(a, np.ones((blob, blob), dtype=np.float32))[:n, :n]
ds = gdal.GetDriverByName('GTiff').Create('speckle.tif', n, n, 1, gdal.GDT_Float32)
ds.SetGeoTransform([0, 1, 0, n, 0, -1])
ds.GetRasterBand(1).WriteArray(a.astype(np.float32))
"
time gdal_contour -p -amin amin -amax amax -fl -2 0 2 -f GPKG speckle.tif out.gpkg
```

53 s at n=2048 (GDAL 3.13.1, Apple M-series); quadrupling n multiplies the wall by ~16 while the raster scan itself stays trivial.

## Measurements

Synthetic speckle grid, `gdal_contour -p`, level 0:

| grid | top-level rings | before | after |
|---|---|---|---|
| 2048² | ~25k | 53 s | 0.67 s |
| 4096² | ~99k | ~15 min | 2.2 s |
| 8192² | ~394k | ~4 h (extrapolated) | ~12 s |

Real 65,536² coastal DEM (New Zealand coast, 2.4 m/px, 20 fixed levels, 91k output polygons across 15 bands): **4,839 s => 121 s**. A 32,768² harbor DEM with no pathological ring count also improves ~3× (the moves and bbox rejects alone).

## Output equivalence

Verified identical (band labels, part counts, and per-band geometry equality) against unpatched builds on:

* the synthetic grids
* the real 65,536² DEM (all 15 bands exact)
* a 32,768² harbor DEM (EPSG:3857)
* an EPSG:4326 non-square-pixel warp of the same data

## What are related issues/pull requests?

Related: #1750, #2241, #2908

## AI tool usage

- [x] AI supported my development of this PR. The analysis, patch, and test were developed with LLM assistance; I have reviewed, benchmarked and tested the result and take responsibility for it.

## Tasklist

- [x] Make sure code is correctly formatted (pre-commit clang-format)
- [x] Add test case(s) — `test_contour_polygonize_many_disjoint_rings`: many disjoint rings captured by a large late-closing ring, exercising the quad-tree index, tombstone capture and prepared-geometry paths; `test_contour_polygonize_sawtooth_ring`: a ring of nearly all full-height vertical segments through the capture path. Both pass on patched and unpatched builds — they guard the nesting semantics the patch must preserve.
- [x] AddressSanitizer clean over the ring-attachment path, with ring and hole counts identical to the unsanitized run
- [x] Add documentation — none needed (internal performance change, no API or output change)
- [x] Updated Python API documentation — n/a
- [ ] Review
- [x] Adjust for comments
- [ ] All CI builds and checks have passed

## Environment

* OS: macOS 15 (arm64) and Ubuntu 24.04 (x86_64, in the GDAL 3.13.1 container)
* Compiler: Apple clang 17 / gcc 13, -O2

## Notes for reviewers

- Tombstoning instead of erasing is what keeps slot indices stable; moved-from slots are dropped once, at traversal time in the destructor.
- The prepared-geometry thresholds (>16 candidates, >512 points) are heuristics; the asymptotics don't depend on them, only the constants.
- `closestExterior` was already unused; left untouched.

