### PR TITLE
cpl::strict_parse: fixes for integer types

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -6271,6 +6271,8 @@ TEST_F(test_cpl, strict_parse)
     EXPECT_EQ(cpl::strict_parse<int>("789.1"), std::nullopt);
     EXPECT_EQ(cpl::strict_parse<int>("50000000000000000"), std::nullopt);
     EXPECT_EQ(cpl::strict_parse<int>(""), std::nullopt);
+    EXPECT_EQ(cpl::strict_parse<int>("123c"), std::nullopt);
+    EXPECT_EQ(cpl::strict_parse<int>("Q"), std::nullopt);
 
     EXPECT_EQ(cpl::strict_parse<double>("3.141569"), 3.141569);
     EXPECT_EQ(cpl::strict_parse<double>("3,141569"), std::nullopt);
@@ -6282,6 +6284,8 @@ TEST_F(test_cpl, strict_parse)
     EXPECT_EQ(cpl::strict_parse<double>(""), std::nullopt);
     EXPECT_EQ(cpl::strict_parse<double>("  "), std::nullopt);
     EXPECT_EQ(cpl::strict_parse<double>(" -"), std::nullopt);
+    EXPECT_EQ(cpl::strict_parse<double>("123.2e"), std::nullopt);
+    EXPECT_EQ(cpl::strict_parse<double>("q"), std::nullopt);
 
     EXPECT_EQ(cpl::strict_parse<double>("inf"),
               std::numeric_limits<double>::infinity());

--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -6269,6 +6269,12 @@ TEST_F(test_cpl, strict_parse)
     EXPECT_EQ(cpl::strict_parse<int>("789.0"), 789);
     EXPECT_EQ(cpl::strict_parse<int>("789.0.0"), std::nullopt);
     EXPECT_EQ(cpl::strict_parse<int>("789.1"), std::nullopt);
+    EXPECT_EQ(cpl::strict_parse<int>("789e3"), 789000);
+    EXPECT_EQ(cpl::strict_parse<int>("789.e3"), 789000);
+    EXPECT_EQ(cpl::strict_parse<int>("789.0e3"), 789000);
+    EXPECT_EQ(cpl::strict_parse<int>("789.0e3f"), std::nullopt);
+    EXPECT_EQ(cpl::strict_parse<int>("789.0e3.2"), std::nullopt);
+    EXPECT_EQ(cpl::strict_parse<int>("789.0e30"), std::nullopt);
     EXPECT_EQ(cpl::strict_parse<int>("50000000000000000"), std::nullopt);
     EXPECT_EQ(cpl::strict_parse<int>(""), std::nullopt);
     EXPECT_EQ(cpl::strict_parse<int>("123c"), std::nullopt);

--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -4140,19 +4140,47 @@ std::optional<T> CPL_DLL strict_parse(std::string_view str)
         {
             constexpr char DIGIT_ZERO = '0';
 
-            if (*ptr++ == '.')
+            if (*ptr == '.')
             {
-                while (ptr != end)
+                ptr++;
+                while (ptr != end && *ptr == DIGIT_ZERO)
                 {
-                    if (*ptr++ != DIGIT_ZERO)
+                    ptr++;
+                }
+            }
+
+            if (ptr != end)
+            {
+                if (*ptr == 'e' || *ptr == 'E')
+                {
+                    ptr++;
+                    T exp_result;
+                    auto [exp_ptr, exp_ec] =
+                        std::from_chars(ptr, end, exp_result);
+
+                    if (exp_ec != std::errc())
                     {
                         return std::nullopt;
                     }
+
+                    if (exp_ptr != end)
+                    {
+                        return std::nullopt;
+                    }
+
+                    for (T pow = 0; pow < exp_result; pow++)
+                    {
+                        if (result > std::numeric_limits<T>::max() / 10)
+                        {
+                            return std::nullopt;
+                        }
+                        result *= 10;
+                    }
                 }
-            }
-            else
-            {
-                return std::nullopt;
+                else
+                {
+                    return std::nullopt;
+                }
             }
         }
         else

--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -4150,6 +4150,10 @@ std::optional<T> CPL_DLL strict_parse(std::string_view str)
                     }
                 }
             }
+            else
+            {
+                return std::nullopt;
+            }
         }
         else
         {


### PR DESCRIPTION
First commit fixes a bug allowing cases like '24x' to unexpectedly succeed. Resolving this introduced a problem where a test was relying on `24e0` succeeding, so the second commit extends `cpl::strict_parse` to handle scientific notation for integer types.