### PR TITLE
Fix `gdal vector update` usage when using the MSSQL driver

### DIFF
--- a/.github/workflows/ubuntu_22.04/test.sh
+++ b/.github/workflows/ubuntu_22.04/test.sh
@@ -31,6 +31,4 @@ AZURE_STORAGE_CONNECTION_STRING=${AZURITE_STORAGE_CONNECTION_STRING} python3 -c 
 # MongoDB v3
 (cd autotest && MONGODBV3_TEST_PORT=27018 MONGODBV3_TEST_HOST=$IP $PYTEST ogr/ogr_mongodbv3.py)
 
-#(cd autotest && OGR_MSSQL_CONNECTION_STRING="MSSQL:server=$IP;database=TestDB;driver=ODBC Driver 17 for SQL Server;UID=SA;PWD=DummyPassw0rd" $PYTEST ogr/ogr_mssqlspatial.py)
-
 (cd autotest && $PYTEST)

--- a/.github/workflows/ubuntu_26.04/test.sh
+++ b/.github/workflows/ubuntu_26.04/test.sh
@@ -45,6 +45,10 @@ AZURE_STORAGE_CONNECTION_STRING=${AZURITE_STORAGE_CONNECTION_STRING} python3 -c 
 # MongoDB v3
 (cd autotest && MONGODBV3_TEST_PORT=27018 MONGODBV3_TEST_HOST=$IP $PYTEST ogr/ogr_mongodbv3.py)
 
-(cd autotest && OGR_MSSQL_CONNECTION_STRING="MSSQL:server=$IP;database=TestDB;driver=ODBC Driver 18 for SQL Server;UID=SA;PWD=DummyPassw0rd;TrustServerCertificate=yes;" $PYTEST ogr/ogr_mssqlspatial.py)
+# MSSQL
+MSSQL_CONNECTION_STRING="MSSQL:server=$IP;database=TestDB;driver=ODBC Driver 18 for SQL Server;UID=SA;PWD=DummyPassw0rd;TrustServerCertificate=yes;"
+(cd autotest && OGR_MSSQL_CONNECTION_STRING="${MSSQL_CONNECTION_STRING}" $PYTEST ogr/ogr_mssqlspatial.py)
+(cd autotest && OGR_MSSQL_CONNECTION_STRING="${MSSQL_CONNECTION_STRING}" $PYTEST utilities/test_gdalalg_vector_update.py)
 
+# Full test suite
 (cd autotest && $PYTEST)

--- a/.github/workflows/ubuntu_26.04/test.sh
+++ b/.github/workflows/ubuntu_26.04/test.sh
@@ -45,6 +45,6 @@ AZURE_STORAGE_CONNECTION_STRING=${AZURITE_STORAGE_CONNECTION_STRING} python3 -c 
 # MongoDB v3
 (cd autotest && MONGODBV3_TEST_PORT=27018 MONGODBV3_TEST_HOST=$IP $PYTEST ogr/ogr_mongodbv3.py)
 
-# (cd autotest && OGR_MSSQL_CONNECTION_STRING="MSSQL:server=$IP;database=TestDB;driver=ODBC Driver 17 for SQL Server;UID=SA;PWD=DummyPassw0rd" $PYTEST ogr/ogr_mssqlspatial.py)
+(cd autotest && OGR_MSSQL_CONNECTION_STRING="MSSQL:server=$IP;database=TestDB;driver=ODBC Driver 18 for SQL Server;UID=SA;PWD=DummyPassw0rd;TrustServerCertificate=yes;" $PYTEST ogr/ogr_mssqlspatial.py)
 
 (cd autotest && $PYTEST)

--- a/apps/gdalalg_vector_update.cpp
+++ b/apps/gdalalg_vector_update.cpp
@@ -304,6 +304,8 @@ bool GDALVectorUpdateAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
             }
         }
 
+        poDstLayer->ResetReading();
+
         if (poDstFeature)
         {
             if (m_mode != MODE_APPEND_ONLY)

--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -25,6 +25,10 @@ from ogr.ogr_pg import (  # noqa
     use_postgis,
 )
 
+from ogr.ogr_mssqlspatial import (  # noqa
+    mssql_ds,
+)
+
 # These files may be non-importable, and don't contain tests anyway.
 # So we skip searching them during test collection.
 collect_ignore = [

--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -16,6 +16,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "pymod"))
 # put the autotest dir on the path too. This lets us import all test modules
 sys.path.insert(1, os.path.dirname(__file__))
 
+from ogr.ogr_mssqlspatial import (  # noqa
+    mssql_ds,
+)
+
 # import fixtures that need to be used outside the test module where they were defined
 from ogr.ogr_pg import (  # noqa
     pg_autotest_ds,
@@ -23,10 +27,6 @@ from ogr.ogr_pg import (  # noqa
     pg_has_postgis,
     pg_postgis_version,
     use_postgis,
-)
-
-from ogr.ogr_mssqlspatial import (  # noqa
-    mssql_ds,
 )
 
 # These files may be non-importable, and don't contain tests anyway.

--- a/autotest/ogr/ogr_mssqlspatial.py
+++ b/autotest/ogr/ogr_mssqlspatial.py
@@ -38,7 +38,8 @@ def mssql_ds():
 
     val = gdal.GetConfigOption("OGR_MSSQL_CONNECTION_STRING", None)
     if val is None:
-        dsname = "MSSQL:server=host.docker.internal;database=TestDB;driver=ODBC Driver 18 for SQL Server;UID=SA;PWD=DummyPassw0rd;TrustServerCertificate=yes;"
+        # localhost doesn't work under chroot
+        dsname = "MSSQL:server=127.0.0.1;database=TestDB;driver=ODBC Driver 18 for SQL Server;UID=SA;PWD=DummyPassw0rd;TrustServerCertificate=yes;"
     else:
         dsname = val
 

--- a/autotest/ogr/ogr_mssqlspatial.py
+++ b/autotest/ogr/ogr_mssqlspatial.py
@@ -43,7 +43,10 @@ def mssql_ds():
     else:
         dsname = val
 
-    ds = ogr.Open(dsname, update=1)
+    try:
+        ds = ogr.Open(dsname, update=1)
+    except RuntimeError:
+        ds = None
 
     if ds is None:
         if val is None:

--- a/autotest/utilities/test_gdalalg_vector_update.py
+++ b/autotest/utilities/test_gdalalg_vector_update.py
@@ -399,3 +399,57 @@ def test_gdalalg_vector_update_pipeline_intermediate_step(tmp_vsimem):
     ) as alg:
         j = alg.Output()
         assert j["layers"][0]["featureCount"] == 1
+
+
+###############################################################################
+# Test with a MSSQL dataset
+
+
+@pytest.fixture()
+def mssql_update_ds(mssql_ds):
+
+    mssql_ds.ExecuteSQL("DROP TABLE IF EXISTS vector_update_cursor_test")
+
+    yield mssql_ds
+
+    mssql_ds.ExecuteSQL("DROP TABLE IF EXISTS vector_update_cursor_test")
+
+
+@pytest.mark.require_driver("MSSQLSpatial")
+def test_gdalalg_mssql_vector_update(mssql_update_ds):
+
+    src_ds = gdal.GetDriverByName("MEM").CreateVector("src")
+    src_lyr = src_ds.CreateLayer("test")
+    src_lyr.CreateField(ogr.FieldDefn("key_field", ogr.OFTInteger))
+    src_lyr.CreateField(ogr.FieldDefn("value_field", ogr.OFTString))
+
+    num_features = 5
+    for i in range(num_features):
+        f = ogr.Feature(src_lyr.GetLayerDefn())
+        f["key_field"] = i
+        f["value_field"] = f"updated_{i}"
+        src_lyr.CreateFeature(f)
+
+    dst_lyr = mssql_update_ds.CreateLayer(
+        "vector_update_cursor_test", geom_type=ogr.wkbNone
+    )
+    dst_lyr.CreateField(ogr.FieldDefn("key_field", ogr.OFTInteger))
+    dst_lyr.CreateField(ogr.FieldDefn("value_field", ogr.OFTString))
+
+    for i in range(num_features):
+        f = ogr.Feature(dst_lyr.GetLayerDefn())
+        f["key_field"] = i
+        f["value_field"] = f"initial_{i}"
+        dst_lyr.CreateFeature(f)
+
+    assert gdal.alg.vector.update(
+        input=src_ds,
+        output=mssql_update_ds,
+        output_layer="vector_update_cursor_test",
+        key=["key_field"],
+        mode="update-only",
+    )
+
+    dst_lyr.ResetReading()
+    updated = {f["key_field"]: f["value_field"] for f in dst_lyr}
+    assert updated == {i: f"updated_{i}" for i in range(num_features)}


### PR DESCRIPTION
In `gdalalg_vector_update.cpp` I added a call to `poDstLayer->ResetReading();` in the loop. MSSQL without [MARS](https://learn.microsoft.com/en-us/sql/relational-databases/native-client/features/using-multiple-active-result-sets-mars?view=sql-server-ver15) (multiple active resultsets) has issues when trying to update a feature if the database cursor still has a select cursor open. Without this the loop only hte first record is updated. Replaces closed #15039. 

With the fix the new test passes, without it it fails with the results below:

```
FAILED utilities/test_gdalalg_vector_update.py::test_gdalalg_mssql_vector_update - AssertionError: assert {0: 'updated_0', 1: 'initial_1', 2: 'initial_2', 3: 'initial_3', 4: 'initial_4'} == {0: 'updated_0', 1: 'updated_1', 2: 'updated_2', 3: 'updated_3', 4: 'updated_4'}
  
  Common items:
  {0: 'updated_0'}
  Differing items:
  {1: 'initial_1'} != {1: 'updated_1'}
  {2: 'initial_2'} != {2: 'updated_2'}
  {3: 'initial_3'} != {3: 'updated_3'}
  {4: 'initial_4'} != {4: 'updated_4'}
```

I also updated the MSSQL tests to use the connection string similar to the other db drivers in `test.sh`. 

The new test is part of the `test_gdalalg_vector_update.py` test suite (as it fits better here). I resued the test fixture for connecting to a MSSQL database, and run it as follows:

```
(cd autotest && OGR_MSSQL_CONNECTION_STRING="${MSSQL_CONNECTION_STRING}" $PYTEST utilities/test_gdalalg_vector_update.py)
```

@rouault - I noticed while working on this that there is a similar CLI test `test_gdalalg_raster_clip_like_postgis` in `test_gdalalg_raster_clip.py` that requires the PG connection string to be set. As far as I can tell it is always skipped. 
Should I update (in a separate PR) https://github.com/OSGeo/gdal/blob/master/.github/workflows/ubuntu_26.04/test.sh to pass in `OGR_PG_CONNECTION_STRING` to `test_gdalalg_raster_clip_like_postgis`?

Alternatively the db connection variables could be passed into the final `(cd autotest && $PYTEST)` command, and avoid running each of the database suites once separately, and then skipping them again at the end? Or just `export` the db connection variables in `test.sh`?