### PR TITLE
hdf4multidim: fix reading dimension names on some HDF4_EOS grids with weird HDF4 EOS metadata

### DIFF
--- a/frmts/hdf4/hdf-eos/GDapi.c
+++ b/frmts/hdf4/hdf-eos/GDapi.c
@@ -1203,7 +1203,7 @@ GDprojinfo(int32 gridID, int32 * projcode, int32 * zonecode,
 -----------------------------------------------------------------------------*/
 intn
 GDfieldinfo(int32 gridID, const char *fieldname, int32 * rank, int32 dims[],
-	    int32 * numbertype, char *dimlist)
+	    int32 * numbertype, char dimlist[HDFE_DIMBUFSIZE+1])
 
 {
     intn            i;		    /* Loop index */
@@ -1355,7 +1355,19 @@ GDfieldinfo(int32 gridID, const char *fieldname, int32 * rank, int32 dims[],
 
 			if (i > 0)
 			{
+			    if( strlen(dimlist) + 1 > HDFE_DIMBUFSIZE )
+			    {
+			        free(metabuf);
+			        free(utlstr);
+			        return -1;
+			    }
 			    strcat(dimlist, ",");
+			}
+			if( strlen(dimlist) + strlen(dimstr) > HDFE_DIMBUFSIZE )
+			{
+			    free(metabuf);
+			    free(utlstr);
+			    return -1;
 			}
 			strcat(dimlist, dimstr);
 		    }

--- a/frmts/hdf4/hdf-eos/HdfEosDef.h
+++ b/frmts/hdf4/hdf-eos/HdfEosDef.h
@@ -153,7 +153,7 @@ int32 GDattach(int32, const char *);
 int32 GDdiminfo(int32, const char *);
 intn GDgridinfo(int32, int32 *, int32 *, float64 [], float64 []);
 intn GDprojinfo(int32, int32 *, int32 *, int32 *, float64 []);
-intn GDfieldinfo(int32, const char *, int32 *, int32 [], int32 *, char *);
+intn GDfieldinfo(int32, const char *, int32 *, int32 [], int32 *, char dimlist[HDFE_DIMBUFSIZE+1]);
 intn GDtileinfo(int32, const char *, int32 *, int32 *, int32 []);
 intn GDreadtile(int32, const char *, int32 [],  VOIDP);
 intn GDreadfield(int32, const char *, int32 [], int32 [], int32 [], VOIDP);

--- a/frmts/hdf4/hdf4multidim.cpp
+++ b/frmts/hdf4/hdf4multidim.cpp
@@ -2132,12 +2132,7 @@ HDF4EOSGridSubGroup::OpenMDArray(const std::string &osName, CSLConstList) const
     std::vector<int32> aiDimSizes(H4_MAX_VAR_DIMS);
     std::string dimNames;
 
-    int32 nStrBufSize = 0;
-    GDnentries(m_poGDHandle->m_handle, HDFE_NENTDIM, &nStrBufSize);
-    if (nStrBufSize <= 0)
-        dimNames.resize(HDFE_DIMBUFSIZE);
-    else
-        dimNames.resize(nStrBufSize);
+    dimNames.resize(HDFE_DIMBUFSIZE);
     if (GDfieldinfo(m_poGDHandle->m_handle, osName.c_str(), &iRank,
                     &aiDimSizes[0], &iNumType, &dimNames[0]) < 0)
     {


### PR DESCRIPTION
Fixes #15038

Some products like https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/MCD19A2.061/MCD19A2.A2003196.h32v12.061.2022239083505/MCD19A2.A2003196.h32v12.061.2022239083505.hdf have weird (wrong ?) HDF4 EOS metadata where the Dimension group only declares parts of the dimensions actually used by data fields:

```
                GROUP=Dimension
                        OBJECT=Dimension_1
                                DimensionName="Orbits"
                                Size=4
                        END_OBJECT=Dimension_1
                END_GROUP=Dimension
                GROUP=DataField
                        OBJECT=DataField_1
                                DataFieldName="Optical_Depth_047"
                                DataType=DFNT_INT16
                                DimList=("Orbits","YDim","XDim")
                        END_OBJECT=DataField_1
```

Thus using GDnentries(... HDFE_NENTDIM ...) returns an inappropriate length for the dimension string.
