### PR TITLE
BYN format: use nRealiz when nDatum is 0 (ITRF)

### DIFF
--- a/frmts/raw/byndataset.cpp
+++ b/frmts/raw/byndataset.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <limits>
+#include <unordered_map>
 
 // Specification at
 // https://www.nrcan.gc.ca/sites/www.nrcan.gc.ca/files/earthsciences/pdf/gpshgrid_e.pdf
@@ -37,6 +38,11 @@ const static BYNEllipsoids EllipsoidTable[] = {
     {"ALT2", 6378136.3, 298.257},
     {"ELLIP2", 6378136.0, 298.257},
     {"CLARKE 1866", 6378206.4, 294.9786982}};
+
+const static std::unordered_map<int, int> ItrfYearEpsgCodes{
+    {1988, 8988}, {1989, 8989}, {1990, 8990}, {1991, 8991}, {1992, 8992},
+    {1992, 8992}, {1993, 8993}, {1994, 8994}, {1996, 8995}, {1997, 8996},
+    {2000, 8997}, {2005, 8998}, {2008, 8999}, {2014, 9000}, {2020, 9990}};
 
 /************************************************************************/
 /*                           BYNRasterBand()                            */
@@ -392,7 +398,22 @@ const OGRSpatialReference *BYNDataset::GetSpatialRef() const
     bool bNoGeogCS = false;
 
     if (hHeader.nDatum == 0)
-        m_oSRS.importFromEPSG(BYN_DATUM_0);
+    {
+        const auto epsg_it = ItrfYearEpsgCodes.find(hHeader.nRealiz);
+        if (epsg_it != ItrfYearEpsgCodes.end())
+        {
+            m_oSRS.importFromEPSG(epsg_it->second);
+        }
+        else
+        {
+            m_oSRS.importFromEPSG(9990);  // ITRF2020
+            CPLError(CE_Warning, CPLE_FileIO,
+                     "BYN file with ITRF datum."
+                     "No EPSG code found for realization %d."
+                     "EPSG:9990 (ITRF2020) will be used instead",
+                     hHeader.nRealiz);
+        }
+    }
     else if (hHeader.nDatum == 1)
         m_oSRS.importFromEPSG(BYN_DATUM_1);
     else

--- a/frmts/raw/byndataset.h
+++ b/frmts/raw/byndataset.h
@@ -165,7 +165,6 @@ struct BYNEllipsoids
 
 constexpr int BYN_DATUM_1_VDATUM_2 =
     6649;                          /* Compounded NAD83(CSRS) + CGVD2013 */
-constexpr int BYN_DATUM_0 = 4140;  /* ITRF2008 (GRS80 based WGS84) */
 constexpr int BYN_DATUM_1 = 4617;  /* NAD83(CSRS) */
 constexpr int BYN_VDATUM_1 = 5713; /* CGVD28 */
 constexpr int BYN_VDATUM_2 = 6647; /* CGVD2013 */

--- a/frmts/raw/byndataset.h
+++ b/frmts/raw/byndataset.h
@@ -31,28 +31,37 @@ Table 1: Header description (80 bytes)
  4 East        East Boundary      long   4    16  (arcsec.)
  5 DLat        NS Spacing         long   2    18  (arcsec.)
  6 DLon        EW Spacing         short  2    20  (arcsec.)
- 7 Global      Global             short  2    22  0: Local/Regional/National
-grid 1: Global grid 8 Type        Type               short  2    24  See Table 2
- 9 Factor      Data factor        double 8    32  Transform data from integer to
-real 10 SizeOf      Data size in bytes short  2    34  2: short integer 4: long
-integer 11 VDatum      Vertical Datum     short  2    36  0: Unspecified 1:
-CGVD28 2: CGVD2013 3: NAVD 88 12             Spare                     6    40
-Always zero 13 Data        Data description   short  2    42  0: Data (e.g., N)
-                                                  1: Data error estimates (e.g.,
-.N) 2: Data velocity (e.g., N-dot) 3: Velocity error estimates (e.g., .N-dot) 14
-SubType     Sub-Type           short  2    44  See table 2 below 15 Datum 3-D
-Ref. Frame     short  2    46  0: ITRF / WGS84 1: NAD83(CSRS) 16 Ellipsoid
-Ellipsoid          short  2    48  See Table 3 17 ByteOrder   Byte Order short
-2    50  0: Big-endian (e.g., HP Unix) 1: Little-endian (e.g., PC, linux) 18
-Scale       Scale Boundaries   short  2    52  0: No scale applied to boundaries
-and spacing 1: Scale is applied (x1000) 19 Wo          Geopotential Wo    double
-8    60  2ms-2 (e.g., W = 62636856.88) 20 GM          GM                 double
-8    68  3ms-2 (e.g., GM = 3.986 E 14) 21 TideSystem  Tidal System       short
-2    70  0: Tide free 1: Mean tide 2: Zero tide 22 RefRealiz.  Realization (3D)
-short  2    72  Version number (e.g., 2005 for ITRF) 23 Epoch       Epoch float
-4    76  Decimal year (e.g., 2007.5) 24 PtType      Node               short  2
-78  0: Point 1: Mean 25 Spare                                 2    80  Always
-zero
+ 7 Global      Global             short  2    22  0: Local/Regional/National grid
+                                                  1: Global grid
+ 8 Type        Type               short  2    24  See Table 2
+ 9 Factor      Data factor        double 8    32  Transform data from integer to real
+10 SizeOf      Data size in bytes short  2    34  2: short integer
+                                                  4: long integer
+11 VDatum      Vertical Datum     short  2    36  0: Unspecified
+                                                  1: CGVD28
+                                                  2: CGVD2013
+                                                  3: NAVD 88
+12             Spare                     4    40  Always zero
+13 Data        Data description   short  2    42  0: Data (e.g., N)
+                                                  1: Data error estimates (e.g.,.N)
+                                                  2: Data velocity (e.g., N-dot)
+                                                  3: Velocity error estimates (e.g., .N-dot)
+14 SubType     Sub-Type           short  2    44  See table 2 below
+15 Datum       3-D Ref. Frame     short  2    46  0: ITRF / WGS84
+                                                  1: NAD83(CSRS)
+16 Ellipsoid   Ellipsoid          short  2    48  See Table 3
+17 ByteOrder   Byte Order         short  2    50  0: Big-endian (e.g., HP Unix)
+                                                  1: Little-endian (e.g., PC, linux)
+18 Scale       Scale Boundaries   short  2    52  0: No scale applied to boundaries and spacing
+                                                  1: Scale is applied (x1000)
+19 Wo          Geopotential Wo    double 8    60  2ms-2 (e.g., W = 62636856.88)
+20 GM          GM                 double 8    68  3ms-2 (e.g., GM = 3.986 E 14)
+21 TideSystem  Tidal System       short  2    70  0: Tide free 1: Mean tide 2: Zero tide
+22 RefRealiz.  Realization (3D)   short  2    72  Version number (e.g., 2005 for ITRF)
+23 Epoch       Epoch              float  4    76  Decimal year (e.g., 2007.5)
+24 PtType      Node               short  2    78  0: Point
+                                                  1: Mean
+25 Spare                                 2    80  Always zero
 --:-----------:------------------:------:----:---:---------------------------
 
 Items #18 to 22 must be defined if the grid is a geoid model.
@@ -87,8 +96,7 @@ Table 2: Sub-Type
 
 Table 3: Ellipsoids
 
-# Name    Semi-major (m)  Inverse flattening GM (m3s2)       Angular velocity
-(rads s**-1)
+# Name    Semi-major (m)  Inverse flattening GM (m3s2)       Angular velocity (rads s**-1)
 -:-------:---------------:-------------------:---------------:-----------------------------
 0 GRS80   6378137.0       298.257222101       3986005.0 E 8   7292115 E -11
 1 WGS84   6378137.0       298.257223564       3986004.418 E 8 7292115 E -11


### PR DESCRIPTION
## What does this PR do?
When reading a BYN file, the SRS for the grid file is currently reading the datum, and setting to EPSG:4140 if the datum is 0.

This PR is setting correctly the SRS. In case of ITRF (datum == 0) the realization (year) is defined in a different entry in the header. Brian Donahue, from NRCAN, told me:

"Yes exactly. You need to combine fields 16 and 23. If field 16 is equal to 0 it indicates ITRF and the version of ITRF will be in field 23 (e.g., 1997, 2008, 2020, etc..). Field 23 is always a 4-digit value for ITRF so for pre-2000 ITRF’s you would need to subtract 1900 to get the correct version (e.g., ITRF97)." (note they use modern ids, 16 and 23. Our old documentation is 15 and 22)

## Comments:
I tested with some BYN files from https://webapp.csrs-scrs.nrcan-rncan.gc.ca/geod/data-donnees/geoid.php and it works as expected. I don't know which kind of test should I add, as those files are a bit big.

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

