### PR TITLE
Add ResetReading to `gdal vector update` and use binary for MSSQL geometry parameters

### DIFF
--- a/apps/gdalalg_vector_update.cpp
+++ b/apps/gdalalg_vector_update.cpp
@@ -304,7 +304,7 @@ bool GDALVectorUpdateAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
             }
         }
 
-        poDstLayer->ResetReading();  // close any open SELECT cursor before updating
+        poDstLayer->ResetReading();
 
         if (poDstFeature)
         {

--- a/apps/gdalalg_vector_update.cpp
+++ b/apps/gdalalg_vector_update.cpp
@@ -304,6 +304,8 @@ bool GDALVectorUpdateAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
             }
         }
 
+        poDstLayer->ResetReading();  // close any open SELECT cursor before updating
+
         if (poDstFeature)
         {
             if (m_mode != MODE_APPEND_ONLY)

--- a/autotest/ogr/ogr_mssqlspatial.py
+++ b/autotest/ogr/ogr_mssqlspatial.py
@@ -248,6 +248,31 @@ def test_ogr_mssqlspatial_4(mssql_ds, mssql_has_z_m):
 
 
 ###############################################################################
+# Test SetFeature() updating the geometry of an existing feature using the
+# native geometry format
+
+
+@pytest.mark.usefixtures("tpoly")
+def test_ogr_mssqlspatial_setfeature_native_geometry(mssql_ds):
+
+    mssqlspatial_lyr = mssql_ds.GetLayer("tpoly")
+
+    mssqlspatial_lyr.ResetReading()
+    feat = mssqlspatial_lyr.GetNextFeature()
+    assert feat is not None
+    fid = feat.GetFID()
+
+    geom = ogr.CreateGeometryFromWkt("POLYGON ((0 0,0 10,10 10,10 0,0 0))")
+    feat.SetGeometryDirectly(geom)
+    assert mssqlspatial_lyr.SetFeature(feat) == ogr.OGRERR_NONE
+
+    mssqlspatial_lyr.ResetReading()
+    feat_read = mssqlspatial_lyr.GetFeature(fid)
+    assert feat_read is not None
+    ogrtest.check_feature_geometry(feat_read, geom, max_error=0.001)
+
+
+###############################################################################
 # Run test_ogrsf
 
 

--- a/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
@@ -1198,9 +1198,6 @@ OGRErr OGRMSSQLSpatialTableLayer::ISetFeature(OGRFeature *poFeature)
 #else
             CPLError(CE_Failure, CPLE_AppDefined,
                      "Native geometry upload is not supported");
-
-            for (i = 0; i < bind_num; i++)
-                CPLFree(bind_buffer[i]);
             CPLFree(bind_buffer);
 
             return OGRERR_FAILURE;

--- a/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
@@ -1150,31 +1150,32 @@ OGRErr OGRMSSQLSpatialTableLayer::ISetFeature(OGRFeature *poFeature)
             GByte *pabyData = static_cast<GByte *>(CPLMalloc(nDataLen + 1));
             if (poWriter.WriteSqlGeometry(pabyData, nDataLen) == OGRERR_NONE)
             {
-                char *pszBytes = GByteArrayToHexString(pabyData, nDataLen);
-                SQLLEN nts = SQL_NTS;
+                SQLLEN nLen = nDataLen;
                 int nRetCode = SQLBindParameter(
                     oStmt.GetStatement(),
                     static_cast<SQLUSMALLINT>(bind_num + 1), SQL_PARAM_INPUT,
-                    SQL_C_CHAR, SQL_LONGVARCHAR, nDataLen, 0,
-                    static_cast<SQLPOINTER>(pszBytes), 0, &nts);
+                    SQL_C_BINARY, SQL_VARBINARY, SQL_SS_LENGTH_UNLIMITED, 0,
+                    static_cast<SQLPOINTER>(pabyData), nDataLen, &nLen);
                 if (nRetCode == SQL_SUCCESS ||
                     nRetCode == SQL_SUCCESS_WITH_INFO)
                 {
-                    oStmt.Append("?");
-                    bind_buffer[bind_num] = pszBytes;
+                    oStmt.Append(nGeomColumnType == MSSQLCOLTYPE_GEOGRAPHY
+                                     ? "CAST(? AS geography)"
+                                     : "CAST(? AS geometry)");
+                    bind_buffer[bind_num] = pabyData;
                     ++bind_num;
                 }
                 else
                 {
                     oStmt.Append("null");
-                    CPLFree(pszBytes);
+                    CPLFree(pabyData);
                 }
             }
             else
             {
                 oStmt.Append("null");
+                CPLFree(pabyData);
             }
-            CPLFree(pabyData);
         }
         else if (nUploadGeometryFormat == MSSQLGEOMETRY_WKB)
         {

--- a/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
@@ -1114,7 +1114,8 @@ OGRErr OGRMSSQLSpatialTableLayer::ISetFeature(OGRFeature *poFeature)
     /* -------------------------------------------------------------------- */
     /*      Form the UPDATE command.                                        */
     /* -------------------------------------------------------------------- */
-    CPLODBCStatement oStmt(poDS->GetSession());
+    CPLODBCSession *poSession = poDS->GetSession();
+    CPLODBCStatement oStmt(poSession);
 
     oStmt.Appendf("UPDATE [%s].[%s] SET ", pszSchemaName, pszTableName);
 
@@ -1135,7 +1136,11 @@ OGRErr OGRMSSQLSpatialTableLayer::ISetFeature(OGRFeature *poFeature)
     int nFieldCount = poFeatureDefn->GetFieldCount();
     int bind_num = 0;
     void **bind_buffer =
-        static_cast<void **>(CPLMalloc(sizeof(void *) * nFieldCount));
+        static_cast<void **>(CPLMalloc(sizeof(void *) * (nFieldCount + 1)));
+#ifdef SQL_SS_UDT
+    SQLLEN *bind_datalen =
+        static_cast<SQLLEN *>(CPLMalloc(sizeof(SQLLEN) * (nFieldCount + 1)));
+#endif
 
     int bNeedComma = FALSE;
     SQLLEN nWKBLenBindParameter;
@@ -1145,23 +1150,37 @@ OGRErr OGRMSSQLSpatialTableLayer::ISetFeature(OGRFeature *poFeature)
 
         if (nUploadGeometryFormat == MSSQLGEOMETRY_NATIVE)
         {
+#ifdef SQL_SS_UDT
             OGRMSSQLGeometryWriter poWriter(poGeom, nGeomColumnType, nSRSId);
-            int nDataLen = poWriter.GetDataLen();
-            GByte *pabyData = static_cast<GByte *>(CPLMalloc(nDataLen + 1));
-            if (poWriter.WriteSqlGeometry(pabyData, nDataLen) == OGRERR_NONE)
+            bind_datalen[bind_num] = poWriter.GetDataLen();
+            GByte *pabyData =
+                static_cast<GByte *>(CPLMalloc(bind_datalen[bind_num] + 1));
+            if (poWriter.WriteSqlGeometry(
+                    pabyData, static_cast<int>(bind_datalen[bind_num])) ==
+                OGRERR_NONE)
             {
-                SQLLEN nLen = nDataLen;
-                int nRetCode = SQLBindParameter(
-                    oStmt.GetStatement(),
-                    static_cast<SQLUSMALLINT>(bind_num + 1), SQL_PARAM_INPUT,
-                    SQL_C_BINARY, SQL_VARBINARY, SQL_SS_LENGTH_UNLIMITED, 0,
-                    static_cast<SQLPOINTER>(pabyData), nDataLen, &nLen);
-                if (nRetCode == SQL_SUCCESS ||
-                    nRetCode == SQL_SUCCESS_WITH_INFO)
+                SQLHANDLE ipd;
+                if ((!poSession->Failed(SQLBindParameter(
+                        oStmt.GetStatement(),
+                        static_cast<SQLUSMALLINT>(bind_num + 1),
+                        SQL_PARAM_INPUT, SQL_C_BINARY, SQL_SS_UDT,
+                        SQL_SS_LENGTH_UNLIMITED, 0,
+                        static_cast<SQLPOINTER>(pabyData),
+                        bind_datalen[bind_num],
+                        reinterpret_cast<SQLLEN *>(
+                            &bind_datalen[bind_num])))) &&
+                    (!poSession->Failed(SQLGetStmtAttr(oStmt.GetStatement(),
+                                                       SQL_ATTR_IMP_PARAM_DESC,
+                                                       &ipd, 0, nullptr))) &&
+                    (!poSession->Failed(SQLSetDescField(
+                        ipd, 1, SQL_CA_SS_UDT_TYPE_NAME,
+                        const_cast<char *>(nGeomColumnType ==
+                                                   MSSQLCOLTYPE_GEOGRAPHY
+                                               ? "geography"
+                                               : "geometry"),
+                        SQL_NTS))))
                 {
-                    oStmt.Append(nGeomColumnType == MSSQLCOLTYPE_GEOGRAPHY
-                                     ? "CAST(? AS geography)"
-                                     : "CAST(? AS geometry)");
+                    oStmt.Append("?");
                     bind_buffer[bind_num] = pabyData;
                     ++bind_num;
                 }
@@ -1176,6 +1195,16 @@ OGRErr OGRMSSQLSpatialTableLayer::ISetFeature(OGRFeature *poFeature)
                 oStmt.Append("null");
                 CPLFree(pabyData);
             }
+#else
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Native geometry upload is not supported");
+
+            for (i = 0; i < bind_num; i++)
+                CPLFree(bind_buffer[i]);
+            CPLFree(bind_buffer);
+
+            return OGRERR_FAILURE;
+#endif
         }
         else if (nUploadGeometryFormat == MSSQLGEOMETRY_WKB)
         {
@@ -1313,12 +1342,19 @@ OGRErr OGRMSSQLSpatialTableLayer::ISetFeature(OGRFeature *poFeature)
             CPLFree(bind_buffer[i]);
         CPLFree(bind_buffer);
 
+#ifdef SQL_SS_UDT
+        CPLFree(bind_datalen);
+#endif
         return OGRERR_FAILURE;
     }
 
     for (i = 0; i < bind_num; i++)
         CPLFree(bind_buffer[i]);
     CPLFree(bind_buffer);
+
+#ifdef SQL_SS_UDT
+    CPLFree(bind_datalen);
+#endif
 
     if (oStmt.GetRowCountAffected() < 1)
         return OGRERR_NON_EXISTING_FEATURE;
@@ -2125,7 +2161,7 @@ OGRErr OGRMSSQLSpatialTableLayer::CreateFeatureBCP(OGRFeature *poFeature)
             {
                 CPLError(
                     CE_Failure, CPLE_NotSupported,
-                    "Filed %s with type %s is not supported for bulk insert.",
+                    "Field %s with type %s is not supported for bulk insert.",
                     poFDefn->GetNameRef(),
                     OGRFieldDefn::GetFieldTypeName(poFDefn->GetType()));
 


### PR DESCRIPTION
Fix for #15024. Two changes were required:

### ResetReading
In `gdalalg_vector_update.cpp` I had to add a call to `poDstLayer->ResetReading();` in the loop. Without using [MARS](https://learn.microsoft.com/en-us/sql/relational-databases/native-client/features/using-multiple-active-result-sets-mars?view=sql-server-ver15) (multiple active resultsets) there are issues when trying to update a feature when the database cursor still has a select cursor open. Without this the loop stopped after the first update. 

I initially tried adding `m_bEOF = FALSE;` here: https://github.com/OSGeo/gdal/blob/ff5f64e2fb31ac136a1bfce51ea04d5047e9e845/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp#L811

But I still ran into errors:
```
ERROR 1: SQL Error SQLState=HY000, NativeError=0, Msg=[Microsoft][ODBC Driver 18 for SQL Server]Not enough columns bound
ODBC: SQLDisconnect()
OGR_MSSQLSpatial: 3 features read on layer ''.
ODBC: SQLDisconnect()
```

### Using Binary for MSSQL Updates

Switch from using a hex string to update the geometry in SQL Server, to passing in binary data and casting it to `varbinary(max)`. 
The hex string approach had several issues I ran into (after applying the first change above):

The hex string was much longer than the raw binary length passed to [SQLBindParameter](https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlbindparameter-function) causing:
```
ERROR 1: Error updating feature with FID:4872, [22001][Microsoft][ODBC Driver 18 for SQL Server]String data, right truncation(0)
```

Even fixing the length resulted in:

```
ERROR 1: Error updating feature with FID:4872, [22005][Microsoft][ODBC Driver 18 for SQL Server][SQL Server]Operand type clash: text is incompatible with geometry(206)
```

Casting to geometry still resulted in the following as `SQL_LONGVARBINARY` maps to the `image` type:

```
ERROR 1: Error updating feature with FID:4872, [22005][Microsoft][ODBC Driver 18 for SQL Server][SQL Server]Explicit conversion from data type image to sys.geometry is not allowed.(529)
```

Switching to pass in binary data resolved these issues. 

I'm not sure how this worked previously. Maybe things have been tightened up in the newer ODBC drivers. Also this code path may not be used often as it does row by row updates, whereas I guess most usage would be inserting whole datasets using `ogr2ogr`.

I've tested locally and the geometry is now correctly updated from a GPKG to a MSSQL database. I guess a new test should also be added, although I'm not sure if it should be in the `gdal vector update` or in the MSSQL driver test suite.
