### PR TITLE
gdal vector layer-algebra: add warnings about inconsistent input/method layer CRS, and honour geometry-type for output features, and warn about unexisting input/method fields

### DIFF
--- a/apps/gdalalg_vector_layer_algebra.cpp
+++ b/apps/gdalalg_vector_layer_algebra.cpp
@@ -209,6 +209,30 @@ bool GDALVectorLayerAlgebraAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
         return false;
     }
 
+    const auto poInputSRS = poInputLayer->GetSpatialRef();
+    const auto poMethodSRS = poMethodLayer->GetSpatialRef();
+    if (poInputSRS && !poMethodSRS)
+    {
+        ReportError(
+            CE_Warning, CPLE_AppDefined,
+            "Input layer has a CRS, but method layer has none. Assuming "
+            "geometries of method layer to be expressed in input layer CRS.");
+    }
+    else if (!poInputSRS && poMethodSRS)
+    {
+        ReportError(
+            CE_Warning, CPLE_AppDefined,
+            "Method layer has a CRS, but input layer has none. Assuming "
+            "geometries of input layer to be expressed in method layer CRS.");
+    }
+    else if (poInputSRS && poMethodSRS && !poInputSRS->IsSame(poMethodSRS))
+    {
+        ReportError(
+            CE_Warning, CPLE_AppDefined,
+            "Input and method layer have non-equivalent CRS. No on-the-fly "
+            "reprojection is performed, and thus results may be incorrect.");
+    }
+
     if (!poDstLayer)
     {
         const CPLStringList aosLayerCreationOptions(
@@ -273,6 +297,14 @@ bool GDALVectorLayerAlgebraAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
                     }
                 }
             }
+            for (const auto &name : srcFields)
+            {
+                if (poFDefn->GetFieldIndex(name.c_str()) < 0)
+                {
+                    CPLError(CE_Warning, CPLE_AppDefined, "Unknown field '%s'",
+                             name.c_str());
+                }
+            }
             return true;
         };
 
@@ -308,10 +340,9 @@ bool GDALVectorLayerAlgebraAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
         }
     }
 
-    if (OGR_GT_IsSubClassOf(poDstLayer->GetGeomType(), wkbGeometryCollection))
-    {
-        aosOptions.SetNameValue("PROMOTE_TO_MULTI", "YES");
-    }
+    aosOptions.SetNameValue(
+        "OUTPUT_GEOMETRY_TYPE",
+        OGRToOGCGeomType(poDstLayer->GetGeomType(), false, true));
 
     const std::map<std::string, decltype(&OGRLayer::Union)>
         mapOperationToMethod = {

--- a/autotest/utilities/test_gdalalg_vector_layer_algebra.py
+++ b/autotest/utilities/test_gdalalg_vector_layer_algebra.py
@@ -11,10 +11,11 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import gdaltest
 import ogrtest
 import pytest
 
-from osgeo import gdal, ogr
+from osgeo import gdal, ogr, osr
 
 pytestmark = pytest.mark.require_geos
 
@@ -49,39 +50,40 @@ def test_gdal_vector_layer_algebra_union():
     f.SetGeometry(ogr.CreateGeometryFromWkt("POINT(3 4)"))
     method_lyr.CreateFeature(f)
 
-    with gdal.Run(
-        "vector",
-        "layer-algebra",
-        operation="union",
-        input=input_ds,
-        method=method_ds,
-        output_format="MEM",
-        geometry_type="MULTIPOINT",
-        input_field=["a", "non_existing"],
-        method_field=["b", "non_existing"],
-    ) as alg:
-        out_ds = alg.Output()
-        out_lyr = out_ds.GetLayer(0)
-        assert out_lyr.GetName() == "output"
-        assert out_lyr.GetLayerDefn().GetFieldCount() == 2
-        assert out_lyr.GetLayerDefn().GetFieldDefn(0).GetName() == "input_a"
-        assert out_lyr.GetLayerDefn().GetFieldDefn(1).GetName() == "method_b"
-        assert out_lyr.GetFeatureCount() == 3
+    with gdaltest.error_raised(gdal.CE_Warning, match="non_existing"):
+        with gdal.Run(
+            "vector",
+            "layer-algebra",
+            operation="union",
+            input=input_ds,
+            method=method_ds,
+            output_format="MEM",
+            geometry_type="MULTIPOINT",
+            input_field=["a", "non_existing"],
+            method_field=["b", "non_existing"],
+        ) as alg:
+            out_ds = alg.Output()
+            out_lyr = out_ds.GetLayer(0)
+            assert out_lyr.GetName() == "output"
+            assert out_lyr.GetLayerDefn().GetFieldCount() == 2
+            assert out_lyr.GetLayerDefn().GetFieldDefn(0).GetName() == "input_a"
+            assert out_lyr.GetLayerDefn().GetFieldDefn(1).GetName() == "method_b"
+            assert out_lyr.GetFeatureCount() == 3
 
-        f = out_lyr.GetNextFeature()
-        assert f["input_a"] == "foo"
-        assert not f.IsFieldSet("method_b")
-        assert f.GetGeometryRef().ExportToIsoWkt() == "MULTIPOINT ((1 2))"
+            f = out_lyr.GetNextFeature()
+            assert f["input_a"] == "foo"
+            assert not f.IsFieldSet("method_b")
+            assert f.GetGeometryRef().ExportToIsoWkt() == "MULTIPOINT ((1 2))"
 
-        f = out_lyr.GetNextFeature()
-        assert f["input_a"] == "foo2"
-        assert f["method_b"] == "bar2"
-        assert f.GetGeometryRef().ExportToIsoWkt() == "MULTIPOINT ((3 4))"
+            f = out_lyr.GetNextFeature()
+            assert f["input_a"] == "foo2"
+            assert f["method_b"] == "bar2"
+            assert f.GetGeometryRef().ExportToIsoWkt() == "MULTIPOINT ((3 4))"
 
-        f = out_lyr.GetNextFeature()
-        assert f["method_b"] == "bar"
-        assert not f.IsFieldSet("input_a")
-        assert f.GetGeometryRef().ExportToIsoWkt() == "MULTIPOINT ((5 6))"
+            f = out_lyr.GetNextFeature()
+            assert f["method_b"] == "bar"
+            assert not f.IsFieldSet("input_a")
+            assert f.GetGeometryRef().ExportToIsoWkt() == "MULTIPOINT ((5 6))"
 
 
 def test_gdal_vector_layer_algebra_input_and_method_same():
@@ -535,10 +537,10 @@ def test_gdal_vector_layer_algebra_overwrite_multilayer(tmp_vsimem):
         )
 
 
-def get_input_method_datasets():
+def get_input_method_datasets(input_crs=None, method_crs=None):
 
     input_ds = gdal.GetDriverByName("MEM").CreateVector("")
-    input_lyr = input_ds.CreateLayer("input")
+    input_lyr = input_ds.CreateLayer("input", srs=input_crs)
     input_lyr.CreateField(ogr.FieldDefn("a"))
     f = ogr.Feature(input_lyr.GetLayerDefn())
     f["a"] = "foo"
@@ -551,7 +553,7 @@ def get_input_method_datasets():
     input_lyr.CreateFeature(f)
 
     method_ds = gdal.GetDriverByName("MEM").CreateVector("")
-    method_lyr = method_ds.CreateLayer("method")
+    method_lyr = method_ds.CreateLayer("method", srs=method_crs)
     method_lyr.CreateField(ogr.FieldDefn("b"))
     f = ogr.Feature(method_lyr.GetLayerDefn())
     f["b"] = "bar"
@@ -820,3 +822,79 @@ def test_gdal_vector_layer_algebra_pipeline(tmp_vsimem):
     )
     with ogr.Open(tmp_vsimem / "out.gpkg") as out_ds:
         check_out_ds(out_ds)
+
+
+@pytest.mark.parametrize(
+    "input_crs,method_crs,warning",
+    [
+        (
+            None,
+            "EPSG:4326",
+            "Method layer has a CRS, but input layer has none. Assuming geometries of input layer to be expressed in method layer CRS",
+        ),
+        (
+            "EPSG:4326",
+            None,
+            "Input layer has a CRS, but method layer has none. Assuming geometries of method layer to be expressed in input layer CRS",
+        ),
+        (
+            "EPSG:4326",
+            "EPSG:4258",
+            "Input and method layer have non-equivalent CRS. No on-the-fly reprojection is performed, and thus results may be incorrect",
+        ),
+    ],
+)
+def test_gdal_vector_layer_algebra_inconsistent_crs(
+    tmp_vsimem, input_crs, method_crs, warning
+):
+
+    if input_crs:
+        crs = osr.SpatialReference()
+        crs.SetFromUserInput(input_crs)
+        input_crs = crs
+
+    if method_crs:
+        crs = osr.SpatialReference()
+        crs.SetFromUserInput(method_crs)
+        method_crs = crs
+
+    input_ds, method_ds = get_input_method_datasets(
+        input_crs=input_crs, method_crs=method_crs
+    )
+
+    with gdaltest.error_raised(gdal.CE_Warning, match=warning):
+        gdal.alg.vector.layer_algebra(
+            input=input_ds,
+            method=method_ds,
+            output_format="MEM",
+            output="",
+            operation="intersection",
+        )
+
+
+def test_gdal_vector_layer_algebra_geometry_type():
+
+    input_ds, method_ds = get_input_method_datasets()
+    with gdal.Run(
+        "vector",
+        "layer-algebra",
+        operation="intersection",
+        input=input_ds,
+        method=method_ds,
+        output_format="MEM",
+        geometry_type="MULTIPOLYGON",
+    ) as alg:
+        out_ds = alg.Output()
+        out_lyr = out_ds.GetLayer(0)
+        assert out_lyr.GetName() == "output"
+        assert out_lyr.GetLayerDefn().GetFieldCount() == 2
+        assert out_lyr.GetLayerDefn().GetFieldDefn(0).GetName() == "input_a"
+        assert out_lyr.GetLayerDefn().GetFieldDefn(1).GetName() == "method_b"
+        assert out_lyr.GetFeatureCount() == 1
+
+        f = out_lyr.GetNextFeature()
+        assert f["input_a"] == "foo"
+        assert f["method_b"] == "bar"
+        ogrtest.check_feature_geometry(
+            f.GetGeometryRef(), "MULTIPOLYGON (((5 0,5 10,10 10,10 0,5 0)))"
+        )

--- a/doc/source/programs/gdal_vector_layer_algebra.rst
+++ b/doc/source/programs/gdal_vector_layer_algebra.rst
@@ -60,6 +60,10 @@ Program-Specific Options
    ``Z``, ``M`` or ``ZM`` suffixes can be appended to the above values to
    indicate the dimensionality.
 
+   If the geometry resulting from the operation cannot be converted to the
+   geometry type, the corresponding output feature is not written in the output
+   layer, without any warning.
+
 .. option:: --input-layer <INPUT-LAYER>
 
     Name of the input vector layer.

--- a/ogr/ogrsf_frmts/generic/ogrlayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayer.cpp
@@ -5290,15 +5290,37 @@ static OGRGeometry *set_filter_from(OGRLayer *pLayer,
     return geom;
 }
 
-static OGRGeometry *promote_to_multi(OGRGeometry *poGeom)
+static std::unique_ptr<OGRGeometry>
+promote_to_multi(std::unique_ptr<OGRGeometry> poGeom)
 {
     OGRwkbGeometryType eType = wkbFlatten(poGeom->getGeometryType());
     if (eType == wkbPoint)
-        return OGRGeometryFactory::forceToMultiPoint(poGeom);
+        return std::unique_ptr<OGRGeometry>(
+            OGRGeometryFactory::forceToMultiPoint(poGeom.release()));
     else if (eType == wkbPolygon)
-        return OGRGeometryFactory::forceToMultiPolygon(poGeom);
+        return std::unique_ptr<OGRGeometry>(
+            OGRGeometryFactory::forceToMultiPolygon(poGeom.release()));
     else if (eType == wkbLineString)
-        return OGRGeometryFactory::forceToMultiLineString(poGeom);
+        return std::unique_ptr<OGRGeometry>(
+            OGRGeometryFactory::forceToMultiLineString(poGeom.release()));
+    else
+        return poGeom;
+}
+
+static std::unique_ptr<OGRGeometry>
+convert_geometry(std::unique_ptr<OGRGeometry> poGeom, bool bPromoteToMulti,
+                 OGRwkbGeometryType eOutputGeometryType)
+{
+    if (eOutputGeometryType != wkbUnknown)
+    {
+        poGeom =
+            OGRGeometryFactory::forceTo(std::move(poGeom), eOutputGeometryType);
+        if (poGeom && poGeom->getGeometryType() != eOutputGeometryType)
+            return nullptr;
+        return poGeom;
+    }
+    else if (bPromoteToMulti)
+        return promote_to_multi(std::move(poGeom));
     else
         return poGeom;
 }
@@ -5335,6 +5357,11 @@ static OGRGeometry *promote_to_multi(OGRGeometry *poGeom)
  * <li>PROMOTE_TO_MULTI=YES/NO. Set to YES to convert Polygons
  *     into MultiPolygons, LineStrings to MultiLineStrings or
  *     Points to MultiPoints (only since GDAL 3.9.2 for the later)
+ * </li>
+ * <li>OUTPUT_GEOMETRY_TYPE=[MULTI]POINT/[MULTI]LINESTRING/[MULTI]POLYGON/GEOMETRYCOLLECTION/GEOMETRY
+ *     Output geometry type (since GDAL 3.14.0). If the output geometry cannot
+ *     be converted to it, the corresponding output feature is silently skipped.
+ *     Takes precedence over PROMOTE_TO_MULTI.
  * </li>
  * <li>INPUT_PREFIX=string. Set a prefix for the field names that
  *     will be created from the fields of the input layer.
@@ -5408,6 +5435,9 @@ OGRErr OGRLayer::Intersection(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
         CSLFetchNameValueDef(papszOptions, "PRETEST_CONTAINMENT", "NO"));
     bool bKeepLowerDimGeom = CPLTestBool(CSLFetchNameValueDef(
         papszOptions, "KEEP_LOWER_DIMENSION_GEOMETRIES", "YES"));
+    const char *pszOutputGeometryType =
+        CSLFetchNameValueDef(papszOptions, "OUTPUT_GEOMETRY_TYPE", "GEOMETRY");
+    const auto eOutputGeometryType = OGRFromOGCGeomType(pszOutputGeometryType);
 
     // check for GEOS
     if (!OGRGeometryFactory::haveGEOS())
@@ -5522,7 +5552,7 @@ OGRErr OGRLayer::Intersection(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
             OGRGeometry *y_geom = y->GetGeometryRef();
             if (!y_geom)
                 continue;
-            OGRGeometryUniquePtr z_geom;
+            std::unique_ptr<OGRGeometry> z_geom;
 
             if (x_prepared_geom)
             {
@@ -5588,8 +5618,10 @@ OGRErr OGRLayer::Intersection(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
             OGRFeatureUniquePtr z(new OGRFeature(poDefnResult));
             z->SetFieldsFrom(x.get(), mapInput);
             z->SetFieldsFrom(y.get(), mapMethod);
-            if (bPromoteToMulti)
-                z_geom.reset(promote_to_multi(z_geom.release()));
+            z_geom = convert_geometry(std::move(z_geom), bPromoteToMulti,
+                                      eOutputGeometryType);
+            if (!z_geom)
+                continue;
             z->SetGeometryDirectly(z_geom.release());
             ret = pLayerResult->CreateFeature(z.get());
 
@@ -5657,6 +5689,11 @@ done:
  * <li>PROMOTE_TO_MULTI=YES/NO. Set to YES to convert Polygons
  *     into MultiPolygons, LineStrings to MultiLineStrings or
  *     Points to MultiPoints (only since GDAL 3.9.2 for the later)
+ * </li>
+ * <li>OUTPUT_GEOMETRY_TYPE=[MULTI]POINT/[MULTI]LINESTRING/[MULTI]POLYGON/GEOMETRYCOLLECTION/GEOMETRY
+ *     Output geometry type (since GDAL 3.14.0). If the output geometry cannot
+ *     be converted to it, the corresponding output feature is silently skipped.
+ *     Takes precedence over PROMOTE_TO_MULTI.
  * </li>
  * <li>INPUT_PREFIX=string. Set a prefix for the field names that
  *     will be created from the fields of the input layer.
@@ -5759,6 +5796,11 @@ OGRErr OGR_L_Intersection(OGRLayerH pLayerInput, OGRLayerH pLayerMethod,
  *     into MultiPolygons, LineStrings to MultiLineStrings or
  *     Points to MultiPoints (only since GDAL 3.9.2 for the later)
  * </li>
+ * <li>OUTPUT_GEOMETRY_TYPE=[MULTI]POINT/[MULTI]LINESTRING/[MULTI]POLYGON/GEOMETRYCOLLECTION/GEOMETRY
+ *     Output geometry type (since GDAL 3.14.0). If the output geometry cannot
+ *     be converted to it, the corresponding output feature is silently skipped.
+ *     Takes precedence over PROMOTE_TO_MULTI.
+ * </li>
  * <li>INPUT_PREFIX=string. Set a prefix for the field names that
  *     will be created from the fields of the input layer.
  * </li>
@@ -5825,6 +5867,9 @@ OGRErr OGRLayer::Union(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
         CSLFetchNameValueDef(papszOptions, "USE_PREPARED_GEOMETRIES", "YES"));
     bool bKeepLowerDimGeom = CPLTestBool(CSLFetchNameValueDef(
         papszOptions, "KEEP_LOWER_DIMENSION_GEOMETRIES", "YES"));
+    const char *pszOutputGeometryType =
+        CSLFetchNameValueDef(papszOptions, "OUTPUT_GEOMETRY_TYPE", "GEOMETRY");
+    const auto eOutputGeometryType = OGRFromOGCGeomType(pszOutputGeometryType);
 
     // check for GEOS
     if (!OGRGeometryFactory::haveGEOS())
@@ -5915,7 +5960,7 @@ OGRErr OGRLayer::Union(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
             }
         }
 
-        OGRGeometryUniquePtr x_geom_diff(
+        std::unique_ptr<OGRGeometry> x_geom_diff(
             x_geom
                 ->clone());  // this will be the geometry of the result feature
         for (auto &&y : pLayerMethod)
@@ -5951,7 +5996,8 @@ OGRErr OGRLayer::Union(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
             }
 
             CPLErrorReset();
-            OGRGeometryUniquePtr poIntersection(x_geom->Intersection(y_geom));
+            std::unique_ptr<OGRGeometry> poIntersection(
+                x_geom->Intersection(y_geom));
             if (CPLGetLastErrorType() != CE_None || poIntersection == nullptr)
             {
                 if (!bSkipFailures)
@@ -5978,15 +6024,15 @@ OGRErr OGRLayer::Union(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
                 OGRFeatureUniquePtr z(new OGRFeature(poDefnResult));
                 z->SetFieldsFrom(x.get(), mapInput);
                 z->SetFieldsFrom(y.get(), mapMethod);
-                if (bPromoteToMulti)
-                    poIntersection.reset(
-                        promote_to_multi(poIntersection.release()));
+                poIntersection =
+                    convert_geometry(std::move(poIntersection), bPromoteToMulti,
+                                     eOutputGeometryType);
                 z->SetGeometryDirectly(poIntersection.release());
 
                 if (x_geom_diff)
                 {
                     CPLErrorReset();
-                    OGRGeometryUniquePtr x_geom_diff_new(
+                    std::unique_ptr<OGRGeometry> x_geom_diff_new(
                         x_geom_diff->Difference(y_geom));
                     if (CPLGetLastErrorType() != CE_None ||
                         x_geom_diff_new == nullptr)
@@ -6032,8 +6078,10 @@ OGRErr OGRLayer::Union(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
         {
             OGRFeatureUniquePtr z(new OGRFeature(poDefnResult));
             z->SetFieldsFrom(x.get(), mapInput);
-            if (bPromoteToMulti)
-                x_geom_diff.reset(promote_to_multi(x_geom_diff.release()));
+            x_geom_diff = convert_geometry(
+                std::move(x_geom_diff), bPromoteToMulti, eOutputGeometryType);
+            if (!x_geom_diff)
+                continue;
             z->SetGeometryDirectly(x_geom_diff.release());
             ret = pLayerResult->CreateFeature(z.get());
             if (ret != OGRERR_NONE)
@@ -6093,7 +6141,7 @@ OGRErr OGRLayer::Union(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
             continue;
         }
 
-        OGRGeometryUniquePtr x_geom_diff(
+        std::unique_ptr<OGRGeometry> x_geom_diff(
             x_geom
                 ->clone());  // this will be the geometry of the result feature
         for (auto &&y : this)
@@ -6107,7 +6155,7 @@ OGRErr OGRLayer::Union(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
             if (x_geom_diff)
             {
                 CPLErrorReset();
-                OGRGeometryUniquePtr x_geom_diff_new(
+                std::unique_ptr<OGRGeometry> x_geom_diff_new(
                     x_geom_diff->Difference(y_geom));
                 if (CPLGetLastErrorType() != CE_None ||
                     x_geom_diff_new == nullptr)
@@ -6138,8 +6186,10 @@ OGRErr OGRLayer::Union(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
         {
             OGRFeatureUniquePtr z(new OGRFeature(poDefnResult));
             z->SetFieldsFrom(x.get(), mapMethod);
-            if (bPromoteToMulti)
-                x_geom_diff.reset(promote_to_multi(x_geom_diff.release()));
+            x_geom_diff = convert_geometry(
+                std::move(x_geom_diff), bPromoteToMulti, eOutputGeometryType);
+            if (!x_geom_diff)
+                continue;
             z->SetGeometryDirectly(x_geom_diff.release());
             ret = pLayerResult->CreateFeature(z.get());
             if (ret != OGRERR_NONE)
@@ -6212,6 +6262,11 @@ done:
  * <li>PROMOTE_TO_MULTI=YES/NO. Set to YES to convert Polygons
  *     into MultiPolygons, LineStrings to MultiLineStrings or
  *     Points to MultiPoints (only since GDAL 3.9.2 for the later)
+ * </li>
+ * <li>OUTPUT_GEOMETRY_TYPE=[MULTI]POINT/[MULTI]LINESTRING/[MULTI]POLYGON/GEOMETRYCOLLECTION/GEOMETRY
+ *     Output geometry type (since GDAL 3.14.0). If the output geometry cannot
+ *     be converted to it, the corresponding output feature is silently skipped.
+ *     Takes precedence over PROMOTE_TO_MULTI.
  * </li>
  * <li>INPUT_PREFIX=string. Set a prefix for the field names that
  *     will be created from the fields of the input layer.
@@ -6306,6 +6361,11 @@ OGRErr OGR_L_Union(OGRLayerH pLayerInput, OGRLayerH pLayerMethod,
  * <li>PROMOTE_TO_MULTI=YES/NO. Set it to YES to convert Polygons
  *     into MultiPolygons, or LineStrings to MultiLineStrings.
  * </li>
+ * <li>OUTPUT_GEOMETRY_TYPE=[MULTI]POINT/[MULTI]LINESTRING/[MULTI]POLYGON/GEOMETRYCOLLECTION/GEOMETRY
+ *     Output geometry type (since GDAL 3.14.0). If the output geometry cannot
+ *     be converted to it, the corresponding output feature is silently skipped.
+ *     Takes precedence over PROMOTE_TO_MULTI.
+ * </li>
  * <li>INPUT_PREFIX=string. Set a prefix for the field names that
  *     will be created from the fields of the input layer.
  * </li>
@@ -6358,6 +6418,9 @@ OGRErr OGRLayer::SymDifference(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
         CPLTestBool(CSLFetchNameValueDef(papszOptions, "SKIP_FAILURES", "NO"));
     const bool bPromoteToMulti = CPLTestBool(
         CSLFetchNameValueDef(papszOptions, "PROMOTE_TO_MULTI", "NO"));
+    const char *pszOutputGeometryType =
+        CSLFetchNameValueDef(papszOptions, "OUTPUT_GEOMETRY_TYPE", "GEOMETRY");
+    const auto eOutputGeometryType = OGRFromOGCGeomType(pszOutputGeometryType);
 
     // check for GEOS
     if (!OGRGeometryFactory::haveGEOS())
@@ -6427,7 +6490,7 @@ OGRErr OGRLayer::SymDifference(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
             continue;
         }
 
-        OGRGeometryUniquePtr geom(
+        std::unique_ptr<OGRGeometry> geom(
             x_geom
                 ->clone());  // this will be the geometry of the result feature
         for (auto &&y : pLayerMethod)
@@ -6440,7 +6503,7 @@ OGRErr OGRLayer::SymDifference(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
             if (geom)
             {
                 CPLErrorReset();
-                OGRGeometryUniquePtr geom_new(geom->Difference(y_geom));
+                std::unique_ptr<OGRGeometry> geom_new(geom->Difference(y_geom));
                 if (CPLGetLastErrorType() != CE_None || geom_new == nullptr)
                 {
                     if (!bSkipFailures)
@@ -6467,8 +6530,10 @@ OGRErr OGRLayer::SymDifference(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
         {
             OGRFeatureUniquePtr z(new OGRFeature(poDefnResult));
             z->SetFieldsFrom(x.get(), mapInput);
-            if (bPromoteToMulti)
-                geom.reset(promote_to_multi(geom.release()));
+            geom = convert_geometry(std::move(geom), bPromoteToMulti,
+                                    eOutputGeometryType);
+            if (!geom)
+                continue;
             z->SetGeometryDirectly(geom.release());
             ret = pLayerResult->CreateFeature(z.get());
             if (ret != OGRERR_NONE)
@@ -6528,7 +6593,7 @@ OGRErr OGRLayer::SymDifference(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
             continue;
         }
 
-        OGRGeometryUniquePtr geom(
+        std::unique_ptr<OGRGeometry> geom(
             x_geom
                 ->clone());  // this will be the geometry of the result feature
         for (auto &&y : this)
@@ -6539,7 +6604,7 @@ OGRErr OGRLayer::SymDifference(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
             if (geom)
             {
                 CPLErrorReset();
-                OGRGeometryUniquePtr geom_new(geom->Difference(y_geom));
+                std::unique_ptr<OGRGeometry> geom_new(geom->Difference(y_geom));
                 if (CPLGetLastErrorType() != CE_None || geom_new == nullptr)
                 {
                     if (!bSkipFailures)
@@ -6566,8 +6631,10 @@ OGRErr OGRLayer::SymDifference(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
         {
             OGRFeatureUniquePtr z(new OGRFeature(poDefnResult));
             z->SetFieldsFrom(x.get(), mapMethod);
-            if (bPromoteToMulti)
-                geom.reset(promote_to_multi(geom.release()));
+            geom = convert_geometry(std::move(geom), bPromoteToMulti,
+                                    eOutputGeometryType);
+            if (!geom)
+                continue;
             z->SetGeometryDirectly(geom.release());
             ret = pLayerResult->CreateFeature(z.get());
             if (ret != OGRERR_NONE)
@@ -6640,6 +6707,11 @@ done:
  * <li>PROMOTE_TO_MULTI=YES/NO. Set to YES to convert Polygons
  *     into MultiPolygons, LineStrings to MultiLineStrings or
  *     Points to MultiPoints (only since GDAL 3.9.2 for the later)
+ * </li>
+ * <li>OUTPUT_GEOMETRY_TYPE=[MULTI]POINT/[MULTI]LINESTRING/[MULTI]POLYGON/GEOMETRYCOLLECTION/GEOMETRY
+ *     Output geometry type (since GDAL 3.14.0). If the output geometry cannot
+ *     be converted to it, the corresponding output feature is silently skipped.
+ *     Takes precedence over PROMOTE_TO_MULTI.
  * </li>
  * <li>INPUT_PREFIX=string. Set a prefix for the field names that
  *     will be created from the fields of the input layer.
@@ -6726,6 +6798,11 @@ OGRErr OGR_L_SymDifference(OGRLayerH pLayerInput, OGRLayerH pLayerMethod,
  *     into MultiPolygons, LineStrings to MultiLineStrings or
  *     Points to MultiPoints (only since GDAL 3.9.2 for the later)
  * </li>
+ * <li>OUTPUT_GEOMETRY_TYPE=[MULTI]POINT/[MULTI]LINESTRING/[MULTI]POLYGON/GEOMETRYCOLLECTION/GEOMETRY
+ *     Output geometry type (since GDAL 3.14.0). If the output geometry cannot
+ *     be converted to it, the corresponding output feature is silently skipped.
+ *     Takes precedence over PROMOTE_TO_MULTI.
+ * </li>
  * <li>INPUT_PREFIX=string. Set a prefix for the field names that
  *     will be created from the fields of the input layer.
  * </li>
@@ -6789,6 +6866,9 @@ OGRErr OGRLayer::Identity(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
         CSLFetchNameValueDef(papszOptions, "USE_PREPARED_GEOMETRIES", "YES"));
     bool bKeepLowerDimGeom = CPLTestBool(CSLFetchNameValueDef(
         papszOptions, "KEEP_LOWER_DIMENSION_GEOMETRIES", "YES"));
+    const char *pszOutputGeometryType =
+        CSLFetchNameValueDef(papszOptions, "OUTPUT_GEOMETRY_TYPE", "GEOMETRY");
+    const auto eOutputGeometryType = OGRFromOGCGeomType(pszOutputGeometryType);
 
     // check for GEOS
     if (!OGRGeometryFactory::haveGEOS())
@@ -6876,7 +6956,7 @@ OGRErr OGRLayer::Identity(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
             }
         }
 
-        OGRGeometryUniquePtr x_geom_diff(
+        std::unique_ptr<OGRGeometry> x_geom_diff(
             x_geom
                 ->clone());  // this will be the geometry of the result feature
         for (auto &&y : pLayerMethod)
@@ -6910,7 +6990,8 @@ OGRErr OGRLayer::Identity(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
             }
 
             CPLErrorReset();
-            OGRGeometryUniquePtr poIntersection(x_geom->Intersection(y_geom));
+            std::unique_ptr<OGRGeometry> poIntersection(
+                x_geom->Intersection(y_geom));
             if (CPLGetLastErrorType() != CE_None || poIntersection == nullptr)
             {
                 if (!bSkipFailures)
@@ -6937,14 +7018,16 @@ OGRErr OGRLayer::Identity(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
                 OGRFeatureUniquePtr z(new OGRFeature(poDefnResult));
                 z->SetFieldsFrom(x.get(), mapInput);
                 z->SetFieldsFrom(y.get(), mapMethod);
-                if (bPromoteToMulti)
-                    poIntersection.reset(
-                        promote_to_multi(poIntersection.release()));
+                poIntersection =
+                    convert_geometry(std::move(poIntersection), bPromoteToMulti,
+                                     eOutputGeometryType);
+                if (!poIntersection)
+                    continue;
                 z->SetGeometryDirectly(poIntersection.release());
                 if (x_geom_diff)
                 {
                     CPLErrorReset();
-                    OGRGeometryUniquePtr x_geom_diff_new(
+                    std::unique_ptr<OGRGeometry> x_geom_diff_new(
                         x_geom_diff->Difference(y_geom));
                     if (CPLGetLastErrorType() != CE_None ||
                         x_geom_diff_new == nullptr)
@@ -6990,8 +7073,10 @@ OGRErr OGRLayer::Identity(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
         {
             OGRFeatureUniquePtr z(new OGRFeature(poDefnResult));
             z->SetFieldsFrom(x.get(), mapInput);
-            if (bPromoteToMulti)
-                x_geom_diff.reset(promote_to_multi(x_geom_diff.release()));
+            x_geom_diff = convert_geometry(
+                std::move(x_geom_diff), bPromoteToMulti, eOutputGeometryType);
+            if (!x_geom_diff)
+                continue;
             z->SetGeometryDirectly(x_geom_diff.release());
             ret = pLayerResult->CreateFeature(z.get());
             if (ret != OGRERR_NONE)
@@ -7059,6 +7144,11 @@ done:
  * <li>PROMOTE_TO_MULTI=YES/NO. Set to YES to convert Polygons
  *     into MultiPolygons, LineStrings to MultiLineStrings or
  *     Points to MultiPoints (only since GDAL 3.9.2 for the later)
+ * </li>
+ * <li>OUTPUT_GEOMETRY_TYPE=[MULTI]POINT/[MULTI]LINESTRING/[MULTI]POLYGON/GEOMETRYCOLLECTION/GEOMETRY
+ *     Output geometry type (since GDAL 3.14.0). If the output geometry cannot
+ *     be converted to it, the corresponding output feature is silently skipped.
+ *     Takes precedence over PROMOTE_TO_MULTI.
  * </li>
  * <li>INPUT_PREFIX=string. Set a prefix for the field names that
  *     will be created from the fields of the input layer.
@@ -7154,6 +7244,11 @@ OGRErr OGR_L_Identity(OGRLayerH pLayerInput, OGRLayerH pLayerMethod,
  *     into MultiPolygons, LineStrings to MultiLineStrings or
  *     Points to MultiPoints (only since GDAL 3.9.2 for the later)
  * </li>
+ * <li>OUTPUT_GEOMETRY_TYPE=[MULTI]POINT/[MULTI]LINESTRING/[MULTI]POLYGON/GEOMETRYCOLLECTION/GEOMETRY
+ *     Output geometry type (since GDAL 3.14.0). If the output geometry cannot
+ *     be converted to it, the corresponding output feature is silently skipped.
+ *     Takes precedence over PROMOTE_TO_MULTI.
+ * </li>
  * <li>INPUT_PREFIX=string. Set a prefix for the field names that
  *     will be created from the fields of the input layer.
  * </li>
@@ -7205,6 +7300,9 @@ OGRErr OGRLayer::Update(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
         CPLTestBool(CSLFetchNameValueDef(papszOptions, "SKIP_FAILURES", "NO"));
     const bool bPromoteToMulti = CPLTestBool(
         CSLFetchNameValueDef(papszOptions, "PROMOTE_TO_MULTI", "NO"));
+    const char *pszOutputGeometryType =
+        CSLFetchNameValueDef(papszOptions, "OUTPUT_GEOMETRY_TYPE", "GEOMETRY");
+    const auto eOutputGeometryType = OGRFromOGCGeomType(pszOutputGeometryType);
 
     // check for GEOS
     if (!OGRGeometryFactory::haveGEOS())
@@ -7271,7 +7369,7 @@ OGRErr OGRLayer::Update(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
             continue;
         }
 
-        OGRGeometryUniquePtr x_geom_diff(
+        std::unique_ptr<OGRGeometry> x_geom_diff(
             x_geom->clone());  // this will be the geometry of a result feature
         for (auto &&y : pLayerMethod)
         {
@@ -7281,7 +7379,7 @@ OGRErr OGRLayer::Update(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
             if (x_geom_diff)
             {
                 CPLErrorReset();
-                OGRGeometryUniquePtr x_geom_diff_new(
+                std::unique_ptr<OGRGeometry> x_geom_diff_new(
                     x_geom_diff->Difference(y_geom));
                 if (CPLGetLastErrorType() != CE_None ||
                     x_geom_diff_new == nullptr)
@@ -7312,8 +7410,10 @@ OGRErr OGRLayer::Update(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
         {
             OGRFeatureUniquePtr z(new OGRFeature(poDefnResult));
             z->SetFieldsFrom(x.get(), mapInput);
-            if (bPromoteToMulti)
-                x_geom_diff.reset(promote_to_multi(x_geom_diff.release()));
+            x_geom_diff = convert_geometry(
+                std::move(x_geom_diff), bPromoteToMulti, eOutputGeometryType);
+            if (!x_geom_diff)
+                continue;
             z->SetGeometryDirectly(x_geom_diff.release());
             ret = pLayerResult->CreateFeature(z.get());
             if (ret != OGRERR_NONE)
@@ -7426,6 +7526,11 @@ done:
  *     into MultiPolygons, LineStrings to MultiLineStrings or
  *     Points to MultiPoints (only since GDAL 3.9.2 for the later)
  * </li>
+ * <li>OUTPUT_GEOMETRY_TYPE=[MULTI]POINT/[MULTI]LINESTRING/[MULTI]POLYGON/GEOMETRYCOLLECTION/GEOMETRY
+ *     Output geometry type (since GDAL 3.14.0). If the output geometry cannot
+ *     be converted to it, the corresponding output feature is silently skipped.
+ *     Takes precedence over PROMOTE_TO_MULTI.
+ * </li>
  * <li>INPUT_PREFIX=string. Set a prefix for the field names that
  *     will be created from the fields of the input layer.
  * </li>
@@ -7503,6 +7608,11 @@ OGRErr OGR_L_Update(OGRLayerH pLayerInput, OGRLayerH pLayerMethod,
  *     into MultiPolygons, LineStrings to MultiLineStrings or
  *     Points to MultiPoints (only since GDAL 3.9.2 for the later)
  * </li>
+ * <li>OUTPUT_GEOMETRY_TYPE=[MULTI]POINT/[MULTI]LINESTRING/[MULTI]POLYGON/GEOMETRYCOLLECTION/GEOMETRY
+ *     Output geometry type (since GDAL 3.14.0). If the output geometry cannot
+ *     be converted to it, the corresponding output feature is silently skipped.
+ *     Takes precedence over PROMOTE_TO_MULTI.
+ * </li>
  * <li>INPUT_PREFIX=string. Set a prefix for the field names that
  *     will be created from the fields of the input layer.
  * </li>
@@ -7550,6 +7660,9 @@ OGRErr OGRLayer::Clip(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
         CPLTestBool(CSLFetchNameValueDef(papszOptions, "SKIP_FAILURES", "NO"));
     const bool bPromoteToMulti = CPLTestBool(
         CSLFetchNameValueDef(papszOptions, "PROMOTE_TO_MULTI", "NO"));
+    const char *pszOutputGeometryType =
+        CSLFetchNameValueDef(papszOptions, "OUTPUT_GEOMETRY_TYPE", "GEOMETRY");
+    const auto eOutputGeometryType = OGRFromOGCGeomType(pszOutputGeometryType);
 
     // check for GEOS
     if (!OGRGeometryFactory::haveGEOS())
@@ -7611,7 +7724,7 @@ OGRErr OGRLayer::Clip(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
             continue;
         }
 
-        OGRGeometryUniquePtr
+        std::unique_ptr<OGRGeometry>
             geom;  // this will be the geometry of the result feature
         // incrementally add area from y to geom
         for (auto &&y : pLayerMethod)
@@ -7626,7 +7739,7 @@ OGRErr OGRLayer::Clip(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
             else
             {
                 CPLErrorReset();
-                OGRGeometryUniquePtr geom_new(geom->Union(y_geom));
+                std::unique_ptr<OGRGeometry> geom_new(geom->Union(y_geom));
                 if (CPLGetLastErrorType() != CE_None || geom_new == nullptr)
                 {
                     if (!bSkipFailures)
@@ -7651,7 +7764,7 @@ OGRErr OGRLayer::Clip(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
         if (geom)
         {
             CPLErrorReset();
-            OGRGeometryUniquePtr poIntersection(
+            std::unique_ptr<OGRGeometry> poIntersection(
                 x_geom->Intersection(geom.get()));
             if (CPLGetLastErrorType() != CE_None || poIntersection == nullptr)
             {
@@ -7670,9 +7783,11 @@ OGRErr OGRLayer::Clip(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
             {
                 OGRFeatureUniquePtr z(new OGRFeature(poDefnResult));
                 z->SetFieldsFrom(x.get(), mapInput);
-                if (bPromoteToMulti)
-                    poIntersection.reset(
-                        promote_to_multi(poIntersection.release()));
+                poIntersection =
+                    convert_geometry(std::move(poIntersection), bPromoteToMulti,
+                                     eOutputGeometryType);
+                if (!poIntersection)
+                    continue;
                 z->SetGeometryDirectly(poIntersection.release());
                 ret = pLayerResult->CreateFeature(z.get());
                 if (ret != OGRERR_NONE)
@@ -7734,6 +7849,11 @@ done:
  * <li>PROMOTE_TO_MULTI=YES/NO. Set to YES to convert Polygons
  *     into MultiPolygons, LineStrings to MultiLineStrings or
  *     Points to MultiPoints (only since GDAL 3.9.2 for the later)
+ * </li>
+ * <li>OUTPUT_GEOMETRY_TYPE=[MULTI]POINT/[MULTI]LINESTRING/[MULTI]POLYGON/GEOMETRYCOLLECTION/GEOMETRY
+ *     Output geometry type (since GDAL 3.14.0). If the output geometry cannot
+ *     be converted to it, the corresponding output feature is silently skipped.
+ *     Takes precedence over PROMOTE_TO_MULTI.
  * </li>
  * <li>INPUT_PREFIX=string. Set a prefix for the field names that
  *     will be created from the fields of the input layer.
@@ -7812,6 +7932,11 @@ OGRErr OGR_L_Clip(OGRLayerH pLayerInput, OGRLayerH pLayerMethod,
  *     into MultiPolygons, LineStrings to MultiLineStrings or
  *     Points to MultiPoints (only since GDAL 3.9.2 for the later)
  * </li>
+ * <li>OUTPUT_GEOMETRY_TYPE=[MULTI]POINT/[MULTI]LINESTRING/[MULTI]POLYGON/GEOMETRYCOLLECTION/GEOMETRY
+ *     Output geometry type (since GDAL 3.14.0). If the output geometry cannot
+ *     be converted to it, the corresponding output feature is silently skipped.
+ *     Takes precedence over PROMOTE_TO_MULTI.
+ * </li>
  * <li>INPUT_PREFIX=string. Set a prefix for the field names that
  *     will be created from the fields of the input layer.
  * </li>
@@ -7859,6 +7984,9 @@ OGRErr OGRLayer::Erase(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
         CPLTestBool(CSLFetchNameValueDef(papszOptions, "SKIP_FAILURES", "NO"));
     const bool bPromoteToMulti = CPLTestBool(
         CSLFetchNameValueDef(papszOptions, "PROMOTE_TO_MULTI", "NO"));
+    const char *pszOutputGeometryType =
+        CSLFetchNameValueDef(papszOptions, "OUTPUT_GEOMETRY_TYPE", "GEOMETRY");
+    const auto eOutputGeometryType = OGRFromOGCGeomType(pszOutputGeometryType);
 
     // check for GEOS
     if (!OGRGeometryFactory::haveGEOS())
@@ -7921,7 +8049,7 @@ OGRErr OGRLayer::Erase(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
             continue;
         }
 
-        OGRGeometryUniquePtr geom(
+        std::unique_ptr<OGRGeometry> geom(
             x_geom
                 ->clone());  // this will be the geometry of the result feature
         // incrementally erase y from geom
@@ -7931,7 +8059,7 @@ OGRErr OGRLayer::Erase(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
             if (!y_geom)
                 continue;
             CPLErrorReset();
-            OGRGeometryUniquePtr geom_new(geom->Difference(y_geom));
+            std::unique_ptr<OGRGeometry> geom_new(geom->Difference(y_geom));
             if (CPLGetLastErrorType() != CE_None || geom_new == nullptr)
             {
                 if (!bSkipFailures)
@@ -7960,8 +8088,10 @@ OGRErr OGRLayer::Erase(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
         {
             OGRFeatureUniquePtr z(new OGRFeature(poDefnResult));
             z->SetFieldsFrom(x.get(), mapInput);
-            if (bPromoteToMulti)
-                geom.reset(promote_to_multi(geom.release()));
+            geom = convert_geometry(std::move(geom), bPromoteToMulti,
+                                    eOutputGeometryType);
+            if (!geom)
+                continue;
             z->SetGeometryDirectly(geom.release());
             ret = pLayerResult->CreateFeature(z.get());
             if (ret != OGRERR_NONE)
@@ -8022,6 +8152,11 @@ done:
  * <li>PROMOTE_TO_MULTI=YES/NO. Set to YES to convert Polygons
  *     into MultiPolygons, LineStrings to MultiLineStrings or
  *     Points to MultiPoints (only since GDAL 3.9.2 for the later)
+ * </li>
+ * <li>OUTPUT_GEOMETRY_TYPE=[MULTI]POINT/[MULTI]LINESTRING/[MULTI]POLYGON/GEOMETRYCOLLECTION/GEOMETRY
+ *     Output geometry type (since GDAL 3.14.0). If the output geometry cannot
+ *     be converted to it, the corresponding output feature is silently skipped.
+ *     Takes precedence over PROMOTE_TO_MULTI.
  * </li>
  * <li>INPUT_PREFIX=string. Set a prefix for the field names that
  *     will be created from the fields of the input layer.


### PR DESCRIPTION
addresses a couple points from @geographika from https://github.com/OSGeo/gdal/pull/15031