### PR TITLE
Skip variable sized attributes when intermixed in TileDB arrays

### DIFF
--- a/autotest/gdrivers/tiledb_multidim.py
+++ b/autotest/gdrivers/tiledb_multidim.py
@@ -17,6 +17,7 @@ import math
 import os
 import shutil
 
+import gdaltest
 import pytest
 
 from osgeo import gdal, osr
@@ -230,11 +231,26 @@ def test_tiledb_multidim_mixed_fixed_and_variable_sized_attributes(tmp_path):
             "Z": z,
             "m_Z_mean": np.arange(16, dtype=np.float32).reshape(4, 4),
         }
-    ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+    skipped_name = os.path.basename(filename) + ".Z"
+    debug_messages = []
+
+    def error_handler(error_class, error_number, message):
+        if error_class == gdal.CE_Debug:
+            debug_messages.append(message)
+
+    with gdal.config_option("CPL_DEBUG", "TileDB"), gdaltest.error_handler(
+        error_handler
+    ):
+        ds = gdal.Open(filename, gdal.OF_MULTIDIM_RASTER)
+
     root_group = ds.GetRootGroup()
-    assert root_group.GetMDArrayNames() == ["m_Z_mean"]
-    mean = root_group.OpenMDArray("m_Z_mean")
-    assert mean.GetDimensionsSize() == [4, 4]
+    mean_name = os.path.basename(filename) + ".m_Z_mean"
+    assert root_group.GetMDArrayNames() == [mean_name]
+    assert debug_messages == [
+        f"TileDB: Skipping unsupported variable-size attribute '{skipped_name}'"
+    ]
+    mean = root_group.OpenMDArray(mean_name)
+    assert [dim.GetSize() for dim in mean.GetDimensions()] == [4, 4]
     assert mean.GetDataType().GetNumericDataType() == gdal.GDT_Float32
 
 

--- a/autotest/gdrivers/tiledb_multidim.py
+++ b/autotest/gdrivers/tiledb_multidim.py
@@ -202,6 +202,45 @@ def test_tiledb_multidim_basic():
 ###############################################################################
 
 
+def test_tiledb_multidim_mixed_fixed_and_variable_sized_attributes(tmp_path):
+    """Variable-size attributes do not hide fixed-size raster attributes."""
+
+    tiledb = pytest.importorskip("tiledb")
+    np = pytest.importorskip("numpy")
+    filename = str(tmp_path / "mixed_attributes.tiledb")
+    domain = tiledb.Domain(
+        tiledb.Dim(name="X", domain=(0, 3), tile=4, dtype=np.uint64),
+        tiledb.Dim(name="Y", domain=(0, 3), tile=4, dtype=np.uint64),
+    )
+    schema = tiledb.ArraySchema(
+        domain=domain,
+        attrs=(
+            tiledb.Attr(name="Z", dtype=np.float64, var=True),
+            tiledb.Attr(name="m_Z_mean", dtype=np.float32, fill=-9999.0),
+        ),
+        sparse=False,
+    )
+    tiledb.DenseArray.create(filename, schema)
+    with tiledb.DenseArray(filename, "w") as array:
+        z = np.empty((4, 4), dtype=object)
+        for x in range(4):
+            for y in range(4):
+                z[x, y] = np.array([x * 10 + y], dtype=np.float64)
+        array[:] = {
+            "Z": z,
+            "m_Z_mean": np.arange(16, dtype=np.float32).reshape(4, 4),
+        }
+    ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+    root_group = ds.GetRootGroup()
+    assert root_group.GetMDArrayNames() == ["m_Z_mean"]
+    mean = root_group.OpenMDArray("m_Z_mean")
+    assert mean.GetDimensionsSize() == [4, 4]
+    assert mean.GetDataType().GetNumericDataType() == gdal.GDT_Float32
+
+
+###############################################################################
+
+
 @pytest.mark.parametrize(
     "gdal_data_type",
     [

--- a/frmts/tiledb/tiledbmultidim.cpp
+++ b/frmts/tiledb/tiledbmultidim.cpp
@@ -38,6 +38,13 @@ std::shared_ptr<GDALGroup> TileDBArrayGroup::Create(
     std::vector<std::shared_ptr<GDALMDArray>> apoArrays;
     if (nAttributes == 1)
     {
+        if (schema.attribute(0).variable_sized())
+        {
+            CPLDebug("TileDB", "Skipping unsupported variable-size "
+                              "attribute '%s'",
+                     schema.attribute(0).name().c_str());
+            return std::make_shared<TileDBArrayGroup>(apoArrays);
+        }
         auto poArray = TileDBArray::OpenFromDisk(poSharedResource, nullptr, "/",
                                                  osBaseName, std::string(),
                                                  osArrayPath, nullptr);
@@ -49,10 +56,20 @@ std::shared_ptr<GDALGroup> TileDBArrayGroup::Create(
     {
         for (uint32_t i = 0; i < nAttributes; ++i)
         {
+            const auto &attr = schema.attribute(i);
+            // Variable-size attributes do not have a rectangular GDAL MDIM
+            // representation.  Do not let them hide fixed-size attributes in
+            // the same TileDB array.
+            if (attr.variable_sized())
+            {
+                CPLDebug("TileDB", "Skipping unsupported variable-size "
+                                  "attribute '%s'",
+                         attr.name().c_str());
+                continue;
+            }
             auto poArray = TileDBArray::OpenFromDisk(
-                poSharedResource, nullptr, "/",
-                osBaseName + "." + schema.attribute(i).name(),
-                schema.attribute(i).name(), osArrayPath, nullptr);
+                poSharedResource, nullptr, "/", attr.name(), attr.name(),
+                osArrayPath, nullptr);
             if (!poArray)
                 return nullptr;
             apoArrays.emplace_back(poArray);

--- a/frmts/tiledb/tiledbmultidim.cpp
+++ b/frmts/tiledb/tiledbmultidim.cpp
@@ -38,6 +38,7 @@ std::shared_ptr<GDALGroup> TileDBArrayGroup::Create(
     std::vector<std::shared_ptr<GDALMDArray>> apoArrays;
     if (nAttributes == 1)
     {
+        // Skip variable_sized attributes
         if (schema.attribute(0).variable_sized())
         {
             CPLDebug("TileDB",
@@ -58,19 +59,20 @@ std::shared_ptr<GDALGroup> TileDBArrayGroup::Create(
         for (uint32_t i = 0; i < nAttributes; ++i)
         {
             const auto &attr = schema.attribute(i);
-            // Variable-size attributes do not have a rectangular GDAL MDIM
-            // representation.  Do not let them hide fixed-size attributes in
-            // the same TileDB array.
+
+            auto osFullName = osBaseName + "." + attr.name();
+
+            // Skip variable_sized attributes
             if (attr.variable_sized())
             {
                 CPLDebug("TileDB",
                          "Skipping unsupported variable-size "
                          "attribute '%s'",
-                         attr.name().c_str());
+                         osFullName.c_str());
                 continue;
             }
             auto poArray = TileDBArray::OpenFromDisk(
-                poSharedResource, nullptr, "/", attr.name(), attr.name(),
+                poSharedResource, nullptr, "/", osFullName, attr.name(),
                 osArrayPath, nullptr);
             if (!poArray)
                 return nullptr;

--- a/frmts/tiledb/tiledbmultidim.cpp
+++ b/frmts/tiledb/tiledbmultidim.cpp
@@ -40,8 +40,9 @@ std::shared_ptr<GDALGroup> TileDBArrayGroup::Create(
     {
         if (schema.attribute(0).variable_sized())
         {
-            CPLDebug("TileDB", "Skipping unsupported variable-size "
-                              "attribute '%s'",
+            CPLDebug("TileDB",
+                     "Skipping unsupported variable-size "
+                     "attribute '%s'",
                      schema.attribute(0).name().c_str());
             return std::make_shared<TileDBArrayGroup>(apoArrays);
         }
@@ -62,8 +63,9 @@ std::shared_ptr<GDALGroup> TileDBArrayGroup::Create(
             // the same TileDB array.
             if (attr.variable_sized())
             {
-                CPLDebug("TileDB", "Skipping unsupported variable-size "
-                                  "attribute '%s'",
+                CPLDebug("TileDB",
+                         "Skipping unsupported variable-size "
+                         "attribute '%s'",
                          attr.name().c_str());
                 continue;
             }


### PR DESCRIPTION
## What does this PR do?

TileDB supports variable-sized arrays, but it isn't possible to do anything in GDAL with them. We should be skipping them instead of failing to read an array that has them mixed with other fixed-size content.

## What are related issues/pull requests?

## AI tool usage

 - [x] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

* GPT wrote most of the autotest after mimicking Silvimetric output of the same shape and composition

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
