### PR TITLE
CSLRemoveStrings(): fix out-of-bounds access

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -694,6 +694,98 @@ TEST_F(test_cpl, CPLStringList_Base)
     ASSERT_TRUE(EQUAL(oCopy[2], "xyz"));
 }
 
+// Test CSLRemoveStrings() with the special values of nFirstLineToDelete
+// documented as meaning "remove the nNumToRemove last strings".
+TEST_F(test_cpl, CSLRemoveStrings_last_strings)
+{
+    const auto MakeList = []()
+    {
+        char **papszList = nullptr;
+        papszList = CSLAddString(papszList, "aaaa");
+        papszList = CSLAddString(papszList, "bbbb");
+        papszList = CSLAddString(papszList, "cccc");
+        papszList = CSLAddString(papszList, "dddd");
+        return papszList;
+    };
+
+    // nFirstLineToDelete == -1, discarding the removed strings.
+    {
+        char **papszList = MakeList();
+        papszList = CSLRemoveStrings(papszList, -1, 2, nullptr);
+        ASSERT_EQ(CSLCount(papszList), 2);
+        EXPECT_STREQ(papszList[0], "aaaa");
+        EXPECT_STREQ(papszList[1], "bbbb");
+        CSLDestroy(papszList);
+    }
+
+    // nFirstLineToDelete == -1, retrieving the removed strings.
+    {
+        char **papszList = MakeList();
+        char **papszRemoved = nullptr;
+        papszList = CSLRemoveStrings(papszList, -1, 2, &papszRemoved);
+        ASSERT_EQ(CSLCount(papszList), 2);
+        EXPECT_STREQ(papszList[0], "aaaa");
+        EXPECT_STREQ(papszList[1], "bbbb");
+        ASSERT_EQ(CSLCount(papszRemoved), 2);
+        EXPECT_STREQ(papszRemoved[0], "cccc");
+        EXPECT_STREQ(papszRemoved[1], "dddd");
+        CSLDestroy(papszRemoved);
+        CSLDestroy(papszList);
+    }
+
+    // nFirstLineToDelete larger than the number of strings.
+    {
+        char **papszList = MakeList();
+        papszList = CSLRemoveStrings(papszList, 100, 2, nullptr);
+        ASSERT_EQ(CSLCount(papszList), 2);
+        EXPECT_STREQ(papszList[0], "aaaa");
+        EXPECT_STREQ(papszList[1], "bbbb");
+        CSLDestroy(papszList);
+    }
+
+    // nFirstLineToDelete equal to the number of strings: the range to remove
+    // would extend past the end of the list.
+    {
+        char **papszList = MakeList();
+        papszList = CSLRemoveStrings(papszList, 4, 1, nullptr);
+        ASSERT_EQ(CSLCount(papszList), 3);
+        EXPECT_STREQ(papszList[0], "aaaa");
+        EXPECT_STREQ(papszList[2], "cccc");
+        CSLDestroy(papszList);
+    }
+
+    // Valid nFirstLineToDelete, but nNumToRemove makes the range overrun the
+    // end of the list by one.
+    {
+        char **papszList = MakeList();
+        papszList = CSLRemoveStrings(papszList, 3, 2, nullptr);
+        ASSERT_EQ(CSLCount(papszList), 2);
+        EXPECT_STREQ(papszList[0], "aaaa");
+        EXPECT_STREQ(papszList[1], "bbbb");
+        CSLDestroy(papszList);
+    }
+
+    // Removing from a well defined offset must be unaffected. Note that all
+    // the removed strings must be freed, which ASAN/valgrind builds check.
+    {
+        char **papszList = MakeList();
+        papszList = CSLRemoveStrings(papszList, 1, 2, nullptr);
+        ASSERT_EQ(CSLCount(papszList), 2);
+        EXPECT_STREQ(papszList[0], "aaaa");
+        EXPECT_STREQ(papszList[1], "dddd");
+        CSLDestroy(papszList);
+    }
+
+    // Same special values through the CPLStringList wrapper.
+    {
+        CPLStringList oCSL(MakeList());
+        oCSL.RemoveStrings(-1, 2);
+        ASSERT_EQ(oCSL.size(), 2);
+        EXPECT_STREQ(oCSL[0], "aaaa");
+        EXPECT_STREQ(oCSL[1], "bbbb");
+    }
+}
+
 TEST_F(test_cpl, CPLStringList_SetString)
 {
     CPLStringList oCSL;

--- a/port/cpl_string.cpp
+++ b/port/cpl_string.cpp
@@ -587,6 +587,11 @@ char **CSLRemoveStrings(char **papszStrList, int nFirstLineToDelete,
         return nullptr;
     }
 
+    // -1, or a range extending past the end, means "remove the last
+    // nNumToRemove strings". Resolve it before deriving any pointer from it.
+    if (nFirstLineToDelete < 0 || nFirstLineToDelete > nDstLines)
+        nFirstLineToDelete = nDstLines;
+
     // Remove lines from the source StringList.
     // Either free() each line or store them to a new StringList depending on
     // the caller's choice.
@@ -599,6 +604,7 @@ char **CSLRemoveStrings(char **papszStrList, int nFirstLineToDelete,
         {
             CPLFree(*ppszDst);
             *ppszDst = nullptr;
+            ++ppszDst;
         }
     }
     else
@@ -616,9 +622,6 @@ char **CSLRemoveStrings(char **papszStrList, int nFirstLineToDelete,
     }
 
     // Shift down all the lines that follow the lines to remove.
-    if (nFirstLineToDelete == -1 || nFirstLineToDelete > nSrcLines)
-        nFirstLineToDelete = nDstLines;
-
     char **ppszSrc = papszStrList + nFirstLineToDelete + nNumToRemove;
     ppszDst = papszStrList + nFirstLineToDelete;
 


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
`CSLRemoveStrings()` says `-1` means "remove the last `nNumToRemove` strings", but it did the pointer math before handling that, so it landed on `papszStrList[-1]` - one slot before the array - and freed whatever it found there. Moved the normalization up so it happens first.

Same thing for any range that runs off the end: on a 4-element list, `(3, 2)` and `(4, 1)` both segfault. Widened the guard to catch those too. Calls that fit are unchanged.

Also, the freeing loop never advanced the pointer, so only the first string got freed and the rest leaked. Added the missing `++`.

`CPLStringList::RemoveStrings()` documents the same `-1` behaviour and calls into this, so it's fixed too.

### Test
New `CSLRemoveStrings_last_strings` in `autotest/cpp/test_cpl.cpp`, covering `-1`, indexes at/past the end, an overrunning range, and the `CPLStringList` wrapper. It aborts without the fix and passes with it. Rest of `test_cpl` still green.

## What are related issues/pull requests?
Fixes #15067
## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS: `Linux Ubuntu 26.04 `
* Compiler: `gcc (Ubuntu 15.2.0-16ubuntu1) 15.2.0`
