### PR TITLE
gdal vector concat: fix use-after-free with streamed output

### DIFF
--- a/apps/gdalalg_vector_concat.cpp
+++ b/apps/gdalalg_vector_concat.cpp
@@ -20,6 +20,7 @@
 #include "ogrsf_frmts.h"
 
 #include "ogrlayerdecorator.h"
+#include "ogrlayerpool.h"
 #include "ogrunionlayer.h"
 #include "ogrwarpedlayer.h"
 
@@ -93,10 +94,37 @@ GDALVectorConcatAlgorithm::~GDALVectorConcatAlgorithm() = default;
 
 class GDALVectorConcatOutputDataset final : public GDALDataset
 {
+    // The layers read lazily from the objects declared before them, and
+    // members are destroyed in reverse declaration order. Do not reorder.
+    std::vector<std::unique_ptr<GDALDataset, GDALDatasetUniquePtrReleaser>>
+        m_srcDatasets{};
+    std::unique_ptr<OGRLayerPool> m_poLayerPool{};
+    std::vector<std::unique_ptr<OGRLayer>> m_tempLayers{};
     std::vector<std::unique_ptr<OGRLayer>> m_layers{};
 
   public:
     GDALVectorConcatOutputDataset() = default;
+
+    /** Add a dataset the layers read from, taking over a reference on it. */
+    void AddSrcDatasetRef(GDALDataset *poSrcDS)
+    {
+        m_srcDatasets.emplace_back(poSrcDS);
+    }
+
+    /** Create the pool used by proxied layers, and return a borrowed pointer. */
+    OGRLayerPool *CreateLayerPool(int nMaxSimultaneouslyOpened)
+    {
+        m_poLayerPool =
+            std::make_unique<OGRLayerPool>(nMaxSimultaneouslyOpened);
+        return m_poLayerPool.get();
+    }
+
+    /** Add an intermediate layer, and return a borrowed pointer to it. */
+    OGRLayer *AddTempLayer(std::unique_ptr<OGRLayer> layer)
+    {
+        m_tempLayers.push_back(std::move(layer));
+        return m_tempLayers.back().get();
+    }
 
     void AddLayer(std::unique_ptr<OGRLayer> layer)
     {
@@ -199,8 +227,10 @@ struct PooledInitData
 {
     std::unique_ptr<GDALDataset> poDS{};
     std::string osDatasetName{};
-    std::vector<std::string> *pInputFormats = nullptr;
-    std::vector<std::string> *pOpenOptions = nullptr;
+    // Copies, and not pointers to the algorithm members, as a layer may be
+    // (re)opened after the algorithm has been destroyed.
+    CPLStringList aosInputFormats{};
+    CPLStringList aosOpenOptions{};
     int iLayer = 0;
 };
 
@@ -209,11 +239,7 @@ static OGRLayer *OpenProxiedLayer(void *pUserData)
     PooledInitData *pData = static_cast<PooledInitData *>(pUserData);
     pData->poDS.reset(GDALDataset::Open(
         pData->osDatasetName.c_str(), GDAL_OF_VECTOR | GDAL_OF_VERBOSE_ERROR,
-        pData->pInputFormats ? CPLStringList(*(pData->pInputFormats)).List()
-                             : nullptr,
-        pData->pOpenOptions ? CPLStringList(*(pData->pOpenOptions)).List()
-                            : nullptr,
-        nullptr));
+        pData->aosInputFormats.List(), pData->aosOpenOptions.List(), nullptr));
     if (!pData->poDS)
         return nullptr;
     return pData->poDS->GetLayer(pData->iLayer);
@@ -361,9 +387,9 @@ bool GDALVectorConcatAlgorithm::RunStep(GDALPipelineStepRunContext &)
 
     auto poUnionDS = std::make_unique<GDALVectorConcatOutputDataset>();
 
+    OGRLayerPool *poLayerPool = nullptr;
     if (nonOpenedDSCount > nMaxSimultaneouslyOpened)
-        m_poLayerPool =
-            std::make_unique<OGRLayerPool>(nMaxSimultaneouslyOpened);
+        poLayerPool = poUnionDS->CreateLayerPool(nMaxSimultaneouslyOpened);
 
     bool ret = true;
     for (const auto &[outLayerName, listOfLayers] : allLayerNames)
@@ -390,19 +416,18 @@ bool GDALVectorConcatAlgorithm::RunStep(GDALPipelineStepRunContext &)
             }
             OGRLayer *poSrcLayer = poSrcDS->GetLayer(layer.iLayer);
 
-            if (m_poLayerPool)
+            if (poLayerPool)
             {
                 auto pData = std::make_unique<PooledInitData>();
                 pData->osDatasetName = layer.osDatasetName;
-                pData->pInputFormats = &m_inputFormats;
-                pData->pOpenOptions = &m_openOptions;
+                pData->aosInputFormats = CPLStringList(m_inputFormats);
+                pData->aosOpenOptions = CPLStringList(m_openOptions);
                 pData->iLayer = layer.iLayer;
                 auto proxiedLayer = std::make_unique<OGRProxiedLayer>(
-                    m_poLayerPool.get(), OpenProxiedLayer, ReleaseProxiedLayer,
+                    poLayerPool, OpenProxiedLayer, ReleaseProxiedLayer,
                     FreeProxiedLayerUserData, pData.release());
                 proxiedLayer->SetDescription(poSrcLayer->GetDescription());
-                m_tempLayersKeeper.push_back(std::move(proxiedLayer));
-                poSrcLayer = m_tempLayersKeeper.back().get();
+                poSrcLayer = poUnionDS->AddTempLayer(std::move(proxiedLayer));
             }
             else if (poTmpDS)
             {
@@ -420,11 +445,9 @@ bool GDALVectorConcatAlgorithm::RunStep(GDALPipelineStepRunContext &)
                     listOfLayers[i].osDatasetName.c_str(),
                     listOfLayers[i].iLayer, poSrcLayer->GetName());
                 ret = !newSrcLayerName.empty() && ret;
-                auto poTmpLayer =
+                papoSrcLayers.get()[i] = poUnionDS->AddTempLayer(
                     std::make_unique<GDALVectorConcatRenamedLayer>(
-                        poSrcLayer, newSrcLayerName);
-                m_tempLayersKeeper.push_back(std::move(poTmpLayer));
-                papoSrcLayers.get()[i] = m_tempLayersKeeper.back().get();
+                        poSrcLayer, newSrcLayerName));
             }
         }
 
@@ -450,13 +473,11 @@ bool GDALVectorConcatAlgorithm::RunStep(GDALPipelineStepRunContext &)
                     ret = (poCT != nullptr) && (poReversedCT != nullptr);
                     if (ret)
                     {
-                        m_tempLayersKeeper.push_back(
+                        papoSrcLayers.get()[i] = poUnionDS->AddTempLayer(
                             std::make_unique<OGRWarpedLayer>(
                                 papoSrcLayers.get()[i], /* iGeomField = */ 0,
                                 /*bTakeOwnership = */ false, std::move(poCT),
                                 std::move(poReversedCT)));
-                        papoSrcLayers.get()[i] =
-                            m_tempLayersKeeper.back().get();
                     }
                 }
             }
@@ -482,6 +503,12 @@ bool GDALVectorConcatAlgorithm::RunStep(GDALPipelineStepRunContext &)
 
     if (ret)
     {
+        for (auto &srcDS : m_inputDataset)
+        {
+            if (GDALDataset *poSrcDS = srcDS.GetDatasetIncreaseRefCount())
+                poUnionDS->AddSrcDatasetRef(poSrcDS);
+        }
+
         m_outputDataset.Set(std::move(poUnionDS));
     }
     return ret;

--- a/apps/gdalalg_vector_concat.h
+++ b/apps/gdalalg_vector_concat.h
@@ -16,7 +16,6 @@
 #include "gdalvectorpipelinestepalgorithm.h"
 
 #include "ogrsf_frmts.h"
-#include "ogrlayerpool.h"
 
 //! @cond Doxygen_Suppress
 
@@ -51,9 +50,6 @@ class GDALVectorConcatAlgorithm /* non final */
     std::string m_fieldStrategy = "union";
     std::string m_srsCrs{};
     std::string m_dstCrs{};
-
-    std::unique_ptr<OGRLayerPool> m_poLayerPool{};
-    std::vector<std::unique_ptr<OGRLayer>> m_tempLayersKeeper{};
 };
 
 /************************************************************************/

--- a/autotest/utilities/test_gdalalg_vector_concat.py
+++ b/autotest/utilities/test_gdalalg_vector_concat.py
@@ -446,3 +446,28 @@ def test_gdalalg_vector_concat_pipeline_nested():
         ds = alg.Output()
         lyr = ds.GetLayer(0)
         assert lyr.GetFeatureCount() == 20
+
+
+@pytest.mark.parametrize("GDAL_VECTOR_CONCAT_MAX_OPENED_DATASETS", ["1", None])
+def test_gdalalg_vector_concat_ds_take_ref(GDAL_VECTOR_CONCAT_MAX_OPENED_DATASETS):
+
+    def build():
+        # alg, and the input datasets it opened, are released when this
+        # returns; only the streamed output dataset survives.
+        return gdal.Run(
+            "vector",
+            "concat",
+            input=["../ogr/data/poly.shp", "../ogr/data/poly.shp"],
+            output_format="stream",
+            output="",
+        ).Output()
+
+    with gdal.config_option(
+        "GDAL_VECTOR_CONCAT_MAX_OPENED_DATASETS",
+        GDAL_VECTOR_CONCAT_MAX_OPENED_DATASETS,
+    ):
+        ds = build()
+
+    lyr = ds.GetLayer(0)
+    assert lyr.GetFeatureCount() == 20
+    assert sum(1 for _ in lyr) == 20


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
Move ownership from the algorithm to `GDALVectorConcatOutputDataset`:

- source datasets are held as `std::vector<std::unique_ptr<GDALDataset, GDALDatasetUniquePtrReleaser>>`,
  filled from `GDALArgDatasetValue::GetDatasetIncreaseRefCount()` - the 2 halves pair up, so there's no manual refcount juggling. Same idiom as `m_apoExtraDS` in `ogr_gensql.h` and `m_apoDatasetsToReleaseRef` in `vrtdataset.h`
- the layer pool and the wrapper layers move out of the algorithm into the output dataset, created there directly instead transferred at the end
- `PooledInitData` keeps `CPLStringList` copies of the formats and open options instead of pointers into the algorithm

No destructor needed: members are destroyed in reverse declaration order, sodeclaring them src-datasets -> pool -> temp layers -> layers gives the right teardown for free. That order matters `~OGRAbstractProxiedLayer` calls
`poPool->UnchainLayer(this)` and `~OGRLayerPool` asserts its MRU list is empty, so getting it wrong cause an assert in debug builds.

Test added. 

## What are related issues/pull requests?
Fixes #15098

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 26.04
* Compiler: gcc (Ubuntu 15.2.0-16ubuntu1) 15.2.0
