### PR TITLE
Add back CI testing for the MSSQL Driver

### DIFF
--- a/.github/workflows/ubuntu_22.04/services.sh
+++ b/.github/workflows/ubuntu_22.04/services.sh
@@ -6,11 +6,6 @@ set -ex
 # Start services #
 ##################
 
-# MSSQL: server side
-#docker rm -f gdal-sql1
-#docker pull mcr.microsoft.com/mssql/server:2017-latest
-#docker run  -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=DummyPassw0rd'  -p 1433:1433 --name gdal-sql1 -d mcr.microsoft.com/mssql/server:2017-latest
-
 # MySQL 8
 docker rm -f gdal-mysql1
 docker run --name gdal-mysql1 -e MYSQL_ROOT_PASSWORD=passwd -e "MYSQL_ROOT_HOST=%" -p 33060:3306 -d mysql/mysql-server:8.0.18 mysqld --default-authentication-plugin=mysql_native_password
@@ -36,9 +31,6 @@ docker run --name gdal-mongo -p 27018:27017 -d mongo:4.4
 ######################
 
 sleep 10
-
-# MSSQL
-#docker exec -t gdal-sql1 /opt/mssql-tools/bin/sqlcmd -l 30 -S localhost -U SA -P DummyPassw0rd -Q "CREATE DATABASE TestDB"
 
 # MySQL
 docker exec gdal-mysql1 sh -c "echo 'CREATE DATABASE test; SELECT Version()' | mysql -uroot -ppasswd"

--- a/.github/workflows/ubuntu_26.04/services.sh
+++ b/.github/workflows/ubuntu_26.04/services.sh
@@ -7,9 +7,9 @@ set -ex
 ##################
 
 # MSSQL: server side
-#docker rm -f gdal-sql1
-#docker pull mcr.microsoft.com/mssql/server:2017-latest
-#docker run  -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=DummyPassw0rd'  -p 1433:1433 --name gdal-sql1 -d mcr.microsoft.com/mssql/server:2017-latest
+docker rm -f gdal-sql1
+docker pull mcr.microsoft.com/mssql/server:2022-latest
+docker run  -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=DummyPassw0rd'  -p 1433:1433 --name gdal-sql1 -d mcr.microsoft.com/mssql/server:2022-latest
 
 # MariaDB 10.3.9
 docker rm -f gdal-mariadb
@@ -34,7 +34,7 @@ docker run --name gdal-mongo -p 27018:27017 -d mongo:4.4
 sleep 10
 
 # MSSQL
-#docker exec -t gdal-sql1 /opt/mssql-tools/bin/sqlcmd -l 30 -S localhost -U SA -P DummyPassw0rd -Q "CREATE DATABASE TestDB"
+docker exec -t gdal-sql1 /opt/mssql-tools18/bin/sqlcmd -C -l 30 -S localhost -U SA -P DummyPassw0rd -Q "CREATE DATABASE TestDB"
 
 # MariaDB
 docker exec gdal-mariadb sh -c "echo 'CREATE DATABASE test; SELECT Version()' | mysql -uroot -ppasswd"

--- a/autotest/ogr/ogr_mssqlspatial.py
+++ b/autotest/ogr/ogr_mssqlspatial.py
@@ -39,13 +39,14 @@ def mssql_ds():
     val = gdal.GetConfigOption("OGR_MSSQL_CONNECTION_STRING", None)
     if val is None:
         # localhost doesn't work under chroot
-        dsname = "MSSQL:server=127.0.0.1;database=TestDB;driver=ODBC Driver 17 for SQL Server;UID=SA;PWD=DummyPassw0rd"
+        dsname = "MSSQL:server=127.0.0.1;database=TestDB;driver=ODBC Driver 18 for SQL Server;UID=SA;PWD=DummyPassw0rd;TrustServerCertificate=yes;"
     else:
         dsname = val
 
     ds = ogr.Open(dsname, update=1)
 
     if ds is None:
+        print(f"GDAL error: {gdal.GetLastErrorMsg()}")  # add this
         if val is None:
             pytest.skip(
                 f"OGR_MSSSQL_CONNECTION_STRING not specified; MS SQL is not available using default connection string {dsname}"

--- a/autotest/ogr/ogr_mssqlspatial.py
+++ b/autotest/ogr/ogr_mssqlspatial.py
@@ -38,8 +38,7 @@ def mssql_ds():
 
     val = gdal.GetConfigOption("OGR_MSSQL_CONNECTION_STRING", None)
     if val is None:
-        # localhost doesn't work under chroot
-        dsname = "MSSQL:server=127.0.0.1;database=TestDB;driver=ODBC Driver 18 for SQL Server;UID=SA;PWD=DummyPassw0rd;TrustServerCertificate=yes;"
+        dsname = "MSSQL:server=host.docker.internal;database=TestDB;driver=ODBC Driver 18 for SQL Server;UID=SA;PWD=DummyPassw0rd;TrustServerCertificate=yes;"
     else:
         dsname = val
 

--- a/autotest/ogr/ogr_mssqlspatial.py
+++ b/autotest/ogr/ogr_mssqlspatial.py
@@ -45,7 +45,6 @@ def mssql_ds():
     ds = ogr.Open(dsname, update=1)
 
     if ds is None:
-        print(f"GDAL error: {gdal.GetLastErrorMsg()}")  # add this
         if val is None:
             pytest.skip(
                 f"OGR_MSSSQL_CONNECTION_STRING not specified; MS SQL is not available using default connection string {dsname}"
@@ -97,6 +96,8 @@ def tpoly(mssql_ds):
     # Create Layer
     sql_lyr = mssql_ds.CreateLayer("tpoly", srs=shp_lyr.GetSpatialRef())
 
+    assert sql_lyr
+
     ######################################################
     # Setup Schema
     ogrtest.quick_create_layer_def(
@@ -147,7 +148,7 @@ def tpoly(mssql_ds):
 
 
 @pytest.mark.usefixtures("tpoly")
-def test_ogr_mssqlspatial_3(mssql_ds, poly_feat):
+def test_ogr_mssqlspatial_3(mssql_ds, multipoly_feat):
 
     mssqlspatial_lyr = mssql_ds.GetLayerByName("tpoly")
     assert mssqlspatial_lyr.GetDataset().GetDescription() == mssql_ds.GetDescription()
@@ -165,8 +166,8 @@ def test_ogr_mssqlspatial_3(mssql_ds, poly_feat):
 
     mssqlspatial_lyr.ResetReading()
 
-    for i in range(len(poly_feat)):
-        orig_feat = poly_feat[i]
+    for i in range(len(multipoly_feat)):
+        orig_feat = multipoly_feat[i]
         read_feat = mssqlspatial_lyr.GetNextFeature()
 
         ogrtest.check_feature_geometry(
@@ -582,7 +583,7 @@ def test_ogr_mssqlspatial_geography_polygon_vertex_order(mssql_ds):
             ds = gdal.VectorTranslate(
                 mssql_ds.GetDescription(),
                 "data/shp/testpoly.shp",
-                options="-nln poly_vertex_order -s_srs EPSG:32632 -t_srs EPSG:4326 -lco OVERWRITE=YES -lco GEOM_TYPE=GEOGRAPHY",
+                options="-nln poly_vertex_order -s_srs EPSG:32632 -t_srs EPSG:4326 -lco OVERWRITE=YES -lco GEOM_TYPE=GEOGRAPHY -makevalid",
             )
 
             lyr = ds.GetLayerByName("poly_vertex_order")


### PR DESCRIPTION
## CI Updates

- Use the MSSQL 2022 Docker image `mcr.microsoft.com/mssql/server:2022-latest`
- Update to use the latest `ODBC Driver 18 for SQL Server`. This driver encrypts by default, so connection strings now need `TrustServerCertificate=yes` for the self-signed cert used in CI.
- Switch to `server=host.docker.internal` - neither `127.0.0.1` nor the Docker host name `gdal-sql1` work (as there is no shared Docker network)

## autotest Fixes

Two tests were failing once I got the suite running again. These are fixed by this PR. 

1. `test_ogr_mssqlspatial_geography_polygon_vertex_order` (created for https://github.com/OSGeo/gdal/pull/7826). 

It looks like `testpoly.shp` contains an invalid shape after projecting:

```
gdal vector reproject .\gdal\autotest\ogr\data\shp\testpoly.shp .\gdal\autotest\ogr\data\shp\testpoly2.shp --src-crs EPSG:32632 --dst-crs EPSG:4326
gdal vector info .\gdal\autotest\ogr\data\shp\testpoly2.shp --features

Warning 1: testpoly contains polygon(s) with rings with invalid winding order. Autocorrecting them, but that shapefile should be corrected using ogr2ogr for example.
OGRFeature(testpoly2):12
  FID (Integer64) = 12
  MULTIPOLYGON (((4.51227744000797 0.001691135346557,4.5122684829113 0.000220975015887,4.51365713065676 0.000248033656041,4.5136033745973 0.001691138438574,4.51227744000797 0.001691135346557),(4.5126447602241 0.001330360479868,4.51334356359097 0.001357419967111,4.51343315494971 0.000428421637226,4.51262684328612 0.000410382375176,4.5126447602241 0.001330360479868)))
```

I added `-makevalid` to `gdal.VectorTranslate` to resolve this. 

2. `test_ogr_mssqlspatial_3`. The test fixture `poly_feat` uses the open option `"PROMOTE_TO_MULTI=NO"` so the comparison of the Shapefile geometry type is `POLYGON` to `MULTIPOLYGON` in the MSSQL database. Switching to the `multipoly_feat` test feature resolved this.