### PR TITLE
Add swig/java bindings for CoordinateTransformation.GetSource() and G…

### DIFF
--- a/swig/include/osr.i
+++ b/swig/include/osr.i
@@ -1267,6 +1267,20 @@ public:
     OCTDestroyCoordinateTransformation( self );
   }
 
+#ifdef SWIGJAVA 
+   %newobject GetSource;
+   OSRSpatialReferenceShadow* GetSource() {
+    OGRSpatialReferenceH srs = OCTGetSourceCS(self);
+    return (OSRSpatialReferenceShadow*) (srs ? OSRClone(srs) : NULL);
+  }
+
+   %newobject GetTarget;
+   OSRSpatialReferenceShadow* GetTarget() {
+    OGRSpatialReferenceH srs = OCTGetTargetCS(self);
+    return (OSRSpatialReferenceShadow*) (srs ? OSRClone(srs) : NULL);
+  }
+#endif
+
   %newobject GetInverse;
   OSRCoordinateTransformationShadow* GetInverse() {
     return (OSRCoordinateTransformationShadow*) OCTGetInverse(self);

--- a/swig/java/CMakeLists.txt
+++ b/swig/java/CMakeLists.txt
@@ -229,6 +229,7 @@ if (Java_Runtime_FOUND AND BUILD_TESTING)
   add_test(NAME java_ogrinfo_3 COMMAND ${JAVA_RUN} ogrinfo -ro -al tmp_test/out2.shp)
   set_tests_properties(java_ogrinfo_3 PROPERTIES DEPENDS java_ogr2ogr_3)
   add_test(NAME java_OSRTransform COMMAND ${JAVA_RUN} OSRTransform)
+  add_test(NAME java_OSRTransform2 COMMAND ${JAVA_RUN} OSRTransform2Test)
   add_test(NAME java_gdalmajorobject COMMAND ${JAVA_RUN} gdalmajorobject)
   add_test(NAME java_GDALTestIO COMMAND ${JAVA_RUN} GDALTestIO)
   add_test(NAME java_GDALTestVSI COMMAND ${JAVA_RUN} GDALTestVSI)
@@ -251,6 +252,7 @@ if (Java_Runtime_FOUND AND BUILD_TESTING)
           java_ogr2ogr_3
           java_ogrinfo_3
           java_OSRTransform
+          java_OSRTransform2
           java_gdalmajorobject
           java_GDALTestIO
           java_GDALTestVSI

--- a/swig/java/apps/OSRTransform2Test.java
+++ b/swig/java/apps/OSRTransform2Test.java
@@ -1,0 +1,83 @@
+import org.gdal.osr.CoordinateTransformation;
+import org.gdal.osr.SpatialReference;
+import org.gdal.osr.osrConstants;
+
+/**
+ * <p>Title: OSRTransform2Test</p>
+ * <p>Description: Quick test for the new GetSource()/GetTarget() bindings on
+ * CoordinateTransformation</p>
+ * @author Tom Moore
+ * @version 1.0
+ */
+public class OSRTransform2Test {
+
+    public static void main(String[] args) {
+        System.out.println("running GetSource/GetTarget test...\n");
+
+        // 1. Instantiate 2 SpatialReference objects.
+        SpatialReference srcSrs = new SpatialReference();
+        srcSrs.ImportFromEPSG(4326); // WGS 84
+        srcSrs.SetAxisMappingStrategy(osrConstants.OAMS_TRADITIONAL_GIS_ORDER);
+
+        SpatialReference dstSrs = new SpatialReference();
+        dstSrs.ImportFromEPSG(26911); // NAD83 / UTM zone 11N
+        dstSrs.SetAxisMappingStrategy(osrConstants.OAMS_TRADITIONAL_GIS_ORDER);
+
+        // 2. Build the transformation from them.
+        CoordinateTransformation transform =
+                CoordinateTransformation.CreateCoordinateTransformation(srcSrs, dstSrs);
+        if (transform == null) {
+            throw new RuntimeException("Could not create coordinate transformation");
+        }
+
+        // 3. Exercise the new bindings.
+        SpatialReference gotSource = transform.GetSource();
+        SpatialReference gotTarget = transform.GetTarget();
+
+        String sourceCode = gotSource.GetAuthorityCode(null);
+        String targetCode = gotTarget.GetAuthorityCode(null);
+
+        System.out.println("GetSource() -> EPSG:" + sourceCode
+                + "  (expected 4326)  " + (("4326".equals(sourceCode)) ? "PASS" : "FAIL"));
+        System.out.println("GetTarget() -> EPSG:" + targetCode
+                + "  (expected 26911) " + (("26911".equals(targetCode)) ? "PASS" : "FAIL"));
+
+        // 4. Confirm these are cloned, independent objects
+        boolean sourceIsIndependent = (gotSource != srcSrs);
+        boolean targetIsIndependent = (gotTarget != dstSrs);
+
+        System.out.println("GetSource() returns a distinct object: "
+                + (sourceIsIndependent ? "PASS" : "FAIL"));
+        System.out.println("GetTarget() returns a distinct object: "
+                + (targetIsIndependent ? "PASS" : "FAIL"));
+
+        // Content equality, via IsSame()
+        int sourceIsSame = gotSource.IsSame(srcSrs);
+        int targetIsSame = gotTarget.IsSame(dstSrs);
+
+        System.out.println("GetSource() is the SAME CRS as srcSrs (IsSame): "
+                + (sourceIsSame == 1 ? "PASS" : "FAIL") + "  (IsSame=" + sourceIsSame + ")");
+        System.out.println("GetTarget() is the SAME CRS as dstSrs (IsSame): "
+                + (targetIsSame == 1 ? "PASS" : "FAIL") + "  (IsSame=" + targetIsSame + ")");
+
+        // Negative control: two genuinely different CRS should NOT be "same".
+        int sourceVsTargetSame = srcSrs.IsSame(dstSrs);
+        System.out.println("srcSrs vs dstSrs correctly NOT the same CRS: "
+                + (sourceVsTargetSame == 0 ? "PASS" : "FAIL") + "  (IsSame=" + sourceVsTargetSame + ")");
+
+        // Mutate the returned clone and confirm the original is untouched.
+        gotSource.ImportFromEPSG(3857); // deliberately corrupt the clone
+        String srcCodeAfterMutation = srcSrs.GetAuthorityCode(null);
+        System.out.println("Original srcSrs unaffected by mutating the clone: "
+                + ("4326".equals(srcCodeAfterMutation) ? "PASS" : "FAIL")
+                + "  (srcSrs is still EPSG:" + srcCodeAfterMutation + ")");
+
+        // 5. exercise GetInverse() too, since it follows the same
+        //    %newobject/Clone-vs-borrowed pattern.
+        CoordinateTransformation inverse = transform.GetInverse();
+        System.out.println("GetInverse() returned non-null: "
+                + (inverse != null ? "PASS" : "FAIL"));
+
+        System.out.println("\nDone.");
+    }
+}

--- a/swig/java/javadoc.java
+++ b/swig/java/javadoc.java
@@ -11637,6 +11637,44 @@ public class CoordinateTransformation:public int TransformPointWithErrorCode(dou
  */
 public class CoordinateTransformation:public int[] TransformPointsWithErrorCodes(double[][] pointArray)
 
+/**
+ * Inverse transformation object.
+ *
+ * This is the same as the C++ function
+ * OGRCreateCoordinateTransformation::GetInverse
+ *
+ * @return a copy of the inverse transformation or NULL on error
+ *
+ * @since GDAL 3.4
+ */
+public class CoordinateTransformation:public CoordinateTransformation GetInverse()
+
+/**
+ * Transformation's source coordinate system reference.
+ *
+ * This is the same as the C++ function
+ * OGRCreateCoordinateTransformation::GetSourceCS
+ *
+ * @return a copy of the transformation's source coordinate system or NULL if not
+ * present.
+ *
+ * @since GDAL 3.4
+ */
+ public class CoordinateTransformation:public class CoordinateTransformation:public SpatialReference GetSource()
+
+/**
+ * Transformation's target coordinate system reference.
+ *
+ * This is the same as the C++ function
+ * OGRCreateCoordinateTransformation::GetTargetCS
+ *
+ * @return a copy of the transformation's target coordinate system or NULL if not
+ * present.
+ *
+ * @since GDAL 3.4
+ */
+ public class CoordinateTransformation:public class CoordinateTransformation:public SpatialReference GetTarget()
+
 
 /**
  * Class of error codes typically related to coordinate operation initialization,


### PR DESCRIPTION
…etTarget()

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## This PR adds java bindings for the CoordinateTransformation.GetSource() and GetTarget() methods. These binding were not present. They did not exist for Python or C##. I have only added them for Java, which is the platform that I develop on.

## AI tool usage

 - [x] I used a LLM chat to provide answers to questions and to search for code examples, similar to how I used to use google in the old days before it went to crap.

## Tasklist

 - [x] Make sure code is correctly formatted.
 - [x] Add test case(s). Added a java test app, it runs successfully
 - [x] Add documentation.  Copied the existing doc strings from the C api into the javadoc.java file.
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

* OS:  Windows 11 2024H2
* Compiler:  Microsoft (R) C/C++ Optimizing Compiler Version 19.29.30159 for x64
