### PR TITLE
VRTCreateCopy(): make it emit an error when output file cannot be written and source dataset is multidimensional

### DIFF
--- a/autotest/gdrivers/vrtmultidim.py
+++ b/autotest/gdrivers/vrtmultidim.py
@@ -1241,7 +1241,7 @@ def test_vrtmultidim_createcopy():
     attr.Write("bar")
     attr = None
 
-    with gdal.quiet_errors():
+    with pytest.raises(Exception, match="Failed to open /i_do/not_exist to write"):
         gdal.GetDriverByName("VRT").CreateCopy("/i_do/not_exist", src_ds)
 
     tmpfile = "/vsimem/test.vrt"

--- a/frmts/vrt/vrtdriver.cpp
+++ b/frmts/vrt/vrtdriver.cpp
@@ -273,6 +273,15 @@ static GDALDataset *VRTCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
                 poSrcDS, poDstDS.get(), false, nullptr, nullptr, nullptr) !=
             CE_None)
             return nullptr;
+
+        if (strcmp(pszFilename, "") != 0)
+        {
+            if (poDstDS->FlushCache(true) != CE_None)
+            {
+                poDstDS.reset();
+            }
+        }
+
         if (pfnProgress)
             pfnProgress(1.0, "", pProgressData);
         return poDstDS.release();
@@ -488,9 +497,7 @@ static GDALDataset *VRTCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
 
     if (strcmp(pszFilename, "") != 0)
     {
-        CPLErrorReset();
-        poVRTDS->FlushCache(true);
-        if (CPLGetLastErrorType() != CE_None)
+        if (poVRTDS->FlushCache(true) != CE_None)
         {
             poVRTDS.reset();
         }

--- a/frmts/vrt/vrtmultidim.cpp
+++ b/frmts/vrt/vrtmultidim.cpp
@@ -250,35 +250,10 @@ bool VRTGroup::Serialize() const
     /* -------------------------------------------------------------------- */
     /*      Create the output file.                                         */
     /* -------------------------------------------------------------------- */
-    VSILFILE *fpVRT = VSIFOpenL(m_osFilename.c_str(), "w");
-    if (fpVRT == nullptr)
-    {
-        CPLError(CE_Failure, CPLE_AppDefined,
-                 "Failed to write .vrt file in Serialize().");
-        return false;
-    }
-
     CPLXMLNode *psDSTree = SerializeToXML(m_osVRTPath.c_str());
-    char *pszXML = CPLSerializeXMLTree(psDSTree);
-
+    const bool bOK =
+        CPL_TO_BOOL(CPLSerializeXMLTreeToFile(psDSTree, m_osFilename.c_str()));
     CPLDestroyXMLNode(psDSTree);
-
-    bool bOK = true;
-    if (pszXML)
-    {
-        /* ------------------------------------------------------------------ */
-        /*      Write to disk.                                                */
-        /* ------------------------------------------------------------------ */
-        bOK &= VSIFWriteL(pszXML, 1, strlen(pszXML), fpVRT) == strlen(pszXML);
-        CPLFree(pszXML);
-    }
-    if (VSIFCloseL(fpVRT) != 0)
-        bOK = false;
-    if (!bOK)
-    {
-        CPLError(CE_Failure, CPLE_AppDefined,
-                 "Failed to write .vrt file in Serialize().");
-    }
     return bOK;
 }
 


### PR DESCRIPTION
Also simplify neighbouring code.

Refs #14817
