### PR TITLE
swig:  Add swig interface code to access SpatialReference.FindMatches from Java

### DIFF
--- a/swig/include/java/typemaps_java.i
+++ b/swig/include/java/typemaps_java.i
@@ -2645,3 +2645,83 @@ DEFINE_BOOLEAN_FUNC_ARRAY_IN(double, jdouble, GetDoubleArrayElements, ReleaseDou
 %typemap(javaout) (OGRCodedValue*) {
     return $jnicall;
   }
+
+
+/***************************************************
+ * Typemaps for SpatialReference.FindMatches()
+ *
+ * C signature (see osr.i):
+ *   OSRSpatialReferenceShadow** FindMatches(
+ *       char** options, int* nvalues, int** confidence_values)
+ *
+ * Resulting Java signature:
+ *   public SpatialReference[] FindMatches(Vector options, int[][] confidenceValuesOut)
+ *
+ * nvalues (arg position 3) is fully hidden from Java -- it only exists to
+ * carry the match count between the two output-producing typemaps below.
+ * confidence_values (arg position 4) is surfaced as an int[][] "out box":
+ * caller passes a 1-element int[][] and this typemap fills element [0]
+ * with a freshly allocated int[] parallel to the returned SpatialReference[].
+ *
+ * NOTE on the nMatches3 / panConfidence4 local variable names: SWIG
+ * appends the argument's position in the full parameter list (self=1,
+ * options=2, nvalues=3, confidence_values=4) to typemap-declared locals to
+ * avoid collisions. These names must match
+ * whatever the generated osr_wrap.cpp actually declares. If SWIG's output
+ * changes (e.g. after a signature edit), check osr_wrap.cpp and update
+ * the suffixes here to match.
+ ***************************************************/
+
+%typemap(in,numinputs=0) int* nvalues (int nMatches = 0)
+{
+  /* %typemap(in,numinputs=0) int* nvalues */
+  $1 = &nMatches;
+}
+
+%typemap(in) int** confidence_values (int* panConfidence = NULL)
+{
+  /* %typemap(in) int** confidence_values -- caller's array contents are
+     ignored; we only keep $input around so argout can write the real
+     result into element [0]. */
+  $1 = &panConfidence;
+}
+
+%typemap(argout) int** confidence_values
+{
+  /* %typemap(argout) int** confidence_values -- fills the caller's int[][] */
+  if ($input && jenv->GetArrayLength($input) >= 1) {
+    jintArray confArray = jenv->NewIntArray(nMatches3);
+    jenv->SetIntArrayRegion(confArray, 0, nMatches3, (jint*)panConfidence4);
+    jenv->SetObjectArrayElement($input, 0, confArray);
+    jenv->DeleteLocalRef(confArray);
+  }
+  CPLFree(panConfidence4);
+}
+
+%typemap(jni) int** confidence_values "jobjectArray"
+%typemap(jtype) int** confidence_values "int[][]"
+%typemap(jstype) int** confidence_values "int[][]"
+%typemap(javain) int** confidence_values "$javainput"
+
+%typemap(out) (OSRSpatialReferenceShadow**)
+{
+  /* %typemap(out) (OSRSpatialReferenceShadow**) -- builds the returned SpatialReference[] */
+  const jclass srsClass = jenv->FindClass("org/gdal/osr/SpatialReference");
+  const jmethodID srsCtor = jenv->GetMethodID(srsClass, "<init>", "(JZ)V");
+
+  jresult = jenv->NewObjectArray(nMatches3, srsClass, NULL);
+  for (int i = 0; i < nMatches3; i++) {
+    OSRReference(result[i]);
+    jobject srsObj = jenv->NewObject(srsClass, srsCtor, (jlong)result[i], (jboolean)true);
+    jenv->SetObjectArrayElement(jresult, i, srsObj);
+    jenv->DeleteLocalRef(srsObj);
+  }
+  OSRFreeSRSArray(result);
+}
+
+%typemap(jni) OSRSpatialReferenceShadow** "jobjectArray"
+%typemap(jtype) OSRSpatialReferenceShadow** "org.gdal.osr.SpatialReference[]"
+%typemap(jstype) OSRSpatialReferenceShadow** "org.gdal.osr.SpatialReference[]"
+%typemap(javaout) OSRSpatialReferenceShadow** {
+    return $jnicall;
+}

--- a/swig/include/java/typemaps_java.i
+++ b/swig/include/java/typemaps_java.i
@@ -2658,59 +2658,26 @@ DEFINE_BOOLEAN_FUNC_ARRAY_IN(double, jdouble, GetDoubleArrayElements, ReleaseDou
  *   public SpatialReference[] FindMatches(Vector options, int[][] confidenceValuesOut)
  *
  * nvalues (arg position 3) is fully hidden from Java -- it only exists to
- * carry the match count between the two output-producing typemaps below.
+ * carry the match count between the two output-producing typemaps.
  * confidence_values (arg position 4) is surfaced as an int[][] "out box":
  * caller passes a 1-element int[][] and this typemap fills element [0]
  * with a freshly allocated int[] parallel to the returned SpatialReference[].
- *
- * NOTE on the nMatches3 / panConfidence4 local variable names: SWIG
- * appends the argument's position in the full parameter list (self=1,
- * options=2, nvalues=3, confidence_values=4) to typemap-declared locals to
- * avoid collisions. These names must match
- * whatever the generated osr_wrap.cpp actually declares. If SWIG's output
- * changes (e.g. after a signature edit), check osr_wrap.cpp and update
- * the suffixes here to match.
+
  ***************************************************/
-
-%typemap(in,numinputs=0) int* nvalues (int nMatches = 0)
-{
-  /* %typemap(in,numinputs=0) int* nvalues */
-  $1 = &nMatches;
-}
-
-%typemap(in) int** confidence_values (int* panConfidence = NULL)
-{
-  /* %typemap(in) int** confidence_values -- caller's array contents are
-     ignored; we only keep $input around so argout can write the real
-     result into element [0]. */
-  $1 = &panConfidence;
-}
-
-%typemap(argout) int** confidence_values
-{
-  /* %typemap(argout) int** confidence_values -- fills the caller's int[][] */
-  if ($input && jenv->GetArrayLength($input) >= 1) {
-    jintArray confArray = jenv->NewIntArray(nMatches3);
-    jenv->SetIntArrayRegion(confArray, 0, nMatches3, (jint*)panConfidence4);
-    jenv->SetObjectArrayElement($input, 0, confArray);
-    jenv->DeleteLocalRef(confArray);
-  }
-  CPLFree(panConfidence4);
-}
-
-%typemap(jni) int** confidence_values "jobjectArray"
-%typemap(jtype) int** confidence_values "int[][]"
-%typemap(jstype) int** confidence_values "int[][]"
-%typemap(javain) int** confidence_values "$javainput"
 
 %typemap(out) (OSRSpatialReferenceShadow**)
 {
   /* %typemap(out) (OSRSpatialReferenceShadow**) -- builds the returned SpatialReference[] */
+  /* nLen3 is hardcoded, $argnum is not useful in out typemaps.
+     nLen was declared under the separate typemap (argument
+     position 3). If FindMatches's parameter order ever
+     changes, re-check the generated osr_wrap.cpp and update this suffix
+     to match. */
   const jclass srsClass = jenv->FindClass("org/gdal/osr/SpatialReference");
   const jmethodID srsCtor = jenv->GetMethodID(srsClass, "<init>", "(JZ)V");
 
-  jresult = jenv->NewObjectArray(nMatches3, srsClass, NULL);
-  for (int i = 0; i < nMatches3; i++) {
+  jresult = jenv->NewObjectArray(nLen3, srsClass, NULL);
+  for (int i = 0; i < nLen3; i++) {
     OSRReference(result[i]);
     jobject srsObj = jenv->NewObject(srsClass, srsCtor, (jlong)result[i], (jboolean)true);
     jenv->SetObjectArrayElement(jresult, i, srsObj);

--- a/swig/include/osr.i
+++ b/swig/include/osr.i
@@ -577,10 +577,12 @@ public:
 #endif
 
 #ifdef SWIGJAVA
+%apply (int* pnList, int** ppListOut) {(int* nvalues, int **confidence_values)};
   OSRSpatialReferenceShadow** FindMatches( char** options, int* nvalues, int** confidence_values )
   {
        return (OSRSpatialReferenceShadow**) OSRFindMatches(self, options, nvalues, confidence_values);
   }
+%clear (int* buckets_ret, int **ppanHistogram);
 #endif
 
   OGRErr SetProjection( char const *arg ) {

--- a/swig/include/osr.i
+++ b/swig/include/osr.i
@@ -576,6 +576,13 @@ public:
   }
 #endif
 
+#ifdef SWIGJAVA
+  OSRSpatialReferenceShadow** FindMatches( char** options, int* nvalues, int** confidence_values )
+  {
+       return (OSRSpatialReferenceShadow**) OSRFindMatches(self, options, nvalues, confidence_values);
+  }
+#endif
+
   OGRErr SetProjection( char const *arg ) {
     return OSRSetProjection( self, arg );
   }

--- a/swig/include/osr.i
+++ b/swig/include/osr.i
@@ -582,7 +582,7 @@ public:
   {
        return (OSRSpatialReferenceShadow**) OSRFindMatches(self, options, nvalues, confidence_values);
   }
-%clear (int* buckets_ret, int **ppanHistogram);
+%clear (int* nvalues, int **confidence_values);
 #endif
 
   OGRErr SetProjection( char const *arg ) {

--- a/swig/java/apps/OSRTest.java
+++ b/swig/java/apps/OSRTest.java
@@ -68,22 +68,21 @@ public class OSRTest {
               throw new Exception("No match found where expected");
 
           if ( matches.length != 1)
-              throw new Exception("Found more than one match");
+              throw new Exception("Found more than one match: "+matches.length);
 
           SpatialReference matched = matches[0];
           if ( !"EPGS".equals(matched.GetAuthorityName(null)))
-              throw new Exception("Authority name not EPSG");
+              throw new Exception("Authority name not EPSG: "+matched.GetAuthorityName(null));
           if ( !"26911".equals(matched.GetAuthorityCode(null)))
-              throw new Exception("Authority code not 26911");
+              throw new Exception("Authority code not 26911 "+matched.GetAuthorityCode(null));
 
           if ( confidence.length != 1)
-              throw new Exception("Length of confidence array not 1");
+              throw new Exception("Length of confidence array not 1: "+confidence.length);
 
           int[] confidenceValues = confidence[0];
           if ( confidenceValues.length != matches.length)
-              throw new Exception("Length of confidenceValues array not the same as the matches array");
+              throw new Exception("Length of confidenceValues array not the same as the matches array: "+confidenceValues.length+" "+ matches.length);
           if ( confidenceValues[0] != 100)
-              throw new Exception("Confidence value not as expected");
-
+              throw new Exception("Confidence value not as expected "+confidenceValues[0]);
       }
 }

--- a/swig/java/apps/OSRTest.java
+++ b/swig/java/apps/OSRTest.java
@@ -14,6 +14,9 @@
 
 import org.gdal.osr.SpatialReference;
 
+import java.util.Vector;
+import java.util.Collections;
+
 public class OSRTest {
       public static void main(String[] args) throws Exception {
           SpatialReference srs = new SpatialReference(null);
@@ -26,5 +29,61 @@ public class OSRTest {
               throw new Exception("srs.EPSGTreatsAsLatLong() should return 1");
           if( srs.EPSGTreatsAsNorthingEasting() != 0 )
               throw new Exception("srs.EPSGTreatsAsNorthingEasting() should return 0");
+
+          /*
+           * Test FindMatches binding
+           */
+          String wkt =
+            "PROJCS[\"NAD83 / UTM zone 11N\",\n" +
+            "    GEOGCS[\"NAD83\",\n" +
+            "        DATUM[\"North_American_Datum_1983\",\n" +
+            "            SPHEROID[\"GRS 1980\",6378137,298.257222101,\n" +
+            "                AUTHORITY[\"EPSG\",\"7019\"]],\n" +
+            "            AUTHORITY[\"EPSG\",\"6269\"]],\n" +
+            "        PRIMEM[\"Greenwich\",0],\n" +
+            "        UNIT[\"Degree\",0.0174532925199433]],\n" +
+            "    PROJECTION[\"Transverse_Mercator\"],\n" +
+            "    PARAMETER[\"latitude_of_origin\",0],\n" +
+            "    PARAMETER[\"central_meridian\",-117],\n" +
+            "    PARAMETER[\"scale_factor\",0.9996],\n" +
+            "    PARAMETER[\"false_easting\",500000],\n" +
+            "    PARAMETER[\"false_northing\",0],\n" +
+            "    UNIT[\"metre\",1,\n" +
+            "        AUTHORITY[\"EPSG\",\"9001\"]],\n" +
+            "    AXIS[\"Easting\",EAST],\n" +
+            "    AXIS[\"Northing\",NORTH]]";
+          Vector<String> lines = new Vector<String>();
+          Collections.addAll(lines, wkt.split("\n"));
+
+          srs = new SpatialReference(null);
+          int importResult = srs.ImportFromESRI(lines);
+          if ( srs.IsProjected() != 1)
+              throw new Exception("srs.IsProjected() should return 1");
+          if ( srs.IsGeographic() != 0)
+              throw new Exception("srs.IsGeographic() should return 0");
+
+          int[][] confidence = new int[1][];
+          SpatialReference[] matches = srs.FindMatches(null, confidence);
+          if ( matches == null || matches.length == 0)
+              throw new Exception("No match found where expected");
+
+          if ( matches.length != 1)
+              throw new Exception("Found more than one match");
+
+          SpatialReference matched = matches[0];
+          if ( !"EPGS".equals(matched.GetAuthorityName(null)))
+              throw new Exception("Authority name not EPSG");
+          if ( !"26911".equals(matched.GetAuthorityCode(null)))
+              throw new Exception("Authority code not 26911");
+
+          if ( confidence.length != 1)
+              throw new Exception("Length of confidence array not 1");
+
+          int[] confidenceValues = confidence[0];
+          if ( confidenceValues.length != matches.length)
+              throw new Exception("Length of confidenceValues array not the same as the matches array");
+          if ( confidenceValues[0] != 100)
+              throw new Exception("Confidence value not as expected");
+
       }
 }

--- a/swig/java/apps/OSRTest.java
+++ b/swig/java/apps/OSRTest.java
@@ -71,7 +71,7 @@ public class OSRTest {
               throw new Exception("Found more than one match: "+matches.length);
 
           SpatialReference matched = matches[0];
-          if ( !"EPGS".equals(matched.GetAuthorityName(null)))
+          if ( !"EPSG".equals(matched.GetAuthorityName(null)))
               throw new Exception("Authority name not EPSG: "+matched.GetAuthorityName(null));
           if ( !"26911".equals(matched.GetAuthorityCode(null)))
               throw new Exception("Authority code not 26911 "+matched.GetAuthorityCode(null));

--- a/swig/java/javadoc.java
+++ b/swig/java/javadoc.java
@@ -10405,6 +10405,33 @@ public class SpatialReference:public double[] GetTOWGS84()
 public class SpatialReference:public int GetTOWGS84(double[] argout)
 
 /**
+ * Try to identify a match between this SRS and a related SRS in a catalog.
+ * <p> 
+ * Matching may be partial, or may fail. Returned entries will be sorted by
+ * decreasing match confidence (first entry has the highest match confidence).
+ * <p>
+ * The exact way matching is done may change in future versions. 
+ * Starting with GDAL 3.0, it relies on PROJ' proj_identify() function.
+ * <p>
+ * The confidence_values array structure will contain output values.  The
+ * outer dimension of the array is the 'box', and the method will allocated
+ * the inner dimension to contain the array of confidence values.
+ * <p>
+ * Typical usage:
+<pre><code>
+    int[][] confidence = new int[1][];
+    SpatialReference[] matches = srs.FindMatches(null, confidence);
+    int[] confidenceValues = confidence[0];
+</code></pre>	
+ * @param options a vector of options or null
+ * @param confidence_values a box to contain an output array, one for each matching SpatialReference,
+ * whose values between 0 and 100 indicate the confidence in the match. 100 is the highest confidence level.
+ *
+ * @return an array, possibly empty, of SpatialReferences that match this reference.
+ */
+public class SpatialReference:public org.gdal.osr.SpatialReference[] FindMatches(java.util.Vector options, int[][] confidence_values)
+
+/**
  * Initialize SRS based on EPSG GCS or PCS code.
  * <p>
  * This method will initialize the spatial reference based on the


### PR DESCRIPTION

## What does this PR do?

This PR adds a swig binding for the Java language for the SpatialReference.FindMatches method.

## What are related issues/pull requests?

This issue was discussed on the developers mailing list.  Submitting this PR now to get a broader review of the code.

## AI tool usage

 - [x] I used an llm chat to assist with the development and debugging of this interface, conceptually similar to the way that I used to use stackoverflow to find explanations and code examples.

## Tasklist

 - [x] Add test to OSRTest.java
 - [x]  Javadoc strings were added that were taken from the GDAL documentation for this feature.  The javadoc builds correctly and describes the purpose, parameters and usage.
 - [x] Review
 Requesting review of the swig code to ensure that it is correct and using preferred form.
 - [x] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:  Windows 11 2024H2
* Compiler: Microsoft (R) C/C++ Optimizing Compiler Version 19.44.35214 for x64
* built using conda, Java 21
