### PR TITLE
[Backport release/3.13] SQLite: avoid warning when reading geometry column with NULL geometry (3.13.0 regression)

### DIFF
--- a/autotest/ogr/ogr_sqlite.py
+++ b/autotest/ogr/ogr_sqlite.py
@@ -3970,6 +3970,11 @@ def test_ogr_sql_sql_first_geom_null(require_spatialite):
     with ds.ExecuteSQL("SELECT ST_Buffer(geom,0.1), * FROM test") as sql_lyr:
         assert sql_lyr.GetGeometryColumn() == "ST_Buffer(geom,0.1)"
 
+    ds = ogr.Open("data/sqlite/first_geometry_null.db")
+    lyr = ds.GetLayer(0)
+    with gdaltest.error_raised(gdal.CE_None):
+        lyr.GetNextFeature()
+
 
 ###############################################################################
 # Test our overloaded LIKE operator

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitelayer.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitelayer.cpp
@@ -957,7 +957,8 @@ OGRFeature *OGRSQLiteLayer::GetNextRawFeature()
                 poFeature->SetGeomFieldDirectly(iField, poGeometry);
             }
         }
-        else if (!(nSQLite3Type == SQLITE_TEXT || nSQLite3Type == SQLITE_BLOB))
+        else if (!(nSQLite3Type == SQLITE_TEXT || nSQLite3Type == SQLITE_BLOB ||
+                   nSQLite3Type == SQLITE_NULL))
         {
             bUnexpectedType = true;
         }


### PR DESCRIPTION
Backport #15102
 **Authored by:** @rouault