### PR TITLE
[Backport release/3.13] PCIDSK: fix heap overflow on tiled channel pixel type mismatch

### DIFF
--- a/autotest/gdrivers/pcidsk.py
+++ b/autotest/gdrivers/pcidsk.py
@@ -771,3 +771,33 @@ def test_pcidsk_web_mercator(tmp_path):
     expected_srs = osr.SpatialReference()
     expected_srs.ImportFromEPSG(3857)
     assert ds.GetSpatialRef().IsSame(expected_srs)
+
+
+###############################################################################
+# Test that a tiled channel whose image header pixel type disagrees with the
+# tile layer data type is rejected instead of overflowing the block buffer.
+
+
+def test_pcidsk_tiled_type_mismatch(tmp_path):
+
+    filename = str(tmp_path / "mismatch.pix")
+    gdal.Translate(
+        filename,
+        "data/byte.tif",
+        options="-of PCIDSK -ot Float32 -co INTERLEAVING=TILED -co TILESIZE=16",
+    )
+
+    # The pixel type is stored in the image band header as an 8-byte field at
+    # offset 160, and independently as the tile layer data type. Change only the
+    # image header type from 32R (Float32, 4 bytes) to 8U (Byte, 1 byte); the
+    # block buffer is then sized for 1 byte per pixel while the tile still holds
+    # 4 bytes per pixel.
+    data = bytearray(open(filename, "rb").read())
+    assert data.count(b"32R     ") == 1
+    pos = data.index(b"32R     ")
+    data[pos : pos + 8] = b"8U      "
+    open(filename, "wb").write(data)
+
+    with gdal.quiet_errors():
+        ds = gdal.Open(filename)
+    assert ds is None

--- a/autotest/gdrivers/pcidsk.py
+++ b/autotest/gdrivers/pcidsk.py
@@ -778,6 +778,7 @@ def test_pcidsk_web_mercator(tmp_path):
 # tile layer data type is rejected instead of overflowing the block buffer.
 
 
+@gdaltest.enable_exceptions()
 def test_pcidsk_tiled_type_mismatch(tmp_path):
 
     filename = str(tmp_path / "mismatch.pix")
@@ -798,6 +799,8 @@ def test_pcidsk_tiled_type_mismatch(tmp_path):
     data[pos : pos + 8] = b"8U      "
     open(filename, "wb").write(data)
 
-    with gdal.quiet_errors():
-        ds = gdal.Open(filename)
-    assert ds is None
+    with pytest.raises(
+        Exception,
+        match=r"Tiled channel .* data type .* does not match image header pixel type",
+    ):
+        gdal.Open(filename)

--- a/frmts/pcidsk/sdk/channel/ctiledchannel.cpp
+++ b/frmts/pcidsk/sdk/channel/ctiledchannel.cpp
@@ -91,8 +91,20 @@ void CTiledChannel::EstablishAccess() const
 
     const char * pszDataType = mpoTileLayer->GetDataType();
 
-    if (GetDataTypeFromName(pszDataType) == CHN_UNKNOWN)
+    eChanType nLayerType = GetDataTypeFromName(pszDataType);
+
+    if (nLayerType == CHN_UNKNOWN)
         return ThrowPCIDSKException("Unknown channel type: %s", pszDataType);
+
+    // The read buffer is sized by the caller from the image band header pixel
+    // type, while the amount copied per tile comes from the tile layer data
+    // type. If they disagree a wider tile can be written into a buffer sized
+    // for a narrower type, so reject the mismatch here.
+    if (pixel_type != CHN_UNKNOWN && pixel_type != nLayerType)
+        return ThrowPCIDSKException(
+            "Tiled channel %d data type (%s) does not match image header "
+            "pixel type (%s).",
+            image, pszDataType, DataTypeName(pixel_type));
 }
 
 /************************************************************************/


### PR DESCRIPTION
Backport #14942
 **Authored by:** @saddamr3e