### PR TITLE
MSSQL: ISetFeature fix

### DIFF
--- a/autotest/ogr/ogr_mssqlspatial.py
+++ b/autotest/ogr/ogr_mssqlspatial.py
@@ -728,3 +728,28 @@ def test_geometry_column_identification(mssql_ds):
 
     finally:
         mssql_ds.ExecuteSQL("DROP TABLE poly_shape")
+
+
+###############################################################################
+# Test SetFeature() updating the geometry of an existing feature using the
+# native geometry format
+
+
+@pytest.mark.usefixtures("tpoly")
+def test_ogr_mssqlspatial_setfeature_native_geometry(mssql_ds):
+
+    mssqlspatial_lyr = mssql_ds.GetLayer("tpoly")
+
+    mssqlspatial_lyr.ResetReading()
+    feat = mssqlspatial_lyr.GetNextFeature()
+    assert feat is not None
+    fid = feat.GetFID()
+
+    geom = ogr.CreateGeometryFromWkt("POLYGON ((0 0,0 10,10 10,10 0,0 0))")
+    feat.SetGeometryDirectly(geom)
+    assert mssqlspatial_lyr.SetFeature(feat) == ogr.OGRERR_NONE
+
+    mssqlspatial_lyr.ResetReading()
+    feat_read = mssqlspatial_lyr.GetFeature(fid)
+    assert feat_read is not None
+    ogrtest.check_feature_geometry(feat_read, geom, max_error=0.001)

--- a/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
@@ -1114,7 +1114,8 @@ OGRErr OGRMSSQLSpatialTableLayer::ISetFeature(OGRFeature *poFeature)
     /* -------------------------------------------------------------------- */
     /*      Form the UPDATE command.                                        */
     /* -------------------------------------------------------------------- */
-    CPLODBCStatement oStmt(poDS->GetSession());
+    CPLODBCSession *poSession = poDS->GetSession();
+    CPLODBCStatement oStmt(poSession);
 
     oStmt.Appendf("UPDATE [%s].[%s] SET ", pszSchemaName, pszTableName);
 
@@ -1135,7 +1136,11 @@ OGRErr OGRMSSQLSpatialTableLayer::ISetFeature(OGRFeature *poFeature)
     int nFieldCount = poFeatureDefn->GetFieldCount();
     int bind_num = 0;
     void **bind_buffer =
-        static_cast<void **>(CPLMalloc(sizeof(void *) * nFieldCount));
+        static_cast<void **>(CPLMalloc(sizeof(void *) * (nFieldCount + 1)));
+#ifdef SQL_SS_UDT
+    SQLLEN *bind_datalen =
+        static_cast<SQLLEN *>(CPLMalloc(sizeof(SQLLEN) * (nFieldCount + 1)));
+#endif
 
     int bNeedComma = FALSE;
     SQLLEN nWKBLenBindParameter;
@@ -1145,36 +1150,58 @@ OGRErr OGRMSSQLSpatialTableLayer::ISetFeature(OGRFeature *poFeature)
 
         if (nUploadGeometryFormat == MSSQLGEOMETRY_NATIVE)
         {
+#ifdef SQL_SS_UDT
             OGRMSSQLGeometryWriter poWriter(poGeom, nGeomColumnType, nSRSId);
-            int nDataLen = poWriter.GetDataLen();
-            GByte *pabyData = static_cast<GByte *>(CPLMalloc(nDataLen + 1));
-            if (poWriter.WriteSqlGeometry(pabyData, nDataLen) == OGRERR_NONE)
+            bind_datalen[bind_num] = poWriter.GetDataLen();
+            GByte *pabyData =
+                static_cast<GByte *>(CPLMalloc(bind_datalen[bind_num] + 1));
+            if (poWriter.WriteSqlGeometry(
+                    pabyData, static_cast<int>(bind_datalen[bind_num])) ==
+                OGRERR_NONE)
             {
-                char *pszBytes = GByteArrayToHexString(pabyData, nDataLen);
-                SQLLEN nts = SQL_NTS;
-                int nRetCode = SQLBindParameter(
-                    oStmt.GetStatement(),
-                    static_cast<SQLUSMALLINT>(bind_num + 1), SQL_PARAM_INPUT,
-                    SQL_C_CHAR, SQL_LONGVARCHAR, nDataLen, 0,
-                    static_cast<SQLPOINTER>(pszBytes), 0, &nts);
-                if (nRetCode == SQL_SUCCESS ||
-                    nRetCode == SQL_SUCCESS_WITH_INFO)
+                SQLHANDLE ipd;
+                if ((!poSession->Failed(SQLBindParameter(
+                        oStmt.GetStatement(),
+                        static_cast<SQLUSMALLINT>(bind_num + 1),
+                        SQL_PARAM_INPUT, SQL_C_BINARY, SQL_SS_UDT,
+                        SQL_SS_LENGTH_UNLIMITED, 0,
+                        static_cast<SQLPOINTER>(pabyData),
+                        bind_datalen[bind_num],
+                        reinterpret_cast<SQLLEN *>(
+                            &bind_datalen[bind_num])))) &&
+                    (!poSession->Failed(SQLGetStmtAttr(oStmt.GetStatement(),
+                                                       SQL_ATTR_IMP_PARAM_DESC,
+                                                       &ipd, 0, nullptr))) &&
+                    (!poSession->Failed(SQLSetDescField(
+                        ipd, 1, SQL_CA_SS_UDT_TYPE_NAME,
+                        const_cast<char *>(nGeomColumnType ==
+                                                   MSSQLCOLTYPE_GEOGRAPHY
+                                               ? "geography"
+                                               : "geometry"),
+                        SQL_NTS))))
                 {
                     oStmt.Append("?");
-                    bind_buffer[bind_num] = pszBytes;
+                    bind_buffer[bind_num] = pabyData;
                     ++bind_num;
                 }
                 else
                 {
                     oStmt.Append("null");
-                    CPLFree(pszBytes);
+                    CPLFree(pabyData);
                 }
             }
             else
             {
                 oStmt.Append("null");
+                CPLFree(pabyData);
             }
-            CPLFree(pabyData);
+#else
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Native geometry upload is not supported");
+            CPLFree(bind_buffer);
+
+            return OGRERR_FAILURE;
+#endif
         }
         else if (nUploadGeometryFormat == MSSQLGEOMETRY_WKB)
         {
@@ -1312,12 +1339,19 @@ OGRErr OGRMSSQLSpatialTableLayer::ISetFeature(OGRFeature *poFeature)
             CPLFree(bind_buffer[i]);
         CPLFree(bind_buffer);
 
+#ifdef SQL_SS_UDT
+        CPLFree(bind_datalen);
+#endif
         return OGRERR_FAILURE;
     }
 
     for (i = 0; i < bind_num; i++)
         CPLFree(bind_buffer[i]);
     CPLFree(bind_buffer);
+
+#ifdef SQL_SS_UDT
+    CPLFree(bind_datalen);
+#endif
 
     if (oStmt.GetRowCountAffected() < 1)
         return OGRERR_NON_EXISTING_FEATURE;
@@ -2124,7 +2158,7 @@ OGRErr OGRMSSQLSpatialTableLayer::CreateFeatureBCP(OGRFeature *poFeature)
             {
                 CPLError(
                     CE_Failure, CPLE_NotSupported,
-                    "Filed %s with type %s is not supported for bulk insert.",
+                    "Field %s with type %s is not supported for bulk insert.",
                     poFDefn->GetNameRef(),
                     OGRFieldDefn::GetFieldTypeName(poFDefn->GetType()));
 


### PR DESCRIPTION
This PR modifies the `ISetFeature` function of the MSSQL OGR driver for native SQL Server geometries to match the approach used in the `ICreateFeature` function (see more details in the PR this replaces #15039). I'm not sure why different approaches were originally used. The test added in this PR fails with the old approach - `ERROR 1: Error updating feature with FID:1, [22001][Microsoft][ODBC Driver 18 for SQL Server]String data, right truncation(0)`, so I'm not sure when this last worked. 

The updated approach will throw an error if `SQL_SS_UDT` is not defined (which are defined in Microsoft's driver headers `msodbcsql.h/sqlncli.h`). The previous `CAST(? AS geometry)` approach may work with other drivers (such as the FreeTDS driver on Linux), but matching `ICreateFeature`, which also throws an error for native geometries if `SQL_SS_UDT` is not defined, makes it more consistent.

The new test passes with the new approach (see [logs](https://productionresultssa6.blob.core.windows.net/actions-results/519471c9-0764-4575-9d50-741d4e71fab4/workflow-job-run-aabb2ee8-377f-5b56-83b7-746595513773/logs/job/job-logs.txt)). 

```
2026-08-18T17:44:01.4581320Z ogr/ogr_mssqlspatial.py::test_ogr_mssqlspatial_setfeature_native_geometry PASSED [ 12%]
```