### PR TITLE
CI: Only build workshop Docker image manually

### DIFF
--- a/.github/workflows/docker-workshop.yml
+++ b/.github/workflows/docker-workshop.yml
@@ -1,7 +1,6 @@
 name: Perform Release
 
 on:
-  push:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
Currently it is being built in all forks on each push causing failures (due to permissions):

```
The push refers to repository [ghcr.io/osgeo/gdal-cli-workshop]
5a83acf61d85: Waiting
44136fa355b3: Waiting
edda1249a6ca: Waiting
e4fb5f1cd4d4: Waiting
edda1249a6ca: Waiting
e4fb5f1cd4d4: Waiting
5a83acf61d85: Waiting
44136fa355b3: Waiting
4c5577d8453b: Waiting
53b6cdd87bd1: Waiting
5a83acf61d85: Waiting
44136fa355b3: Already exists
edda1249a6ca: Waiting
e4fb5f1cd4d4: Layer already exists
4c5577d8453b: Waiting
53b6cdd87bd1: Waiting
5a83acf61d85: Waiting
edda1249a6ca: Waiting
error from registry: permission_denied: The requested installation does not exist.
```