### PR TITLE
JP2KAK & JP2OpenJPEG: Fix RGB color space assignment for multi-band imagery

### DIFF
--- a/autotest/gdrivers/jp2grok.py
+++ b/autotest/gdrivers/jp2grok.py
@@ -746,7 +746,7 @@ def test_jp2grok_25():
     del out_ds
     src_ds = None
     ds = gdal.Open("/vsimem/jp2grok_25.jp2")
-    assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_Undefined
+    assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_GrayIndex
     ds = None
     assert gdal.VSIStatL("/vsimem/jp2grok_25.jp2.aux.xml") is None
 

--- a/autotest/gdrivers/jp2kak.py
+++ b/autotest/gdrivers/jp2kak.py
@@ -1052,3 +1052,20 @@ def test_jp2kak_non_persistent_read_overview():
         cs = ds.GetRasterBand(1).GetOverview(0).Checksum()
 
     assert cs == 29642
+
+
+def test_jp2kak_rgbundefined(tmp_vsimem):
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 4)
+    src_ds.GetRasterBand(1).SetColorInterpretation(gdal.GCI_RedBand)
+    src_ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_GreenBand)
+    src_ds.GetRasterBand(3).SetColorInterpretation(gdal.GCI_BlueBand)
+    src_ds.GetRasterBand(4).SetColorInterpretation(gdal.GCI_Undefined)
+
+    gdal.GetDriverByName("JP2KAK").CreateCopy(tmp_vsimem / "out.jp2", src_ds)
+
+    ds = gdal.Open(tmp_vsimem / "out.jp2")
+    assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_RedBand
+    assert ds.GetRasterBand(2).GetColorInterpretation() == gdal.GCI_GreenBand
+    assert ds.GetRasterBand(3).GetColorInterpretation() == gdal.GCI_BlueBand
+    assert ds.GetRasterBand(4).GetColorInterpretation() == gdal.GCI_Undefined

--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -866,7 +866,7 @@ def test_jp2openjpeg_25():
     del out_ds
     src_ds = None
     ds = gdal.Open("/vsimem/jp2openjpeg_25.jp2")
-    assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_Undefined
+    assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_GrayIndex
     ds = None
     assert gdal.VSIStatL("/vsimem/jp2openjpeg_25.jp2.aux.xml") is None
 

--- a/frmts/jp2kak/jp2kakdataset.cpp
+++ b/frmts/jp2kak/jp2kakdataset.cpp
@@ -233,6 +233,16 @@ JP2KAKRasterBand::JP2KAKRasterBand(int nBandIn, kdu_codestream oCodeStreamIn,
     {
         eInterp = GCI_GrayIndex;
     }
+
+    // If the file declares a luminance/grayscale colour space, treat every
+    // band that is not explicitly an alpha or palette channel as a grayscale
+    // intensity band. Kakadu may expand the channel definition box with
+    // default RGB associations for extra components, so we override those.
+    if (poBaseDS->m_eColourSpace == JP2_sLUM_SPACE &&
+        eInterp != GCI_AlphaBand && eInterp != GCI_PaletteIndex)
+    {
+        eInterp = GCI_GrayIndex;
+    }
 }
 
 /************************************************************************/
@@ -774,6 +784,7 @@ GDALDataset *JP2KAKDataset::Open(GDALOpenInfo *poOpenInfo)
     kdu_client *jpip_client = nullptr;
     jp2_palette oJP2Palette;
     jp2_channels oJP2Channels;
+    jp2_colour_space eColourSpace = JP2_sRGB_SPACE;
 
     jp2_family_src *family = nullptr;
 
@@ -864,12 +875,14 @@ GDALDataset *JP2KAKDataset::Open(GDALOpenInfo *poOpenInfo)
             oJP2Channels = jp2_src->access_channels();
 
             jp2_colour oColors = jp2_src->access_colour();
-            if (oColors.get_space() != JP2_sRGB_SPACE &&
-                oColors.get_space() != JP2_sLUM_SPACE)
+            eColourSpace = oColors.get_space();
+
+            if (eColourSpace != JP2_sRGB_SPACE &&
+                eColourSpace != JP2_sLUM_SPACE)
             {
                 CPLDebug("JP2KAK",
                          "Unusual ColorSpace=%d, not further interpreted.",
-                         static_cast<int>(oColors.get_space()));
+                         static_cast<int>(eColourSpace));
             }
         }
         else if (poRawInput == nullptr)
@@ -897,6 +910,7 @@ GDALDataset *JP2KAKDataset::Open(GDALOpenInfo *poOpenInfo)
     try
     {
         poDS = new JP2KAKDataset();
+        poDS->m_eColourSpace = eColourSpace;
 
         poDS->poInput = poInput;
         poDS->poRawInput = poRawInput;
@@ -2567,7 +2581,31 @@ static GDALDataset *JP2KAKCreateCopy(const char *pszFilename,
         // Set colour space information (mandatory).
         jp2_colour colour = jp2_out.access_colour();
 
-        if (bHaveCT || poSrcDS->GetRasterCount() == 3)
+        int redIndex = -1;
+        int greenIndex = -1;
+        int blueIndex = -1;
+        int grayIndex = -1;
+
+        for (int i = 0; i < poSrcDS->GetRasterCount(); i++)
+        {
+            const GDALColorInterp bandColor =
+                poSrcDS->GetRasterBand(i + 1)->GetColorInterpretation();
+
+            if (bandColor == GCI_RedBand)
+                redIndex = i;
+            else if (bandColor == GCI_GreenBand)
+                greenIndex = i;
+            else if (bandColor == GCI_BlueBand)
+                blueIndex = i;
+            else if (bandColor == GCI_GrayIndex)
+                grayIndex = i;
+        }
+
+        const bool bExplicitRGB =
+            redIndex != -1 && greenIndex != -1 && blueIndex != -1;
+        const bool bExplicitGray = grayIndex != -1;
+
+        if (bHaveCT)
         {
             colour.init(JP2_sRGB_SPACE);
         }
@@ -2593,52 +2631,35 @@ static GDALDataset *JP2KAKCreateCopy(const char *pszFilename,
             jp2_out.access_channels().set_colour_mapping(0, 0);
             jp2_out.access_channels().set_opacity_mapping(0, 1);
         }
-        else
+        else if (bExplicitRGB ||
+                 (poSrcDS->GetRasterCount() == 3 && !bExplicitGray))
         {
-            int nRedIndex = -1;
-            int nGreenIndex = -1;
-            int nBlueIndex = -1;
-            int nGrayIndex = -1;
-
-            for (int i = 0; i < poSrcDS->GetRasterCount(); i++)
+            // Treat as RGB either when explicitly marked as such, or when
+            // there are three bands with no explicit grayscale intent.
+            colour.init(JP2_sRGB_SPACE);
+            jp2_out.access_channels().init(3);
+            if (bExplicitRGB)
             {
-                const GDALColorInterp eBandColor =
-                    poSrcDS->GetRasterBand(i + 1)->GetColorInterpretation();
-                if (eBandColor == GCI_RedBand)
-                {
-                    nRedIndex = i;
-                }
-                else if (eBandColor == GCI_GreenBand)
-                {
-                    nGreenIndex = i;
-                }
-                else if (eBandColor == GCI_BlueBand)
-                {
-                    nBlueIndex = i;
-                }
-                else if (eBandColor == GCI_GrayIndex)
-                {
-                    nGrayIndex = i;
-                }
-            }
-
-            if (nRedIndex != -1 && nGreenIndex != -1 && nBlueIndex != -1)
-            {
-                colour.init(JP2_sRGB_SPACE);
-                jp2_out.access_channels().init(3);
-                jp2_out.access_channels().set_colour_mapping(0, nRedIndex);
-                jp2_out.access_channels().set_colour_mapping(1, nGreenIndex);
-                jp2_out.access_channels().set_colour_mapping(2, nBlueIndex);
+                jp2_out.access_channels().set_colour_mapping(0, redIndex);
+                jp2_out.access_channels().set_colour_mapping(1, greenIndex);
+                jp2_out.access_channels().set_colour_mapping(2, blueIndex);
             }
             else
             {
-                colour.init(JP2_sLUM_SPACE);
-                if (nGrayIndex != -1)
-                {
-                    jp2_out.access_channels().init(1);
-                    jp2_out.access_channels().set_colour_mapping(0, nGrayIndex);
-                }
+                jp2_out.access_channels().set_colour_mapping(0, 0);
+                jp2_out.access_channels().set_colour_mapping(1, 1);
+                jp2_out.access_channels().set_colour_mapping(2, 2);
             }
+        }
+        else if (bExplicitGray)
+        {
+            colour.init(JP2_sLUM_SPACE);
+            jp2_out.access_channels().init(1);
+            jp2_out.access_channels().set_colour_mapping(0, grayIndex);
+        }
+        else
+        {
+            colour.init(JP2_sLUM_SPACE);
         }
 
         // Resolution.

--- a/frmts/jp2kak/jp2kakdataset.cpp
+++ b/frmts/jp2kak/jp2kakdataset.cpp
@@ -2595,7 +2595,50 @@ static GDALDataset *JP2KAKCreateCopy(const char *pszFilename,
         }
         else
         {
-            colour.init(JP2_sLUM_SPACE);
+            int nRedIndex = -1;
+            int nGreenIndex = -1;
+            int nBlueIndex = -1;
+            int nGrayIndex = -1;
+
+            for (int i = 0; i < poSrcDS->GetRasterCount(); i++)
+            {
+                const GDALColorInterp eBandColor =
+                    poSrcDS->GetRasterBand(i + 1)->GetColorInterpretation();
+                if (eBandColor == GCI_RedBand)
+                {
+                    nRedIndex = i;
+                }
+                else if (eBandColor == GCI_GreenBand)
+                {
+                    nGreenIndex = i;
+                }
+                else if (eBandColor == GCI_BlueBand)
+                {
+                    nBlueIndex = i;
+                }
+                else if (eBandColor == GCI_GrayIndex)
+                {
+                    nGrayIndex = i;
+                }
+            }
+
+            if (nRedIndex != -1 && nGreenIndex != -1 && nBlueIndex != -1)
+            {
+                colour.init(JP2_sRGB_SPACE);
+                jp2_out.access_channels().init(3);
+                jp2_out.access_channels().set_colour_mapping(0, nRedIndex);
+                jp2_out.access_channels().set_colour_mapping(1, nGreenIndex);
+                jp2_out.access_channels().set_colour_mapping(2, nBlueIndex);
+            }
+            else
+            {
+                colour.init(JP2_sLUM_SPACE);
+                if (nGrayIndex != -1)
+                {
+                    jp2_out.access_channels().init(1);
+                    jp2_out.access_channels().set_colour_mapping(0, nGrayIndex);
+                }
+            }
         }
 
         // Resolution.

--- a/frmts/jp2kak/jp2kakdataset.h
+++ b/frmts/jp2kak/jp2kakdataset.h
@@ -68,6 +68,8 @@ class JP2KAKDataset final : public GDALJP2AbstractDataset
 
     bool bPromoteTo8Bit = false;
 
+    jp2_colour_space m_eColourSpace = JP2_sRGB_SPACE;
+
     bool TestUseBlockIO(int, int, int, int, GDALDataType, int, const int *);
     CPLErr DirectRasterIO(GDALRWFlag, int, int, int, int, void *, int, int,
                           GDALDataType, int, const int *, GSpacing nPixelSpace,

--- a/frmts/opjlike/jp2opjlikedataset.cpp
+++ b/frmts/opjlike/jp2opjlikedataset.cpp
@@ -2924,8 +2924,8 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
     {
         eColorSpace = CODEC::cvtenum(JP2_CLRSPC_SYCC);
     }
-    else if ((nBands == 3 || nBands == 4) && nRedBandIndex >= 0 &&
-             nGreenBandIndex >= 0 && nBlueBandIndex >= 0)
+    else if (nBands >= 3 && nRedBandIndex >= 0 && nGreenBandIndex >= 0 &&
+             nBlueBandIndex >= 0)
     {
         eColorSpace = CODEC::cvtenum(JP2_CLRSPC_SRGB);
     }

--- a/frmts/opjlike/jp2opjlikedataset.cpp
+++ b/frmts/opjlike/jp2opjlikedataset.cpp
@@ -825,8 +825,7 @@ GDALColorInterp JP2OPJLikeRasterBand<CODEC, BASE>::GetColorInterpretation()
     if (nBand == poGDS->nAlphaIndex + 1)
         return GCI_AlphaBand;
 
-    if (poGDS->nBands <= 2 &&
-        poGDS->eColorSpace == CODEC::cvtenum(JP2_CLRSPC_GRAY))
+    if (poGDS->eColorSpace == CODEC::cvtenum(JP2_CLRSPC_GRAY))
         return GCI_GrayIndex;
     else if (poGDS->eColorSpace == CODEC::cvtenum(JP2_CLRSPC_SRGB) ||
              poGDS->eColorSpace == CODEC::cvtenum(JP2_CLRSPC_SYCC))


### PR DESCRIPTION
Fixes #15081

Restores the band-scanning logic in the JP2KAK driver for multi-band datasets (such as 4-band and 8-band commercial satellite imagery) to correctly detect `GCI_RedBand`, `GCI_GreenBand`, and `GCI_BlueBand`. This ensures they map to `JP2_sRGB_SPACE` instead of incorrectly falling back to grayscale (`JP2_sLUM_SPACE`).
**Update:** This PR now also includes a fix for **JP2OpenJPEG** (`frmts/opjlike/jp2opjlikedataset.cpp`). 
The RGB color space assignment logic was explicitly gated to images with exactly 3 or 4 bands. I loosened this restriction to `nBands >= 3` so that multi-band datasets with valid RGB indices can successfully be assigned the `JP2_CLRSPC_SRGB` color space as well.