### PR TITLE
gdal_translate: set band scale/offset when using -scale

### DIFF
--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -2334,7 +2334,7 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
                 }
             }
 
-            if (!bExponentScaling)
+            if (!bExponentScaling || dfExponent == 1)
             {
                 dfScale = (dfScaleDstMax - dfScaleDstMin) /
                           (dfScaleSrcMax - dfScaleSrcMin);
@@ -2348,33 +2348,44 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
             dfOffset = poSrcBand->GetOffset();
         }
 
-        /* --------------------------------------------------------------------
-         */
-        /*      Create a simple or complex data source depending on the */
-        /*      translation type required. */
-        /* --------------------------------------------------------------------
-         */
+        /* ------------------------------------------------------------------ */
+        /*      Create a simple or complex data source depending on the       */
+        /*      translation type required.                                    */
+        /* ------------------------------------------------------------------ */
         std::unique_ptr<VRTSimpleSource> poSimpleSource;
         if (psOptions->bUnscale || bScale ||
             (psOptions->nRGBExpand != 0 && i < psOptions->nRGBExpand))
         {
             auto poComplexSource = std::make_unique<VRTComplexSource>();
 
-            /* --------------------------------------------------------------------
-             */
-            /*      Set complex parameters. */
-            /* --------------------------------------------------------------------
-             */
+            /* -------------------------------------------------------------- */
+            /*      Set complex parameters.                                   */
+            /* -------------------------------------------------------------- */
 
-            if (dfOffset != 0.0 || dfScale != 1.0)
-            {
-                poComplexSource->SetLinearScaling(dfOffset, dfScale);
-            }
-            else if (bExponentScaling)
+            bool bSetBandScaleOffset = false;
+            if (bExponentScaling)
             {
                 poComplexSource->SetPowerScaling(
                     dfExponent, dfScaleSrcMin, dfScaleSrcMax, dfScaleDstMin,
                     dfScaleDstMax, !psOptions->bNoClip);
+                if (dfExponent == 1)
+                {
+                    bSetBandScaleOffset = true;
+                }
+            }
+            else if (dfOffset != 0.0 || dfScale != 1.0)
+            {
+                poComplexSource->SetLinearScaling(dfOffset, dfScale);
+                if (!psOptions->bUnscale)
+                {
+                    bSetBandScaleOffset = true;
+                }
+            }
+
+            if (bSetBandScaleOffset && dfScale != 0)
+            {
+                poVRTBand->SetScale(1 / dfScale);
+                poVRTBand->SetOffset(-dfOffset / dfScale);
             }
 
             poComplexSource->SetColorTableComponent(nComponent);
@@ -2421,17 +2432,18 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
                 static_cast<GDALColorInterp>(GCI_RedBand + i));
         }
 
-        /* --------------------------------------------------------------------
-         */
-        /*      copy over some other information of interest. */
-        /* --------------------------------------------------------------------
-         */
+        /* ------------------------------------------------------------------ */
+        /*      copy over some other information of interest.                 */
+        /* ------------------------------------------------------------------ */
         else
         {
+            const bool bCopyScale = !psOptions->bUnscale &&
+                                    !psOptions->bSetScale &&
+                                    !psOptions->bSetOffset && !bScale;
+
             CopyBandInfo(poSrcBand, poVRTBand,
                          !psOptions->bStats && !bFilterOutStatsMetadata,
-                         !psOptions->bUnscale && !psOptions->bSetScale &&
-                             !psOptions->bSetOffset,
+                         bCopyScale,
                          !psOptions->bSetNoData && !psOptions->bUnsetNoData,
                          !psOptions->bNoRAT, psOptions.get());
             if (psOptions->asScaleParams.empty() &&

--- a/apps/gdalalg_raster_scale.cpp
+++ b/apps/gdalalg_raster_scale.cpp
@@ -52,7 +52,7 @@ GDALRasterScaleAlgorithm::GDALRasterScaleAlgorithm(bool standaloneStep)
            _("Exponent to apply non-linear scaling with a power function"),
            &m_exponent);
     AddArg("no-clip", 0,
-           _("Do not clip input values to [innput-min, input-max]"), &m_noClip);
+           _("Do not clip input values to [input-min, input-max]"), &m_noClip);
 }
 
 /************************************************************************/

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -2494,15 +2494,18 @@ def test_vrt_read_compute_statistics_mosaic_optimization_src_with_nodata(
 ):
 
     src_ds = gdal.Translate("", gdal.Open("data/byte.tif"), format="MEM")
-    src_ds1 = gdal.Translate(
-        "", src_ds, options="-of MEM -srcwin 0 0 8 20 -scale 0 255 10 10"
-    )
+    src_ds1 = gdal.Translate("", src_ds, options="-of MEM -srcwin 0 0 8 20")
+    src_ds1.GetRasterBand(1).Fill(10)
+
     src_ds2 = gdal.Translate("", src_ds, options="-of MEM -srcwin 8 0 12 20")
     vrt_ds = gdal.BuildVRT("", [src_ds1, src_ds2])
     if band_ndv:
         src_ds1.GetRasterBand(1).SetNoDataValue(band_ndv)
     if global_ndv:
         vrt_ds.GetRasterBand(1).SetNoDataValue(global_ndv)
+
+    assert vrt_ds.RasterXSize == src_ds.RasterXSize
+    assert vrt_ds.RasterYSize == src_ds.RasterYSize
 
     vrt_materialized = gdal.Translate("", vrt_ds, format="MEM")
 

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -568,6 +568,9 @@ def test_gdal_translate_lib_102():
     result = ds.GetRasterBand(1).ComputeRasterMinMax(False)
     assert result == (19018.0, 65535.0)
 
+    assert ds.GetRasterBand(1).GetScale() == 1 / 257
+    assert ds.GetRasterBand(1).GetOffset() is None
+
     approx_min, approx_max = ds.GetRasterBand(1).ComputeRasterMinMax(True)
     ds2 = gdal.Translate(
         "",
@@ -1400,7 +1403,7 @@ def test_gdal_translate_lib_no_input_band(tmp_vsimem):
 
 
 ###############################################################################
-# Test -scale and -unscape
+# Test -scale and -unscale
 
 
 @gdaltest.enable_exceptions()
@@ -1632,3 +1635,32 @@ def test_gdal_translate_lib_unset_NODATA_VALUES():
     )
     assert "NODATA_VALUES" not in out_ds.GetMetadata_Dict()
     assert out_ds.GetMetadataItem("FOO") == "BAR"
+
+
+###############################################################################
+
+
+def test_gdal_translate_lib_unscale():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 2, eType=gdal.GDT_Int16)
+    src_ds.GetRasterBand(1).Fill(5)
+    src_ds.GetRasterBand(1).SetScale(0.5)
+    src_ds.GetRasterBand(1).SetOffset(-200)
+
+    src_ds.GetRasterBand(2).Fill(-802)
+    src_ds.GetRasterBand(2).SetScale(5)
+    src_ds.GetRasterBand(2).SetOffset(1002)
+
+    out_ds = gdal.Translate(
+        "", src_ds, format="VRT", unscale=True, outputType=gdal.GDT_Float32
+    )
+
+    assert struct.unpack("f", out_ds.GetRasterBand(1).ReadRaster()) == (5 * 0.5 - 200,)
+    assert out_ds.GetRasterBand(1).GetScale() == 1
+    assert out_ds.GetRasterBand(1).GetOffset() == 0
+
+    assert struct.unpack("f", out_ds.GetRasterBand(2).ReadRaster()) == (
+        -802 * 5 + 1002,
+    )
+    assert out_ds.GetRasterBand(2).GetScale() == 1
+    assert out_ds.GetRasterBand(2).GetOffset() == 0

--- a/autotest/utilities/test_gdalalg_raster_scale.py
+++ b/autotest/utilities/test_gdalalg_raster_scale.py
@@ -68,8 +68,11 @@ def test_gdalalg_raster_scale_srcmin_srcmax_only():
     out_ds = alg["output"].GetDataset()
     assert out_ds.GetRasterBand(1).ComputeRasterMinMax() == (85, 170)
 
+    assert out_ds.GetRasterBand(1).GetScale() == 3 / 255
+    assert out_ds.GetRasterBand(1).GetOffset() is None
 
-def test_gdalalg_raster_scale_dstcmin_dstmax_only():
+
+def test_gdalalg_raster_scale_dstmin_dstmax_only():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 2)
     src_ds.GetRasterBand(1).WriteRaster(0, 0, 1, 2, b"\x01\x02")
@@ -83,6 +86,9 @@ def test_gdalalg_raster_scale_dstcmin_dstmax_only():
     assert alg.Run()
     out_ds = alg["output"].GetDataset()
     assert out_ds.GetRasterBand(1).ComputeRasterMinMax() == (0, 3)
+
+    assert out_ds.GetRasterBand(1).GetScale() == 1 / 3
+    assert out_ds.GetRasterBand(1).GetOffset() == 1
 
 
 def test_gdalalg_raster_scale_missing_srcmin():
@@ -153,7 +159,7 @@ def test_gdalalg_raster_scale_missing_dstmax():
         alg.Run()
 
 
-def test_gdalalg_raster_scale_srcmin_srcmax_destmin_dstmax():
+def test_gdalalg_raster_scale_srcmin_srcmax_dstmin_dstmax():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 2)
     src_ds.GetRasterBand(1).Fill(15)
@@ -171,6 +177,12 @@ def test_gdalalg_raster_scale_srcmin_srcmax_destmin_dstmax():
     out_ds = alg["output"].GetDataset()
     assert out_ds.GetRasterBand(1).ComputeRasterMinMax() == (150, 150)
     assert out_ds.GetRasterBand(2).ComputeRasterMinMax() == (100, 100)
+
+    assert out_ds.GetRasterBand(1).GetScale() == 1 / 10
+    assert out_ds.GetRasterBand(1).GetOffset() is None
+
+    assert out_ds.GetRasterBand(2).GetScale() == 1 / 10
+    assert out_ds.GetRasterBand(2).GetOffset() is None
 
 
 def test_gdalalg_raster_scale_band():
@@ -193,6 +205,12 @@ def test_gdalalg_raster_scale_band():
     assert out_ds.GetRasterBand(1).ComputeRasterMinMax() == (150, 150)
     assert out_ds.GetRasterBand(2).ComputeRasterMinMax() == (10, 10)
 
+    assert out_ds.GetRasterBand(1).GetScale() == 1 / 10
+    assert out_ds.GetRasterBand(1).GetOffset() is None
+
+    assert out_ds.GetRasterBand(2).GetScale() is None
+    assert out_ds.GetRasterBand(2).GetOffset() is None
+
 
 def test_gdalalg_raster_exponent():
 
@@ -213,6 +231,12 @@ def test_gdalalg_raster_exponent():
     out_ds = alg["output"].GetDataset()
     assert out_ds.GetRasterBand(1).ComputeRasterMinMax() == (135, 135)
     assert out_ds.GetRasterBand(2).ComputeRasterMinMax() == (125, 125)
+
+    assert out_ds.GetRasterBand(1).GetScale() is None
+    assert out_ds.GetRasterBand(1).GetOffset() is None
+
+    assert out_ds.GetRasterBand(2).GetScale() is None
+    assert out_ds.GetRasterBand(2).GetOffset() is None
 
 
 def test_gdalalg_raster_band_exponent_datatype():
@@ -262,6 +286,9 @@ def test_gdalalg_raster_scale_clip():
         200,
     )
 
+    assert out_ds.GetRasterBand(1).GetScale() == 1 / 50
+    assert out_ds.GetRasterBand(1).GetOffset() == -1
+
 
 def test_gdalalg_raster_scale_no_clip():
 
@@ -286,6 +313,9 @@ def test_gdalalg_raster_scale_no_clip():
         200,
         250,
     )
+
+    assert out_ds.GetRasterBand(1).GetScale() == 1 / 50
+    assert out_ds.GetRasterBand(1).GetOffset() == -1
 
 
 def test_gdalalg_raster_scale_no_clip_exponent():
@@ -312,3 +342,6 @@ def test_gdalalg_raster_scale_no_clip_exponent():
         200,
         255,
     )
+
+    assert out_ds.GetRasterBand(1).GetScale() is None
+    assert out_ds.GetRasterBand(1).GetOffset() is None

--- a/autotest/utilities/test_gdalalg_raster_unscale.py
+++ b/autotest/utilities/test_gdalalg_raster_unscale.py
@@ -36,6 +36,8 @@ def test_gdalalg_raster_unscale_no_option():
     assert alg.Run()
     out_ds = alg["output"].GetDataset()
     assert out_ds.GetRasterBand(1).ComputeRasterMinMax() == (1 * 2 + 3, 1 * 2 + 3)
+    assert out_ds.GetRasterBand(1).GetScale() is None
+    assert out_ds.GetRasterBand(1).GetOffset() is None
     assert out_ds.GetRasterBand(1).DataType == gdal.GDT_Float32
 
 
@@ -54,6 +56,8 @@ def test_gdalalg_raster_unscale_datatype():
     assert alg.Run()
     out_ds = alg["output"].GetDataset()
     assert out_ds.GetRasterBand(1).ComputeRasterMinMax() == (1 * 2.1 + 3, 1 * 2.1 + 3)
+    assert out_ds.GetRasterBand(1).GetScale() is None
+    assert out_ds.GetRasterBand(1).GetOffset() is None
     assert out_ds.GetRasterBand(1).DataType == gdal.GDT_Float64
 
 
@@ -81,3 +85,11 @@ def test_gdalalg_raster_unscale_auto_datatype(input_dt, out_dt):
     assert alg.Run()
     out_ds = alg["output"].GetDataset()
     assert out_ds.GetRasterBand(1).DataType == out_dt
+
+
+def test_gdalalg_raster_scale_unscale_round_trip_pipeline():
+
+    with gdal.alg.pipeline(
+        pipeline="read ../gcore/data/byte.tif ! scale --output-data-type Int16 ! unscale --output-data-type Byte ! compare ../gcore/data/byte.tif"
+    ) as alg:
+        assert "pixels differing" not in alg["output-string"]


### PR DESCRIPTION
This PR modifies gdal_translate to set band scale/offset metadata when `-scale` is used with linear scaling. This allows the produced file to be unscaled automatically using `gdal_translate -unscale` or `gdal raster unscale`. Because `gdal raster scale` or `gdal_translate` may calculate the scale factors internally, not having them stored in the file effectively prevents the file from being unscaled.

See https://gis.stackexchange.com/questions/256206/storing-scale-offset-values-from-gdal-translate for an example of user confusion around this.

I am very hesitant to change a long-standing behavior (`-scale` was added in GDAL 1.1.7), so I am considering whether it might be better to set this metadata when using `gdal raster scale` only.