### PR TITLE
JP2Grok: link to version 20.3.9 of Grok library

### DIFF
--- a/.github/workflows/ubuntu_26.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_26.04/Dockerfile.ci
@@ -234,7 +234,7 @@ RUN curl -LO -fsS https://github.com/apache/arrow/archive/refs/heads/main.zip \
     && rm -rf arrow-main
 
 # Build Grok JPEG 2000 library
-ARG GROK_VERSION=v20.3.5
+ARG GROK_VERSION=v20.3.9
 
 RUN git clone --recursive --depth 1 --branch ${GROK_VERSION} \
     https://github.com/GrokImageCompression/grok.git grok-git && \

--- a/autotest/gdrivers/jp2grok.py
+++ b/autotest/gdrivers/jp2grok.py
@@ -277,7 +277,7 @@ def test_jp2grok_10():
     gdal.Unlink("/vsimem/jp2grok_10.jp2")
 
     # Quite a bit of difference...
-    assert maxdiff <= 38, "Image too different from reference"
+    assert maxdiff <= 39, "Image too different from reference"
 
 
 ###############################################################################
@@ -592,7 +592,7 @@ def test_jp2grok_22():
     assert fourth_band.GetMetadataItem("NBITS", "IMAGE_STRUCTURE") == "1"
     ds = None
     ds = gdal.Open("/vsimem/jp2grok_22.jp2")
-    assert ds.GetRasterBand(4).Checksum() == 26477
+    assert ds.GetRasterBand(4).Checksum() in (26477, 30223)
     ds = None
     gdal.Unlink("/vsimem/jp2grok_22.jp2")
 
@@ -721,7 +721,7 @@ def test_jp2grok_24():
     ds = None
     ds = gdal.Open("/vsimem/jp2grok_24.jp2")
     assert ds.GetRasterBand(2).GetMetadataItem("NBITS", "IMAGE_STRUCTURE") is None
-    assert ds.GetRasterBand(2).Checksum() == 27389
+    assert ds.GetRasterBand(2).Checksum() in (27389, 30223)
     ds = None
     gdal.Unlink("/vsimem/jp2grok_24.jp2")
 

--- a/cmake/helpers/CheckDependentLibrariesGrok.cmake
+++ b/cmake/helpers/CheckDependentLibrariesGrok.cmake
@@ -2,4 +2,4 @@ gdal_check_package(Grok "Enable JPEG2000 support with Grok library"
                    CONFIG
                    CAN_DISABLE
                    TARGETS GROK::grokj2k
-                   VERSION 20.3.5)
+                   VERSION 20.3.9)


### PR DESCRIPTION
## What does this PR do?

Link to latest version of Grok. As the library has a new 16 bit fast path that can have slightly lower precision, a few unit tests needed adjusting.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))

