### PR TITLE
swig/python: give each Extension its own compile/link args

### DIFF
--- a/swig/python/setup.py.in
+++ b/swig/python/setup.py.in
@@ -364,34 +364,34 @@ extra_compile_args = []
 
 gdal_module = Extension('osgeo._gdal',
                         sources=['extensions/gdal_wrap.cpp'],
-                        extra_compile_args=extra_compile_args,
-                        extra_link_args=extra_link_args)
+                        extra_compile_args=list(extra_compile_args),
+                        extra_link_args=list(extra_link_args))
 
 gdalconst_module = Extension('osgeo._gdalconst',
                              sources=['extensions/gdalconst_wrap.c'],
-                             extra_compile_args=extra_compile_args,
-                             extra_link_args=extra_link_args)
+                             extra_compile_args=list(extra_compile_args),
+                             extra_link_args=list(extra_link_args))
 
 osr_module = Extension('osgeo._osr',
                        sources=['extensions/osr_wrap.cpp'],
-                       extra_compile_args=extra_compile_args,
-                       extra_link_args=extra_link_args)
+                       extra_compile_args=list(extra_compile_args),
+                       extra_link_args=list(extra_link_args))
 
 ogr_module = Extension('osgeo._ogr',
                        sources=['extensions/ogr_wrap.cpp'],
-                       extra_compile_args=extra_compile_args,
-                       extra_link_args=extra_link_args)
+                       extra_compile_args=list(extra_compile_args),
+                       extra_link_args=list(extra_link_args))
 
 
 array_module = Extension('osgeo._gdal_array',
                          sources=['extensions/gdal_array_wrap.cpp'],
-                         extra_compile_args=extra_compile_args,
-                         extra_link_args=extra_link_args)
+                         extra_compile_args=list(extra_compile_args),
+                         extra_link_args=list(extra_link_args))
 
 gnm_module = Extension('osgeo._gnm',
                        sources=['extensions/gnm_wrap.cpp'],
-                       extra_compile_args=extra_compile_args,
-                       extra_link_args=extra_link_args)
+                       extra_compile_args=list(extra_compile_args),
+                       extra_link_args=list(extra_link_args))
 
 ext_modules = [gdal_module,
                gdalconst_module,


### PR DESCRIPTION
## What does this PR do?

`extra_compile_args` and `extra_link_args` in `swig/python/setup.py.in` were single list objects shared by all six `Extension` objects, so the in-place `+=` in `gdal_ext.build_extensions` mutated the same list for every module. The guard that skips `-std=c++11` for the C-only `osgeo._gdalconst` module therefore had no effect.

On a compiler whose default standard predates C++11 the `supports_cxx11()` probe fails, `-std=c++11` is appended once per C++ module, and all five copies land on `gdalconst_wrap.c`:

    error: invalid argument '-std=c++11' not allowed with 'C'

Passing each `Extension` its own copy restores the intended per-module behaviour. The same aliasing also duplicated `-isysroot` six times in every link command; that is fixed too.

Hit on macOS 14 (Apple clang from CLT 16.2) while building 3.13.3 for Homebrew.

## What are related issues/pull requests?

None.

## AI tool usage

 - [x] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

* OS: macOS 14 (arm64)
* Compiler: Apple clang (Command Line Tools 16.2)