### PR TITLE
gdal raster select: allow selecting a range of bands

### DIFF
--- a/apps/gdalalg_raster_select.cpp
+++ b/apps/gdalalg_raster_select.cpp
@@ -201,8 +201,7 @@ GDALRasterSelectAlgorithm::GDALRasterSelectAlgorithm(bool standaloneStep)
                 {
                     if (!STARTS_WITH(v.c_str(), "mask") &&
                         v.find(":") == std::string::npos &&
-                        !(CPLGetValueType(v.c_str()) == CPL_VALUE_INTEGER &&
-                          atoi(v.c_str()) >= 1) &&
+                        CPLGetValueType(v.c_str()) != CPL_VALUE_INTEGER &&
                         !cpl::contains(oSetValidColorInterp,
                                        CPLString(v).tolower()))
                     {
@@ -341,10 +340,36 @@ bool GDALRasterSelectAlgorithm::RunStep(GDALPipelineStepRunContext &)
                     aosOptions.AddString(std::to_string(iBand));
                 }
             }
-            else
+            else if (cpl::equals_ci(v, "mask"))
             {
                 aosOptions.AddString("-b");
-                aosOptions.AddString(CPLString(v).replaceAll(':', ',').c_str());
+                aosOptions.AddString(v);
+            }
+            else
+            {
+                const auto maybeBand = cpl::strict_parse<int>(v);
+                if (!maybeBand)
+                {
+                    CPLError(CE_Failure, CPLE_IllegalArg, "Invalid band: %s",
+                             v.c_str());
+                    return false;
+                }
+                const int nBands = poSrcDS->GetRasterCount();
+                int iBand = maybeBand.value();
+                if (iBand < 0)
+                {
+                    iBand += nBands + 1;
+                }
+
+                if (iBand > nBands || iBand < 1)
+                {
+                    CPLError(CE_Failure, CPLE_IllegalArg, "Invalid band: %s",
+                             v.c_str());
+                    return false;
+                }
+
+                aosOptions.AddString("-b");
+                aosOptions.AddString(std::to_string(iBand));
             }
         }
     }

--- a/apps/gdalalg_raster_select.cpp
+++ b/apps/gdalalg_raster_select.cpp
@@ -24,6 +24,115 @@
 #define _(x) (x)
 #endif
 
+static std::optional<std::vector<int>> ParseBandRange(const std::string &v,
+                                                      int nBands)
+{
+    CPLStringList bandSel = cpl::tokenize_string(v, ":", CSLT_ALLOWEMPTYTOKENS);
+    if (bandSel.Count() < 2 || bandSel.Count() > 3)
+    {
+        CPLError(CE_Failure, CPLE_IllegalArg, "Invalid value for --band: %s",
+                 v.c_str());
+        return std::nullopt;
+    }
+    int nFirst = 1;
+    const auto osvFirst = cpl::trim(bandSel[0]);
+    if (!osvFirst.empty())
+    {
+        const auto maybeStart = cpl::strict_parse<int>(osvFirst);
+        if (maybeStart.has_value())
+        {
+            nFirst = maybeStart.value();
+            if (nFirst < 0)
+            {
+                nFirst += nBands + 1;
+            }
+            if (nFirst > nBands || nFirst <= 0)
+            {
+                CPLError(CE_Failure, CPLE_IllegalArg, "Invalid band: %s",
+                         bandSel[0]);
+                return std::nullopt;
+            }
+        }
+        else
+        {
+            CPLError(CE_Failure, CPLE_IllegalArg,
+                     "Failed to parse start value of --band range: %s",
+                     bandSel[0]);
+            return std::nullopt;
+        }
+    }
+    int nLast = nBands;
+    const auto osvLast = cpl::trim(bandSel[1]);
+    if (!osvLast.empty())
+    {
+        const auto maybeLast = cpl::strict_parse<int>(osvLast);
+        if (maybeLast.has_value())
+        {
+            nLast = maybeLast.value();
+            if (nLast < 0)
+            {
+                nLast += nBands + 1;
+            }
+            if (nLast > nBands || nLast <= 0)
+            {
+                CPLError(CE_Failure, CPLE_IllegalArg, "Invalid band: %s",
+                         bandSel[1]);
+                return std::nullopt;
+            }
+        }
+        else
+        {
+            CPLError(CE_Failure, CPLE_IllegalArg,
+                     "Failed to parse stop value of --band range: %s",
+                     bandSel[1]);
+            return std::nullopt;
+        }
+    }
+    int nStep = nFirst < nLast ? 1 : -1;
+    if (bandSel.Count() == 3)
+    {
+        const auto maybeStep = cpl::strict_parse<int>(bandSel[2]);
+        if (maybeStep.has_value())
+        {
+            nStep = maybeStep.value();
+        }
+        else
+        {
+            CPLError(CE_Failure, CPLE_IllegalArg,
+                     "Failed to parse step value of --band range: %s",
+                     bandSel[2]);
+            return std::nullopt;
+        }
+    }
+
+    if (nFirst < nLast && nStep <= 0)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Step value must be positive");
+        return std::nullopt;
+    }
+    if (nFirst > nLast && nStep >= 0)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Step value must be negative");
+        return std::nullopt;
+    }
+
+    std::vector<int> ret;
+
+    for (int iBand = nFirst; nStep > 0 ? iBand <= nLast : iBand >= nLast;
+         iBand += nStep)
+    {
+        if (iBand < 1 || iBand > nBands)
+        {
+            CPLError(CE_Failure, CPLE_IllegalArg, "Invalid band: %d", iBand);
+            return std::nullopt;
+        }
+
+        ret.push_back(iBand);
+    }
+
+    return ret;
+}
+
 /************************************************************************/
 /*        GDALRasterSelectAlgorithm::GDALRasterSelectAlgorithm()        */
 /************************************************************************/
@@ -91,6 +200,7 @@ GDALRasterSelectAlgorithm::GDALRasterSelectAlgorithm(bool standaloneStep)
                 for (const auto &v : val)
                 {
                     if (!STARTS_WITH(v.c_str(), "mask") &&
+                        v.find(":") == std::string::npos &&
                         !(CPLGetValueType(v.c_str()) == CPL_VALUE_INTEGER &&
                           atoi(v.c_str()) >= 1) &&
                         !cpl::contains(oSetValidColorInterp,
@@ -212,6 +322,20 @@ bool GDALRasterSelectAlgorithm::RunStep(GDALPipelineStepRunContext &)
                     return false;
                 }
                 for (const int iBand : iter->second)
+                {
+                    aosOptions.AddString("-b");
+                    aosOptions.AddString(std::to_string(iBand));
+                }
+            }
+            else if (v.find(':') != std::string::npos)
+            {
+                const auto &aiBands =
+                    ParseBandRange(v, poSrcDS->GetRasterCount());
+                if (!aiBands.has_value())
+                {
+                    return false;
+                }
+                for (int iBand : aiBands.value())
                 {
                     aosOptions.AddString("-b");
                     aosOptions.AddString(std::to_string(iBand));

--- a/autotest/utilities/test_gdalalg_raster_select.py
+++ b/autotest/utilities/test_gdalalg_raster_select.py
@@ -52,6 +52,17 @@ def test_gdalalg_raster_select(tmp_vsimem):
         ]
 
 
+def test_gdalalg_raster_select_negative(tmp_vsimem):
+
+    with gdal.alg.raster.select(
+        input="../gcore/data/rgbsmall.tif", output="", output_format="MEM", band=[-1, 1]
+    ) as alg:
+        ds = alg.Output()
+        assert ds.RasterCount == 2
+        assert ds.GetRasterBand(1).Checksum() == 21349
+        assert ds.GetRasterBand(2).Checksum() == 21212
+
+
 def test_gdalalg_raster_select_mask():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 3, 1)

--- a/autotest/utilities/test_gdalalg_raster_select.py
+++ b/autotest/utilities/test_gdalalg_raster_select.py
@@ -11,6 +11,8 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import struct
+
 import gdaltest
 import pytest
 import test_cli_utilities
@@ -184,6 +186,60 @@ def test_gdalalg_raster_select_by_band_color():
             output_format="MEM",
             band="undefined",
         )
+
+
+@pytest.mark.parametrize(
+    "bands,expected",
+    (
+        ["17:", (17, 18, 19, 20)],
+        [":3", (1, 2, 3)],
+        ["13:15", (13, 14, 15)],
+        ["17::3", (17, 20)],
+        [":4:3", (1, 4)],
+        ["4:16:4", (4, 8, 12, 16)],
+        ["::5", (1, 6, 11, 16)],
+        ["-4:", (17, 18, 19, 20)],
+        ["-4:-6", (17, 16, 15)],
+        ["-4:-6:-2", (17, 15)],
+        [["1:3:2", "2:4:2"], (1, 3, 2, 4)],
+        ["2::100", (2,)],
+        [":", tuple(range(1, 21))],
+        [" : ", tuple(range(1, 21))],
+        ["21:", "Invalid band: 21"],
+        ["-21:", "Invalid band: -21"],
+        ["0:15", "Invalid band: 0"],
+        ["1:3:0", "Step value must be positive"],
+        ["1:3:-1", "Step value must be positive"],
+        ["3:1:0", "Step value must be negative"],
+        ["3:1:1", "Step value must be negative"],
+        ["1:3:5:7", "Invalid value for --band"],
+        ["2.2:3", "Failed to parse start value of --band range"],
+        ["2:3.2", "Failed to parse stop value of --band range"],
+        ["2:3:0.1", "Failed to parse step value of --band range"],
+    ),
+)
+def test_gdalalg_raster_select_range(bands, expected):
+
+    nBands = 20
+    src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1, nBands)
+    for i in range(nBands):
+        src_ds.GetRasterBand(i + 1).Fill(i + 1)
+
+    alg = gdal.Algorithm("raster", "select")
+    alg["input"] = src_ds
+    alg["output"] = ""
+    alg["output-format"] = "MEM"
+    alg["band"] = bands
+
+    if type(expected) is tuple:
+        assert alg.Run()
+        dst_ds = alg.Output()
+        assert dst_ds.RasterCount == len(expected)
+        dat = struct.unpack("B" * len(expected), dst_ds.ReadRaster())
+        assert dat == expected
+    else:
+        with pytest.raises(Exception, match=expected):
+            alg.Run()
 
 
 def test_gdalalg_raster_select_autocomplete():

--- a/doc/source/programs/gdal_raster_select.rst
+++ b/doc/source/programs/gdal_raster_select.rst
@@ -54,6 +54,10 @@ Program-Specific Options
     Starting with GDAL 3.13, <BAND> can also be a color interpretation such
     as "red", "green", "blue", "alpha", "nir", etc.
 
+    Starting with GDAL 3.14, <BAND> can be a range of bands expressed as
+    ``FIRST:LAST`` or ``FIRST:LAST:STEP``. Values of ``FIRST`` and ``LAST``
+    may be negative; for example, ``-2`` would select the second-to-last band.
+
 .. option:: --mask <BAND>
 
     Select one input band to create output dataset mask band.. Bands are numbered from 1.


### PR DESCRIPTION
Initial motivation came from wanting to select every 12th band from a time-series raster to get data for a specific month.

Perhaps the syntax needs to be harmonized with [`GDALMDArray::GetView`](https://gdal.org/en/stable/api/gdalmdarray_cpp.html#_CPPv4NK11GDALMDArray7GetViewERKNSt6stringE), though I would find `1:4` to be a confusing way to select bands 1-3.