### PR TITLE
docs(raster): fix typos and standardize 'e.g.,' usage

### DIFF
--- a/doc/source/drivers/raster/arcinfo_grid_format.rst
+++ b/doc/source/drivers/raster/arcinfo_grid_format.rst
@@ -427,7 +427,7 @@ just two bytes (zeros) for the RTileSize for that tile.
 Raster Size
 ~~~~~~~~~~~
 
-The size of a the grid isn't as easy to deduce as one might expect. The
+The size of the grid isn't as easy to deduce as one might expect. The
 hdr.adf file contains the HTilesPerRow, HTilesPerColumn, HTileXSize, and
 HTileYSize fields which imply a particular raster space. However, it
 seems that this is created much larger than necessary to hold the users

--- a/doc/source/drivers/raster/cog.rst
+++ b/doc/source/drivers/raster/cog.rst
@@ -498,7 +498,7 @@ Reprojection related creation options
      Starting with GDAL 3.2, the value of :co:`TILING_SCHEME` can also be the filename
      of a JSON file according to the `OGC Two Dimensional Tile Matrix Set standard`_,
      a URL to such file, the radical of a definition file in the GDAL data directory
-     (e.g. ``FOO`` for a file named ``tms_FOO.json``) or the inline JSON definition.
+     (e.g., ``FOO`` for a file named ``tms_FOO.json``) or the inline JSON definition.
      The list of available tiling schemes can be obtained by looking at values of
      the TILING_SCHEME option reported by ``gdalinfo --format COG``.
 

--- a/doc/source/drivers/raster/ehdr.rst
+++ b/doc/source/drivers/raster/ehdr.rst
@@ -24,7 +24,7 @@ differentiate is to add a field named PIXELTYPE with values of either
 FLOAT, SIGNEDINT or UNSIGNEDINT. In combination with the NBITS field it
 is possible to described all variations of pixel types.
 
-eg.
+e.g.,
 
 ::
 

--- a/doc/source/drivers/raster/envi.rst
+++ b/doc/source/drivers/raster/envi.rst
@@ -43,9 +43,9 @@ Creation Options:
       :choices: REPLACE, ADD
 
       Force adding ".hdr" suffix to supplied
-      filename, e.g. if user selects "file.bin" name for output dataset,
+      filename, e.g., if user selects "file.bin" name for output dataset,
       "file.bin.hdr" header file will be created. By default header file
-      suffix replaces the binary file suffix, e.g. for "file.bin" name
+      suffix replaces the binary file suffix, e.g., for "file.bin" name
       "file.hdr" header file will be created.
 
 NOTE: Implemented as :source_file:`frmts/raw/envidataset.cpp`.

--- a/doc/source/drivers/raster/fits.rst
+++ b/doc/source/drivers/raster/fits.rst
@@ -351,7 +351,7 @@ Linux
 ^^^^^
 From source
 """""""""""
-Install CFITSIO headers from your distribution (eg, cfitsio-devel on Fedora; libcfitsio-dev on Debian-Ubuntu), then compile GDAL as usual. CFITSIO will be automatically detected and linked.
+Install CFITSIO headers from your distribution (e.g., cfitsio-devel on Fedora; libcfitsio-dev on Debian-Ubuntu), then compile GDAL as usual. CFITSIO will be automatically detected and linked.
 
 From distributions
 """"""""""""""""""

--- a/doc/source/drivers/raster/gpkg.rst
+++ b/doc/source/drivers/raster/gpkg.rst
@@ -219,7 +219,7 @@ reproducibility, the timestamp can be forced to a specific value by setting the
 :config:`OGR_CURRENT_DATE` global configuration option.
 When setting the option, take care to meet the specific time format
 requirement of the GeoPackage standard,
-e.g. `for version 1.2 <https://www.geopackage.org/spec120/#r15>`__.
+e.g., `for version 1.2 <https://www.geopackage.org/spec120/#r15>`__.
 
 
 .. _raster.gpkg.tile_formats:
@@ -326,7 +326,7 @@ schemes are :
    `global-mercator <http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification#global-mercator>`__
    profile of OSGeo TMS (Tile Map Service) specification. That tiling
    schemes consists of four 256x256 tiles at its zoom level 0, in
-   EPSG:3857 CRS, with extent extent in easting and northing in the
+   EPSG:3857 CRS, with extent in easting and northing in the
    range [-20037508.34,20037508.34]. The same remark as with
    PseudoTMS_GlobalGeodetic applies regarding interoperability with TMS.
 -  *GoogleCRS84Quad*, as described in `OGC 07-057r7 WMTS
@@ -431,7 +431,7 @@ The following creation options are available:
 
 -  .. co:: RASTER_IDENTIFIER
 
-      Human-readable identifier (e.g. short
+      Human-readable identifier (e.g., short
       name), put in the *identifier* column of the *gpkg_contents* table.
 
 -  .. co:: RASTER_DESCRIPTION
@@ -493,7 +493,7 @@ The following creation options are available:
       Starting with GDAL 3.2, the value of TILING_SCHEME can also be the filename
       of a JSON file according to the `OGC Two Dimensional Tile Matrix Set standard`_,
       a URL to such file, the radical of a definition file in the GDAL data directory
-      (e.g. ``FOO`` for a file named ``tms_FOO.json``) or the inline JSON definition.
+      (e.g., ``FOO`` for a file named ``tms_FOO.json``) or the inline JSON definition.
       Note: the TILING_SCHEME option with a non-CUSTOM value is best used
       with the gdal_translate utility / CreateCopy() API operation. If used
       with gdalwarp, it requires setting the -tr switch to the exact value

--- a/doc/source/drivers/raster/gti.rst
+++ b/doc/source/drivers/raster/gti.rst
@@ -193,7 +193,7 @@ PostGIS, ...), the following layer metadata items may be set:
 
   .. note::
      For on-the-fly reprojection of the whole GTI mosaic output, wrapping
-     the GTI file in a warped VRT (e.g. via ``gdal raster reproject``) is
+     the GTI file in a warped VRT (e.g., via ``gdal raster reproject``) is
      an alternative that does not require ``SRS_BEHAVIOR``.
 
 * ``LOCATION_FIELD=<string>``: name of the field where the tile location is
@@ -571,7 +571,7 @@ also defined as layer metadata items or in the .gti XML file
 
       Set the amount of memory that the warp API is allowed to use for caching
       when on-the-fly reprojection occurs.
-      The value can be specified either as a fixed amount of memory (e.g.
+      The value can be specified either as a fixed amount of memory (e.g.,
       ``200MB``, ``1G``) or as a percentage of usable RAM (``10%``).
       Note that, in case of multi-threaded optimizations described in the
       paragraph below, the value applies for each warped source.
@@ -729,7 +729,7 @@ an integer index (starting at 0 since GDAL 3.9.2, starting at 1 in previous vers
   Sub-sampling factor, greater or equal to 1 (1 accepted only since GDAL 3.13)
 
   Before GDAL 3.13, was only taken into account if ``OVERVIEW_<idx>_DATASET=<string>``
-  was not not specified, or pointed to a GTI dataset. Since GDAL 3.13,
+  was not specified, or pointed to a GTI dataset. Since GDAL 3.13,
   ``OVERVIEW_<idx>_FACTOR`` is also accepted on any valid ``OVERVIEW_<idx>_DATASET``.
 
   If ``OVERVIEW_<idx>_DATASET`` and ``OVERVIEW_<idx>_LAYER`` are not specified, then all tiles of the full

--- a/doc/source/drivers/raster/hdf4.rst
+++ b/doc/source/drivers/raster/hdf4.rst
@@ -220,7 +220,7 @@ Metadata
 --------
 
 All HDF4 attributes are transparently translated as GDAL metadata. In
-the HDF file attributes may be assigned assigned to the whole file as
+the HDF file attributes may be assigned to the whole file as
 well as to particular subdatasets.
 
 Open options

--- a/doc/source/drivers/raster/heif.rst
+++ b/doc/source/drivers/raster/heif.rst
@@ -33,9 +33,9 @@ AVIF support
 ------------
 
 Starting with GDAL 3.10, the AVIF_HEIF companion driver to the HEIF driver may
-be used to open images encoding with the AVIF (AV1 Image File) codec if the
+be used to open images encoded with the AVIF (AV1 Image File) codec if the
 :ref:`raster.avif` driver is not available and if libheif has been compiled with
-support for one of the libraries it support that are able of AV1 decoding
+support for one of the libraries it supports that are able of AV1 decoding
 (libaom or libdav1d).
 
 

--- a/doc/source/drivers/raster/icechunk.rst
+++ b/doc/source/drivers/raster/icechunk.rst
@@ -80,7 +80,7 @@ When opening an Icechunk dataset, the Icechunk driver essentially prepends
 name to the Zarr driver.
 
 It is possible to directly use ``/vsiicechunk/`` filenames for low-level inspection
-of an Icechunk repository, e.g. with :ref:`gdal_vsi_list`.
+of an Icechunk repository, e.g., with :ref:`gdal_vsi_list`.
 
 ::
 

--- a/doc/source/drivers/raster/isis3.rst
+++ b/doc/source/drivers/raster/isis3.rst
@@ -193,11 +193,11 @@ The available creation options are:
 -  .. co:: GEOTIFF_OPTIONS
 
       Comma separated list of KEY=VALUE
-      tuples to forward to the GeoTIFF driver. e.g.
+      tuples to forward to the GeoTIFF driver, e.g.,
       ``GEOTIFF_OPTIONS=COMPRESS=LZW``.
 
 -  .. co:: EXTERNAL_FILENAME
-      :choices: <filena,e>
+      :choices: <filename>
 
       Override default external filename.
       Only for DATA_LOCATION=EXTERNAL or GEOTIFF.

--- a/doc/source/drivers/raster/jp2ecw.rst
+++ b/doc/source/drivers/raster/jp2ecw.rst
@@ -216,14 +216,14 @@ impact decoding speed and compatibility with other JPEG2000 toolkits.
 
 -  .. co:: TILE_WIDTH
 
-      Tile Width (default, image width eg. 1 tile). Apart
+      Tile Width (default, image width, e.g., 1 tile). Apart
       from GeoTIFF, in JPEG2000 tiling is not critical for speed if
       precincts are used. The minimum tile size allowed by the standard is
       1024x1024 pixels.
 
 -  .. co:: TILE_HEIGHT
 
-      Tile Height (default, image height eg. 1 tile)
+      Tile Height (default, image height, e.g., 1 tile)
 
 -  .. co:: INCLUDE_SOP
       :choices: YES, NO
@@ -357,7 +357,7 @@ generic File Metadata reported under "JPEG2000" metadata domain (-mdd):
    (smallest to largest) on Y Axis
 -  **CODE_BLOCK_SIZE_X**: Code block size on X Axis
 -  **CODE_BLOCK_SIZE_Y**: Code block size on Y Axis
--  **PRECISION**: Precision / Bit-depth of each component eg. 8,8,8 for
+-  **PRECISION**: Precision / Bit-depth of each component, e.g., 8,8,8 for
    8bit 3 band imagery.
 -  **RESOLUTION_LEVELS**: Number of resolution levels
 -  **QUALITY_LAYERS**: Number of quality layers

--- a/doc/source/drivers/raster/jp2kak.rst
+++ b/doc/source/drivers/raster/jp2kak.rst
@@ -279,7 +279,7 @@ to version 7.9.
 kdu_get_num_processors always returns 0 for some platforms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-On non-windows / non-mac installs (e.g. Linux), Kakadu SDK might not include
+On non-windows / non-mac installs (e.g., Linux), Kakadu SDK might not include
 unistd.h in kdu_arch.cpp. This means that \_SC_NPROCESSORS_ONLN and
 \_SC_NPROCESSORS_CONF are not defined and kdu_get_num_processors will
 always return 0. Therefore the jp2kak driver might not default to
@@ -315,7 +315,7 @@ See Also
 
 -  Implemented as :source_file:`frmts/jp2kak/jp2kakdataset.cpp`.
 -  If you're using a Kakadu SDK release before v7.5, configure & compile
-   GDAL with eg.
+   GDAL with e.g.,
    `CXXFLAGS="-DKDU_MAJOR_VERSION=7 -DKDU_MINOR_VERSION=3 -DKDU_PATCH_VERSION=2"`
    for Kakadu SDK version 7.3.2.
 -  Alternate :ref:`raster.jp2openjpeg` driver.

--- a/doc/source/drivers/raster/jpeg.rst
+++ b/doc/source/drivers/raster/jpeg.rst
@@ -287,11 +287,11 @@ The below tables list the EXIF and GPS tags that can be written.
 
    -  ASCII is for text values that are NUL-terminated (for a fixed
       length tag, the length includes this NUL-terminating characters).
-      e.g EXIF_Make=the_make
+      e.g., EXIF_Make=the_make
    -  BYTE/UNDEFINED is for values that can be made of any byte value.
       The value of the corresponding GDAL metadata item must be a string
-      of hexadecimal formatted values, e.g EXIF_GPSVersionID=0x02 0x00
-      0x00 0x00. GDAL also accepts an ASCII string: e.g.
+      of hexadecimal formatted values, e.g., EXIF_GPSVersionID=0x02 0x00
+      0x00 0x00. GDAL also accepts an ASCII string: e.g.,
       EXIF_ExifVersion=0231
    -  SHORT is for unsigned integer values in the range [0,65535]. Some
       tags may accept multiple values, in which case they must be
@@ -301,7 +301,7 @@ The below tables list the EXIF and GPS tags that can be written.
       separated by space.
    -  RATIONAL is for positive floating-point values. Some tags may
       accept multiple values, in which case they must be separated by
-      space. e.g EXIF_GPSLatitude=49 2 3.5
+      space. e.g., EXIF_GPSLatitude=49 2 3.5
    -  SRATIONAL is for positive or negative floating-point values. Some
       tags may accept multiple values, in which case they must be
       separated by space.

--- a/doc/source/drivers/raster/jpegxl.rst
+++ b/doc/source/drivers/raster/jpegxl.rst
@@ -188,7 +188,7 @@ The following creation options are available:
       :choices: YES, NO
       :default: NO
 
-      (libjxl > 0.6.1) Whether to to decompress Exif/XMP/GeoJP2 boxes
+      (libjxl > 0.6.1) Whether to compress Exif/XMP/GeoJP2 boxes
       using Brotli compression.
 
 See Also

--- a/doc/source/drivers/raster/jpipkak.rst
+++ b/doc/source/drivers/raster/jpipkak.rst
@@ -43,14 +43,14 @@ are made at the 1:1 resolution level.
    that can be used to identify the image on the server and a JPIP-cnew
    response header which includes the path to the JPIP server which will
    handle all future requests and a cid session identifier. A session is
-   required so that that the server can model the state of the client
+   required so that the server can model the state of the client
    connection, only sending the data that is required.
 #. Client requests particular view windows on the target image with a
    maximum response length and includes the session identifier
    established in the previous communication. 'fsiz' is used to identify
    the resolution associated with the requested view-window. The values
    'fx' and 'fy' specify the dimensions of the desired image resolution.
-   'roff' is used to identify the upper left hand corner off the spatial
+   'roff' is used to identify the upper left hand corner of the spatial
    region associated with the requested view-window. 'rsiz' is used to
    identify the horizontal and vertical extents of the spatial region
    associated with the requested view-window.
@@ -216,7 +216,7 @@ been made to the GDAL HTTP portability library to support this.
    The region passed into this function is passed by reference, and the
    caller can read this region when the result returns to find the
    region that has been decompressed. The image data is packed into the
-   buffer, e.g. RGB if the region requested has 3 components.
+   buffer, e.g., RGB if the region requested has 3 components.
 
 #. GDALUnlockBuffer
 

--- a/doc/source/drivers/raster/mem.rst
+++ b/doc/source/drivers/raster/mem.rst
@@ -58,7 +58,7 @@ or
 -  LINES: Height of raster in lines. (required)
 -  BANDS: Number of bands, defaults to 1. (optional)
 -  DATATYPE: Name of the data type, as returned by GDALGetDataTypeName()
-   (eg. Byte, Int16) Defaults to Byte. (optional)
+   (e.g., Byte, Int16) Defaults to Byte. (optional)
 -  PIXELOFFSET: Offset in bytes between the start of one pixel and the
    next on the same scanline. (optional)
 -  LINEOFFSET: Offset in bytes between the start of one scanline and the
@@ -73,7 +73,7 @@ or
    :ref:`gdal_translate`. If the passed string includes comma or double-quote characters (typically WKT),
    it should be surrounded by double-quote characters and the double-quote characters inside it
    should be escaped with anti-slash.
-   e.g ``SPATIALREFERENCE="GEOGCRS[\"WGS 84\",[... snip ...],ID[\"EPSG\",4326]]"``
+   e.g., ``SPATIALREFERENCE="GEOGCRS[\"WGS 84\",[... snip ...],ID[\"EPSG\",4326]]"``
 
 .. warning::
 

--- a/doc/source/drivers/raster/mff2.rst
+++ b/doc/source/drivers/raster/mff2.rst
@@ -70,7 +70,7 @@ example,
 specifies an image that is 1040 lines by 800 pixels in extent. The
 pixels are 32 bits of real data in "most significant byte first" (msbf)
 order, encoded according to the ieee_754 specification. In MFF2, when a
-value must belong to a certain subset (eg. pixel.order must be either
+value must belong to a certain subset (e.g., pixel.order must be either
 lsbf or msbf), all options are displayed between curly brackets, and the
 one appropriate for the current file is indicated with a "*".
 
@@ -202,7 +202,7 @@ Explanation of fields
 ::
 
    channel.enumeration:  (optional- only needed for multiband)
-   Number of channels of data (eg. 3 for rgb)
+   Number of channels of data (e.g., 3 for rgb)
 
    channel.interleave = { *pixel tile sequential } :  (optional- only
    needed for multiband)

--- a/doc/source/drivers/raster/miramon.rst
+++ b/doc/source/drivers/raster/miramon.rst
@@ -151,7 +151,7 @@ Open examples
        gdal_translate -oo RAT_OR_CT=RAT datasetI.rel output_only_with_rat.tiff (only RAT will be translated, without the color table)
        gdal_translate -oo RAT_OR_CT=CT datasetI.rel output_only_with_ct.tiff (only color table will be translated, without the attribute table)
 
--  A MiraMon dataset can be translated preserving it's own metadata, by using the SRC_MDD creation option:
+-  A MiraMon dataset can be translated preserving its own metadata, by using the SRC_MDD creation option:
    .. code-block::
 
        gdal_translate -oo SRC_MDD=MIRAMON datasetI.rel output_with_miramon_metadata.vrt

--- a/doc/source/drivers/raster/msg.rst
+++ b/doc/source/drivers/raster/msg.rst
@@ -11,7 +11,7 @@ MSG -- Meteosat Second Generation
 This driver implements reading support for Meteosat Second Generation
 files. These are files with names like
 ``H-000-MSG1\_\_-MSG1\_\_\_\_\_\_\_\_-HRV\_\_\_\_\_\_-000007\_\_\_-200405311115-C\_``, commonly
-distributed into a folder structure with dates (e.g. ``2004\05\31`` for the
+distributed into a folder structure with dates (e.g., ``2004\05\31`` for the
 file mentioned).
 
 The MSG files are wavelet-compressed. A decompression library licensed
@@ -61,7 +61,7 @@ files:
    -  source_folder: a path to a folder structure that contains the
       files
    -  timestamp: 12 digits representing a date/time that identifies the
-      114 files of the 12 images of that time, e.g. 200501181200
+      114 files of the 12 images of that time, e.g., 200501181200
    -  channel: a number between 1 and 12, representing each of the 12
       available channels. When only specifying one channel, the brackets
       are optional.
@@ -86,7 +86,7 @@ files:
       cycles to be included in the same file (time series). These are
       appended as additional bands.
    -  step: a number that indicates what is the stepsize when multiple
-      cycles are chosen. E.g. every 15 minutes: step = 1, every 30
+      cycles are chosen. E.g., every 15 minutes: step = 1, every 30
       minutes: step = 2 etc. Note that the cycles are exactly 15 minutes
       apart, so you can not get images from times in-between (the step
       is an integer).

--- a/doc/source/drivers/raster/netcdf.rst
+++ b/doc/source/drivers/raster/netcdf.rst
@@ -255,7 +255,7 @@ spatial reference system using an OGC WKT string. The attribute name ``crs_wkt``
 not specified until version 1.7 of the CF conventions; before that time, GDAL used
 the attribute name ``spatial_ref`` for the same purpose.
 
-When reading a variable from a netCDF file, GDAL first checks the ``grid_mapping`` attribute to find the name of the grid mapping variable. If this variable has a ``spatial_ref`` or ``crs_wkt`` attribute (checked in that order), it will be used to assign a spatial reference system. If not, the spatial reference system will be assigned using using projection parameter attributes (``semi_major_axis``, etc.) If these parameters are not present, GDAL will check the grid mapping variable for a (non-standard) ``srid`` attribute and attempt to interpret it if present.
+When reading a variable from a netCDF file, GDAL first checks the ``grid_mapping`` attribute to find the name of the grid mapping variable. If this variable has a ``spatial_ref`` or ``crs_wkt`` attribute (checked in that order), it will be used to assign a spatial reference system. If not, the spatial reference system will be assigned using projection parameter attributes (``semi_major_axis``, etc.) If these parameters are not present, GDAL will check the grid mapping variable for a (non-standard) ``srid`` attribute and attempt to interpret it if present.
 
 If no ``grid_mapping`` attribute is present, GDAL will check the data variable for a (non-standard) ``crs`` attribute and read a WKT, EPSG, or PROJ.4 string from it.
 
@@ -557,7 +557,7 @@ The following creation options are available:
 Creation of multidimensional files with CreateCopy() 2D raster API
 ------------------------------------------------------------------
 
-Starting with GDAL 3.1, the preferred way of creating > 2D files is to use the
+Starting with GDAL 3.1, the preferred way of creating > 2D files is to use
 the :ref:`multidim_raster_data_model` API. However it is possible to create
 such files with the 2D raster API using the CreateCopy() method (note that at
 time of writing, this is not supported using the Create() method).
@@ -630,7 +630,7 @@ Configuration Options
       :default: NO
 
       Whether X/Y dimensions
-      should be always considered as geospatial axis, even if the lack
+      should be always considered as geospatial axis, even if they lack
       conventional attributes confirming it.
 
 -  .. config:: GDAL_NETCDF_ASSUME_LONGLAT
@@ -757,7 +757,7 @@ The :cpp:func:`GDALGroup::OpenMDArray` method supports the following options:
 
 For RAW_DATA_CHUNK_CACHE_SIZE, CHUNK_SLOTS and PREEMPTION, consult
 `nc_set_var_chunk_cache <https://docs.unidata.ucar.edu/netcdf-c/current/group__variables.html#ga2788cbfc6880ec70c304292af2bc7546>`__ and
-`documentation about netCDF chunk cacke <https://docs.unidata.ucar.edu/nug/current/netcdf_perf_chunking.html>`__
+`documentation about netCDF chunk cache <https://docs.unidata.ucar.edu/nug/current/netcdf_perf_chunking.html>`__
 
 The :cpp:func:`GDALGroup::CreateMDArray` method supports the following options:
 

--- a/doc/source/drivers/raster/nitf.rst
+++ b/doc/source/drivers/raster/nitf.rst
@@ -259,7 +259,7 @@ The following creation options are available:
       :choices: <tre-name=tre-contents>
 
       One or more TRE (Tagged Record Extension) creation options may
-      be used provided to write arbitrary user defined TREs to the image
+      be provided to write arbitrary user defined TREs to the image
       header. The tre-name should be at most six characters, and the
       tre-contents should be "backslash escaped" if it contains backslashes
       or zero bytes. The argument is the same format as returned in the TRE
@@ -557,7 +557,7 @@ The following options are only valid for PRODUCT_TYPE=CADRG.
       :since: 3.13
 
       Short title for the identification of a group of products usually having
-      the same scale and/or cartographic specification (e.g. JOG 1501A).
+      the same scale and/or cartographic specification (e.g., JOG 1501A).
       Up to 10 characters. Derived from SERIES_CODE and SCALE when not specified.
       Only used when PRODUCT_TYPE=CADRG.
 
@@ -565,7 +565,7 @@ The following options are only valid for PRODUCT_TYPE=CADRG.
       :choices: <string>
       :since: 3.13
 
-      Designation, within the data series, of the hard-copy source (e.g. G18 if
+      Designation, within the data series, of the hard-copy source (e.g., G18 if
       the hard-copy source is ONC G18).
       Up to 8 characters.
       Only used when PRODUCT_TYPE=CADRG.

--- a/doc/source/drivers/raster/ogcapi.rst
+++ b/doc/source/drivers/raster/ogcapi.rst
@@ -60,7 +60,7 @@ The driver supports opening by:
 
 
 When the driver opens a collection, for raster, it will look if tiles or maps
-API are advertized for it. It will use tiles API by default, and fallback to maps
+API are advertised for it. It will use tiles API by default, and fallback to maps
 API when not available. It will also look at the image formats, and will prefer
 PNG When available.
 

--- a/doc/source/drivers/raster/pcidsk.rst
+++ b/doc/source/drivers/raster/pcidsk.rst
@@ -46,7 +46,7 @@ though other organizations are supported for read.
       Sets the compression to use. Values
       other than NONE may only be used with TILED
       interleaving. If JPEG is select it may include a quality value
-      between 1 and 100 - eg. COMPRESSION=JPEG40.
+      between 1 and 100 - e.g., COMPRESSION=JPEG40.
 
 -  .. co:: TILESIZE
       :default: 127

--- a/doc/source/drivers/raster/pdf.rst
+++ b/doc/source/drivers/raster/pdf.rst
@@ -318,7 +318,7 @@ The following creation options are available:
 -  .. co:: LAYER_NAME
 
       Name for layer where the raster is placed. If
-      specified, the raster will be be placed into a layer that can be
+      specified, the raster will be placed into a layer that can be
       toggled/un-toggled in the "Layer tree" of the PDF reader.
 
 -  .. co:: EXTRA_RASTERS
@@ -335,7 +335,7 @@ The following creation options are available:
 
       Comma separated list of
       name for each raster specified in EXTRA_RASTERS. If specified, each
-      extra raster will be be placed into a layer, named with the specified
+      extra raster will be placed into a layer, named with the specified
       value, that can be toggled/un-toggled in the "Layer tree" of the PDF
       reader. If not specified, all the extra rasters will be placed in the
       default layer.
@@ -364,7 +364,7 @@ The following creation options are available:
 
       Name for layer where the extra content
       specified with EXTRA_STREAM or EXTRA_IMAGES is placed. If specified,
-      the extra content will be be placed into a layer that can be
+      the extra content will be placed into a layer that can be
       toggled/un-toggled in the "Layer tree" of the PDF reader.
 
 -  .. co:: MARGIN
@@ -430,7 +430,7 @@ The following creation options are available:
 -  .. co:: CREATION_DATE
 
       Create date metadata to write into the PDF Info block. The format of
-      the value must be D:YYYYMMDDHHmmSSOHH'mm' (e.g.
+      the value must be D:YYYYMMDDHHmmSSOHH'mm' (e.g.,
       D:20121122132447+02'00' for 22 nov 2012 13:24:47 GMT+02) (see `PDF
       Reference, version
       1.7 <http://www.adobe.com/devnet/acrobat/pdfs/pdf_reference_1-7.pdf>`__,

--- a/doc/source/drivers/raster/postgisraster.rst
+++ b/doc/source/drivers/raster/postgisraster.rst
@@ -42,7 +42,7 @@ unnecessary fields (like password, in some cases).
 -  **schema** - name of PostgreSQL schema where requested raster table
    is stored.
 -  **table** - name of PostGIS Raster table. The table was created by
-   the raster loader (eg. raster2pgsql utility).
+   the raster loader (e.g., raster2pgsql utility).
 -  **column** - name of raster column in raster table
 -  **where** - option is used to filter the results of the raster table.
    Any SQL-WHERE expression is valid.
@@ -67,7 +67,7 @@ unnecessary fields (like password, in some cases).
       the server.
    -  **client_side**: The outDB raster filenames will be returned to
       the GDAL PostGISRaster client, which will open it on the client
-      side. This implies that the filename stored on te server can be
+      side. This implies that the filename stored on the server can be
       accessed by the client.
    -  **client_side_if_possible**: The outDB raster filenames will be
       returned to the GDAL PostGISRaster client, which will check if it

--- a/doc/source/drivers/raster/prf.rst
+++ b/doc/source/drivers/raster/prf.rst
@@ -13,7 +13,7 @@ large images.
 
 This format was developed to store images larger than 4 GB. As a basis
 for storing data used TIFF or JPEG2000 format. Raster is split into
-fragments (tiles) such that each fragment does not exceeded a predefined
+fragments (tiles) such that each fragment does not exceed a predefined
 size (e.g., less than 1 GB). An overview file also added to process
 raster data on a small scales.
 
@@ -28,7 +28,7 @@ Image format has the following structure:
 -  files \*.tif/*.jp2/*.demtif inside folder 'image_name', containing
    raster fragments and the overview image
 
-The driver support the data type among Byte, UInt16, UInt32, Float32 or
+The driver supports the data type among Byte, UInt16, UInt32, Float32 or
 Float64.
 
 Driver capabilities

--- a/doc/source/drivers/raster/rpftoc.rst
+++ b/doc/source/drivers/raster/rpftoc.rst
@@ -120,7 +120,7 @@ Program-Specific Options
 
 .. option:: --scale <SCALE>
 
-   (Reciprocal) scale (e.g. 1000000). If not specified, it will be guessed from
+   (Reciprocal) scale (e.g., 1000000). If not specified, it will be guessed from
    the content of CADRG frames (except for those where this cannot be inferred
    automatically)
 

--- a/doc/source/drivers/raster/s104.rst
+++ b/doc/source/drivers/raster/s104.rst
@@ -199,7 +199,7 @@ The following creation options are available:
 -  .. co:: TREND_INTERVAL
       :choices: <number>
 
-      Interval, in minutes, over which trend at a a particular time is calculated
+      Interval, in minutes, over which trend at a particular time is calculated
 
 -  .. co:: DATASET_DELIVERY_INTERVAL
       :choices: <string>

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1727,7 +1727,7 @@ A :cpp:type:`GDALDerivedPixelFuncWithArgs` is defined with a signature similar t
    :param nLineSpace: The byte offset from the start of one scanline in
     pData to the start of the next.
 
-   :param papszArgs: An optional string list of named function arguments (e.g. ``y=4``)
+   :param papszArgs: An optional string list of named function arguments (e.g., ``y=4``)
 
 
 It is also possible to register a :cpp:type:`GDALDerivedPixelFunc` (which omits the final :cpp:type:`CSLConstList` argument) using :cpp:func:`GDALAddDerivedBandPixelFunc`.
@@ -2045,7 +2045,7 @@ Currently only CPython 3 is supported. The GDAL shared object
 is not explicitly linked at build time to any of the CPython library. When GDAL
 will need to run Python code, it will first determine if the Python interpreter
 is loaded in the current process (which is the case if the program is a Python
-interpreter itself, or if another program, e.g. QGIS, has already loaded the
+interpreter itself, or if another program, e.g., QGIS, has already loaded the
 CPython library). Otherwise it will look if the :config:`PYTHONSO` configuration option is
 defined. This option can be set to point to the name of the Python library to
 use, either as a shortname like "libpython3.10.so" if it is accessible through
@@ -2298,7 +2298,7 @@ projection and geotransform from the panchromatic band will be reused for the VR
 dataset.
 
 It is possible to create more explicit and declarative pansharpened VRT, allowing
-for example to only output part of the input spectral bands (e.g. only RGB when
+for example to only output part of the input spectral bands (e.g., only RGB when
 the input multispectral dataset is RGBNir). It is also possible to add "classic"
 VRTRasterBands, in addition to the pansharpened bands.
 
@@ -2309,7 +2309,7 @@ the PansharpeningOptions element may have the following children elements :
 - **AlgorithmOptions**: to specify the options of the pansharpening algorithm. With WeightedBrovey algorithm, the only supported option is a **Weights** child element whose content must be a comma separated list of real values assigning the weight of each of the declared input spectral bands. There must be as many values as declared input spectral bands.
 - **Resampling**: the resampling kernel used to resample the spectral bands to the resolution of the panchromatic band. Can be one of Cubic (default), Average, Near, CubicSpline, Bilinear, Lanczos.
 - **NumThreads**: Number of worker threads. Integer number or ALL_CPUS. If this option is not set, the :config:`GDAL_NUM_THREADS` configuration option will be queried (its value can also be set to an integer or ALL_CPUS)
-- **BitDepth**: Can be used to specify the bit depth of the panchromatic and spectral bands (e.g. 12). If not specified, the NBITS metadata item from the panchromatic band will be used if it exists.
+- **BitDepth**: Can be used to specify the bit depth of the panchromatic and spectral bands (e.g., 12). If not specified, the NBITS metadata item from the panchromatic band will be used if it exists.
 - **NoData**: Nodata value to take into account for panchromatic and spectral bands. It will be also used as the output nodata value. If not specified and all input bands have the same nodata value, it will be implicitly used (unless the special None value is put in NoData to prevent that).
 - **SpatialExtentAdjustment**: Can be one of **Union** (default), **Intersection**, **None** or **NoneWithoutWarning**. Controls the behavior when panchromatic and spectral bands have not the same geospatial extent. By default, Union will take the union of all spatial extents. Intersection the intersection of all spatial extents. None will not proceed to any adjustment at all, but will emit a warning. NoneWithoutWarning is the same as None, but in a silent way.
 
@@ -2528,7 +2528,7 @@ The effect of the ``a_gt`` option (added in GDAL 3.8) is to override/assign the 
 the order 'gt(0),gt(1),gt(2),gt(3),gt(4),gt(5)'.
 
 The effect of the ``oo`` option (added in GDAL 3.8) is to set driver-specific dataset open options, multiple values are allowed. The value
-consists of string key value pairs with multiple pairs separated by commas e.g. ``oo=<key>=<val>`` or . ``oo=<key1>=<val1>,<key2>=<val2>,...``. This is applied in the same way as (:ref:`gdal_translate`).
+consists of string key value pairs with multiple pairs separated by commas, e.g., ``oo=<key>=<val>`` or . ``oo=<key1>=<val1>,<key2>=<val2>,...``. This is applied in the same way as (:ref:`gdal_translate`).
 
 The effect of the ``unscale`` option (added in GDAL 3.8) is to apply the scale/offset metadata for the bands to convert scaled values to unscaled values. To apply this use syntax ``unscale=true``, or ``unscale=false`` (which is the default if not specified). Do consider the need for also using ``ot`` option in order to accommodate the intended output range, see more details for the same argument as with (:ref:`gdal_translate`).
 

--- a/doc/source/drivers/raster/wcs.rst
+++ b/doc/source/drivers/raster/wcs.rst
@@ -113,11 +113,11 @@ is meant to be modified by using options.
 -  **HttpAuth**: May be BASIC, NTLM or ANY to control the authentication
    scheme to be used.
 -  **GetCoverageExtra**: An additional set of keywords to add to
-   GetCoverage requests in URL encoded form. e.g.
+   GetCoverage requests in URL encoded form, e.g.,
    ``&RESAMPLE=BILINEAR&Band=1``. Note that the extra parameters should
    not be known parameters (see below).
 -  **DescribeCoverageExtra**: An additional set of keywords to add to
-   DescribeCoverage requests in URL encoded form. e.g. ``&CustNo=775``
+   DescribeCoverage requests in URL encoded form, e.g., ``&CustNo=775``
 
    **Elements that may be needed to deal with server quirks (GDAL 2.3):**
 

--- a/doc/source/drivers/raster/wld.rst
+++ b/doc/source/drivers/raster/wld.rst
@@ -4,7 +4,7 @@
 WLD -- ESRI World File
 ================================================================================
 
-A world file file is a plain ASCII text file consisting of six values
+A world file is a plain ASCII text file consisting of six values
 separated by newlines. The format is:
 
 .. code-block::

--- a/doc/source/drivers/raster/wmts.rst
+++ b/doc/source/drivers/raster/wmts.rst
@@ -9,7 +9,7 @@ WMTS -- OGC Web Map Tile Service
 .. build_dependencies:: libcurl
 
 Access to WMTS layers is possible with the GDAL WMTS
-client driver (needs Curl support). It support both RESTful and KVP
+client driver (needs Curl support). It supports both RESTful and KVP
 protocols.
 
 Driver capabilities
@@ -89,7 +89,7 @@ The following open options are available:
 -  .. oo:: URL
 
       URL (or filename for local files) to GetCapabilities response document.
-      Required if not specified in the connection string (e.g if using "WMTS:" only)
+      Required if not specified in the connection string (e.g., if using "WMTS:" only)
 
 -  .. oo:: LAYER
 
@@ -212,7 +212,7 @@ It is important that there be no spaces or other content before the
                                                                            Byte)
 <ExtendBeyondDateLine>false</ExtendBeyondDateLine>                         Whether to make the extent go over dateline and warp tile requests. Only appropriate when the 2 following
                                                                            conditions are met (optional, defaults to false): for a geodetic SRS or EPSG:3857, with tile matrix sets such
-                                                                           as the whole [-180,180] range of longitude is entirely covered by an integral number of tiles (e.g.
+                                                                           as the whole [-180,180] range of longitude is entirely covered by an integral number of tiles (e.g.,
                                                                            GoogleMapsCompatible). AND when the layer BoundingBox in the SRS of the tile matrix set covers the whole
                                                                            [-180,180] range of longitude, and that there is another BoundingBox in another SRS that is centered around
                                                                            longitude 180. If such alternate BoundingBox is not present in the GetCapabilities document, DataWindow must be

--- a/doc/source/drivers/raster/zarr.rst
+++ b/doc/source/drivers/raster/zarr.rst
@@ -15,7 +15,7 @@ Zarr is a format for the storage of chunked, compressed, N-dimensional arrays.
 This format is supported for read and write access, and using the traditional
 2D raster API or the multidimensional API
 
-The driver supports the Zarr V2 an V3 specifications. It also supports Kerchunk reference
+The driver supports the Zarr V2 and V3 specifications. It also supports Kerchunk reference
 files since GDAL 3.11. See also :ref:`raster.icechunk`.
 
 Local and cloud storage (see :ref:`virtual_file_systems`) are supported in read and write.
@@ -53,7 +53,7 @@ a directory that contains a :file:`zarr.json` file (root of the dataset).
 For datasets on file systems where file listing is not reliable, as often with
 /vsicurl/, it is also possible to prefix the directory name with ``ZARR:``,
 and it is necessary to surround the /vsicurl/-prefixed URL with double quotes.
-e.g `ZARR:"/vsicurl/https://example.org/foo.zarr"`. Note that when passing such
+e.g., `ZARR:"/vsicurl/https://example.org/foo.zarr"`. Note that when passing such
 string in a command line shell, extra quoting might be necessary to preserve the
 double-quoting.
 
@@ -203,14 +203,14 @@ and decompressors with :cpp:func:`CPLRegisterCompressor` and :cpp:func:`CPLRegis
 XArray _ARRAY_DIMENSIONS
 ------------------------
 
-The driver support the ``_ARRAY_DIMENSIONS`` special attribute used by
+The driver supports the ``_ARRAY_DIMENSIONS`` special attribute used by
 `XArray <http://xarray.pydata.org/en/stable/generated/xarray.open_zarr.html>`__
 to store the dimension names of an array.
 
 NCZarr extensions
 -----------------
 
-The driver support the
+The driver supports the
 `NCZarr v2 <https://www.unidata.ucar.edu/software/netcdf/documentation/NUG/nczarr_head.html>`__
 extensions of storing the dimension names of an array (read-only)
 
@@ -617,7 +617,7 @@ with ``ARRAY:`` using :program:`gdalmdimtranslate`):
       Default to decimal point for ZarrV2 and slash for ZarrV3.
 
 -  .. co:: BLOSC_CNAME
-      :choices: bloclz, lz4, lz4hc, snappy, zlib, zstd
+      :choices: blosclz, lz4, lz4hc, snappy, zlib, zstd
       :default: lz4
 
       Blosc compressor name. Only used when :co:`COMPRESS=BLOSC`.


### PR DESCRIPTION
Fix spelling and grammatical typos across raster driver documentation files and standardize instances of 'e.g.' and 'eg.' to 'e.g.,'.

In doc/source/drivers/raster.

I spotted the first `e.g` and then gemini 3.7 flash found the rest.

## AI tool usage

 - [x] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.
