### PR TITLE
CI: Don't run Release action on forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   safety_checks:
     runs-on: ubuntu-latest
+    if: github.repository == 'OSGeo/gdal'
     outputs:
         RC: ${{ steps.unpack_tag.outputs.RC }}
         BETA: ${{ steps.unpack_tag.outputs.BETA }}


### PR DESCRIPTION
I'm not sure why this has suddenly started running on forks (e.g., https://github.com/dbaston/gdal/actions/runs/31826894747, https://github.com/geographika/gdal/actions/runs/31809108226). This is an attempt to stop it.