### PR TITLE
gdal vector info: emit upper case geometry type name that can be used…

### DIFF
--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -1127,8 +1127,17 @@ static void ReportOnLayer(CPLString &osRet, CPLJSONObject &oLayer,
         }
         else if (psOptions->bGeomType)
         {
-            Concat(osRet, psOptions->bStdoutOutput, "Geometry: %s\n",
-                   OGRGeometryTypeToName(poLayer->GetGeomType()));
+            const auto eGeomType = poLayer->GetGeomType();
+            Concat(osRet, psOptions->bStdoutOutput, "Geometry: %s",
+                   OGRGeometryTypeToName(eGeomType));
+            if (eGeomType != wkbNone)
+            {
+                Concat(osRet, psOptions->bStdoutOutput, " (%s)",
+                       OGRToOGCGeomType(eGeomType,
+                                        /* camelCase = */ false,
+                                        /* includeZM = */ true));
+            }
+            Concat(osRet, psOptions->bStdoutOutput, "\n");
         }
 
         if (psOptions->bFeatureCount)

--- a/autotest/utilities/test_ogrinfo.py
+++ b/autotest/utilities/test_ogrinfo.py
@@ -73,7 +73,7 @@ def test_ogrinfo_3(ogrinfo_path):
 
     ret = gdaltest.runexternal(ogrinfo_path + " -al ../ogr/data/poly.shp")
     assert ret.find("Layer name: poly") != -1
-    assert "Geometry: Multi Polygon" in ret
+    assert "Geometry: Multi Polygon (MULTIPOLYGON)" in ret
     assert ret.find("Feature Count: 10") != -1
     assert ret.find("Extent: (478315") != -1
     assert ret.find('PROJCRS["OSGB') != -1
@@ -109,8 +109,8 @@ def test_ogrinfo_5(ogrinfo_path):
 def test_ogrinfo_6(ogrinfo_path):
 
     ret = gdaltest.runexternal(ogrinfo_path + " ../ogr/data/poly.shp poly -geom=no")
-    assert ret.find("Feature Count: 10") != -1
-    assert ret.find("POLYGON") == -1
+    assert "Feature Count: 10" in ret
+    assert "POLYGON ((" not in ret
 
 
 ###############################################################################

--- a/doc/source/programs/gdal_vector_edit.rst
+++ b/doc/source/programs/gdal_vector_edit.rst
@@ -57,6 +57,11 @@ Program-Specific Options
    ``SURFACE``, ``CURVEPOLYGON``, ``MULTICURVE``, ``MULTISURFACE``, ``POLYHEDRALSURFACE`` or ``TIN``.
    ``Z``, ``M`` or ``ZM`` suffixes can be appended to the above values to
    indicate the dimensionality.
+
+   That value can be found in existing datasets by looking at lines like
+   ``Geometry: 3D Multi Polygon (MULTIPOLYGONZ)`` in the output of
+   :program:`gdal vector info`.
+
    Note that feature geometries themselves are not modified. Thus this option
    can be used to fix an inappropriate geometry type at the layer level.
 


### PR DESCRIPTION
… as the --geometry-type value of gdal vector edit

Fixes #15009
