### PR TITLE
Doc: Add layer-algebra examples and diagrams

### DIFF
--- a/doc/data/line1.geojson
+++ b/doc/data/line1.geojson
@@ -1,0 +1,18 @@
+{
+    "type" : "FeatureCollection",
+             "name" : "line1",
+                      "crs"
+        : {
+            "type" : "name",
+            "properties" : {"name" : "urn:ogc:def:crs:OGC:1.3:CRS84"}
+        },
+          "features" : [ {
+              "type" : "Feature",
+              "properties" : {"name" : null},
+              "geometry" : {
+                  "type" : "LineString",
+                  "coordinates" :
+                      [ [ 0.0, 0.0 ], [ 1.0, 1.0 ], [ 2.0, 1.0 ], [ 3.0, 0.0 ] ]
+              }
+          } ]
+}

--- a/doc/data/line2.geojson
+++ b/doc/data/line2.geojson
@@ -1,0 +1,18 @@
+{
+    "type" : "FeatureCollection",
+             "name" : "line2",
+                      "crs"
+        : {
+            "type" : "name",
+            "properties" : {"name" : "urn:ogc:def:crs:OGC:1.3:CRS84"}
+        },
+          "features" : [ {
+              "type" : "Feature",
+              "properties" : {"name" : null},
+              "geometry" : {
+                  "type" : "LineString",
+                  "coordinates" :
+                      [ [ 0.0, 1.0 ], [ 1.0, 1.0 ], [ 2.0, 1.0 ], [ 3.0, 1.0 ] ]
+              }
+          } ]
+}

--- a/doc/data/line3.geojson
+++ b/doc/data/line3.geojson
@@ -1,0 +1,17 @@
+{
+    "type" : "FeatureCollection",
+             "name" : "line3",
+                      "crs"
+        : {
+            "type" : "name",
+            "properties" : {"name" : "urn:ogc:def:crs:OGC:1.3:CRS84"}
+        },
+          "features" : [ {
+              "type" : "Feature",
+              "properties" : {"name" : null},
+              "geometry" : {
+                  "type" : "LineString",
+                  "coordinates" : [ [ -1.0, 0.5 ], [ 1.0, 2.5 ], [ 3.0, 0.5 ] ]
+              }
+          } ]
+}

--- a/doc/data/points.geojson
+++ b/doc/data/points.geojson
@@ -1,0 +1,41 @@
+{
+    "type" : "FeatureCollection",
+             "name" : "points",
+                      "crs"
+        : {
+            "type" : "name",
+            "properties" : {"name" : "urn:ogc:def:crs:OGC:1.3:CRS84"}
+        },
+          "features" : [
+              {
+                  "type" : "Feature",
+                  "properties" : {"fid" : 1},
+                  "geometry" : {"type" : "Point", "coordinates" : [ 0.5, 0.5 ]}
+              },
+              {
+                  "type" : "Feature",
+                  "properties" : {"fid" : 2},
+                  "geometry" : {"type" : "Point", "coordinates" : [ 1.5, 0.5 ]}
+              },
+              {
+                  "type" : "Feature",
+                  "properties" : {"fid" : 3},
+                  "geometry" : {"type" : "Point", "coordinates" : [ 1.0, 1.5 ]}
+              },
+              {
+                  "type" : "Feature",
+                  "properties" : {"fid" : 4},
+                  "geometry" : {"type" : "Point", "coordinates" : [ 3.0, 1.0 ]}
+              },
+              {
+                  "type" : "Feature",
+                  "properties" : {"fid" : 5},
+                  "geometry" : {"type" : "Point", "coordinates" : [ -1.0, 1.0 ]}
+              },
+              {
+                  "type" : "Feature",
+                  "properties" : {"fid" : 6},
+                  "geometry" : {"type" : "Point", "coordinates" : [ 1.0, 3.0 ]}
+              }
+          ]
+}

--- a/doc/data/polygon.geojson
+++ b/doc/data/polygon.geojson
@@ -1,0 +1,20 @@
+{
+    "type" : "FeatureCollection",
+             "name" : "polygon",
+                      "crs"
+        : {
+            "type" : "name",
+            "properties" : {"name" : "urn:ogc:def:crs:OGC:1.3:CRS84"}
+        },
+          "features" : [ {
+              "type" : "Feature",
+              "properties" : {"fid" : 1},
+              "geometry" : {
+                  "type" : "Polygon",
+                  "coordinates" : [[
+                      [ 0.0, 0.0 ], [ 0.0, 2.0 ], [ 2.0, 2.0 ], [ 2.0, 0.0 ],
+                      [ 0.0, 0.0 ]
+                  ]]
+              }
+          } ]
+}

--- a/doc/generate_images.py
+++ b/doc/generate_images.py
@@ -503,6 +503,144 @@ def test_gdal_vector_layer_algebra(tmp_path, operation):
     )
 
 
+@pytest.mark.parametrize(
+    "operation",
+    ("identity", "sym-difference"),
+)
+def test_gdal_vector_layer_algebra_lines(tmp_path, operation):
+
+    line1_fname = DATA_DIR / "line1.geojson"
+    line2_fname = DATA_DIR / "line2.geojson"
+    result_fname = tmp_path / "out.geojson"
+
+    alg = gdal.Run(
+        "vector layer-algebra",
+        operation=operation,
+        input=line1_fname,
+        method=line2_fname,
+        output=result_fname,
+    )
+    alg.Finalize()
+
+    scale = 0.6
+    plt, (ax, ax2) = pyplot.subplots(
+        1, 2, figsize=(12 * scale, 5 * scale), sharex=True, sharey=True
+    )
+    ax.set_axis_off()
+    ax2.set_axis_off()
+
+    line1 = gpd.read_file(line1_fname)
+    line2 = gpd.read_file(line2_fname)
+
+    line1.plot(ax=ax, color="blue", linewidth=3, alpha=0.6)
+    line2.plot(ax=ax, color="red", linewidth=3, alpha=0.6)
+
+    op = gpd.read_file(result_fname)
+    op.plot(ax=ax2, color="#e67e22", linewidth=3)
+
+    plt.savefig(
+        f'{IMAGE_ROOT}/programs/gdal_vector_layer_algebra_lines_{operation.replace("-", "_")}.svg',
+        bbox_inches="tight",
+        transparent=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "operation",
+    ("clip",),
+)
+def test_gdal_vector_layer_algebra_line_polygon(tmp_path, operation):
+
+    line_fname = DATA_DIR / "line3.geojson"
+    polygon_fname = DATA_DIR / "polygon.geojson"
+    result_fname = tmp_path / "out.geojson"
+
+    alg = gdal.Run(
+        "vector layer-algebra",
+        operation=operation,
+        input=line_fname,
+        method=polygon_fname,
+        output=result_fname,
+    )
+    alg.Finalize()
+
+    scale = 0.6
+    plt, (ax, ax2) = pyplot.subplots(
+        1, 2, figsize=(12 * scale, 5 * scale), sharex=True, sharey=True
+    )
+    ax.set_axis_off()
+    ax2.set_axis_off()
+
+    line = gpd.read_file(line_fname)
+    polygon = gpd.read_file(polygon_fname)
+
+    polygon.plot(ax=ax, facecolor="blue", alpha=0.5, edgecolor="black")
+    line.plot(ax=ax, color="red", linewidth=3)
+
+    op = gpd.read_file(result_fname)
+    if op.empty:
+        ax2.set_xlim(ax.get_xlim())
+        ax2.set_ylim(ax.get_ylim())
+    elif (op.geom_type.isin(["Polygon", "MultiPolygon"])).any():
+        op.plot(ax=ax2, facecolor="yellow", edgecolor="black", alpha=0.3)
+    else:
+        op.plot(ax=ax2, color="#e67e22", linewidth=3)
+
+    plt.savefig(
+        f'{IMAGE_ROOT}/programs/gdal_vector_layer_algebra_line_polygon_{operation.replace("-", "_")}.svg',
+        bbox_inches="tight",
+        transparent=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "operation",
+    ("erase",),
+)
+def test_gdal_vector_layer_algebra_points_polygon(tmp_path, operation):
+
+    points_fname = DATA_DIR / "points.geojson"
+    polygon_fname = DATA_DIR / "polygon.geojson"
+    result_fname = tmp_path / "out.gpkg"
+
+    alg = gdal.Run(
+        "vector layer-algebra",
+        operation=operation,
+        input=points_fname,
+        method=polygon_fname,
+        output=result_fname,
+    )
+    alg.Finalize()
+
+    scale = 0.6
+    plt, (ax, ax2) = pyplot.subplots(
+        1, 2, figsize=(12 * scale, 5 * scale), sharex=True, sharey=True
+    )
+    ax.set_axis_off()
+    ax2.set_axis_off()
+
+    points = gpd.read_file(points_fname)
+    polygon = gpd.read_file(polygon_fname)
+
+    polygon.plot(ax=ax, facecolor="blue", alpha=0.5, edgecolor="black")
+    points.plot(ax=ax, color="red", markersize=60, zorder=3)
+
+    op = gpd.read_file(result_fname)
+    if op.empty:
+        ax2.set_xlim(ax.get_xlim())
+        ax2.set_ylim(ax.get_ylim())
+    elif (op.geom_type.isin(["Polygon", "MultiPolygon"])).any():
+        op.plot(ax=ax2, facecolor="yellow", edgecolor="black", alpha=0.3)
+    else:
+        op.plot(ax=ax2, color="#e67e22", markersize=60, zorder=3)
+
+    plt.savefig(
+        f'{IMAGE_ROOT}/programs/gdal_vector_layer_algebra_points_polygon_{operation.replace("-", "_")}.svg',
+        bbox_inches="tight",
+        transparent=True,
+    )
+
+
 def test_gdal_vector_simplify(tmp_path):
 
     src_fname = DATA_DIR / "wells.geojson"

--- a/doc/images/programs/gdal_vector_layer_algebra_line_polygon_clip.svg
+++ b/doc/images/programs/gdal_vector_layer_algebra_line_polygon_clip.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="416.16pt" height="128.589623pt" viewBox="0 0 416.16 128.589623" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-14T16:18:54.378448</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 128.589623 
+L 416.16 128.589623 
+L 416.16 0 
+L 0 0 
+L 0 128.589623 
+z
+" style="fill: none"/>
+  </g>
+  <g id="axes_1">
+   <g id="PatchCollection_1">
+    <defs>
+     <path id="mdd21d8b11e" d="M 57.004959 -12.396862 
+L 57.004959 -95.433581 
+L 140.013223 -95.433581 
+L 140.013223 -12.396862 
+z
+" style="stroke: #000000; stroke-opacity: 0.5"/>
+    </defs>
+    <g clip-path="url(#p292acc8a83)">
+     <use xlink:href="#mdd21d8b11e" x="0" y="128.589623" style="fill: #0000ff; fill-opacity: 0.5; stroke: #000000; stroke-opacity: 0.5"/>
+    </g>
+   </g>
+   <g id="LineCollection_1">
+    <path d="M 15.500826 95.433581 
+L 98.509091 12.396862 
+L 181.517355 95.433581 
+" clip-path="url(#p292acc8a83)" style="fill: none; stroke: #ff0000; stroke-width: 3"/>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="LineCollection_2">
+    <path d="M 338.402975 33.152187 
+L 359.155041 53.913937 
+" clip-path="url(#pcc7c5f4f28)" style="fill: none; stroke: #e67e22; stroke-width: 3"/>
+    <path d="M 276.146777 53.913937 
+L 296.898843 33.152187 
+" clip-path="url(#pcc7c5f4f28)" style="fill: none; stroke: #e67e22; stroke-width: 3"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p292acc8a83">
+   <rect x="7.2" y="7.207067" width="182.618182" height="114.175489"/>
+  </clipPath>
+  <clipPath id="pcc7c5f4f28">
+   <rect x="226.341818" y="7.2" width="182.618182" height="114.189623"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/doc/images/programs/gdal_vector_layer_algebra_lines_identity.svg
+++ b/doc/images/programs/gdal_vector_layer_algebra_lines_identity.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="416.16pt" height="75.282pt" viewBox="0 0 416.16 75.282" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-14T16:18:49.565364</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 75.282 
+L 416.16 75.282 
+L 416.16 0 
+L 0 0 
+L 0 75.282 
+z
+" style="fill: none"/>
+  </g>
+  <g id="axes_1">
+   <g id="LineCollection_1">
+    <path d="M 15.500826 65.314636 
+L 70.839669 9.967364 
+L 126.178512 9.967364 
+L 181.517355 65.314636 
+" clip-path="url(#p796cf96090)" style="fill: none; stroke: #0000ff; stroke-opacity: 0.6; stroke-width: 3"/>
+   </g>
+   <g id="LineCollection_2">
+    <path d="M 15.500826 9.967364 
+L 70.839669 9.967364 
+L 126.178512 9.967364 
+L 181.517355 9.967364 
+" clip-path="url(#p796cf96090)" style="fill: none; stroke: #ff0000; stroke-opacity: 0.6; stroke-width: 3"/>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="LineCollection_3">
+    <path d="M 289.981488 9.970525 
+L 345.320331 9.970525 
+" clip-path="url(#p6c7f93aac0)" style="fill: none; stroke: #e67e22; stroke-width: 3"/>
+    <path d="M 345.320331 9.970525 
+L 400.659174 65.311475 
+" clip-path="url(#p6c7f93aac0)" style="fill: none; stroke: #e67e22; stroke-width: 3"/>
+    <path d="M 234.642645 65.311475 
+L 289.981488 9.970525 
+" clip-path="url(#p6c7f93aac0)" style="fill: none; stroke: #e67e22; stroke-width: 3"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p796cf96090">
+   <rect x="7.2" y="7.2" width="182.618182" height="60.882"/>
+  </clipPath>
+  <clipPath id="p6c7f93aac0">
+   <rect x="226.341818" y="7.203477" width="182.618182" height="60.875045"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/doc/images/programs/gdal_vector_layer_algebra_lines_sym_difference.svg
+++ b/doc/images/programs/gdal_vector_layer_algebra_lines_sym_difference.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="416.16pt" height="75.282pt" viewBox="0 0 416.16 75.282" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-14T16:18:49.639442</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 75.282 
+L 416.16 75.282 
+L 416.16 0 
+L 0 0 
+L 0 75.282 
+z
+" style="fill: none"/>
+  </g>
+  <g id="axes_1">
+   <g id="LineCollection_1">
+    <path d="M 15.500826 65.314636 
+L 70.839669 9.967364 
+L 126.178512 9.967364 
+L 181.517355 65.314636 
+" clip-path="url(#pcceb432eae)" style="fill: none; stroke: #0000ff; stroke-opacity: 0.6; stroke-width: 3"/>
+   </g>
+   <g id="LineCollection_2">
+    <path d="M 15.500826 9.967364 
+L 70.839669 9.967364 
+L 126.178512 9.967364 
+L 181.517355 9.967364 
+" clip-path="url(#pcceb432eae)" style="fill: none; stroke: #ff0000; stroke-opacity: 0.6; stroke-width: 3"/>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="LineCollection_3">
+    <path d="M 345.320331 9.970525 
+L 400.659174 65.311475 
+" clip-path="url(#pdc7d74a198)" style="fill: none; stroke: #e67e22; stroke-width: 3"/>
+    <path d="M 234.642645 65.311475 
+L 289.981488 9.970525 
+" clip-path="url(#pdc7d74a198)" style="fill: none; stroke: #e67e22; stroke-width: 3"/>
+    <path d="M 345.320331 9.970525 
+L 400.659174 9.970525 
+" clip-path="url(#pdc7d74a198)" style="fill: none; stroke: #e67e22; stroke-width: 3"/>
+    <path d="M 234.642645 9.970525 
+L 289.981488 9.970525 
+" clip-path="url(#pdc7d74a198)" style="fill: none; stroke: #e67e22; stroke-width: 3"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pcceb432eae">
+   <rect x="7.2" y="7.2" width="182.618182" height="60.882"/>
+  </clipPath>
+  <clipPath id="pdc7d74a198">
+   <rect x="226.341818" y="7.203477" width="182.618182" height="60.875045"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/doc/images/programs/gdal_vector_layer_algebra_points_polygon_erase.svg
+++ b/doc/images/programs/gdal_vector_layer_algebra_points_polygon_erase.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="416.16pt" height="151.447122pt" viewBox="0 0 416.16 151.447122" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-14T16:19:00.002919</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 151.447122 
+L 416.16 151.447122 
+L 416.16 0 
+L 0 0 
+L 0 151.447122 
+z
+" style="fill: none"/>
+  </g>
+  <g id="axes_1">
+   <g id="PatchCollection_1">
+    <defs>
+     <path id="mdb22fff20f" d="M 57.004959 -13.438312 
+L 57.004959 -96.48531 
+L 140.013223 -96.48531 
+L 140.013223 -13.438312 
+z
+" style="stroke: #000000; stroke-opacity: 0.5"/>
+    </defs>
+    <g clip-path="url(#pd052ab4d03)">
+     <use xlink:href="#mdb22fff20f" x="0" y="151.447122" style="fill: #0000ff; fill-opacity: 0.5; stroke: #000000; stroke-opacity: 0.5"/>
+    </g>
+   </g>
+   <g id="PathCollection_1">
+    <defs>
+     <path id="me2d6063470" d="M 0 3.872983 
+C 1.027127 3.872983 2.012324 3.464901 2.738613 2.738613 
+C 3.464901 2.012324 3.872983 1.027127 3.872983 0 
+C 3.872983 -1.027127 3.464901 -2.012324 2.738613 -2.738613 
+C 2.012324 -3.464901 1.027127 -3.872983 0 -3.872983 
+C -1.027127 -3.872983 -2.012324 -3.464901 -2.738613 -2.738613 
+C -3.464901 -2.012324 -3.872983 -1.027127 -3.872983 0 
+C -3.872983 1.027127 -3.464901 2.012324 -2.738613 2.738613 
+C -2.012324 3.464901 -1.027127 3.872983 0 3.872983 
+z
+" style="stroke: #ff0000"/>
+    </defs>
+    <g clip-path="url(#pd052ab4d03)">
+     <use xlink:href="#me2d6063470" x="77.757025" y="117.24706" style="fill: #ff0000; stroke: #ff0000"/>
+     <use xlink:href="#me2d6063470" x="119.261157" y="117.24706" style="fill: #ff0000; stroke: #ff0000"/>
+     <use xlink:href="#me2d6063470" x="98.509091" y="75.723561" style="fill: #ff0000; stroke: #ff0000"/>
+     <use xlink:href="#me2d6063470" x="181.517355" y="96.48531" style="fill: #ff0000; stroke: #ff0000"/>
+     <use xlink:href="#me2d6063470" x="15.500826" y="96.48531" style="fill: #ff0000; stroke: #ff0000"/>
+     <use xlink:href="#me2d6063470" x="98.509091" y="13.438312" style="fill: #ff0000; stroke: #ff0000"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="PathCollection_2">
+    <defs>
+     <path id="m605b71c024" d="M 0 3.872983 
+C 1.027127 3.872983 2.012324 3.464901 2.738613 2.738613 
+C 3.464901 2.012324 3.872983 1.027127 3.872983 0 
+C 3.872983 -1.027127 3.464901 -2.012324 2.738613 -2.738613 
+C 2.012324 -3.464901 1.027127 -3.872983 0 -3.872983 
+C -1.027127 -3.872983 -2.012324 -3.464901 -2.738613 -2.738613 
+C -3.464901 -2.012324 -3.872983 -1.027127 -3.872983 0 
+C -3.872983 1.027127 -3.464901 2.012324 -2.738613 2.738613 
+C -2.012324 3.464901 -1.027127 3.872983 0 3.872983 
+z
+" style="stroke: #e67e22"/>
+    </defs>
+    <g clip-path="url(#p1c1e1290e5)">
+     <use xlink:href="#m605b71c024" x="400.659174" y="96.488276" style="fill: #e67e22; stroke: #e67e22"/>
+     <use xlink:href="#m605b71c024" x="234.642645" y="96.488276" style="fill: #e67e22; stroke: #e67e22"/>
+     <use xlink:href="#m605b71c024" x="317.650909" y="13.429415" style="fill: #e67e22; stroke: #e67e22"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pd052ab4d03">
+   <rect x="7.2" y="7.209787" width="182.618182" height="137.027547"/>
+  </clipPath>
+  <clipPath id="p1c1e1290e5">
+   <rect x="226.341818" y="7.2" width="182.618182" height="137.047122"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/doc/source/programs/gdal_vector_layer_algebra.rst
+++ b/doc/source/programs/gdal_vector_layer_algebra.rst
@@ -218,7 +218,7 @@ Examples
    rather than the default name ``method_fid``. It will contain values from the
    ``fid`` field of the method layer.
 
-   ``--geometry-type`` is set to ``GEOMETRYCOLLECTION`` to allow the output layer to contain different
+   ``--geometry-type`` is set to ``GEOMETRY`` to allow the output layer to contain different
    geometry types.
 
    .. code-block:: bash
@@ -226,7 +226,7 @@ Examples
         $ gdal vector layer-algebra points.geojson polygon.geojson output.gpkg \
             --operation union --all-input-field \
             --method-field fid --method-prefix "analysis_" \
-            --geometry-type GEOMETRYCOLLECTION
+            --geometry-type GEOMETRY
 
 .. example::
    :title: Clip a line with a polygon.

--- a/doc/source/programs/gdal_vector_layer_algebra.rst
+++ b/doc/source/programs/gdal_vector_layer_algebra.rst
@@ -27,6 +27,11 @@ The command takes a vector input source and a method source and generates the
 output of the operation in the specified output file. The output fields depend on the
 operation and can be controlled with the field options.
 
+Z and M coordinates do not affect the result of algebraic operations, which
+are computed using X and Y coordinates. When present, Z and M coordinates
+are propagated to the output, with values interpolated from the input
+geometries.
+
 When operations result in mixed geometry types, for example, a ``union`` operation
 between a polygon layer and a point layer, the output data format must be able to
 support mixed geometry types, such as GeoPackage or GeoJSON.
@@ -67,6 +72,7 @@ Program-Specific Options
 
         A union is a set of features, which represent areas that are in either of the operand layers.
         The operation is symmetric, and input and method layers can be interchanged.
+        See also the :cpp:func:`Union <OGRLayer::Union>` C++ API documentation.
 
         .. image:: ../../images/programs/gdal_vector_layer_algebra_union.svg
 
@@ -74,6 +80,7 @@ Program-Specific Options
 
         An intersection is a set of features, which represent the common areas of two layers.
         The operation is symmetric, and input and method layers can be interchanged.
+        See also the :cpp:func:`Intersection <OGRLayer::Intersection>` C++ API documentation.
 
         .. image:: ../../images/programs/gdal_vector_layer_algebra_intersection.svg
 
@@ -81,6 +88,7 @@ Program-Specific Options
 
         A symmetric difference is a set of features, which represent areas that are in operand layers but which do not intersect.
         The operation is symmetric, and input and method layers can be interchanged.
+        See also the :cpp:func:`SymDifference <OGRLayer::SymDifference>` C++ API documentation.
 
         .. image:: ../../images/programs/gdal_vector_layer_algebra_sym_difference.svg
 
@@ -88,6 +96,7 @@ Program-Specific Options
 
         The identity method identifies features in the input layer with features in the method layer possibly splitting features into several features.
         By default the result layer has attributes from both operand layers.
+        See also the :cpp:func:`Identity <OGRLayer::Identity>` C++ API documentation.
 
         .. image:: ../../images/programs/gdal_vector_layer_algebra_identity.svg
 
@@ -95,6 +104,7 @@ Program-Specific Options
 
         The update method creates a layer, which add features into the input layer from the method layer possibly cutting features in the input layer.
         By default the result layer has attributes only from the input layer.
+        See also the :cpp:func:`Update <OGRLayer::Update>` C++ API documentation.
 
         .. image:: ../../images/programs/gdal_vector_layer_algebra_update.svg
 
@@ -102,6 +112,7 @@ Program-Specific Options
 
         The clip method creates a layer, which has features from the input layer clipped to the areas of the features in the method layer.
         By default the result layer has attributes of the input layer.
+        See also the :cpp:func:`Clip <OGRLayer::Clip>` C++ API documentation.
 
         .. image:: ../../images/programs/gdal_vector_layer_algebra_clip.svg
 
@@ -109,6 +120,7 @@ Program-Specific Options
 
         The erase method creates a layer, which has features from the input layer whose areas are erased by the features in the method layer.
         By default the result layer has attributes of the input layer.
+        See also the :cpp:func:`Erase <OGRLayer::Erase>` C++ API documentation.
 
         .. image:: ../../images/programs/gdal_vector_layer_algebra_erase.svg
 

--- a/doc/source/programs/gdal_vector_layer_algebra.rst
+++ b/doc/source/programs/gdal_vector_layer_algebra.rst
@@ -23,8 +23,23 @@ Description
 -----------
 
 :program:`gdal vector layer-algebra` performs various vector layer algebraic operations.
-The  command takes a vector input source and a method source and generates the
-output of the operation in the specified output file.
+The command takes a vector input source and a method source and generates the
+output of the operation in the specified output file. The output fields depend on the
+operation and can be controlled with the field options.
+
+When operations result in mixed geometry types, for example, a ``union`` operation
+between a polygon layer and a point layer, the output data format must be able to
+support mixed geometry types, such as GeoPackage or GeoJSON.
+
+By default, the output layer will have the geometry type of the input layer, but this
+can be overridden with the :option:`--geometry-type` option.
+
+.. code-block:: bash
+
+    $ gdal vector layer-algebra union points.gpkg polygon.gpkg output.gpkg --geometry-type GEOMETRYCOLLECTION
+    $ gdal vector info output.gpkg
+    Layer name: output
+    Geometry: Geometry Collection
 
 Since GDAL 3.14, :program:`gdal vector layer-algebra` can be used as a step of a pipeline.
 
@@ -76,7 +91,6 @@ Program-Specific Options
 
         .. image:: ../../images/programs/gdal_vector_layer_algebra_identity.svg
 
-
     * ``update``
 
         The update method creates a layer, which add features into the input layer from the method layer possibly cutting features in the input layer.
@@ -90,7 +104,6 @@ Program-Specific Options
         By default the result layer has attributes of the input layer.
 
         .. image:: ../../images/programs/gdal_vector_layer_algebra_clip.svg
-
 
     * ``erase``
 
@@ -185,3 +198,86 @@ Examples
    .. code-block:: bash
 
         $ gdal vector layer-algebra union input.shp method.shp output.shp
+
+.. example::
+   :title: Performs a union between layers, with custom field names.
+
+   In this example ``output.gpkg`` will include a field named ``analysis_fid``
+   rather than the default name ``method_fid``. It will contain values from the
+   ``fid`` field of the method layer.
+
+   ``--geometry-type`` is set to ``GEOMETRYCOLLECTION`` to allow the output layer to contain different
+   geometry types.
+
+   .. code-block:: bash
+
+        $ gdal vector layer-algebra points.geojson polygon.geojson output.gpkg \
+            --operation union --all-input-field \
+            --method-field fid --method-prefix "analysis_" \
+            --geometry-type GEOMETRYCOLLECTION
+
+.. example::
+   :title: Clip a line with a polygon.
+
+   The same result is obtained using :option:`--operation intersection`.
+
+   .. image:: ../../images/programs/gdal_vector_layer_algebra_line_polygon_clip.svg
+
+   .. code-block:: bash
+
+        $ gdal vector layer-algebra line3.geojson polygon.geojson out.geojson --operation clip
+
+.. example::
+   :title: Erase points with a polygon.
+
+   .. image:: ../../images/programs/gdal_vector_layer_algebra_points_polygon_erase.svg
+
+   .. code-block:: bash
+
+        $ gdal vector layer-algebra points.geojson polygon.geojson out.geojson --operation erase
+
+.. example::
+   :title: Symmetric difference between line layers.
+
+   The input layer is displayed in blue, and the method layer in red.
+
+   The input layer contains:
+
+   ::
+
+      LINESTRING (0 0,1 1,2 1,3 0)
+
+   The method layer contains:
+
+   ::
+
+      LINESTRING (0 1,1 1,2 1,3 1)
+
+   This produces two features:
+
+   ::
+
+      MULTILINESTRING ((0 0,1 1),(2 1,3 0))
+      MULTILINESTRING ((0 1,1 1),(2 1,3 1))
+
+   .. image:: ../../images/programs/gdal_vector_layer_algebra_lines_sym_difference.svg
+
+   .. code-block:: bash
+
+      $ gdal vector layer-algebra line1.geojson line2.geojson out.geojson --operation sym-difference
+
+.. example::
+   :title: Identity operation between line layers.
+
+   The output contains two features:
+
+   ::
+
+      LINESTRING (1 1,2 1) # has input and method attributes
+      MULTILINESTRING ((0 0,1 1),(2 1,3 0)) # has input attributes only
+
+   .. image:: ../../images/programs/gdal_vector_layer_algebra_lines_identity.svg
+
+   .. code-block:: bash
+
+      $ gdal vector layer-algebra line1.geojson line2.geojson out.geojson --operation identity


### PR DESCRIPTION
This PR adds more examples to the `gdal vector layer-algebra` docs page. 

Preview available at: https://gdal--15031.org.readthedocs.build/en/15031/programs/gdal_vector_layer_algebra.html

I added a few new diagrams to the `generate_images.py` script to illustrate operations between different geometry types - especially the ones I was unclear on. Initially I generated images for all operations, but reduced these to just the ones used in the examples (`black` also seems to have reformatted some unrelated code as part of the precommit). 

I have a few questions comments after working with the tool that I can address in the docs if required.

1. The tool is based on https://github.com/OSGeo/gdal/blob/master/swig/python/gdal-utils/osgeo_utils/ogr_layer_algebra.py. This had CRS checks to make sure they matched before running the operations (see [here](https://github.com/OSGeo/gdal/blob/fd8c20dfbd219c2073efa1b0e5fb0efb9822a31e/swig/python/gdal-utils/osgeo_utils/ogr_layer_algebra.py#L403-L415)). I think it would be useful to also port these warnings to avoid users wondering why operations are not returning expected results. 

2. There don't seem to be any checks or warnings if any of the specified `--input-field` names are missing. 

3. Do Z or M values have any affect on these operations (I would presume not, but would like to make it explicit in the docs)?

4. Will the `gdal-utils/osgeo_utils/ogr_layer_algebra.py` script be removed or kept?

5. When setting `--geometry-type GEOMETRYCOLLECTION` then it appears to convert all features in the output to ``MULTI`` feature types (even when not required) e.g. `POINT(0.5, 0.5)` becomes `MULTIPOINT ((0.5 0.5))`. Is this intended behaviour?

