### PR TITLE
[Backport release/3.13] Unix file read(): file 3.13.0 regression regarding buffering

### DIFF
--- a/autotest/gcore/vsifile.py
+++ b/autotest/gcore/vsifile.py
@@ -1946,3 +1946,21 @@ def test_vsifile_mkdir_recursive_huge_filename(tmp_vsimem):
     filename += "a/" * ((4096 - len(filename)) // len("a/"))
     assert gdal.MkdirRecursive(filename, 0o755) == 0
     assert gdal.MkdirRecursive(filename + "a/", 0o755) < 0
+
+
+###############################################################################
+def test_vsifile_buffering_fix_14997(tmp_path):
+
+    filename = tmp_path / "test.bin"
+
+    buffer = bytearray(b"\xff" * 8192)
+    buffer[4096] = 0
+    with gdal.VSIFile(filename, "wb") as f:
+        f.write(buffer)
+    with gdal.VSIFile(filename, "rb") as f:
+        f.seek(0)
+        assert f.read(1) == buffer[0:1]
+        f.seek(0)
+        assert f.read(4096 + 4096) == buffer[0 : 4096 + 4096]
+        f.seek(4096)
+        assert f.read(1) == buffer[4096 : 4096 + 1]

--- a/port/cpl_vsil_unix_stdio_64.cpp
+++ b/port/cpl_vsil_unix_stdio_64.cpp
@@ -624,6 +624,8 @@ size_t VSIUnixStdioHandle::Read(void *pBuffer, size_t nBytes)
                 }
                 m_nFilePos += nBytesReadThisTime;
                 nBytesRead += nBytesReadThisTime;
+                m_nBufferCurPos = 0;
+                m_nBufferSize = 0;
             }
             else
             {
@@ -654,6 +656,9 @@ size_t VSIUnixStdioHandle::Read(void *pBuffer, size_t nBytes)
         nBytesRead += nToCopy;
         m_nBufferCurPos += nToCopy;
         m_nFilePos += nToCopy;
+
+        CPLAssert(m_nFilePos - m_nBufferCurPos + m_nBufferSize ==
+                  static_cast<uint64_t>(VSI_LSEEK64(fd, 0, SEEK_CUR)));
     }
 
 #ifdef VSI_DEBUG


### PR DESCRIPTION
Backport #15008
 **Authored by:** @rouault