### PR TITLE
GDALMathOperationMDArray: use count, not dim size, in the stride check

### DIFF
--- a/autotest/gcore/multidim.py
+++ b/autotest/gcore/multidim.py
@@ -2583,3 +2583,25 @@ def test_multidim_array_arithmetic_coordinate_variables():
     assert coordinates.WriteString("varX varY") == 0
 
     assert len((ar + ar).GetCoordinateVariables()) == 2
+
+
+def test_multidim_array_arithmetic_read_with_buffer_stride():
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("")
+    rg = mem_ds.GetRootGroup()
+    dimY = rg.CreateDimension("Y", None, None, 2)
+    dimX = rg.CreateDimension("X", None, None, 2)
+    ar = rg.CreateMDArray(
+        "ar", [dimY, dimX], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    ar.Write(struct.pack("d" * 4, 1, 2, 3, 4))
+
+    # Reading the first column into a buffer shaped like the whole array
+    # puts the two values at offsets 0 and 2.
+    kwargs = {"count": [2, 1], "buffer_stride": [2, 1]}
+    assert struct.unpack("d" * 3, ar.Read(**kwargs)) == (1, 0, 3)
+    assert struct.unpack("d" * 3, (ar + ar).Read(**kwargs)) == (2, 0, 6)
+    assert struct.unpack("d" * 3, (ar * ar).Read(**kwargs)) == (1, 0, 9)
+    assert struct.unpack("d" * 3, (ar / ar).Read(**kwargs)) == (1, 0, 1)
+
+    assert struct.unpack("d" * 4, (ar + ar).Read()) == (2, 4, 6, 8)

--- a/gcore/multidim/gdalmultidim_array_maths.cpp
+++ b/gcore/multidim/gdalmultidim_array_maths.cpp
@@ -561,8 +561,11 @@ bool GDALMathOperationMDArray::IRead(const GUInt64 *arrayStartIdx,
             bRowMajorBufferStride = false;
             break;
         }
-        nExpectedStrideValue = static_cast<GPtrDiff_t>(nExpectedStrideValue *
-                                                       apoDims[i]->GetSize());
+        // The expected stride derives from the requested count, not
+        // from the size of the array dimensions, which are only equal when
+        // the whole array is requested.
+        nExpectedStrideValue =
+            static_cast<GPtrDiff_t>(nExpectedStrideValue * count[i]);
     }
 
     size_t nElts = 1;


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

Fixes the contiguous-buffer fast path in `GDALMathOperationMDArray::IRead()`, which built the expected stride from the array dimensions instead of the requested `count`. Reading a sub-window of `a + b` into a buffer whose strides match the full-array layout then wrote the values packed instead of strided - wrong placement, no error.

`count[i]` is what `gdalmultidim_array_mask.cpp:357` and `CheckReadWriteParams()` already use.

Introduced by 1a33cddfed when the fast path was added.

Test in `autotest/gcore/multidim.py`. Existing coverage only ever does full reads, i.e. `count == dim size`, which is the one case where the old formula happened to be right. With the fix backed out, three of the five new assertions fail.

## What are related issues/pull requests?
Fixes #15083
## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 26.04
* Compiler: gcc 15.2.0
