### PR TITLE
GeoParquet: add read/write support for GeoParquet 2.0.0, …

### DIFF
--- a/autotest/ogr/data/parquet/schema_2_0_0.json
+++ b/autotest/ogr/data/parquet/schema_2_0_0.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GeoParquet",
+  "description": "Parquet metadata included in the geo field.",
+  "type": "object",
+  "required": ["version", "primary_column", "columns"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "2.0.0"
+    },
+    "primary_column": {
+      "type": "string",
+      "minLength": 1
+    },
+    "columns": {
+      "type": "object",
+      "minProperties": 1,
+      "patternProperties": {
+        ".+": {
+          "type": "object",
+          "required": ["encoding", "geometry_types"],
+          "properties": {
+            "encoding": {
+              "type": "string",
+              "const": "WKB"
+            },
+            "geometry_types": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "pattern": "^(GeometryCollection|(Multi)?(Point|LineString|Polygon))( Z| M| ZM)?$"
+              }
+            },
+            "crs": {
+              "oneOf": [
+                {
+                  "$ref": "https://proj.org/schemas/v0.7/projjson.schema.json"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "edges": {
+              "type": "string",
+              "enum": ["planar", "spherical", "vincenty", "thomas", "andoyer", "karney"]
+            },
+            "orientation": {
+              "type": "string",
+              "const": "counterclockwise"
+            },
+            "bbox": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "oneOf": [
+                {
+                  "description": "2D bbox consisting of (xmin, ymin, xmax, ymax)",
+                  "minItems": 4,
+                  "maxItems": 4
+                },
+                {
+                  "description": "3D bbox consisting of (xmin, ymin, zmin, xmax, ymax, zmax) or 2D+M bbox (xmin, ymin, mmin, xmax, ymax, mmax)",
+                  "minItems": 6,
+                  "maxItems": 6
+                },
+                {
+                  "description": "3D+M bbox consisting of (xmin, ymin, zmin, mmin, xmax, ymax, zmax, mmax)",
+                  "minItems": 8,
+                  "maxItems": 8
+                }
+              ]
+            },
+            "epoch": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -25,6 +25,7 @@ from osgeo import gdal, ogr, osr
 pytestmark = pytest.mark.require_driver("Parquet")
 
 GEOPARQUET_1_1_0_JSON_SCHEMA = "data/parquet/schema_1_1_0.json"
+GEOPARQUET_2_0_0_JSON_SCHEMA = "data/parquet/schema_2_0_0.json"
 
 
 ###############################################################################
@@ -60,14 +61,14 @@ def _has_validate():
     return True
 
 
-def _validate(filename, check_data=False):
+def _validate(filename, check_data=False, local_schema=GEOPARQUET_1_1_0_JSON_SCHEMA):
     if not _has_validate():
         return
 
     import validate_geoparquet
 
     ret = validate_geoparquet.check(
-        filename, check_data=check_data, local_schema=GEOPARQUET_1_1_0_JSON_SCHEMA
+        filename, check_data=check_data, local_schema=local_schema
     )
     assert not ret
 
@@ -4584,6 +4585,137 @@ def test_ogr_parquet_test_ogrsf_parquet_geometry():
 
     assert "INFO" in ret
     assert "ERROR" not in ret
+
+
+###############################################################################
+
+
+@pytest.mark.skipif(
+    not _parquet_has_geo_types(),
+    reason="requires libarrow >= 21",
+)
+def test_ogr_parquet_write_geoparquet_2_0_error(tmp_vsimem):
+
+    with gdal.GetDriverByName("Parquet").CreateVector(tmp_vsimem / "out.parquet") as ds:
+        with pytest.raises(
+            Exception,
+            match="GEOPARQUET_VERSION = 2.0 is not compatible with USE_PARQUET_GEO_TYPES = NO",
+        ):
+            ds.CreateLayer(
+                "test",
+                srs=osr.SpatialReference(epsg=4326),
+                options=["GEOPARQUET_VERSION=2.0", "USE_PARQUET_GEO_TYPES=NO"],
+            )
+
+
+###############################################################################
+
+
+@pytest.mark.skipif(
+    not _parquet_has_geo_types(),
+    reason="requires libarrow >= 21",
+)
+def test_ogr_parquet_write_geoparquet_2_0_epsg_4326(tmp_vsimem):
+
+    with gdal.GetDriverByName("Parquet").CreateVector(tmp_vsimem / "out.parquet") as ds:
+        lyr = ds.CreateLayer(
+            "test",
+            srs=osr.SpatialReference(epsg=4326),
+            options=["GEOPARQUET_VERSION=2.0"],
+        )
+        lyr.SetMetadataItem("EDGES", "SPHERICAL")
+
+    _validate(tmp_vsimem / "out.parquet", local_schema=GEOPARQUET_2_0_0_JSON_SCHEMA)
+
+    with gdal.Open(tmp_vsimem / "out.parquet") as ds:
+        lyr = ds.GetLayer(0)
+        assert lyr.GetSpatialRef().GetAuthorityCode() == "4326"
+        assert lyr.GetMetadataItem("EDGES") == "SPHERICAL"
+
+        geo = lyr.GetMetadataItem("geo", "_PARQUET_METADATA_")
+        assert geo is not None
+        j = json.loads(geo)
+        assert j is not None
+        assert "version" in j
+        assert j["version"] == "2.0.0"
+        assert "primary_column" in j
+        assert j["primary_column"] == "geometry"
+        assert "columns" in j
+        assert "geometry" in j["columns"]
+        assert "encoding" in j["columns"]["geometry"]
+        assert "crs" not in j["columns"]["geometry"]
+        assert j["columns"]["geometry"]["encoding"] == "WKB"
+        assert "covering" not in j["columns"]["geometry"]
+
+        assert lyr.GetMetadataItem("geometry", "_PARQUET_GEO_CRS_") == ""
+
+
+###############################################################################
+
+
+@pytest.mark.skipif(
+    not _parquet_has_geo_types(),
+    reason="requires libarrow >= 21",
+)
+def test_ogr_parquet_write_geoparquet_2_0_epsg_32631(tmp_vsimem):
+
+    with gdal.GetDriverByName("Parquet").CreateVector(tmp_vsimem / "out.parquet") as ds:
+        ds.CreateLayer(
+            "test",
+            srs=osr.SpatialReference(epsg=32631),
+            options=["GEOPARQUET_VERSION=2.0"],
+        )
+
+    _validate(tmp_vsimem / "out.parquet", local_schema=GEOPARQUET_2_0_0_JSON_SCHEMA)
+
+    with gdal.Open(tmp_vsimem / "out.parquet") as ds:
+        lyr = ds.GetLayer(0)
+        assert lyr.GetSpatialRef().GetAuthorityCode() == "32631"
+        assert lyr.GetMetadataItem("EDGES") is None
+
+        geo = lyr.GetMetadataItem("geo", "_PARQUET_METADATA_")
+        assert geo is not None
+        j = json.loads(geo)
+        assert j is not None
+        assert "version" in j
+        assert j["version"] == "2.0.0"
+        assert "crs" in j["columns"]["geometry"]
+
+        assert '"type":"ProjectedCRS"' in lyr.GetMetadataItem(
+            "geometry", "_PARQUET_GEO_CRS_"
+        )
+
+
+###############################################################################
+
+
+@pytest.mark.skipif(
+    not _parquet_has_geo_types(),
+    reason="requires libarrow >= 21",
+)
+def test_ogr_parquet_write_geoparquet_2_0_no_crs(tmp_vsimem):
+
+    with gdal.GetDriverByName("Parquet").CreateVector(tmp_vsimem / "out.parquet") as ds:
+        ds.CreateLayer(
+            "test",
+            options=["GEOPARQUET_VERSION=2.0"],
+        )
+
+    _validate(tmp_vsimem / "out.parquet", local_schema=GEOPARQUET_2_0_0_JSON_SCHEMA)
+
+    with gdal.Open(tmp_vsimem / "out.parquet") as ds:
+        lyr = ds.GetLayer(0)
+        assert lyr.GetSpatialRef() is None
+
+        geo = lyr.GetMetadataItem("geo", "_PARQUET_METADATA_")
+        assert geo is not None
+        j = json.loads(geo)
+        assert j is not None
+        assert "version" in j
+        assert j["version"] == "2.0.0"
+        assert j["columns"]["geometry"]["crs"] is None
+
+        assert lyr.GetMetadataItem("geometry", "_PARQUET_GEO_CRS_") == "srid:0"
 
 
 ###############################################################################

--- a/doc/source/drivers/vector/parquet.rst
+++ b/doc/source/drivers/vector/parquet.rst
@@ -18,6 +18,7 @@ This driver also supports geometry columns using the GeoParquet specification.
 
 The GeoParquet 1.0.0 specification is supported since GDAL 3.8.0.
 The GeoParquet 1.1.0 specification is supported since GDAL 3.9.0.
+The GeoParquet 2.0.0 specification is supported since GDAL 3.14.0.
 
 Driver capabilities
 -------------------
@@ -74,6 +75,14 @@ Layer creation options
 
 |about-layer-creation-options|
 The following layer creation options are supported:
+
+- .. lco:: GEOPARQUET_VERSION
+     :choices: 1.1, 2.0
+     :default: 1.1
+     :since: 3.14
+
+      GeoParquet specification version. Defaults to 1.1.
+      2.0 can be selected for GDAL built against libarrow >= 21.
 
 - .. lco:: COMPRESSION
      :choices: NONE, UNCOMPRESSED, SNAPPY, GZIP, BROTLI, ZSTD, LZ4_RAW, LZ4_HADOOP
@@ -159,7 +168,8 @@ The following layer creation options are supported:
      necessary for the GeoArrow geometry encoding than for the default WKB, as
      implementations may be able to directly use the geometry columns.
 
-     If the :lco:`USE_PARQUET_GEO_TYPES` layer creation option is set to ``ONLY``,
+     If the :lco:`GEOPARQUET_VERSION` layer creation option is set to ``2.0`` or
+     :lco:`USE_PARQUET_GEO_TYPES` is set to ``ONLY``,
      and :lco:`WRITE_COVERING_BBOX` is set or let to its default ``AUTO`` value,
      no covering bounding box columns is written.
 
@@ -171,8 +181,8 @@ The following layer creation options are supported:
      If not set, it defaults to the geometry column name, suffixed with ``_bbox``.
 
 - .. lco:: USE_PARQUET_GEO_TYPES
-     :choices: YES, NO, ONLY
-     :default: NO
+     :choices: AUTO, YES, NO, ONLY
+     :default: AUTO
      :since: 3.12
 
      Only available with libarrow >= 21.
@@ -180,13 +190,17 @@ The following layer creation options are supported:
      Whether to use Parquet Geometry/Geography logical types (introduced in libarrow 21),
      when using the default GEOMETRY_ENCODING=WKB encoding.
 
+     - ``AUTO`` (added in GDAL 3.14): Evaluates to ``YES`` when :lco:`GEOPARQUET_VERSION`
+       is set to ``2.0``, otherwise evaluates to ``NO``.
+
      - ``YES``: use the Geometry logical type (or the Geography
        one if the EDGES=SPHERICAL creation option is also set), and also
        write file-level GeoParquet metadata. Such files can be read by older
        GDAL, but require libarrow >= 20.
 
-     - ``NO`` (default): only file-level GeoParquet metadata is written. Such
-       files can be read by older GDAL and libarrow versions.
+     - ``NO``: only file-level GeoParquet metadata is written. Such
+       files can be read by older GDAL and libarrow versions. Incompatible with
+       :lco:`GEOPARQUET_VERSION` set to ``2.0``.
 
      - ``ONLY``: use the Geometry logical type (or the Geography
        one if the EDGES=SPHERICAL creation option is also set), but do not

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowwriterlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowwriterlayer.hpp
@@ -507,6 +507,10 @@ inline void OGRArrowWriterLayer::CreateSchemaCommon()
 
                         oMetadataDoc.GetRoot().Add("crs", oCRSRoot);
                     }
+                    else
+                    {
+                        oMetadataDoc.GetRoot().Add("crs", "srid:0");
+                    }
 
                     if (m_bEdgesSpherical)
                     {

--- a/ogr/ogrsf_frmts/parquet/ogr_parquet.h
+++ b/ogr/ogrsf_frmts/parquet/ogr_parquet.h
@@ -52,6 +52,10 @@ class OGRParquetLayerBase CPL_NON_FINAL : public OGRArrowLayer
         m_geoStatsWithBBOXAvailable{};  // key is index of OGR geometry column
 #endif
 
+    //! Only for testing/validation purposes, with Arrow >= 21, value of 'crs'
+    // field from GeometryLogicalType/GeographyLogicalType
+    std::map<std::string, std::string> m_mapGeomFieldToParquetGeoCrs{};
+
     void LoadGeoMetadata(
         const std::shared_ptr<const arrow::KeyValueMetadata> &kv_metadata);
     bool DealWithGeometryColumn(
@@ -333,6 +337,16 @@ class OGRParquetDataset final : public OGRArrowDataset
 };
 
 /************************************************************************/
+/*                         OGRGeoParquetVersion                         */
+/************************************************************************/
+
+enum class OGRGeoParquetVersion
+{
+    VERSION_1_1,
+    VERSION_2_0,
+};
+
+/************************************************************************/
 /*                        OGRParquetWriterLayer                         */
 /************************************************************************/
 
@@ -358,6 +372,9 @@ class OGRParquetWriterLayer final : public OGRArrowWriterLayer
 
     //! Whether to write "geo" footer metadata;
     bool m_bWriteGeoMetadata = true;
+
+    OGRGeoParquetVersion m_nGeoParquetVersion =
+        OGRGeoParquetVersion::VERSION_1_1;
 
     bool IsFileWriterCreated() const override
     {

--- a/ogr/ogrsf_frmts/parquet/ogrparquetdriver.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetdriver.cpp
@@ -777,6 +777,23 @@ void OGRParquetDriver::InitMetadata()
     CPLXMLTreeCloser oTree(
         CPLCreateXMLNode(nullptr, CXT_Element, "LayerCreationOptionList"));
 
+    {
+        auto psOption = CPLCreateXMLNode(oTree.get(), CXT_Element, "Option");
+        CPLAddXMLAttributeAndValue(psOption, "name", "GEOPARQUET_VERSION");
+        CPLAddXMLAttributeAndValue(psOption, "type", "string-select");
+        CPLAddXMLAttributeAndValue(psOption, "description",
+                                   "GeoParquet specification version");
+        CPLAddXMLAttributeAndValue(psOption, "default", "1.1");
+        {
+            auto poValueNode = CPLCreateXMLNode(psOption, CXT_Element, "Value");
+            CPLCreateXMLNode(poValueNode, CXT_Text, "1.1");
+        }
+        {
+            auto poValueNode = CPLCreateXMLNode(psOption, CXT_Element, "Value");
+            CPLCreateXMLNode(poValueNode, CXT_Text, "2.0");
+        }
+    }
+
     std::vector<const char *> apszCompressionMethods;
     bool bHasSnappy = false;
     int minComprLevel = INT_MAX;
@@ -974,12 +991,13 @@ void OGRParquetDriver::InitMetadata()
     {
         auto psOption = CPLCreateXMLNode(oTree.get(), CXT_Element, "Option");
         CPLAddXMLAttributeAndValue(psOption, "name", "USE_PARQUET_GEO_TYPES");
-        CPLAddXMLAttributeAndValue(psOption, "default", "NO");
+        CPLAddXMLAttributeAndValue(psOption, "default", "AUTO");
         CPLAddXMLAttributeAndValue(psOption, "type", "string-select");
         CPLAddXMLAttributeAndValue(psOption, "description",
                                    "Whether to use Parquet Geometry/Geography "
                                    "logical types (introduced in libarrow 21), "
                                    "when using GEOMETRY_ENCODING=WKB encoding");
+        CPLCreateXMLElementAndValue(psOption, "Value", "AUTO");
         CPLCreateXMLElementAndValue(psOption, "Value", "YES");
         CPLCreateXMLElementAndValue(psOption, "Value", "NO");
         CPLCreateXMLElementAndValue(psOption, "Value", "ONLY");

--- a/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
@@ -103,7 +103,8 @@ void OGRParquetLayerBase::LoadGeoMetadata(
                 if (osVersion != "0.1.0" && osVersion != "0.2.0" &&
                     osVersion != "0.3.0" && osVersion != "0.4.0" &&
                     osVersion != "1.0.0-beta.1" && osVersion != "1.0.0-rc.1" &&
-                    osVersion != "1.0.0" && osVersion != "1.1.0")
+                    osVersion != "1.0.0" && osVersion != "1.1.0" &&
+                    osVersion != "2.0.0")
                 {
                     CPLDebug(
                         "PARQUET",
@@ -248,6 +249,7 @@ bool OGRParquetLayerBase::DealWithArrow21GeometryGeographyNativeTypes(
             crs = static_cast<const parquet::GeometryLogicalType *>(
                       logicalType.get())
                       ->crs();
+            m_mapGeomFieldToParquetGeoCrs[field->name()] = crs;
             if (crs.empty())
                 crs = "EPSG:4326";
             CPLDebugOnly("PARQUET", "GeometryLogicalType crs=%s", crs.c_str());
@@ -258,6 +260,7 @@ bool OGRParquetLayerBase::DealWithArrow21GeometryGeographyNativeTypes(
                 static_cast<const parquet::GeographyLogicalType *>(
                     logicalType.get());
             crs = geographyType->crs();
+            m_mapGeomFieldToParquetGeoCrs[field->name()] = crs;
             if (crs.empty())
                 crs = "EPSG:4326";
 
@@ -485,7 +488,7 @@ bool OGRParquetLayerBase::DealWithArrow21GeometryGeographyNativeTypes(
     OGRGeomFieldDefn oField(field->name().c_str(), eGeomType);
     oField.SetNullable(field->nullable());
 
-    if (!crs.empty())
+    if (!crs.empty() && crs != "srid:0")
     {
         // Cf https://github.com/apache/parquet-format/blob/master/Geospatial.md#crs-customization
         // "srid: Spatial reference identifier, identifier is the SRID itself.."
@@ -2865,6 +2868,13 @@ const char *OGRParquetLayer::GetMetadataItem(const char *pszName,
             }
         }
         return nullptr;
+    }
+    if (pszDomain != nullptr && EQUAL(pszDomain, "_PARQUET_GEO_CRS_"))
+    {
+        const auto oIter = m_mapGeomFieldToParquetGeoCrs.find(pszName);
+        if (oIter == m_mapGeomFieldToParquetGeoCrs.end())
+            return nullptr;
+        return oIter->second.c_str();
     }
     return OGRLayer::GetMetadataItem(pszName, pszDomain);
 }

--- a/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
@@ -505,6 +505,31 @@ bool OGRParquetWriterLayer::SetOptions(
         m_oWriterPropertiesBuilder.enable_write_page_index();
 #endif
 
+    const char *pszGeoParquetVersion =
+        CSLFetchNameValueDef(papszOptions, "GEOPARQUET_VERSION", "1.1");
+    if (EQUAL(pszGeoParquetVersion, "1.1") ||
+        EQUAL(pszGeoParquetVersion, "AUTO"))
+        m_nGeoParquetVersion = OGRGeoParquetVersion::VERSION_1_1;
+    else if (EQUAL(pszGeoParquetVersion, "2.0"))
+    {
+#if ARROW_VERSION_MAJOR >= 21
+        m_nGeoParquetVersion = OGRGeoParquetVersion::VERSION_2_0;
+        if (pszWriteCoveringBBox == nullptr)
+            m_bWriteBBoxStruct = false;
+#else
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "GEOPARQUET_VERSION = 2.0 is only supported in a GDAL build "
+                 "against libarrow >= 21");
+        return false;
+#endif
+    }
+    else
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Unrecognized GeoParquet version: %s", pszGeoParquetVersion);
+        return false;
+    }
+
     const char *pszWriteGeo =
         CPLGetConfigOption("OGR_PARQUET_WRITE_GEO", nullptr);
     m_bWriteGeoMetadata = pszWriteGeo == nullptr || CPLTestBool(pszWriteGeo);
@@ -513,8 +538,13 @@ bool OGRParquetWriterLayer::SetOptions(
     {
 #if ARROW_VERSION_MAJOR >= 21
         const char *pszUseParquetGeoTypes =
-            CSLFetchNameValueDef(papszOptions, "USE_PARQUET_GEO_TYPES", "NO");
-        if (EQUAL(pszUseParquetGeoTypes, "ONLY"))
+            CSLFetchNameValueDef(papszOptions, "USE_PARQUET_GEO_TYPES", "AUTO");
+        if (EQUAL(pszUseParquetGeoTypes, "AUTO"))
+        {
+            m_bUseArrowWKBExtension =
+                (m_nGeoParquetVersion == OGRGeoParquetVersion::VERSION_2_0);
+        }
+        else if (EQUAL(pszUseParquetGeoTypes, "ONLY"))
         {
             m_bUseArrowWKBExtension = true;
             if (pszWriteGeo == nullptr)
@@ -525,6 +555,14 @@ bool OGRParquetWriterLayer::SetOptions(
         else
         {
             m_bUseArrowWKBExtension = CPLTestBool(pszUseParquetGeoTypes);
+            if (!m_bUseArrowWKBExtension &&
+                m_nGeoParquetVersion == OGRGeoParquetVersion::VERSION_2_0)
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "GEOPARQUET_VERSION = 2.0 is not compatible with "
+                         "USE_PARQUET_GEO_TYPES = NO");
+                return false;
+            }
         }
 #else
         m_oWriterPropertiesBuilder.disable_statistics(
@@ -584,7 +622,10 @@ std::string OGRParquetWriterLayer::GetGeoMetadata() const
     if (m_poFeatureDefn->GetGeomFieldCount() != 0 && m_bWriteGeoMetadata)
     {
         CPLJSONObject oRoot;
-        oRoot.Add("version", "1.1.0");
+        oRoot.Add("version",
+                  m_nGeoParquetVersion == OGRGeoParquetVersion::VERSION_1_1
+                      ? "1.1.0"
+                      : "2.0.0");
         oRoot.Add("primary_column",
                   m_poFeatureDefn->GetGeomFieldDefn(0)->GetNameRef());
         CPLJSONObject oColumns;

--- a/swig/python/gdal-utils/osgeo_utils/samples/validate_geoparquet.py
+++ b/swig/python/gdal-utils/osgeo_utils/samples/validate_geoparquet.py
@@ -189,7 +189,12 @@ class GeoParquetValidator:
         if self.local_schema:
             schema_j = json.loads(open(self.local_schema, "rb").read())
         else:
-            schema_url = f"https://github.com/opengeospatial/geoparquet/releases/download/v{version}/schema.json"
+            # TODO: remove this when v2.0.0 is published
+            if version == "2.0.0":
+                schema_url_version = "2.0.0-rc.1"
+            else:
+                schema_url_version = version
+            schema_url = f"https://github.com/opengeospatial/geoparquet/releases/download/v{schema_url_version}/schema.json"
 
             if schema_url not in geoparquet_schemas:
                 import urllib.request
@@ -245,15 +250,16 @@ class GeoParquetValidator:
                     f'geo["columns"] lists a {column_name} column which is not found in the Parquet fields'
                 )
 
-            self._check_column_metadata(column_name, column_def)
+            self._check_column_metadata(lyr, version, column_name, column_def)
 
         if self.check_data:
             self._check_data(lyr, columns)
 
-    def _check_column_metadata(self, column_name, column_def):
+    def _check_column_metadata(self, lyr, version, column_name, column_def):
         srs = None
         if "crs" in column_def:
             crs = column_def["crs"]
+
             if crs and (
                 osr.GetPROJVersionMajor() * 100 + osr.GetPROJVersionMinor() >= 602
             ):
@@ -265,7 +271,37 @@ class GeoParquetValidator:
                         srs.SetFromUserInput(crs)
                 except Exception as e:
                     self._error(f"crs {crs} cannot be parsed: %s" % str(e))
+
+            if version == "2.0.0":
+                parquet_crs = lyr.GetMetadataItem(column_name, "_PARQUET_GEO_CRS_")
+                if crs is None:
+                    if parquet_crs != "srid:0":
+                        self._error(
+                            f"For column {column_name}, GeoParquet CRS is null, but parquet_crs = '{parquet_crs}' (different from srid:0)"
+                        )
+                else:
+                    if parquet_crs.startswith("{") and parquet_crs.endswith("}"):
+                        # PROJJSON
+                        pass
+                    elif parquet_crs.count(":") == 1:
+                        # {auth_name}:{code}
+                        pass
+                    elif srs and srs.GetName() in ("WGS 84", "WGS 84 (CRS84)"):
+                        pass
+                    else:
+                        self._error(
+                            f"For column {column_name}, GeoParquet CRS is not null, but parquet_crs = '{parquet_crs}' and crs = {crs}"
+                        )
+
         else:
+
+            if version == "2.0.0":
+                parquet_crs = lyr.GetMetadataItem(column_name, "_PARQUET_GEO_CRS_")
+                if parquet_crs != "":
+                    self._error(
+                        f"For column {column_name}, GeoParquet CRS is null, but parquet_crs = '{parquet_crs}'"
+                    )
+
             srs = osr.SpatialReference()
             srs.ImportFromEPSG(4326)
 


### PR DESCRIPTION
…and a GEOPARQUET_VERSION = 1.1 / 2.0 layer creation option that defaults to 1.1

CC @cholmes 