### PR TITLE
autotest: fix tests to not generate, modify or delete files in autotest/ and enforce it

### DIFF
--- a/.github/workflows/coverage/test.sh
+++ b/.github/workflows/coverage/test.sh
@@ -4,6 +4,9 @@ set -eu
 
 export OGR_HANA_CONNECTION_STRING='DRIVER=/usr/sap/hdbclient/libodbcHDB.so;HOST=917df316-4e01-4a10-be54-eac1b6ab15fb.hana.prod-us10.hanacloud.ondemand.com;PORT=443;USER=GDALCI;PASSWORD=u7t!Ukeugzq7'
 
+# Because of MrSID and ECW that create temporary files in the current directory
+export CHECK_NO_UNINTENDED_FILES=NO
+
 ctest -V -j $(nproc)
 
 # Run extra tests depending on services

--- a/.github/workflows/ubuntu_20.04/test.sh
+++ b/.github/workflows/ubuntu_20.04/test.sh
@@ -4,4 +4,7 @@ set -eu
 
 export OGR_HANA_CONNECTION_STRING='DRIVER=/usr/sap/hdbclient/libodbcHDB.so;HOST=917df316-4e01-4a10-be54-eac1b6ab15fb.hana.prod-us10.hanacloud.ondemand.com;PORT=443;USER=GDALCI;PASSWORD=u7t!Ukeugzq7'
 
+# Because of MrSID and ECW that create temporary files in the current directory
+export CHECK_NO_UNINTENDED_FILES=NO
+
 ctest -V -j $(nproc)

--- a/autotest/alg/fillnodata.py
+++ b/autotest/alg/fillnodata.py
@@ -12,11 +12,19 @@
 ###############################################################################
 
 import array
+import os
 import struct
 
 import pytest
 
 from osgeo import gdal
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
+        yield
 
 
 def test_fillnodata_1x1_no_nodata():

--- a/autotest/alg/fillnodata.py
+++ b/autotest/alg/fillnodata.py
@@ -12,19 +12,17 @@
 ###############################################################################
 
 import array
-import os
 import struct
 
+import gdaltest
 import pytest
 
 from osgeo import gdal
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "fillnodata")
 
 
 def test_fillnodata_1x1_no_nodata():

--- a/autotest/alg/polygonize.py
+++ b/autotest/alg/polygonize.py
@@ -12,10 +12,10 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
-import os
 import struct
 from collections import defaultdict
 
+import gdaltest
 import ogrtest
 import pytest
 
@@ -23,10 +23,8 @@ from osgeo import gdal, ogr
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "polygonize")
 
 
 ###############################################################################

--- a/autotest/alg/polygonize.py
+++ b/autotest/alg/polygonize.py
@@ -12,7 +12,7 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
-
+import os
 import struct
 from collections import defaultdict
 
@@ -20,6 +20,14 @@ import ogrtest
 import pytest
 
 from osgeo import gdal, ogr
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
+        yield
+
 
 ###############################################################################
 # Test a fairly simple case, with nodata masking.

--- a/autotest/alg/proximity.py
+++ b/autotest/alg/proximity.py
@@ -11,10 +11,19 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import os
 
 import pytest
 
 from osgeo import gdal
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
+        yield
+
 
 ###############################################################################
 # Test a fairly default case.

--- a/autotest/alg/proximity.py
+++ b/autotest/alg/proximity.py
@@ -11,18 +11,15 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
-import os
-
+import gdaltest
 import pytest
 
 from osgeo import gdal
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "proximity")
 
 
 ###############################################################################

--- a/autotest/alg/warp.py
+++ b/autotest/alg/warp.py
@@ -2306,11 +2306,13 @@ def test_warp_geolocation_array_with_rotation(tmp_path):
     causes a ~ 90 degree rotation. Our input image is a checker of black and
     white, and the expected output is also a non-blurred checker.
     """
-    gdal.Warp(
-        tmp_path / "out.tif",
-        "data/input_for_geoloc_array_with_rotation.tif",
-        options="-r cubic -t_srs EPSG:32640 -to METHOD=GEOLOC_ARRAY -to GEOLOC_ARRAY=data/geoloc_array_with_rotation.tif -tr 30 30",
-    )
+
+    with gdal.config_option("CPL_TMPDIR", tmp_path):
+        gdal.Warp(
+            tmp_path / "out.tif",
+            "data/input_for_geoloc_array_with_rotation.tif",
+            options="-r cubic -t_srs EPSG:32640 -to METHOD=GEOLOC_ARRAY -to GEOLOC_ARRAY=data/geoloc_array_with_rotation.tif -tr 30 30",
+        )
     ds = gdal.Open(tmp_path / "out.tif")
     ref_ds = gdal.Open("data/expected_output_for_geoloc_array_with_rotation.tif")
     assert ds.GetRasterBand(1).Checksum() == ref_ds.GetRasterBand(1).Checksum()

--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -1,6 +1,8 @@
 # coding: utf-8
+import glob
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -126,17 +128,80 @@ def chdir_to_test_file(request):
     os.chdir(old)
 
 
-@pytest.fixture(autouse=True, scope="function")
-def check_no_unintended_side_car_files(request):
-    """Detect if some tests generate unintended side car files that can cause
-    troubles to other tests.
-    """
+def _list_files(root_dir, include_dir=True):
+
+    res = set()
+    for filename in glob.glob(root_dir + "/**", recursive=True):
+        if (
+            "/tmp" not in filename
+            and "\\tmp" not in filename
+            and "__pycache__" not in filename
+            and (include_dir or not os.path.isdir(filename))
+        ):
+            res.add(
+                frozenset(
+                    {"filename": filename, "mtime": os.stat(filename).st_mtime}.items()
+                )
+            )
+
+    return res
+
+
+def _get_check_no_unintended_files():
+    check_no_unintended_files = gdal.GetConfigOption(
+        "CHECK_NO_UNINTENDED_FILES", "SESSION"
+    )
+    assert check_no_unintended_files in ("NO", "SESSION", "FULL", "PARTIAL")
+    return check_no_unintended_files
+
+
+@pytest.fixture(autouse=True, scope="session")
+def check_no_unintended_files_session(request):
+    """Detect if any test generates, modifies or deletes files in autotest/"""
+
+    check_no_unintended_files = _get_check_no_unintended_files()
+    if check_no_unintended_files != "SESSION":
+        yield
+        return
+
+    root_dir = os.path.dirname(Path(__file__).resolve())
+    files_before = _list_files(root_dir, include_dir=False)
+
     yield
 
-    filename = os.path.dirname(__file__) + "/gcore/data/byte.tif.aux.xml"
-    if os.path.exists(filename):
-        os.unlink(filename)
-        assert False, f"{filename} exists but should not"
+    files_after = _list_files(root_dir, include_dir=False)
+    if files_before != files_after:
+        sym_diff = files_before.symmetric_difference(files_after)
+        assert False, f"Files {sym_diff} have been created/modified/deleted"
+
+
+@pytest.fixture(autouse=True, scope="function")
+def check_no_unintended_files_function(request):
+    """Detect if each test generates, modifies or deletes files in autotest/"""
+
+    check_no_unintended_files = _get_check_no_unintended_files()
+    if check_no_unintended_files not in ("FULL", "PARTIAL"):
+        yield
+        return
+
+    if check_no_unintended_files == "FULL":
+        root_dir = os.path.dirname(Path(__file__).resolve())
+    else:
+        # If running tests from autotest/xxxxx, only check that subdirectory
+        cur_dir = os.getcwd()
+        while os.path.basename(os.path.dirname(cur_dir)) != "autotest":
+            cur_dir = os.path.dirname(cur_dir)
+        cur_subdir = os.path.basename(cur_dir)
+        root_dir = os.path.join(os.path.dirname(Path(__file__).resolve()), cur_subdir)
+
+    files_before = _list_files(root_dir)
+
+    yield
+
+    files_after = _list_files(root_dir)
+    if files_before != files_after:
+        sym_diff = files_before.symmetric_difference(files_after)
+        assert False, f"Files {sym_diff} have been created/modified/deleted"
 
 
 def pytest_collection_modifyitems(config, items):

--- a/autotest/gcore/geoloc.py
+++ b/autotest/gcore/geoloc.py
@@ -13,7 +13,6 @@
 ###############################################################################
 
 import array
-import os
 import random
 import struct
 
@@ -24,10 +23,8 @@ from osgeo import gdal, osr
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "geoloc")
 
 
 ###############################################################################

--- a/autotest/gcore/geoloc.py
+++ b/autotest/gcore/geoloc.py
@@ -13,6 +13,7 @@
 ###############################################################################
 
 import array
+import os
 import random
 import struct
 
@@ -20,6 +21,14 @@ import gdaltest
 import pytest
 
 from osgeo import gdal, osr
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
+        yield
+
 
 ###############################################################################
 # Verify warped result.

--- a/autotest/gcore/histogram.py
+++ b/autotest/gcore/histogram.py
@@ -343,9 +343,11 @@ def test_histogram_2(utmsmall_tif):
 
 
 @pytest.mark.require_driver("AAIGRID")
-def test_histogram_3():
+def test_histogram_3(tmp_vsimem):
 
-    ds = gdal.Open("data/int32_withneg.grd")
+    gdal.CopyFile("data/int32_withneg.grd", tmp_vsimem / "test.grd")
+
+    ds = gdal.Open(tmp_vsimem / "test.grd")
     hist = ds.GetRasterBand(1).GetHistogram(
         buckets=21, max=100, min=-100, include_out_of_range=1, approx_ok=0
     )
@@ -360,9 +362,11 @@ def test_histogram_3():
 
 
 @pytest.mark.require_driver("AAIGRID")
-def test_histogram_4():
+def test_histogram_4(tmp_vsimem):
 
-    ds = gdal.Open("data/int32_withneg.grd")
+    gdal.CopyFile("data/int32_withneg.grd", tmp_vsimem / "test.grd")
+
+    ds = gdal.Open(tmp_vsimem / "test.grd")
     hist = ds.GetRasterBand(1).GetHistogram(
         buckets=21, max=100, min=-100, include_out_of_range=0, approx_ok=0
     )
@@ -372,8 +376,6 @@ def test_histogram_4():
     assert hist == exp_hist, "did not get expected histogram."
 
     ds = None
-
-    gdal.Unlink("data/int32_withneg.grd.aux.xml")
 
 
 ###############################################################################

--- a/autotest/gcore/misc.py
+++ b/autotest/gcore/misc.py
@@ -452,7 +452,7 @@ def misc_6_internal(datatype, nBands, setDriversDone):
     ds = None
 
 
-def test_misc_6():
+def test_misc_6(tmp_path):
 
     with gdal.quiet_errors():
 
@@ -473,7 +473,9 @@ def test_misc_6():
         # This is to speed-up the runtime of tests on EXT4 filesystems
         # Do not use this for production environment if you care about data safety
         # w.r.t system/OS crashes, unless you know what you are doing.
-        with gdal.config_option("OGR_SQLITE_SYNCHRONOUS", "OFF"):
+        with gdal.config_options(
+            {"OGR_SQLITE_SYNCHRONOUS": "OFF", "CPL_TMPDIR": tmp_path}
+        ):
 
             datatype = gdal.GDT_UInt8
             setDriversDone = set()
@@ -640,14 +642,11 @@ def test_misc_9():
 # Test VSIBufferedReaderHandle (fix done in r21358)
 
 
-def test_misc_10():
+def test_misc_10(tmp_path):
 
-    try:
-        os.remove("data/byte.tif.gz.properties")
-    except OSError:
-        pass
+    gdal.CopyFile("data/byte.tif.gz", tmp_path / "byte.tif.gz")
 
-    f = gdal.VSIFOpenL("/vsigzip/./data/byte.tif.gz", "rb")
+    f = gdal.VSIFOpenL("/vsigzip/" + str(tmp_path / "byte.tif.gz"), "rb")
     gdal.VSIFReadL(1, 1, f)
     gdal.VSIFSeekL(f, 0, 2)
     gdal.VSIFSeekL(f, 0, 0)
@@ -658,11 +657,6 @@ def test_misc_10():
 
     ar = struct.unpack("B" * 4, data)
     assert ar == (73, 73, 42, 0)
-
-    try:
-        os.remove("data/byte.tif.gz.properties")
-    except OSError:
-        pass
 
 
 ###############################################################################
@@ -698,16 +692,21 @@ def test_misc_11():
 @pytest.mark.skipif(
     gdaltest.is_travis_branch("build-windows-conda"), reason="fails for unknown reason"
 )
-def test_misc_12():
+@pytest.mark.parametrize(
+    "driver_name", [gdal.GetDriver(i).ShortName for i in range(gdal.GetDriverCount())]
+)
+def test_misc_12(driver_name, tmp_vsimem):
 
-    import test_cli_utilities
+    drv = gdal.GetDriverByName(driver_name)
+    md = drv.GetMetadata()
 
-    gdal_translate_path = test_cli_utilities.get_gdal_translate_path()
+    config_options = dict()
+    if driver_name == "COG":
+        config_options["CPL_TMPDIR"] = tmp_vsimem
 
-    for i in range(gdal.GetDriverCount()):
-        drv = gdal.GetDriver(i)
-        md = drv.GetMetadata()
-        if ("DCAP_CREATECOPY" in md or "DCAP_CREATE" in md) and "DCAP_RASTER" in md:
+    if ("DCAP_CREATECOPY" in md or "DCAP_CREATE" in md) and "DCAP_RASTER" in md:
+
+        with gdal.config_options(config_options):
 
             nbands = 1
             if drv.ShortName == "WEBP" or drv.ShortName == "ADRG":
@@ -728,7 +727,7 @@ def test_misc_12():
                 size = 128
 
             src_ds = gdal.GetDriverByName("GTiff").Create(
-                "/vsimem/misc_12_src.tif", size, size, nbands, datatype
+                tmp_vsimem / "misc_12_src.tif", size, size, nbands, datatype
             )
             set_gt = (2, 1.0 / size, 0, 49, 0, -1.0 / size)
             src_ds.SetGeoTransform(set_gt)
@@ -740,44 +739,10 @@ def test_misc_12():
             with gdal.quiet_errors():
                 ds = drv.CreateCopy("/nonexistingpath" + get_filename(drv, ""), src_ds)
             if ds is None and gdal.GetLastErrorMsg() == "":
-                gdal.Unlink("/vsimem/misc_12_src.tif")
                 pytest.fail(
                     "CreateCopy() into non existing dir fails without error message for driver %s"
                     % drv.ShortName
                 )
-            ds = None
-
-            if gdal_translate_path is not None:
-                # Test to detect memleaks
-                ds = gdal.GetDriverByName("VRT").CreateCopy("tmp/misc_12.vrt", src_ds)
-                out, _ = gdaltest.runexternal_out_and_err(
-                    gdal_translate_path
-                    + " -of "
-                    + drv.ShortName
-                    + " tmp/misc_12.vrt /nonexistingpath/"
-                    + get_filename(drv, ""),
-                    check_memleak=False,
-                )
-                del ds
-                gdal.Unlink("tmp/misc_12.vrt")
-
-                # If DEBUG_VSIMALLOC_STATS is defined, this is an easy way
-                # to catch some memory leaks
-                if (
-                    out.find("VSIMalloc + VSICalloc - VSIFree") != -1
-                    and out.find("VSIMalloc + VSICalloc - VSIFree : 0") == -1
-                ):
-                    if (
-                        drv.ShortName == "Rasterlite"
-                        and out.find("VSIMalloc + VSICalloc - VSIFree : 1") != -1
-                    ):
-                        pass
-                    else:
-                        print("memleak detected for driver %s" % drv.ShortName)
-
-            src_ds = None
-
-            gdal.Unlink("/vsimem/misc_12_src.tif")
 
 
 ###############################################################################

--- a/autotest/gcore/multidim.py
+++ b/autotest/gcore/multidim.py
@@ -379,7 +379,7 @@ def test_multidim_getresampled_error_single_dim():
         ar.GetResampled([None], gdal.GRIORA_NearestNeighbour, None)
 
 
-def test_multidim_getresampled_error_too_large_y():
+def test_multidim_getresampled_error_too_large_y(tmp_path):
 
     drv = gdal.GetDriverByName("MEM")
     mem_ds = drv.CreateMultiDimensional("myds")
@@ -390,8 +390,9 @@ def test_multidim_getresampled_error_too_large_y():
         "ar", [dimY, dimX], gdal.ExtendedDataType.Create(gdal.GDT_UInt8)
     )
     new_dimY = rg.CreateDimension("Ynew", None, None, 4 * 1000 * 1000 * 1000)
-    with pytest.raises(Exception, match="Too big size for Y dimension"):
-        ar.GetResampled([new_dimY, None], gdal.GRIORA_NearestNeighbour, None)
+    with gdal.config_option("CPL_TMPDIR", tmp_path):
+        with pytest.raises(Exception, match="Too big size for Y dimension"):
+            ar.GetResampled([new_dimY, None], gdal.GRIORA_NearestNeighbour, None)
 
 
 def test_multidim_getresampled_error_too_large_x():

--- a/autotest/gcore/overviewds.py
+++ b/autotest/gcore/overviewds.py
@@ -243,41 +243,42 @@ def test_overviewds_5(tmp_path):
     shutil.copy("data/sstgeo.tif", tmp_path)
     shutil.copy("data/sstgeo.vrt", tmp_path)
 
-    ds = gdal.Open(tmp_path / "sstgeo.vrt")
-    geoloc_md = ds.GetMetadata("GEOLOCATION")
+    with gdal.config_option("CPL_TMPDIR", tmp_path):
 
-    tr = gdal.Transformer(ds, None, ["METHOD=GEOLOC_ARRAY"])
-    _, ref_pnt = tr.TransformPoint(0, 20, 10)
+        ds = gdal.Open(tmp_path / "sstgeo.vrt")
+        geoloc_md = ds.GetMetadata("GEOLOCATION")
 
-    ds.BuildOverviews("NEAR", overviewlist=[2, 4])
-    ds = None
+        tr = gdal.Transformer(ds, None, ["METHOD=GEOLOC_ARRAY"])
+        _, ref_pnt = tr.TransformPoint(0, 20, 10)
 
-    ds = gdal.Open(tmp_path / "sstgeo.vrt", open_options=["OVERVIEW_LEVEL=0"])
-    got_md = ds.GetMetadata("GEOLOCATION")
+        ds.BuildOverviews("NEAR", overviewlist=[2, 4])
+        ds = None
 
-    for key in geoloc_md:
-        assert ds.GetMetadataItem(key, "GEOLOCATION") == got_md[key]
-        if key == "PIXEL_OFFSET" or key == "LINE_OFFSET":
-            assert float(got_md[key]) == pytest.approx(
-                myfloat(geoloc_md[key]) * 2, abs=1e-1
-            )
-        elif key == "PIXEL_STEP" or key == "LINE_STEP":
-            assert float(got_md[key]) == pytest.approx(
-                myfloat(geoloc_md[key]) / 2, abs=1e-1
-            )
-        elif got_md[key] != geoloc_md[key]:
-            print(got_md[key])
-            print(geoloc_md[key])
-            pytest.fail(key)
+        ds = gdal.Open(tmp_path / "sstgeo.vrt", open_options=["OVERVIEW_LEVEL=0"])
+        got_md = ds.GetMetadata("GEOLOCATION")
 
-    # Really check that the transformer works
-    tr = gdal.Transformer(ds, None, ["METHOD=GEOLOC_ARRAY"])
-    expected_xyz = (20.0 / 2, 10.0 / 2, 0)
-    _, pnt = tr.TransformPoint(1, ref_pnt[0], ref_pnt[1])
+        for key in geoloc_md:
+            assert ds.GetMetadataItem(key, "GEOLOCATION") == got_md[key]
+            if key == "PIXEL_OFFSET" or key == "LINE_OFFSET":
+                assert float(got_md[key]) == pytest.approx(
+                    myfloat(geoloc_md[key]) * 2, abs=1e-1
+                )
+            elif key == "PIXEL_STEP" or key == "LINE_STEP":
+                assert float(got_md[key]) == pytest.approx(
+                    myfloat(geoloc_md[key]) / 2, abs=1e-1
+                )
+            elif got_md[key] != geoloc_md[key]:
+                print(got_md[key])
+                print(geoloc_md[key])
+                pytest.fail(key)
 
-    for i in range(3):
-        assert pnt[i] == pytest.approx(expected_xyz[i], abs=0.5)
-    ds = None
+        # Really check that the transformer works
+        tr = gdal.Transformer(ds, None, ["METHOD=GEOLOC_ARRAY"])
+        expected_xyz = (20.0 / 2, 10.0 / 2, 0)
+        _, pnt = tr.TransformPoint(1, ref_pnt[0], ref_pnt[1])
+
+        for i in range(3):
+            assert pnt[i] == pytest.approx(expected_xyz[i], abs=0.5)
 
 
 ###############################################################################

--- a/autotest/gcore/pam.py
+++ b/autotest/gcore/pam.py
@@ -30,12 +30,7 @@ def startup_and_cleanup():
         yield
 
     try:
-        os.chmod("tmpdirreadonly", stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
-        shutil.rmtree("tmpdirreadonly")
-    except OSError:
-        pass
-    try:
-        shutil.rmtree("tmppamproxydir")
+        shutil.rmtree("tmp/tmppamproxydir")
     except OSError:
         pass
 
@@ -327,24 +322,20 @@ def test_pam_10():
 # Test PamProxyDb mechanism
 
 
-def test_pam_11():
+def test_pam_11(tmp_path):
 
     # Create a read-only directory
-    try:
-        os.chmod("tmpdirreadonly", stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
-        shutil.rmtree("tmpdirreadonly")
-    except OSError:
-        pass
-    os.mkdir("tmpdirreadonly")
-    shutil.copy("data/byte.tif", "tmpdirreadonly/byte.tif")
+    tmpdirreadonly = tmp_path / "tmpdirreadonly"
+    os.mkdir(tmpdirreadonly)
+    shutil.copy("data/byte.tif", tmpdirreadonly / "byte.tif")
 
     # FIXME: how do we create a read-only dir on windows ?
     # The following has no effect
-    os.chmod("tmpdirreadonly", stat.S_IRUSR | stat.S_IXUSR)
+    os.chmod(tmpdirreadonly, stat.S_IRUSR | stat.S_IXUSR)
 
     # Test that the directory is really read-only
     try:
-        f = open("tmpdirreadonly/test", "w")
+        f = open(tmpdirreadonly / "test", "w")
         if f is not None:
             f.close()
             pytest.skip()
@@ -352,7 +343,7 @@ def test_pam_11():
         pass
 
     # Compute statistics --> the saving as .aux.xml should fail
-    ds = gdal.Open("tmpdirreadonly/byte.tif")
+    ds = gdal.Open(tmpdirreadonly / "byte.tif")
     stats = ds.GetRasterBand(1).ComputeStatistics(False)
     assert stats[0] == 74, "did not get expected minimum"
     gdal.ErrorReset()
@@ -364,7 +355,7 @@ def test_pam_11():
     ), "warning was expected at that point"
 
     # Check that we actually have no saved statistics
-    ds = gdal.Open("tmpdirreadonly/byte.tif")
+    ds = gdal.Open(tmpdirreadonly / "byte.tif")
     stats = ds.GetRasterBand(1).GetStatistics(False, False)
     assert stats is None
     ds = None
@@ -373,12 +364,16 @@ def test_pam_11():
     # at the beginning of the process
     import test_py_scripts
 
-    ret = test_py_scripts.run_py_script_as_external_script(".", "pamproxydb", "-test1")
-    assert ret.find("success") != -1, "pamproxydb.py -test1 failed %s" % ret
+    ret = test_py_scripts.run_py_script_as_external_script(
+        ".", "pamproxydb", " ".join(["-test1", str(tmpdirreadonly)])
+    )
+    assert "success" in ret, "pamproxydb.py -test1 failed %s" % ret
 
     # Test loading an existing proxydb
-    ret = test_py_scripts.run_py_script_as_external_script(".", "pamproxydb", "-test2")
-    assert ret.find("success") != -1, "pamproxydb.py -test2 failed %s" % ret
+    ret = test_py_scripts.run_py_script_as_external_script(
+        ".", "pamproxydb", " ".join(["-test2", str(tmpdirreadonly)])
+    )
+    assert "success" in ret, "pamproxydb.py -test2 failed %s" % ret
 
 
 ###############################################################################

--- a/autotest/gcore/pamproxydb.py
+++ b/autotest/gcore/pamproxydb.py
@@ -21,22 +21,24 @@ except OSError:
 
 # Must to be launched from pam.py/pam_11()
 # Test creating a new proxydb
-if len(sys.argv) == 2 and sys.argv[1] == "-test1":
+if len(sys.argv) == 3 and sys.argv[1] == "-test1":
 
     import shutil
 
     from osgeo import gdal
 
     try:
-        shutil.rmtree("tmppamproxydir")
+        shutil.rmtree("tmp/tmppamproxydir")
     except OSError:
         pass
-    os.mkdir("tmppamproxydir")
+    os.mkdir("tmp/tmppamproxydir")
 
-    gdal.SetConfigOption("GDAL_PAM_PROXY_DIR", "tmppamproxydir")
+    tmpdirreadonly = sys.argv[2]
+
+    gdal.SetConfigOption("GDAL_PAM_PROXY_DIR", "tmp/tmppamproxydir")
 
     # Compute statistics. They should be saved in the  .aux.xml in the proxyDB
-    ds = gdal.Open("tmpdirreadonly/byte.tif")
+    ds = gdal.Open(f"{tmpdirreadonly}/byte.tif")
     stats = ds.GetRasterBand(1).ComputeStatistics(False)
     gdal.ErrorReset()
     ds = None
@@ -46,13 +48,20 @@ if len(sys.argv) == 2 and sys.argv[1] == "-test1":
         sys.exit(1)
 
     # Check that the .aux.xml in the proxyDB exists
-    filelist = gdal.ReadDir("tmppamproxydir")
-    if "000000_tmpdirreadonly_byte.tif.aux.xml" not in filelist:
+    filelist = gdal.ReadDir("tmp/tmppamproxydir")
+    aux_xml = None
+    for filename in filelist:
+        if filename.startswith("000000_") and filename.endswith(
+            "tmpdirreadonly_byte.tif.aux.xml"
+        ):
+            aux_xml = "tmp/tmppamproxydir/" + filename
+    if not aux_xml:
         print("did not get find 000000_tmpdirreadonly_byte.tif.aux.xml on filesystem")
+        print(filelist)
         sys.exit(1)
 
     # Test altering a value to check that the file will be used
-    f = open("tmppamproxydir/000000_tmpdirreadonly_byte.tif.aux.xml", "w")
+    f = open(aux_xml, "w")
     f.write("""<PAMDataset>
   <PAMRasterBand band="1">
     <Metadata>
@@ -65,7 +74,7 @@ if len(sys.argv) == 2 and sys.argv[1] == "-test1":
 </PAMDataset>""")
     f.close()
 
-    ds = gdal.Open("tmpdirreadonly/byte.tif")
+    ds = gdal.Open(f"{tmpdirreadonly}/byte.tif")
     filelist = ds.GetFileList()
     if len(filelist) != 2:
         print(
@@ -81,18 +90,24 @@ if len(sys.argv) == 2 and sys.argv[1] == "-test1":
     ds = None
 
     # Check that proxy overviews work
-    ds = gdal.Open("tmpdirreadonly/byte.tif")
+    ds = gdal.Open(f"{tmpdirreadonly}/byte.tif")
     gdal.PushErrorHandler()
     assert ds.BuildOverviews("NEAR", overviewlist=[2]) == gdal.CE_None
     gdal.PopErrorHandler()
     ds = None
 
-    filelist = gdal.ReadDir("tmppamproxydir")
-    if "000001_tmpdirreadonly_byte.tif.ovr" not in filelist:
+    filelist = gdal.ReadDir("tmp/tmppamproxydir")
+    ovr_filename = None
+    for filename in filelist:
+        if filename.startswith("000001_") and filename.endswith(
+            "tmpdirreadonly_byte.tif.ovr"
+        ):
+            ovr_filename = "tmp/tmppamproxydir/" + filename
+    if not ovr_filename:
         print("did not get find 000001_tmpdirreadonly_byte.tif.ovr")
         sys.exit(1)
 
-    ds = gdal.Open("tmpdirreadonly/byte.tif")
+    ds = gdal.Open(f"{tmpdirreadonly}/byte.tif")
     filelist = ds.GetFileList()
     if len(filelist) != 3:
         print(
@@ -113,13 +128,14 @@ if len(sys.argv) == 2 and sys.argv[1] == "-test1":
 
 # Must to be launched from pam.py/pam_11()
 # Test loading an existing proxydb
-if len(sys.argv) == 2 and sys.argv[1] == "-test2":
+if len(sys.argv) == 3 and sys.argv[1] == "-test2":
 
     from osgeo import gdal
 
-    gdal.SetConfigOption("GDAL_PAM_PROXY_DIR", "tmppamproxydir")
+    gdal.SetConfigOption("GDAL_PAM_PROXY_DIR", "tmp/tmppamproxydir")
 
-    ds = gdal.Open("tmpdirreadonly/byte.tif")
+    tmpdirreadonly = sys.argv[2]
+    ds = gdal.Open(f"{tmpdirreadonly}/byte.tif")
     filelist = ds.GetFileList()
     if len(filelist) != 3:
         print(

--- a/autotest/gcore/rasterio.py
+++ b/autotest/gcore/rasterio.py
@@ -26,11 +26,11 @@ from osgeo import gdal
 # Test writing a 1x1 buffer to a 10x6 raster and read it back
 
 
-def test_rasterio_1():
+def test_rasterio_1(tmp_path):
     data = "A".encode("ascii")
 
     drv = gdal.GetDriverByName("GTiff")
-    ds = drv.Create("tmp/rasterio1.tif", 10, 6, 1)
+    ds = drv.Create(tmp_path / "rasterio1.tif", 10, 6, 1)
 
     ds.GetRasterBand(1).Fill(65)
     checksum = ds.GetRasterBand(1).Checksum()
@@ -53,18 +53,17 @@ def test_rasterio_1():
     assert data2 == data, "Didn't get expected buffer "
 
     ds = None
-    drv.Delete("tmp/rasterio1.tif")
 
 
 ###############################################################################
 # Test writing a 5x4 buffer to a 10x6 raster and read it back
 
 
-def test_rasterio_2():
+def test_rasterio_2(tmp_path):
     data = "AAAAAAAAAAAAAAAAAAAA".encode("ascii")
 
     drv = gdal.GetDriverByName("GTiff")
-    ds = drv.Create("tmp/rasterio2.tif", 10, 6, 1)
+    ds = drv.Create(tmp_path / "rasterio2.tif", 10, 6, 1)
 
     ds.GetRasterBand(1).Fill(65)
     checksum = ds.GetRasterBand(1).Checksum()
@@ -87,14 +86,13 @@ def test_rasterio_2():
     assert data2 == data, "Didn't get expected buffer "
 
     ds = None
-    drv.Delete("tmp/rasterio2.tif")
 
 
 ###############################################################################
 # Test extensive read & writes into a non tiled raster
 
 
-def test_rasterio_3():
+def test_rasterio_3(tmp_path):
 
     data = [["" for i in range(4)] for i in range(5)]
     for xsize in range(5):
@@ -104,7 +102,7 @@ def test_rasterio_3():
             data[xsize][ysize] = data[xsize][ysize].encode("ascii")
 
     drv = gdal.GetDriverByName("GTiff")
-    ds = drv.Create("tmp/rasterio3.tif", 10, 6, 1)
+    ds = drv.Create(tmp_path / "rasterio3.tif", 10, 6, 1)
 
     i = 0
     while i < ds.RasterXSize:
@@ -139,14 +137,13 @@ def test_rasterio_3():
         i = i + 1
 
     ds = None
-    drv.Delete("tmp/rasterio3.tif")
 
 
 ###############################################################################
 # Test extensive read & writes into a tiled raster
 
 
-def test_rasterio_4():
+def test_rasterio_4(tmp_path):
 
     data = ["" for i in range(5 * 4)]
     for size in range(5 * 4):
@@ -156,7 +153,7 @@ def test_rasterio_4():
 
     drv = gdal.GetDriverByName("GTiff")
     ds = drv.Create(
-        "tmp/rasterio4.tif",
+        tmp_path / "rasterio4.tif",
         20,
         20,
         1,
@@ -202,7 +199,6 @@ def test_rasterio_4():
             i = i + 3
 
     ds = None
-    drv.Delete("tmp/rasterio4.tif")
 
 
 ###############################################################################
@@ -709,12 +705,12 @@ def test_rasterio_9():
 # Test resampled reading from an overview level (#8794)
 
 
-def test_rasterio_overview_subpixel_resampling():
+def test_rasterio_overview_subpixel_resampling(tmp_vsimem):
 
     gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
-    temp_path = "/vsimem/rasterio_ovr.tif"
+    temp_path = tmp_vsimem / "rasterio_ovr.tif"
     ds = gdal.GetDriverByName("GTiff").Create(temp_path, 8, 8, 1, gdal.GDT_UInt8)
     ds.GetRasterBand(1).WriteArray(
         numpy.array(
@@ -746,7 +742,6 @@ def test_rasterio_overview_subpixel_resampling():
     )
 
     ds = None
-    gdal.Unlink("/vsimem/rasterio_ovr.tif")
 
 
 ###############################################################################
@@ -1032,10 +1027,10 @@ def test_rasterio_nearest_or_mode(dt, resample_alg, use_nan):
 
 
 @pytest.mark.require_driver("AAIGRID")
-def test_rasterio_14():
+def test_rasterio_14(tmp_vsimem):
 
     gdal.FileFromMemBuffer(
-        "/vsimem/rasterio_14.asc",
+        tmp_vsimem / "rasterio_14.asc",
         """ncols        6
 nrows        6
 xllcorner    0
@@ -1050,15 +1045,15 @@ cellsize     0
     )
 
     ds = gdal.Translate(
-        "/vsimem/rasterio_14_out.asc",
-        "/vsimem/rasterio_14.asc",
+        tmp_vsimem / "rasterio_14_out.asc",
+        tmp_vsimem / "rasterio_14.asc",
         options="-of AAIGRID -r average -outsize 50% 50%",
     )
     cs = ds.GetRasterBand(1).Checksum()
     assert cs == 110, ds.ReadAsArray()
 
-    gdal.Unlink("/vsimem/rasterio_14.asc")
-    gdal.Unlink("/vsimem/rasterio_14_out.asc")
+    gdal.Unlink(tmp_vsimem / "rasterio_14.asc")
+    gdal.Unlink(tmp_vsimem / "rasterio_14_out.asc")
 
     ds = gdal.GetDriverByName("MEM").Create("", 1000000, 1)
     ds.GetRasterBand(1).WriteRaster(
@@ -1110,10 +1105,10 @@ cellsize     0
 
 
 @pytest.mark.require_driver("AAIGRID")
-def test_rasterio_average_4by4_to_3by3():
+def test_rasterio_average_4by4_to_3by3(tmp_vsimem):
 
     gdal.FileFromMemBuffer(
-        "/vsimem/test_rasterio_average_4by4_to_3by3.asc",
+        tmp_vsimem / "test.asc",
         """ncols        4
 nrows        4
 xllcorner    0
@@ -1127,7 +1122,7 @@ cellsize     1
 
     ds = gdal.Translate(
         "",
-        "/vsimem/test_rasterio_average_4by4_to_3by3.asc",
+        tmp_vsimem / "test.asc",
         options="-ot Float32 -f MEM -r average -outsize 3 3",
     )
     data = ds.GetRasterBand(1).ReadRaster()
@@ -1142,8 +1137,6 @@ cellsize     1
         9.75,
         14.75,
     )
-
-    gdal.Unlink("/vsimem/test_rasterio_average_4by4_to_3by3.asc")
 
 
 ###############################################################################

--- a/autotest/gcore/tiff_ovr.py
+++ b/autotest/gcore/tiff_ovr.py
@@ -2705,14 +2705,15 @@ def test_tiff_ovr_external_mask_update(tmp_vsimem):
         },
     ],
 )
-def test_tiff_ovr_fallback_to_multiband_overview_generate(config_options):
+def test_tiff_ovr_fallback_to_multiband_overview_generate(config_options, tmp_vsimem):
 
-    filename = "/vsimem/test_tiff_ovr_issue_4932_src.tif"
+    filename = tmp_vsimem / "test_tiff_ovr_issue_4932_src.tif"
     ds = gdal.Translate(
         filename,
         "data/byte.tif",
         options="-b 1 -b 1 -b 1 -co INTERLEAVE=BAND -co TILED=YES -outsize 1024 1024",
     )
+    config_options["CPL_TMPDIR"] = tmp_vsimem
     with gdaltest.config_options(config_options):
         ds.BuildOverviews("NEAR", overviewlist=[2, 4, 8])
     ds = None
@@ -2721,8 +2722,6 @@ def test_tiff_ovr_fallback_to_multiband_overview_generate(config_options):
     cs = ds.GetRasterBand(1).GetOverview(0).Checksum()
     assert cs == 36766
     ds = None
-
-    gdal.GetDriverByName("GTiff").Delete(filename)
 
 
 ###############################################################################

--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -415,30 +415,30 @@ def test_tiff_read_tar_2():
 # Read a .tgz file (with explicit filename)
 
 
-def test_tiff_read_tgz_1():
+def test_tiff_read_tgz_1(tmp_vsimem):
 
-    ds = gdal.Open("/vsitar/./data/byte.tgz/byte.tif")
+    gdal.CopyFile("data/byte.tgz", tmp_vsimem / "byte.tgz")
+
+    ds = gdal.Open(f"/vsitar/{tmp_vsimem}/byte.tgz/byte.tif")
     assert (
         ds.GetRasterBand(1).Checksum() == 4672
     ), "Expected checksum = %d. Got = %d" % (4672, ds.GetRasterBand(1).Checksum())
     ds = None
-
-    gdal.Unlink("data/byte.tgz.properties")
 
 
 ###############################################################################
 # Read a .tgz file (with implicit filename)
 
 
-def test_tiff_read_tgz_2():
+def test_tiff_read_tgz_2(tmp_vsimem):
 
-    ds = gdal.Open("/vsitar/./data/byte.tgz")
+    gdal.CopyFile("data/byte.tgz", tmp_vsimem / "byte.tgz")
+
+    ds = gdal.Open(f"/vsitar/{tmp_vsimem}/byte.tgz")
     assert (
         ds.GetRasterBand(1).Checksum() == 4672
     ), "Expected checksum = %d. Got = %d" % (4672, ds.GetRasterBand(1).Checksum())
     ds = None
-
-    gdal.Unlink("data/byte.tgz.properties")
 
 
 ###############################################################################
@@ -714,15 +714,13 @@ def test_tiff_GTModelTypeGeoKey_only():
 )
 @pytest.mark.require_creation_option("GTiff", "JPEG")
 @gdaltest.disable_exceptions()
-def test_tiff_12bitjpeg():
+def test_tiff_12bitjpeg(tmp_vsimem):
     gdal.ErrorReset()
     with gdal.config_option("CPL_ACCUM_ERROR_MSG", "ON"), gdaltest.error_handler():
 
-        if os.path.exists("data/mandrilmini_12bitjpeg.tif.aux.xml"):
-            os.unlink("data/mandrilmini_12bitjpeg.tif.aux.xml")
-
+        gdal.CopyFile("data/mandrilmini_12bitjpeg.tif", tmp_vsimem / "test.tif")
         try:
-            ds = gdal.Open("data/mandrilmini_12bitjpeg.tif")
+            ds = gdal.Open(tmp_vsimem / "test.tif")
             ds.GetRasterBand(1).ReadRaster(0, 0, 1, 1)
         except Exception:
             ds = None
@@ -741,8 +739,6 @@ def test_tiff_12bitjpeg():
         stats[2] < 2150 or stats[2] > 2180 or str(stats[2]) == "nan"
     ), "did not get expected mean for band1."
     ds = None
-
-    os.unlink("data/mandrilmini_12bitjpeg.tif.aux.xml")
 
 
 ###############################################################################
@@ -4046,10 +4042,18 @@ def test_tiff_read_zstd_corrupted2(tmp_path):
 @pytest.mark.require_creation_option("GTiff", "WEBP")
 def test_tiff_read_webp(tmp_path):
 
+    gdal.CopyFile("data/tif_webp.tif", tmp_path / "tif_webp.tif")
+
     stats = (0, 215, 66.38, 47.186)
-    ut = gdaltest.GDALTest("GTiff", "tif_webp.tif", 1, None, tmpdir=tmp_path)
+    ut = gdaltest.GDALTest(
+        "GTiff",
+        tmp_path / "tif_webp.tif",
+        1,
+        None,
+        tmpdir=tmp_path,
+        filename_absolute=True,
+    )
     ut.testOpen(check_approx_stat=stats, stat_epsilon=1)
-    gdal.Unlink("data/tif_webp.tif.aux.xml")
 
 
 ###############################################################################

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -8463,10 +8463,12 @@ def test_tiff_write_webp(writeImageStructureMetadata):
 @pytest.mark.parametrize("writeImageStructureMetadata", [True, False])
 @pytest.mark.require_creation_option("GTiff", "WEBP")
 @pytest.mark.require_creation_option("GTiff", "WEBP_LOSSLESS")
-def test_tiff_write_tiled_webp(writeImageStructureMetadata):
+def test_tiff_write_tiled_webp(writeImageStructureMetadata, tmp_vsimem):
 
-    filename = "/vsimem/tiff_write_tiled_webp.tif"
-    src_ds = gdal.Open("data/md_ge_rgb_0010000.tif")
+    gdal.CopyFile("data/md_ge_rgb_0010000.tif", tmp_vsimem / "src.tif")
+
+    filename = tmp_vsimem / "tiff_write_tiled_webp.tif"
+    src_ds = gdal.Open(tmp_vsimem / "src.tif")
     with gdaltest.config_option(
         "GTIFF_WRITE_IMAGE_STRUCTURE_METADATA",
         "YES" if writeImageStructureMetadata else "NO",
@@ -8498,19 +8500,18 @@ def test_tiff_write_tiled_webp(writeImageStructureMetadata):
         )
     ds = None
 
-    gdaltest.tiff_drv.Delete(filename)
-    gdal.Unlink("data/md_ge_rgb_0010000.tif.aux.xml")
-
 
 ###############################################################################
 # Test WEBP compression with huge single strip
 
 
 @pytest.mark.require_creation_option("GTiff", "WEBP")
-def test_tiff_write_webp_huge_single_strip():
+def test_tiff_write_webp_huge_single_strip(tmp_vsimem):
 
-    filename = "/vsimem/tif_webp_huge_single_strip.tif"
-    src_ds = gdal.Open("data/tif_webp_huge_single_strip.tif")
+    gdal.CopyFile("data/tif_webp_huge_single_strip.tif", tmp_vsimem / "src.tif")
+
+    filename = tmp_vsimem / "out.tif"
+    src_ds = gdal.Open(tmp_vsimem / "src.tif")
     gdaltest.tiff_drv.CreateCopy(
         filename, src_ds, options=["COMPRESS=WEBP", "BLOCKYSIZE=2001"]
     )
@@ -8527,9 +8528,6 @@ def test_tiff_write_webp_huge_single_strip():
             assert original_stats[i][j] == pytest.approx(
                 got_stats[i][j], abs=1e-1 * abs(original_stats[i][j])
             ), "did not get expected statistics"
-
-    gdaltest.tiff_drv.Delete(filename)
-    gdal.Unlink("data/tif_webp_huge_single_strip.tif.aux.xml")
 
 
 ###############################################################################

--- a/autotest/gcore/transformer.py
+++ b/autotest/gcore/transformer.py
@@ -153,28 +153,29 @@ def test_transformer_homography():
     not gdaltest.vrt_has_open_support(),
     reason="VRT driver open missing",
 )
-def test_transformer_4():
+def test_transformer_4(tmp_path):
 
-    ds = gdal.Open("data/sstgeo.vrt")
-    tr = gdal.Transformer(ds, None, ["METHOD=GEOLOC_ARRAY"])
+    with gdal.config_option("CPL_TMPDIR", tmp_path):
+        ds = gdal.Open("data/sstgeo.vrt")
+        tr = gdal.Transformer(ds, None, ["METHOD=GEOLOC_ARRAY"])
 
-    success, pnt = tr.TransformPoint(0, 20, 10)
+        success, pnt = tr.TransformPoint(0, 20, 10)
 
-    assert (
-        success
-        and pnt[0] == pytest.approx(-81.961341857910156, abs=0.000001)
-        and pnt[1] == pytest.approx(29.612689971923828, abs=0.000001)
-        and pnt[2] == 0
-    ), "got wrong forward transform result."
+        assert (
+            success
+            and pnt[0] == pytest.approx(-81.961341857910156, abs=0.000001)
+            and pnt[1] == pytest.approx(29.612689971923828, abs=0.000001)
+            and pnt[2] == 0
+        ), "got wrong forward transform result."
 
-    success, pnt = tr.TransformPoint(1, pnt[0], pnt[1], pnt[2])
+        success, pnt = tr.TransformPoint(1, pnt[0], pnt[1], pnt[2])
 
-    assert (
-        success
-        and pnt[0] == pytest.approx(20, abs=0.000001)
-        and pnt[1] == pytest.approx(10, abs=0.000001)
-        and pnt[2] == 0
-    ), "got wrong reverse transform result."
+        assert (
+            success
+            and pnt[0] == pytest.approx(20, abs=0.000001)
+            and pnt[1] == pytest.approx(10, abs=0.000001)
+            and pnt[2] == 0
+        ), "got wrong reverse transform result."
 
 
 ###############################################################################

--- a/autotest/gcore/vsifile.py
+++ b/autotest/gcore/vsifile.py
@@ -1218,9 +1218,13 @@ def test_vsifile_vsizip_error():
 # Test bugfix for https://github.com/OSGeo/gdal/issues/5225
 
 
-def test_vsifile_vsitar_gz_with_tar_multiple_of_65536_bytes():
+def test_vsifile_vsitar_gz_with_tar_multiple_of_65536_bytes(tmp_path):
 
-    f = gdal.VSIFOpenL("/vsitar/data/tar_of_65536_bytes.tar.gz/zero.bin", "rb")
+    gdal.CopyFile(
+        "data/tar_of_65536_bytes.tar.gz", tmp_path / "tar_of_65536_bytes.tar.gz"
+    )
+
+    f = gdal.VSIFOpenL(f"/vsitar/{tmp_path}/tar_of_65536_bytes.tar.gz/zero.bin", "rb")
     assert f is not None
     read_bytes = gdal.VSIFReadL(1, 65024, f)
     assert gdal.VSIFEofL(f) == 0
@@ -1230,7 +1234,6 @@ def test_vsifile_vsitar_gz_with_tar_multiple_of_65536_bytes():
     assert gdal.VSIFErrorL(f) == 0
     gdal.VSIFCloseL(f)
     assert read_bytes == b"\x00" * 65024
-    gdal.Unlink("data/tar_of_65536_bytes.tar.gz.properties")
 
 
 ###############################################################################

--- a/autotest/gcore/vsis3.py
+++ b/autotest/gcore/vsis3.py
@@ -4932,15 +4932,16 @@ def test_vsis3_no_useless_requests(aws_test_config, webserver_port):
 # Test w+ access
 
 
-def test_vsis3_random_write(aws_test_config, webserver_port):
+def test_vsis3_random_write(tmp_vsimem, aws_test_config, webserver_port):
 
     gdal.VSICurlClearCache()
 
     with gdal.quiet_errors():
         assert gdal.VSIFOpenL("/vsis3/random_write/test.bin", "w+b") is None
 
-    with gdaltest.config_option(
-        "CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE", "YES", thread_local=False
+    with gdaltest.config_options(
+        {"CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE": "YES", "CPL_TMPDIR": tmp_vsimem},
+        thread_local=False,
     ):
         f = gdal.VSIFOpenL("/vsis3/random_write/test.bin", "w+b")
     assert f
@@ -4960,12 +4961,13 @@ def test_vsis3_random_write(aws_test_config, webserver_port):
 # Test w+ access
 
 
-def test_vsis3_random_write_failure_1(aws_test_config, webserver_port):
+def test_vsis3_random_write_failure_1(tmp_vsimem, aws_test_config, webserver_port):
 
     gdal.VSICurlClearCache()
 
-    with gdaltest.config_option(
-        "CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE", "YES", thread_local=False
+    with gdaltest.config_options(
+        {"CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE": "YES", "CPL_TMPDIR": tmp_vsimem},
+        thread_local=False,
     ):
         f = gdal.VSIFOpenL("/vsis3/random_write/test.bin", "w+b")
     assert f
@@ -4981,12 +4983,13 @@ def test_vsis3_random_write_failure_1(aws_test_config, webserver_port):
 # Test w+ access
 
 
-def test_vsis3_random_write_failure_2(aws_test_config, webserver_port):
+def test_vsis3_random_write_failure_2(tmp_vsimem, aws_test_config, webserver_port):
 
     gdal.VSICurlClearCache()
 
-    with gdaltest.config_option(
-        "CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE", "YES", thread_local=False
+    with gdaltest.config_options(
+        {"CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE": "YES", "CPL_TMPDIR": tmp_vsimem},
+        thread_local=False,
     ):
         with gdaltest.config_option("VSIS3_CHUNK_SIZE_BYTES", "1"):
             f = gdal.VSIFOpenL("/vsis3/random_write/test.bin", "w+b")
@@ -5004,7 +5007,9 @@ def test_vsis3_random_write_failure_2(aws_test_config, webserver_port):
 # Test w+ access
 
 
-def test_vsis3_random_write_gtiff_create_copy(aws_test_config, webserver_port):
+def test_vsis3_random_write_gtiff_create_copy(
+    tmp_vsimem, aws_test_config, webserver_port
+):
 
     gdal.VSICurlClearCache()
 
@@ -5052,8 +5057,9 @@ def test_vsis3_random_write_gtiff_create_copy(aws_test_config, webserver_port):
     )
     src_ds = gdal.Open("data/byte.tif")
 
-    with gdaltest.config_option(
-        "CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE", "YES", thread_local=False
+    with gdaltest.config_options(
+        {"CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE": "YES", "CPL_TMPDIR": tmp_vsimem},
+        thread_local=False,
     ):
         with webserver.install_http_handler(handler):
             ds = gdal.GetDriverByName("GTiff").CreateCopy(
@@ -5071,7 +5077,9 @@ def test_vsis3_random_write_gtiff_create_copy(aws_test_config, webserver_port):
 # Test r+ access
 
 
-def test_vsis3_random_write_on_existing_file(aws_test_config, webserver_port):
+def test_vsis3_random_write_on_existing_file(
+    tmp_vsimem, aws_test_config, webserver_port
+):
 
     gdal.VSICurlClearCache()
 
@@ -5097,8 +5105,9 @@ def test_vsis3_random_write_on_existing_file(aws_test_config, webserver_port):
     )
     handler.add("GET", "/random_write/test.bin", 200, {}, "f")
     handler.add("PUT", "/random_write/test.bin", 200, {}, expected_body=b"foo")
-    with webserver.install_http_handler(handler), gdaltest.config_option(
-        "CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE", "YES", thread_local=False
+    with webserver.install_http_handler(handler), gdaltest.config_options(
+        {"CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE": "YES", "CPL_TMPDIR": tmp_vsimem},
+        thread_local=False,
     ):
         f = gdal.VSIFOpenL("/vsis3/random_write/test.bin", "r+b")
         assert f
@@ -5112,7 +5121,7 @@ def test_vsis3_random_write_on_existing_file(aws_test_config, webserver_port):
 
 
 def test_vsis3_random_write_on_existing_file_that_does_not_exist(
-    aws_test_config, webserver_port
+    tmp_vsimem, aws_test_config, webserver_port
 ):
 
     gdal.VSICurlClearCache()
@@ -5130,8 +5139,9 @@ def test_vsis3_random_write_on_existing_file_that_does_not_exist(
             </ListBucketResult>
             """,
     )
-    with webserver.install_http_handler(handler), gdaltest.config_option(
-        "CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE", "YES", thread_local=False
+    with webserver.install_http_handler(handler), gdaltest.config_options(
+        {"CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE": "YES", "CPL_TMPDIR": tmp_vsimem},
+        thread_local=False,
     ):
         f = gdal.VSIFOpenL("/vsis3/random_write/test.bin", "r+b")
         assert f is None

--- a/autotest/gdrivers/basisu.py
+++ b/autotest/gdrivers/basisu.py
@@ -11,12 +11,21 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import os
+
 import gdaltest
 import pytest
 
 from osgeo import gdal
 
 pytestmark = pytest.mark.require_driver("BASISU")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
+        yield
 
 
 ###############################################################################

--- a/autotest/gdrivers/basisu.py
+++ b/autotest/gdrivers/basisu.py
@@ -11,8 +11,6 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
-import os
-
 import gdaltest
 import pytest
 
@@ -22,10 +20,8 @@ pytestmark = pytest.mark.require_driver("BASISU")
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "basisu")
 
 
 ###############################################################################

--- a/autotest/gdrivers/gif.py
+++ b/autotest/gdrivers/gif.py
@@ -134,25 +134,26 @@ def test_gif_6():
 # Confirm reading with the BIGGIF driver.
 
 
-def test_gif_7():
+def test_gif_7(tmp_path):
 
-    # Move the GIF driver after the BIGGIF driver.
-    try:
-        drv = gdal.GetDriverByName("GIF")
-        drv.Deregister()
-        drv.Register()
+    with gdal.config_option("CPL_TMPDIR", tmp_path):
+        # Move the GIF driver after the BIGGIF driver.
+        try:
+            drv = gdal.GetDriverByName("GIF")
+            drv.Deregister()
+            drv.Register()
 
-        tst = gdaltest.GDALTest("BIGGIF", "gif/bug407.gif", 1, 57921)
-        tst.testOpen()
+            tst = gdaltest.GDALTest("BIGGIF", "gif/bug407.gif", 1, 57921)
+            tst.testOpen()
 
-        ds = gdal.Open("data/gif/bug407.gif")
-        assert ds is not None
+            ds = gdal.Open("data/gif/bug407.gif")
+            assert ds is not None
 
-        assert ds.GetDriver().ShortName == "BIGGIF"
-    finally:
-        drv = gdal.GetDriverByName("BIGGIF")
-        drv.Deregister()
-        drv.Register()
+            assert ds.GetDriver().ShortName == "BIGGIF"
+        finally:
+            drv = gdal.GetDriverByName("BIGGIF")
+            drv.Deregister()
+            drv.Register()
 
 
 ###############################################################################

--- a/autotest/gdrivers/gpkg.py
+++ b/autotest/gdrivers/gpkg.py
@@ -3618,35 +3618,46 @@ def test_gpkg_47():
 # subdatasets on Windows)
 
 
-def test_gpkg_48():
+def test_gpkg_48(tmp_path):
 
-    if sys.platform == "win32":
-        filename = os.path.join(os.getcwd(), "tmp", "byte.gpkg")
-    else:
-        # Test Windows code path in a weird way...
-        filename = "C:\\byte.gpkg"
+    gdal.CopyFile("data/byte.tif", tmp_path / "byte.tif")
 
-    gdal.Translate(
-        filename, "data/byte.tif", format="GPKG", creationOptions=["RASTER_TABLE=foo"]
-    )
-    gdal.Translate(
-        filename,
-        "data/byte.tif",
-        format="GPKG",
-        creationOptions=["APPEND_SUBDATASET=YES", "RASTER_TABLE=bar"],
-    )
-    ds = gdal.Open("GPKG:" + filename + ":foo")
-    if ds is None:
+    old_pwd = os.getcwd()
+    try:
+        if sys.platform == "win32":
+            filename = os.path.join(os.getcwd(), "tmp", "byte.gpkg")
+        else:
+            # Test Windows code path in a weird way...
+            os.chdir(os.path.join(old_pwd, "tmp"))
+            filename = "C:\\byte.gpkg"
+
+        gdal.Translate(
+            filename,
+            tmp_path / "byte.tif",
+            format="GPKG",
+            creationOptions=["RASTER_TABLE=foo"],
+        )
+        gdal.Translate(
+            filename,
+            tmp_path / "byte.tif",
+            format="GPKG",
+            creationOptions=["APPEND_SUBDATASET=YES", "RASTER_TABLE=bar"],
+        )
+        ds = gdal.Open("GPKG:" + filename + ":foo")
+        if ds is None:
+            gdal.Unlink(filename)
+            pytest.fail()
+        ds = None
+        ds = gdal.Open("GPKG:" + filename + ":bar")
+        if ds is None:
+            gdal.Unlink(filename)
+            pytest.fail()
+        ds = None
+
         gdal.Unlink(filename)
-        pytest.fail()
-    ds = None
-    ds = gdal.Open("GPKG:" + filename + ":bar")
-    if ds is None:
-        gdal.Unlink(filename)
-        pytest.fail()
-    ds = None
 
-    gdal.Unlink(filename)
+    finally:
+        os.chdir(old_pwd)
 
 
 ###############################################################################

--- a/autotest/gdrivers/heif.py
+++ b/autotest/gdrivers/heif.py
@@ -69,13 +69,14 @@ def _has_geoheif_support():
 
 
 @pytest.mark.parametrize("endianness", ["big_endian", "little_endian"])
-def test_heif_exif_endian(endianness):
+def test_heif_exif_endian(endianness, tmp_path):
     if not _has_hevc_decoding_support():
         pytest.skip("no HEVC decoding support")
 
     filename = "data/heif/byte_exif_%s.heic" % endianness
+    gdal.CopyFile(filename, tmp_path / "in.heic")
     gdal.ErrorReset()
-    ds = gdal.Open(filename)
+    ds = gdal.Open(tmp_path / "in.heic")
     assert gdal.GetLastErrorMsg() == ""
     assert ds
     assert ds.RasterXSize == 64
@@ -98,7 +99,6 @@ def test_heif_exif_endian(endianness):
         assert "xpacket" in ds.GetMetadata("xml:XMP")[0]
 
     ds = None
-    gdal.Unlink(filename + ".aux.xml")
 
 
 def test_heif_thumbnail():

--- a/autotest/gdrivers/isce.py
+++ b/autotest/gdrivers/isce.py
@@ -67,17 +67,27 @@ def test_isce_2():
 # Verify this can be exported losslessly.
 
 
-def test_isce_3():
+def test_isce_3(tmp_path):
 
-    tst = gdaltest.GDALTest("isce", "isce/isce.slc", 1, 350)
-    tst.testCreateCopy(check_gt=0, new_filename="isce.tst.slc")
+    gdal.CopyFile("data/isce/isce.slc", tmp_path / "isce.slc")
+    gdal.CopyFile("data/isce/isce.slc.xml", tmp_path / "isce.slc.xml")
+
+    tst = gdaltest.GDALTest(
+        "isce", tmp_path / "isce.slc", 1, 350, filename_absolute=True
+    )
+    tst.testCreateCopy(check_gt=0, new_filename=tmp_path / "isce.tst.slc")
 
 
 ###############################################################################
 # Verify VSIF*L capacity
 
 
-def test_isce_4():
+def test_isce_4(tmp_path):
 
-    tst = gdaltest.GDALTest("isce", "isce/isce.slc", 1, 350)
-    tst.testCreateCopy(check_gt=0, new_filename="isce.tst.slc", vsimem=1)
+    gdal.CopyFile("data/isce/isce.slc", tmp_path / "isce.slc")
+    gdal.CopyFile("data/isce/isce.slc.xml", tmp_path / "isce.slc.xml")
+
+    tst = gdaltest.GDALTest(
+        "isce", tmp_path / "isce.slc", 1, 350, filename_absolute=True
+    )
+    tst.testCreateCopy(check_gt=0, new_filename=tmp_path / "isce.tst.slc", vsimem=1)

--- a/autotest/gdrivers/jp2grok.py
+++ b/autotest/gdrivers/jp2grok.py
@@ -206,17 +206,17 @@ def test_jp2grok_6():
 # Open byte.jp2.gz (test use of the VSIL API)
 
 
-def test_jp2grok_7():
+def test_jp2grok_7(tmp_path):
 
+    gdal.CopyFile("data/jpeg2000/byte.jp2.gz", tmp_path / "byte.jp2.gz")
     tst = gdaltest.GDALTest(
         "JP2Grok",
-        "/vsigzip/data/jpeg2000/byte.jp2.gz",
+        f"/vsigzip/{tmp_path}/byte.jp2.gz",
         1,
         50054,
         filename_absolute=1,
     )
     tst.testOpen()
-    gdal.Unlink("data/jpeg2000/byte.jp2.gz.properties")
 
 
 ###############################################################################
@@ -1633,17 +1633,18 @@ def test_jp2grok_vrt_read_no_advise():
     assert arr[:128].max() > 0 and arr[128:].max() > 0
 
 
-def test_jp2grok_translate_scale_multi_tile_row():
+def test_jp2grok_translate_scale_multi_tile_row(tmp_path):
     # gdal_translate -scale wraps source in a VRT and
     # reads it without AdviseRead. Identity scale preserves pixels, so the
     # output must match source below first tile row.
     np = pytest.importorskip("numpy")
     truth = _truth(SYNC_SRC)
-    src_ds = gdal.Open(SYNC_SRC)
+    gdal.CopyFile(SYNC_SRC, tmp_path / "in.jp2")
+    src_ds = gdal.Open(tmp_path / "in.jp2")
     smin, smax, _, _ = src_ds.GetRasterBand(1).GetStatistics(False, True)
     out = "/vsimem/jp2grok_scale.tif"
     ds = gdal.Translate(
-        out, SYNC_SRC, format="GTiff", scaleParams=[[smin, smax, smin, smax]]
+        out, tmp_path / "in.jp2", format="GTiff", scaleParams=[[smin, smax, smin, smax]]
     )
     assert ds.RasterYSize == 513
     assert np.array_equal(ds.GetRasterBand(1).ReadAsArray(), truth)

--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -210,17 +210,17 @@ def test_jp2openjpeg_6():
 # Open byte.jp2.gz (test use of the VSIL API)
 
 
-def test_jp2openjpeg_7():
+def test_jp2openjpeg_7(tmp_path):
 
+    gdal.CopyFile("data/jpeg2000/byte.jp2.gz", tmp_path / "byte.jp2.gz")
     tst = gdaltest.GDALTest(
-        "JP2OpenJPEG",
-        "/vsigzip/data/jpeg2000/byte.jp2.gz",
+        "JP2Grok",
+        f"/vsigzip/{tmp_path}/byte.jp2.gz",
         1,
         50054,
         filename_absolute=1,
     )
     tst.testOpen()
-    gdal.Unlink("data/jpeg2000/byte.jp2.gz.properties")
 
 
 ###############################################################################

--- a/autotest/gdrivers/jpeg.py
+++ b/autotest/gdrivers/jpeg.py
@@ -360,21 +360,12 @@ def test_jpeg_10(jpeg_version):
     if md[gdal.DMD_CREATIONDATATYPES].find("UInt16") == -1:
         pytest.skip("12bit jpeg not available")
 
-    try:
-        os.remove("data/jpeg/12bit_rose_extract.jpg.aux.xml")
-    except OSError:
-        pass
-
-    ds = gdal.Open("data/jpeg/12bit_rose_extract.jpg")
+    with gdal.config_option("GDAL_PAM_ENABLED", "NO"):
+        ds = gdal.Open("data/jpeg/12bit_rose_extract.jpg")
     assert ds.GetRasterBand(1).DataType == gdal.GDT_UInt16
     stats = ds.GetRasterBand(1).GetStatistics(0, 1)
     assert stats[2] >= 3613 and stats[2] <= 3614
     ds = None
-
-    try:
-        os.remove("data/jpeg/12bit_rose_extract.jpg.aux.xml")
-    except OSError:
-        pass
 
 
 ###############################################################################

--- a/autotest/gdrivers/ktx2.py
+++ b/autotest/gdrivers/ktx2.py
@@ -11,12 +11,21 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import os
+
 import gdaltest
 import pytest
 
 from osgeo import gdal
 
 pytestmark = pytest.mark.require_driver("KTX2")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
+        yield
 
 
 ###############################################################################

--- a/autotest/gdrivers/ktx2.py
+++ b/autotest/gdrivers/ktx2.py
@@ -11,8 +11,6 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
-import os
-
 import gdaltest
 import pytest
 
@@ -22,10 +20,8 @@ pytestmark = pytest.mark.require_driver("KTX2")
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "ktx2")
 
 
 ###############################################################################

--- a/autotest/gdrivers/loslas.py
+++ b/autotest/gdrivers/loslas.py
@@ -11,10 +11,10 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
-import os
-
 import gdaltest
 import pytest
+
+from osgeo import gdal
 
 pytestmark = pytest.mark.require_driver("LOSLAS")
 
@@ -24,15 +24,15 @@ pytestmark = pytest.mark.require_driver("LOSLAS")
 
 def test_loslas_1():
 
-    tst = gdaltest.GDALTest(
-        "LOSLAS", "data/loslas/wyhpgn.los", 1, 0, filename_absolute=1
-    )
-    gt = (-111.625, 0.25, 0.0, 45.625, 0.0, -0.25)
-    stats = (
-        -0.027868999168276787,
-        0.033906999975442886,
-        0.009716129862575248,
-        0.008260044951413324,
-    )
-    tst.testOpen(check_gt=gt, check_stat=stats, check_prj="WGS84")
-    os.unlink("data/loslas/wyhpgn.los.aux.xml")
+    with gdal.config_option("GDAL_PAM_ENABLED", "NO"):
+        tst = gdaltest.GDALTest(
+            "LOSLAS", "data/loslas/wyhpgn.los", 1, 0, filename_absolute=1
+        )
+        gt = (-111.625, 0.25, 0.0, 45.625, 0.0, -0.25)
+        stats = (
+            -0.027868999168276787,
+            0.033906999975442886,
+            0.009716129862575248,
+            0.008260044951413324,
+        )
+        tst.testOpen(check_gt=gt, check_stat=stats, check_prj="WGS84")

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -40,6 +40,13 @@ def fail_on_warnings():
         yield
 
 
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
+        yield
+
+
 ###############################################################################
 # Netcdf Functions
 ###############################################################################
@@ -3186,11 +3193,18 @@ def test_netcdf_79():
 # Test creating and opening with accent
 
 
-def test_netcdf_80():
+def test_netcdf_80(tmp_path):
 
-    test = gdaltest.GDALTest("NETCDF", "../data/byte.tif", 1, 4672)
+    gdal.CopyFile("data/byte.tif", tmp_path / "byte.tif")
+
+    test = gdaltest.GDALTest(
+        "NETCDF", tmp_path / "byte.tif", 1, 4672, filename_absolute=1
+    )
     test.testCreateCopy(
-        new_filename="test\xc3\xa9.nc", check_gt=0, check_srs=0, check_minmax=0
+        new_filename=tmp_path / "test\xc3\xa9.nc",
+        check_gt=0,
+        check_srs=0,
+        check_minmax=0,
     )
 
 
@@ -3733,7 +3747,7 @@ def test_netcdf_functions_2(filename, checksum, options, testfunction):
         ("corrupted_polygon_ir", "interior_ring values must be 0 or 1"),
     ),
 )
-def test_bad_cf1_8(fname, expected_warning):
+def test_netcdf_bad_cf1_8(fname, expected_warning):
 
     # basic resilience test, make sure it can exit "gracefully"
     fpath = f"data/netcdf-sg/{fname}.nc"

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -41,10 +41,8 @@ def fail_on_warnings():
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "netcdf")
 
 
 ###############################################################################

--- a/autotest/gdrivers/netcdf_multidim.py
+++ b/autotest/gdrivers/netcdf_multidim.py
@@ -35,6 +35,13 @@ def module_disable_exceptions():
         yield
 
 
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
+        yield
+
+
 def test_netcdf_multidim_invalid_file():
 
     ds = gdal.Open("data/netcdf/byte_truncated.nc", gdal.OF_MULTIDIM_RASTER)
@@ -4124,10 +4131,15 @@ def test_netcdf_multidim_chunk_cache_options():
 ###############################################################################
 
 
-def test_netcdf_multidim_as_classic_dataset_metadata():
+def test_netcdf_multidim_as_classic_dataset_metadata(tmp_path):
+
+    gdal.CopyFile(
+        "data/netcdf/fake_EMIT_L2A_with_good_wavelengths.nc", tmp_path / "tmp.nc"
+    )
+
     def set_metadata():
         ds = gdal.Open(
-            "data/netcdf/fake_EMIT_L2A_with_good_wavelengths.nc",
+            tmp_path / "tmp.nc",
             gdal.OF_MULTIDIM_RASTER,
         )
         rg = ds.GetRootGroup()
@@ -4141,7 +4153,7 @@ def test_netcdf_multidim_as_classic_dataset_metadata():
 
     def check_metadata():
         ds = gdal.Open(
-            "data/netcdf/fake_EMIT_L2A_with_good_wavelengths.nc",
+            tmp_path / "tmp.nc",
             gdal.OF_MULTIDIM_RASTER,
         )
         rg = ds.GetRootGroup()
@@ -4153,7 +4165,7 @@ def test_netcdf_multidim_as_classic_dataset_metadata():
         classic_ds = ar.AsClassicDataset(1, 0)
         assert classic_ds.GetMetadataItem("foo") == "bar"
 
-    pam_filename = "data/netcdf/fake_EMIT_L2A_with_good_wavelengths.nc.aux.xml"
+    pam_filename = tmp_path / "tmp.nc.aux.xml"
     if os.path.exists(pam_filename):
         os.unlink(pam_filename)
 

--- a/autotest/gdrivers/netcdf_multidim.py
+++ b/autotest/gdrivers/netcdf_multidim.py
@@ -36,10 +36,8 @@ def module_disable_exceptions():
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "netcdf_multidim")
 
 
 def test_netcdf_multidim_invalid_file():

--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -1652,15 +1652,11 @@ def test_nitf_41(not_jpeg_9b):
     if md[gdal.DMD_CREATIONDATATYPES].find("UInt16") == -1:
         pytest.skip("12bit jpeg not available")
 
-    gdal.Unlink("data/nitf/U_4017A.NTF.aux.xml")
-
-    ds = gdal.Open("data/nitf/U_4017A.NTF")
-    assert ds.GetRasterBand(1).DataType == gdal.GDT_UInt16
-    stats = ds.GetRasterBand(1).GetStatistics(0, 1)
-    assert stats[2] >= 2385 and stats[2] <= 2386
-    ds = None
-
-    gdal.Unlink("data/nitf/U_4017A.NTF.aux.xml")
+    with gdal.config_option("GDAL_PAM_ENABLED", "NO"):
+        ds = gdal.Open("data/nitf/U_4017A.NTF")
+        assert ds.GetRasterBand(1).DataType == gdal.GDT_UInt16
+        stats = ds.GetRasterBand(1).GetStatistics(0, 1)
+        assert stats[2] >= 2385 and stats[2] <= 2386
 
 
 ###############################################################################

--- a/autotest/gdrivers/pnm.py
+++ b/autotest/gdrivers/pnm.py
@@ -64,12 +64,11 @@ def test_pnm_4():
 
 @pytest.mark.parametrize("nbands", [1, 3])
 @gdaltest.disable_exceptions()
-def test_pnm_write_non_standard_extension(nbands):
+def test_pnm_write_non_standard_extension(tmp_path, nbands):
     gdal.ErrorReset()
     with gdal.quiet_errors():
-        gdal.GetDriverByName("PNM").Create("foo.foo", 1, 1, nbands)
+        gdal.GetDriverByName("PNM").Create(tmp_path / "foo.foo", 1, 1, nbands)
     assert gdal.GetLastErrorType() != 0
-    gdal.Unlink("foo.foo")
 
 
 @gdaltest.disable_exceptions()

--- a/autotest/gdrivers/postgisraster.py
+++ b/autotest/gdrivers/postgisraster.py
@@ -172,10 +172,12 @@ def test_postgisraster_compare_small_world():
 #
 
 
-def test_postgisraster_test_utm_open():
+def test_postgisraster_test_utm_open(tmp_path):
+
+    gdal.CopyFile("data/utm.tif", tmp_path / "utm.tif")
 
     # First open tif file
-    src_ds = gdal.Open("data/utm.tif")
+    src_ds = gdal.Open(tmp_path / "utm.tif")
     prj = src_ds.GetProjectionRef()
     gt = src_ds.GetGeoTransform()
 
@@ -202,10 +204,12 @@ def test_postgisraster_test_utm_open():
 #
 
 
-def test_postgisraster_test_small_world_open_b1():
+def test_postgisraster_test_small_world_open_b1(tmp_path):
+
+    gdal.CopyFile("data/small_world.tif", tmp_path / "small_world.tif")
 
     # First open tif file
-    src_ds = gdal.Open("data/small_world.tif")
+    src_ds = gdal.Open(tmp_path / "small_world.tif")
     prj = src_ds.GetProjectionRef()
     gt = src_ds.GetGeoTransform()
 
@@ -234,10 +238,12 @@ def test_postgisraster_test_small_world_open_b1():
 #
 
 
-def test_postgisraster_test_small_world_open_b2():
+def test_postgisraster_test_small_world_open_b2(tmp_path):
+
+    gdal.CopyFile("data/small_world.tif", tmp_path / "small_world.tif")
 
     # First open tif file
-    src_ds = gdal.Open("data/small_world.tif")
+    src_ds = gdal.Open(tmp_path / "small_world.tif")
     prj = src_ds.GetProjectionRef()
     gt = src_ds.GetGeoTransform()
 
@@ -266,10 +272,12 @@ def test_postgisraster_test_small_world_open_b2():
 #
 
 
-def test_postgisraster_test_small_world_open_b3():
+def test_postgisraster_test_small_world_open_b3(tmp_path):
+
+    gdal.CopyFile("data/small_world.tif", tmp_path / "small_world.tif")
 
     # First open tif file
-    src_ds = gdal.Open("data/small_world.tif")
+    src_ds = gdal.Open(tmp_path / "small_world.tif")
     prj = src_ds.GetProjectionRef()
     gt = src_ds.GetGeoTransform()
 

--- a/autotest/gdrivers/roipac.py
+++ b/autotest/gdrivers/roipac.py
@@ -60,20 +60,20 @@ def test_roipac_2():
 # Verify this can be exported losslessly.
 
 
-def test_roipac_3():
+def test_roipac_3(tmp_path):
 
     tst = gdaltest.GDALTest("roi_pac", "roipac/srtm.dem", 1, 64074)
-    tst.testCreateCopy(check_gt=1, new_filename="strm.tst.dem")
+    tst.testCreateCopy(check_gt=1, new_filename=tmp_path / "strm.tst.dem")
 
 
 ###############################################################################
 # Verify VSIF*L capacity
 
 
-def test_roipac_4():
+def test_roipac_4(tmp_path):
 
     tst = gdaltest.GDALTest("roi_pac", "roipac/srtm.dem", 1, 64074)
-    tst.testCreateCopy(check_gt=1, new_filename="strm.tst.dem", vsimem=1)
+    tst.testCreateCopy(check_gt=1, new_filename=tmp_path / "strm.tst.dem", vsimem=1)
 
 
 ###############################################################################
@@ -94,8 +94,8 @@ def test_roipac_5():
 # Test .flg
 
 
-def test_roipac_6():
+def test_roipac_6(tmp_path):
 
     tst = gdaltest.GDALTest("roi_pac", "byte.tif", 1, 4672)
     with gdal.quiet_errors():
-        tst.testCreateCopy(check_gt=1, new_filename="byte.flg", vsimem=1)
+        tst.testCreateCopy(check_gt=1, new_filename=tmp_path / "byte.flg", vsimem=1)

--- a/autotest/gdrivers/srp.py
+++ b/autotest/gdrivers/srp.py
@@ -12,7 +12,7 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
-import os
+import shutil
 
 import gdaltest
 import pytest
@@ -20,18 +20,6 @@ import pytest
 from osgeo import gdal, osr
 
 pytestmark = pytest.mark.require_driver("SRP")
-
-
-@pytest.fixture(scope="module", autouse=True)
-def setup_and_cleanup():
-
-    yield
-
-    try:
-        os.unlink("data/srp/USRP_PCB0/TRANSH01.THF.aux.xml")
-    except OSError:
-        pass
-
 
 ###############################################################################
 # Read USRP dataset with PCB=0
@@ -92,18 +80,22 @@ def test_srp_4():
 # Read from TRANSH01.THF file (without "optimization" for single GEN in THF)
 
 
-def test_srp_5():
+def test_srp_5(tmp_path):
 
-    with gdal.config_option("SRP_SINGLE_GEN_IN_THF_AS_DATASET", "FALSE"):
-        ds = gdal.Open("data/srp/USRP_PCB0/TRANSH01.THF")
+    shutil.copytree("data/srp/USRP_PCB0", tmp_path / "USRP_PCB0")
+
+    with gdal.config_options({"SRP_SINGLE_GEN_IN_THF_AS_DATASET": "FALSE"}):
+        ds = gdal.Open(tmp_path / "USRP_PCB0" / "TRANSH01.THF")
     subdatasets = ds.GetMetadata("SUBDATASETS")
-    assert (
-        subdatasets["SUBDATASET_1_NAME"].replace("\\", "/")
-        == "SRP:data/srp/USRP_PCB0/FKUSRP01.GEN,data/srp/USRP_PCB0/FKUSRP01.IMG"
+    assert subdatasets["SUBDATASET_1_NAME"].replace(
+        "\\", "/"
+    ) == f"SRP:{tmp_path}/USRP_PCB0/FKUSRP01.GEN,{tmp_path}/USRP_PCB0/FKUSRP01.IMG".replace(
+        "\\", "/"
     )
-    assert (
-        subdatasets["SUBDATASET_1_DESC"].replace("\\", "/")
-        == "SRP:data/srp/USRP_PCB0/FKUSRP01.GEN,data/srp/USRP_PCB0/FKUSRP01.IMG"
+    assert subdatasets["SUBDATASET_1_DESC"].replace(
+        "\\", "/"
+    ) == f"SRP:{tmp_path}/USRP_PCB0/FKUSRP01.GEN,{tmp_path}/USRP_PCB0/FKUSRP01.IMG".replace(
+        "\\", "/"
     )
 
     expected_md = [

--- a/autotest/gdrivers/vrtovr.py
+++ b/autotest/gdrivers/vrtovr.py
@@ -11,6 +11,7 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import os
 import struct
 
 import gdaltest
@@ -312,14 +313,19 @@ def test_vrtovr_external_ovr_has_priority_over_implicit(tmp_vsimem):
 
 def test_vrtovr_anonymous_vrt():
 
-    gdal.GetDriverByName("GTiff").Create(".ovr", 1, 1)
-
+    old_cwd = os.getcwd()
+    os.chdir(os.path.join(old_cwd, "tmp"))
     try:
-        ds = gdal.GetDriverByName("MEM").Create("", 2, 2)
-        vrt_ds = gdal.Translate("", ds, format="VRT")
-        assert vrt_ds.GetRasterBand(1).GetOverviewCount() == 0
+        gdal.GetDriverByName("GTiff").Create(".ovr", 1, 1)
+
+        try:
+            ds = gdal.GetDriverByName("MEM").Create("", 2, 2)
+            vrt_ds = gdal.Translate("", ds, format="VRT")
+            assert vrt_ds.GetRasterBand(1).GetOverviewCount() == 0
+        finally:
+            gdal.Unlink(".ovr")
     finally:
-        gdal.Unlink(".ovr")
+        os.chdir(old_cwd)
 
 
 ###############################################################################

--- a/autotest/gdrivers/vrtwarp.py
+++ b/autotest/gdrivers/vrtwarp.py
@@ -348,22 +348,22 @@ def test_vrtwarp_9(tmp_vsimem):
     ds.BuildOverviews("NEAR", overviewlist=[2])
     ds = None
 
-    ds = gdal.Warp("", tmp_vsimem / "sstgeo.vrt", options="-of MEM -geoloc")
-    expected_cs_main = ds.GetRasterBand(1).Checksum()
-    ds = None
-
-    vrtwarp_ds = gdal.Warp(
-        tmp_vsimem / "vrtwarp_9.vrt",
-        tmp_vsimem / "sstgeo.vrt",
-        options="-overwrite -of VRT -geoloc",
-    )
-    assert vrtwarp_ds.GetRasterBand(1).GetOverviewCount() == 1
-    assert vrtwarp_ds.GetRasterBand(1).Checksum() == expected_cs_main
-    assert vrtwarp_ds.GetRasterBand(1).GetOverview(0).Checksum() == 62489, (
-        vrtwarp_ds.GetRasterBand(1).GetOverview(0).XSize,
-        vrtwarp_ds.GetRasterBand(1).GetOverview(0).YSize,
-    )
-    vrtwarp_ds = None
+    with gdal.config_option("CPL_TMPDIR", tmp_vsimem):
+        ds = gdal.Warp("", tmp_vsimem / "sstgeo.vrt", options="-of MEM -geoloc")
+        expected_cs_main = ds.GetRasterBand(1).Checksum()
+        ds = None
+        vrtwarp_ds = gdal.Warp(
+            tmp_vsimem / "vrtwarp_9.vrt",
+            tmp_vsimem / "sstgeo.vrt",
+            options="-overwrite -of VRT -geoloc",
+        )
+        assert vrtwarp_ds.GetRasterBand(1).GetOverviewCount() == 1
+        assert vrtwarp_ds.GetRasterBand(1).Checksum() == expected_cs_main
+        assert vrtwarp_ds.GetRasterBand(1).GetOverview(0).Checksum() == 62489, (
+            vrtwarp_ds.GetRasterBand(1).GetOverview(0).XSize,
+            vrtwarp_ds.GetRasterBand(1).GetOverview(0).YSize,
+        )
+        vrtwarp_ds = None
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_basic_test.py
+++ b/autotest/ogr/ogr_basic_test.py
@@ -458,7 +458,7 @@ def test_ogr_basic_10():
     # under UBSAN.
     ret = gdaltest.runexternal(
         test_cli_utilities.get_test_ogrsf_path()
-        + " -all_drivers --config OPENFILEGDB_REPRODUCIBLE_UUID=YES"
+        + " -all_drivers --config OPENFILEGDB_REPRODUCIBLE_UUID=YES --config CPL_TMPDIR tmp"
     )
 
     assert "INFO" in ret

--- a/autotest/ogr/ogr_fgdb.py
+++ b/autotest/ogr/ogr_fgdb.py
@@ -553,9 +553,10 @@ def test_ogr_fgdb_17(openfilegdb_drv, tmp_path):
 
 
 @pytest.mark.require_driver("CSV")
-def test_ogr_fgdb_22():
+def test_ogr_fgdb_22(tmp_path):
 
-    ds = ogr.Open("data/filegdb/curves.gdb")
+    shutil.copytree("data/filegdb/curves.gdb", tmp_path / "curves.gdb")
+    ds = ogr.Open(tmp_path / "curves.gdb")
     lyr = ds.GetLayerByName("line")
     ds_ref = ogr.Open("data/filegdb/curves_line.csv")
     lyr_ref = ds_ref.GetLayer(0)
@@ -570,7 +571,11 @@ def test_ogr_fgdb_22():
         f_ref = lyr_ref.GetNextFeature()
         ogrtest.check_feature_geometry(f, f_ref.GetGeometryRef())
 
-    ds = ogr.Open("data/filegdb/curve_circle_by_center.gdb")
+    shutil.copytree(
+        "data/filegdb/curve_circle_by_center.gdb",
+        tmp_path / "curve_circle_by_center.gdb",
+    )
+    ds = ogr.Open(tmp_path / "curve_circle_by_center.gdb")
     lyr = ds.GetLayer(0)
     ds_ref = ogr.Open("data/filegdb/curve_circle_by_center.csv")
     lyr_ref = ds_ref.GetLayer(0)
@@ -583,11 +588,15 @@ def test_ogr_fgdb_22():
 # Test opening '.'
 
 
-def test_ogr_fgdb_23():
+def test_ogr_fgdb_23(tmp_path):
 
-    os.chdir("data/filegdb/curves.gdb")
-    ds = ogr.Open(".")
-    os.chdir("../../..")
+    shutil.copytree("data/filegdb/curves.gdb", tmp_path / "curves.gdb")
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path / "curves.gdb")
+        ds = ogr.Open(".")
+    finally:
+        os.chdir(old_cwd)
     assert ds is not None
 
 
@@ -597,9 +606,13 @@ def test_ogr_fgdb_23():
 
 
 @pytest.mark.require_driver("CSV")
-def test_ogr_fgdb_24():
+def test_ogr_fgdb_24(tmp_path):
 
-    ds = ogr.Open("data/filegdb/filegdb_polygonzm_m_not_closing_with_curves.gdb")
+    shutil.copytree(
+        "data/filegdb/filegdb_polygonzm_m_not_closing_with_curves.gdb",
+        tmp_path / "filegdb_polygonzm_m_not_closing_with_curves.gdb",
+    )
+    ds = ogr.Open(tmp_path / "filegdb_polygonzm_m_not_closing_with_curves.gdb")
     lyr = ds.GetLayer(0)
     ds_ref = ogr.Open(
         "data/filegdb/filegdb_polygonzm_m_not_closing_with_curves.gdb.csv"
@@ -609,7 +622,11 @@ def test_ogr_fgdb_24():
         f_ref = lyr_ref.GetNextFeature()
         ogrtest.check_feature_geometry(f, f_ref.GetGeometryRef())
 
-    ds = ogr.Open("data/filegdb/filegdb_polygonzm_nan_m_with_curves.gdb")
+    shutil.copytree(
+        "data/filegdb/filegdb_polygonzm_nan_m_with_curves.gdb",
+        tmp_path / "filegdb_polygonzm_nan_m_with_curves.gdb",
+    )
+    ds = ogr.Open(tmp_path / "filegdb_polygonzm_nan_m_with_curves.gdb")
     lyr = ds.GetLayer(0)
     ds_ref = ogr.Open("data/filegdb/filegdb_polygonzm_nan_m_with_curves.gdb.csv")
     lyr_ref = ds_ref.GetLayer(0)
@@ -622,9 +639,10 @@ def test_ogr_fgdb_24():
 # Test selecting FID column with OGRSQL
 
 
-def test_ogr_fgdb_25():
+def test_ogr_fgdb_25(tmp_path):
 
-    ds = ogr.Open("data/filegdb/curves.gdb")
+    shutil.copytree("data/filegdb/curves.gdb", tmp_path / "curves.gdb")
+    ds = ogr.Open(tmp_path / "curves.gdb")
     sql_lyr = ds.ExecuteSQL("SELECT OBJECTID FROM polygon WHERE OBJECTID = 2")
     assert sql_lyr is not None
     f = sql_lyr.GetNextFeature()
@@ -666,9 +684,12 @@ def test_ogr_fgdb_weird_winding_order(tmp_path):
 # where a polygon with inner rings has its exterior ring with wrong orientation
 
 
-def test_ogr_fgdb_utc_datetime():
+def test_ogr_fgdb_utc_datetime(tmp_path):
 
-    ds = ogr.Open("data/filegdb/testdatetimeutc.gdb")
+    shutil.copytree(
+        "data/filegdb/testdatetimeutc.gdb", tmp_path / "testdatetimeutc.gdb"
+    )
+    ds = ogr.Open(tmp_path / "testdatetimeutc.gdb")
     lyr = ds.GetLayer(0)
     f = lyr.GetNextFeature()
     # Check that the timezone +00 is present
@@ -718,9 +739,10 @@ def _check_domains(ds):
     assert domain.GetEnumeration() == {"0": "None", "1": "Cement"}
 
 
-def test_ogr_fgdb_read_domains():
+def test_ogr_fgdb_read_domains(tmp_path):
 
-    ds = gdal.Open("data/filegdb/Domains.gdb", gdal.OF_VECTOR)
+    shutil.copytree("data/filegdb/Domains.gdb", tmp_path / "domains.gdb")
+    ds = gdal.Open(tmp_path / "domains.gdb", gdal.OF_VECTOR)
     _check_domains(ds)
 
 
@@ -729,7 +751,7 @@ def test_ogr_fgdb_read_domains():
 
 
 @gdaltest.disable_exceptions()
-def test_ogr_fgdb_read_layer_hierarchy():
+def test_ogr_fgdb_read_layer_hierarchy(tmp_path):
 
     if False:
         # Test dataset produced with:
@@ -753,7 +775,8 @@ def test_ogr_fgdb_read_layer_hierarchy():
             "fd2_lyr", srs=srs3, geom_type=ogr.wkbPoint, options=["FEATURE_DATASET=fd2"]
         )
 
-    ds = gdal.Open("data/filegdb/featuredataset.gdb")
+    shutil.copytree("data/filegdb/featuredataset.gdb", tmp_path / "featuredataset.gdb")
+    ds = gdal.Open(tmp_path / "featuredataset.gdb")
     rg = ds.GetRootGroup()
 
     assert rg.GetGroupNames() == ["fd1", "fd2"]
@@ -790,7 +813,9 @@ def test_ogr_fgdb_read_layer_hierarchy():
 
 
 @pytest.mark.require_driver("OpenFileGDB")
-def test_ogr_filegdb_non_spatial_table_outside_gdb_items(openfilegdb_drv, fgdb_drv):
+def test_ogr_filegdb_non_spatial_table_outside_gdb_items(
+    tmp_path, openfilegdb_drv, fgdb_drv
+):
     openfilegdb_drv.Deregister()
     fgdb_drv.Deregister()
 
@@ -798,7 +823,11 @@ def test_ogr_filegdb_non_spatial_table_outside_gdb_items(openfilegdb_drv, fgdb_d
     fgdb_drv.Register()
     openfilegdb_drv.Register()
 
-    ds = ogr.Open("data/filegdb/table_outside_gdbitems.gdb")
+    shutil.copytree(
+        "data/filegdb/table_outside_gdbitems.gdb",
+        tmp_path / "table_outside_gdbitems.gdb",
+    )
+    ds = ogr.Open(tmp_path / "table_outside_gdbitems.gdb")
     assert ds is not None
     assert ds.GetDriver().GetName() == "FileGDB"
 
@@ -812,8 +841,13 @@ def test_ogr_filegdb_non_spatial_table_outside_gdb_items(openfilegdb_drv, fgdb_d
 # table is not consistent with the one of the feature dataset
 
 
-def test_ogr_filegdb_inconsistent_crs_feature_dataset_and_feature_table():
-    ds = ogr.Open("data/filegdb/inconsistent_crs_feature_dataset_and_feature_table.gdb")
+def test_ogr_filegdb_inconsistent_crs_feature_dataset_and_feature_table(tmp_path):
+
+    shutil.copytree(
+        "data/filegdb/inconsistent_crs_feature_dataset_and_feature_table.gdb",
+        tmp_path / "inconsistent_crs_feature_dataset_and_feature_table.gdb",
+    )
+    ds = ogr.Open(tmp_path / "inconsistent_crs_feature_dataset_and_feature_table.gdb")
     assert ds is not None
     lyr = ds.GetLayer(0)
     srs = lyr.GetSpatialRef()
@@ -825,8 +859,14 @@ def test_ogr_filegdb_inconsistent_crs_feature_dataset_and_feature_table():
 # Test reading .gdb with LengthFieldName / AreaFieldName
 
 
-def test_ogr_filegdb_shape_length_shape_area_as_default_in_field_defn(fgdb_drv):
-    ds = ogr.Open("data/filegdb/filegdb_polygonzm_m_not_closing_with_curves.gdb")
+def test_ogr_filegdb_shape_length_shape_area_as_default_in_field_defn(
+    tmp_path, fgdb_drv
+):
+    shutil.copytree(
+        "data/filegdb/filegdb_polygonzm_m_not_closing_with_curves.gdb",
+        tmp_path / "filegdb_polygonzm_m_not_closing_with_curves.gdb",
+    )
+    ds = ogr.Open(tmp_path / "filegdb_polygonzm_m_not_closing_with_curves.gdb")
     lyr = ds.GetLayer(0)
     lyr_defn = lyr.GetLayerDefn()
     assert (
@@ -920,9 +960,13 @@ def test_ogr_filegdb_CREATE_SHAPE_AREA_AND_LENGTH_FIELDS_implicit(fgdb_drv, tmp_
     dirname = (
         tmp_path / "test_ogr_filegdb_CREATE_SHAPE_AREA_AND_LENGTH_FIELDS_implicit.gdb"
     )
+    shutil.copytree(
+        "data/filegdb/filegdb_polygonzm_m_not_closing_with_curves.gdb",
+        tmp_path / "filegdb_polygonzm_m_not_closing_with_curves.gdb",
+    )
     gdal.VectorTranslate(
         dirname,
-        "data/filegdb/filegdb_polygonzm_m_not_closing_with_curves.gdb",
+        tmp_path / "filegdb_polygonzm_m_not_closing_with_curves.gdb",
         options="-f FileGDB -unsetfid -fid 1",
     )
 
@@ -942,7 +986,7 @@ def test_ogr_filegdb_CREATE_SHAPE_AREA_AND_LENGTH_FIELDS_implicit(fgdb_drv, tmp_
 
 
 @pytest.mark.require_driver("OpenFileGDB")
-def test_ogr_filegdb_read_relationships(openfilegdb_drv, fgdb_drv):
+def test_ogr_filegdb_read_relationships(tmp_path, openfilegdb_drv, fgdb_drv):
     openfilegdb_drv.Deregister()
     fgdb_drv.Deregister()
 
@@ -951,11 +995,13 @@ def test_ogr_filegdb_read_relationships(openfilegdb_drv, fgdb_drv):
     openfilegdb_drv.Register()
 
     # no relationships
-    ds = gdal.Open("data/filegdb/Domains.gdb", gdal.OF_VECTOR)
+    shutil.copytree("data/filegdb/Domains.gdb", tmp_path / "Domains.gdb")
+    ds = gdal.Open(tmp_path / "Domains.gdb", gdal.OF_VECTOR)
     assert ds.GetRelationshipNames() is None
 
     # has relationships
-    ds = gdal.Open("data/filegdb/relationships.gdb", gdal.OF_VECTOR)
+    shutil.copytree("data/filegdb/relationships.gdb", tmp_path / "relationships.gdb")
+    ds = gdal.Open(tmp_path / "relationships.gdb", gdal.OF_VECTOR)
     assert ds.GetDriver().GetDescription() == "FileGDB"
     assert set(ds.GetRelationshipNames()) == {
         "composite_many_to_many",
@@ -1072,10 +1118,11 @@ def test_ogr_filegdb_read_relationships(openfilegdb_drv, fgdb_drv):
 # Test reading an empty polygon
 
 
-def test_ogr_filegdb_read_empty_polygon():
+def test_ogr_filegdb_read_empty_polygon(tmp_path):
 
     # Dataset generated by OpenFileGDB driver
-    ds = ogr.Open("data/filegdb/empty_polygon.gdb")
+    shutil.copytree("data/filegdb/empty_polygon.gdb", tmp_path / "empty_polygon.gdb")
+    ds = ogr.Open(tmp_path / "empty_polygon.gdb")
     lyr = ds.GetLayer(0)
     f = lyr.GetNextFeature()
     assert f.GetGeometryRef().IsEmpty()
@@ -1086,7 +1133,7 @@ def test_ogr_filegdb_read_empty_polygon():
 
 
 @pytest.mark.require_driver("OpenFileGDB")
-def test_ogr_filegdb_read_cdf_if_openfilegdb(openfilegdb_drv, fgdb_drv):
+def test_ogr_filegdb_read_cdf_if_openfilegdb(tmp_path, openfilegdb_drv, fgdb_drv):
     openfilegdb_drv.Deregister()
     fgdb_drv.Deregister()
 
@@ -1094,7 +1141,8 @@ def test_ogr_filegdb_read_cdf_if_openfilegdb(openfilegdb_drv, fgdb_drv):
     openfilegdb_drv.Register()
     fgdb_drv.Register()
 
-    ds = ogr.Open("data/filegdb/with_cdf.gdb")
+    shutil.copytree("data/filegdb/with_cdf.gdb", tmp_path / "with_cdf.gdb")
+    ds = ogr.Open(tmp_path / "with_cdf.gdb")
     assert ds.GetDriver().GetDescription() == "FileGDB"
     lyr = ds.GetLayer(0)
     assert lyr.GetFeatureCount() == 3
@@ -1104,8 +1152,9 @@ def test_ogr_filegdb_read_cdf_if_openfilegdb(openfilegdb_drv, fgdb_drv):
 # Test reading a database with a compressed layer (.cdf)
 
 
-def test_ogr_filegdb_read_cdf():
+def test_ogr_filegdb_read_cdf(tmp_path):
 
-    ds = ogr.Open("data/filegdb/with_cdf.gdb")
+    shutil.copytree("data/filegdb/with_cdf.gdb", tmp_path / "with_cdf.gdb")
+    ds = ogr.Open(tmp_path / "with_cdf.gdb")
     lyr = ds.GetLayer(0)
     assert lyr.GetFeatureCount() == 3

--- a/autotest/ogr/ogr_flatgeobuf.py
+++ b/autotest/ogr/ogr_flatgeobuf.py
@@ -596,15 +596,16 @@ def test_ogr_flatgeobuf_bool_short_float_binary():
 @pytest.mark.parametrize(
     "options", [[], ["SPATIAL_INDEX=NO"]], ids=["spatial_index", "no_spatial_index"]
 )
-def test_ogr_flatgeobuf_write_to_vsizip(options):
+def test_ogr_flatgeobuf_write_to_vsizip(options, tmp_vsimem):
 
     srcDS = gdal.Open("data/poly.shp")
-    destDS = gdal.VectorTranslate(
-        "/vsizip//vsimem/test.fgb.zip/test.fgb",
-        srcDS=srcDS,
-        format="FlatGeobuf",
-        layerCreationOptions=options,
-    )
+    with gdal.config_option("CPL_TMPDIR", tmp_vsimem):
+        destDS = gdal.VectorTranslate(
+            "/vsizip//vsimem/test.fgb.zip/test.fgb",
+            srcDS=srcDS,
+            format="FlatGeobuf",
+            layerCreationOptions=options,
+        )
     assert destDS is not None
     destDS = None
     destDS = ogr.Open("/vsizip//vsimem/test.fgb.zip/test.fgb")
@@ -1686,13 +1687,14 @@ def test_ogr_flatgeobuf_write_check_temporary_file_vsizip(tmp_path):
     with gdal.VSIFile(tmp_path / "out_temp.fgb", "wb") as f:
         f.write(b"foo")
 
-    with gdal.GetDriverByName("FlatGeobuf").CreateVector(
-        "/vsizip/" + str(tmp_path / "out.fgb.zip" / "out.fgb")
-    ) as ds:
-        lyr = ds.CreateLayer("test")
-        f = ogr.Feature(lyr.GetLayerDefn())
-        f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (0 0)"))
-        lyr.CreateFeature(f)
+    with gdal.config_option("CPL_TMPDIR", tmp_path):
+        with gdal.GetDriverByName("FlatGeobuf").CreateVector(
+            "/vsizip/" + str(tmp_path / "out.fgb.zip" / "out.fgb")
+        ) as ds:
+            lyr = ds.CreateLayer("test")
+            f = ogr.Feature(lyr.GetLayerDefn())
+            f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (0 0)"))
+            lyr.CreateFeature(f)
 
     with ogr.Open("/vsizip/" + str(tmp_path / "out.fgb.zip" / "out.fgb")) as ds:
         lyr = ds.GetLayer(0)

--- a/autotest/ogr/ogr_gml.py
+++ b/autotest/ogr/ogr_gml.py
@@ -409,24 +409,31 @@ def test_ogr_gml_10(tmp_path):
 # Test reading a geometry element specified with <GeometryElementPath>
 
 
-def test_ogr_gml_11():
+def test_ogr_gml_11(tmp_path):
+
+    gdal.CopyFile(
+        "data/gml/testgeometryelementpath.gml", tmp_path / "testgeometryelementpath.gml"
+    )
+    gdal.CopyFile(
+        "data/gml/testgeometryelementpath.gfs", tmp_path / "testgeometryelementpath.gfs"
+    )
 
     # Make sure the .gfs file is more recent that the .gml one
     try:
-        gml_mtime = os.stat("data/gml/testgeometryelementpath.gml").st_mtime
-        gfs_mtime = os.stat("data/gml/testgeometryelementpath.gfs").st_mtime
+        gml_mtime = os.stat(tmp_path / "testgeometryelementpath.gml").st_mtime
+        gfs_mtime = os.stat(tmp_path / "testgeometryelementpath.gfs").st_mtime
         touch_gfs = gfs_mtime <= gml_mtime
     except Exception:
         touch_gfs = True
     if touch_gfs:
         print("Touching .gfs file")
-        f = open("data/gml/testgeometryelementpath.gfs", "rb+")
+        f = open(tmp_path / "testgeometryelementpath.gfs", "rb+")
         data = f.read(1)
         f.seek(0, 0)
         f.write(data)
         f.close()
 
-    ds = ogr.Open("data/gml/testgeometryelementpath.gml")
+    ds = ogr.Open(tmp_path / "testgeometryelementpath.gml")
     lyr = ds.GetLayer(0)
     assert (
         lyr.GetGeometryColumn() == "location1container|location1"
@@ -2360,24 +2367,27 @@ def test_ogr_gml_58c(tmp_path):
 # Test GFS conditions
 
 
-def test_ogr_gml_59():
+def test_ogr_gml_59(tmp_path):
+
+    gdal.CopyFile("data/gml/testcondition.gml", tmp_path / "testcondition.gml")
+    gdal.CopyFile("data/gml/testcondition.gfs", tmp_path / "testcondition.gfs")
 
     # Make sure the .gfs file is more recent that the .gml one
     try:
-        gml_mtime = os.stat("data/gml/testcondition.gml").st_mtime
-        gfs_mtime = os.stat("data/gml/testcondition.gfs").st_mtime
+        gml_mtime = os.stat(tmp_path / "testcondition.gml").st_mtime
+        gfs_mtime = os.stat(tmp_path / "testcondition.gfs").st_mtime
         touch_gfs = gfs_mtime <= gml_mtime
     except Exception:
         touch_gfs = True
     if touch_gfs:
         print("Touching .gfs file")
-        f = open("data/gml/testcondition.gfs", "rb+")
+        f = open(tmp_path / "testcondition.gfs", "rb+")
         data = f.read(1)
         f.seek(0, 0)
         f.write(data)
         f.close()
 
-    ds = ogr.Open("data/gml/testcondition.gml")
+    ds = ogr.Open(tmp_path / "testcondition.gml")
     lyr = ds.GetLayer(0)
     feat = lyr.GetNextFeature()
     expected = [
@@ -2419,24 +2429,27 @@ def test_ogr_gml_60(tmp_path):
 # Test reading a element specified with a full path in <ElementPath>
 
 
-def test_ogr_gml_61():
+def test_ogr_gml_61(tmp_path):
+
+    gdal.CopyFile("data/gml/gmlsubfeature.gml", tmp_path / "gmlsubfeature.gml")
+    gdal.CopyFile("data/gml/gmlsubfeature.gfs", tmp_path / "gmlsubfeature.gfs")
 
     # Make sure the .gfs file is more recent that the .gml one
     try:
-        gml_mtime = os.stat("data/gml/gmlsubfeature.gml").st_mtime
-        gfs_mtime = os.stat("data/gml/gmlsubfeature.gfs").st_mtime
+        gml_mtime = os.stat(tmp_path / "gmlsubfeature.gml").st_mtime
+        gfs_mtime = os.stat(tmp_path / "gmlsubfeature.gfs").st_mtime
         touch_gfs = gfs_mtime <= gml_mtime
     except Exception:
         touch_gfs = True
     if touch_gfs:
         print("Touching .gfs file")
-        f = open("data/gml/gmlsubfeature.gfs", "rb+")
+        f = open(tmp_path / "gmlsubfeature.gfs", "rb+")
         data = f.read(1)
         f.seek(0, 0)
         f.write(data)
         f.close()
 
-    ds = ogr.Open("data/gml/gmlsubfeature.gml")
+    ds = ogr.Open(tmp_path / "gmlsubfeature.gml")
     lyr = ds.GetLayer(0)
     assert lyr.GetFeatureCount() == 2, "did not get expected geometry column name"
 

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -9593,7 +9593,11 @@ def test_ogr_gpkg_sozip(tmp_vsimem):
     filename = tmp_vsimem / "test_ogr_gpkg_sozip.gpkg.zip"
 
     with gdaltest.config_options(
-        {"CPL_SOZIP_MIN_FILE_SIZE": "256", "CPL_VSIL_DEFLATE_CHUNK_SIZE": "128"}
+        {
+            "CPL_SOZIP_MIN_FILE_SIZE": "256",
+            "CPL_VSIL_DEFLATE_CHUNK_SIZE": "128",
+            "CPL_TMPDIR": tmp_vsimem,
+        }
     ):
         ds = ogr.GetDriverByName("GPKG").CreateDataSource(filename)
         ds.CreateLayer("foo")
@@ -9674,47 +9678,48 @@ def test_ogr_gpkg_update_feature(tmp_vsimem):
 
     filename = tmp_vsimem / "test_ogr_gpkg_update_feature.gpkg.zip"
 
-    ds = ogr.GetDriverByName("GPKG").CreateDataSource(filename)
-    lyr = ds.CreateLayer("test")
-    lyr.CreateField(ogr.FieldDefn("int_field", ogr.OFTInteger))
-    lyr.CreateField(ogr.FieldDefn("str_field", ogr.OFTString))
-    f = ogr.Feature(lyr.GetLayerDefn())
-    f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (1 2)"))
-    f["int_field"] = 1
-    f["str_field"] = "foo"
-    assert lyr.CreateFeature(f) == ogr.OGRERR_NONE
-    assert lyr.TestCapability(ogr.OLCUpdateFeature) == 1
-    f = ogr.Feature(lyr.GetLayerDefn())
-    f.SetFID(1)
-    f["int_field"] = 123  # will be ignored
-    f["str_field"] = "bar"
-    assert lyr.UpdateFeature(f, [1], [], False) == ogr.OGRERR_NONE
-    # Check recycling of existing statement
-    f["str_field"] = "baz"
-    assert lyr.UpdateFeature(f, [1], [], False) == ogr.OGRERR_NONE
-    f = lyr.GetFeature(1)
-    assert f.GetGeometryRef().ExportToWkt() == "POINT (1 2)"
-    assert f["int_field"] == 1
-    assert f["str_field"] == "baz"
+    with gdal.config_option("CPL_TMPDIR", tmp_vsimem):
+        ds = ogr.GetDriverByName("GPKG").CreateDataSource(filename)
+        lyr = ds.CreateLayer("test")
+        lyr.CreateField(ogr.FieldDefn("int_field", ogr.OFTInteger))
+        lyr.CreateField(ogr.FieldDefn("str_field", ogr.OFTString))
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (1 2)"))
+        f["int_field"] = 1
+        f["str_field"] = "foo"
+        assert lyr.CreateFeature(f) == ogr.OGRERR_NONE
+        assert lyr.TestCapability(ogr.OLCUpdateFeature) == 1
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetFID(1)
+        f["int_field"] = 123  # will be ignored
+        f["str_field"] = "bar"
+        assert lyr.UpdateFeature(f, [1], [], False) == ogr.OGRERR_NONE
+        # Check recycling of existing statement
+        f["str_field"] = "baz"
+        assert lyr.UpdateFeature(f, [1], [], False) == ogr.OGRERR_NONE
+        f = lyr.GetFeature(1)
+        assert f.GetGeometryRef().ExportToWkt() == "POINT (1 2)"
+        assert f["int_field"] == 1
+        assert f["str_field"] == "baz"
 
-    # Do not modify unset fields
-    f.UnsetField(1)
-    assert lyr.UpdateFeature(f, [1], [], False) == ogr.OGRERR_NONE
-    f = lyr.GetFeature(1)
-    assert f["str_field"] == "baz"
+        # Do not modify unset fields
+        f.UnsetField(1)
+        assert lyr.UpdateFeature(f, [1], [], False) == ogr.OGRERR_NONE
+        f = lyr.GetFeature(1)
+        assert f["str_field"] == "baz"
 
-    # Nullify geometry
-    f.SetGeometry(None)
-    assert lyr.UpdateFeature(f, [], [0], False) == ogr.OGRERR_NONE
-    f = lyr.GetFeature(1)
-    assert f.GetGeometryRef() is None
+        # Nullify geometry
+        f.SetGeometry(None)
+        assert lyr.UpdateFeature(f, [], [0], False) == ogr.OGRERR_NONE
+        f = lyr.GetFeature(1)
+        assert f.GetGeometryRef() is None
 
-    # Set non null geometry
-    f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (1 2)"))
-    assert lyr.UpdateFeature(f, [], [0], False) == ogr.OGRERR_NONE
-    assert f.GetGeometryRef().ExportToWkt() == "POINT (1 2)"
+        # Set non null geometry
+        f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (1 2)"))
+        assert lyr.UpdateFeature(f, [], [0], False) == ogr.OGRERR_NONE
+        assert f.GetGeometryRef().ExportToWkt() == "POINT (1 2)"
 
-    ds = None
+        ds = None
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_index_test.py
+++ b/autotest/ogr/ogr_index_test.py
@@ -49,7 +49,7 @@ def startup_and_cleanup():
 @contextlib.contextmanager
 def create_index_p_test_file():
     drv = ogr.GetDriverByName("MapInfo File")
-    with drv.CreateDataSource("index_p.mif") as p_ds:
+    with drv.CreateDataSource("tmp/index_p.mif") as p_ds:
         p_lyr = p_ds.CreateLayer("index_p")
 
         ogrtest.quick_create_layer_def(p_lyr, [("PKEY", ogr.OFTInteger)])
@@ -62,13 +62,13 @@ def create_index_p_test_file():
 
     yield
 
-    ogr.GetDriverByName("MapInfo File").DeleteDataSource("index_p.mif")
+    ogr.GetDriverByName("MapInfo File").DeleteDataSource("tmp/index_p.mif")
 
 
 @contextlib.contextmanager
 def create_join_t_test_file(create_index=False):
     drv = ogr.GetDriverByName("ESRI Shapefile")
-    with drv.CreateDataSource("join_t.dbf") as s_ds:
+    with drv.CreateDataSource("tmp/join_t.dbf") as s_ds:
         s_lyr = s_ds.CreateLayer("join_t", geom_type=ogr.wkbNone)
 
         ogrtest.quick_create_layer_def(
@@ -84,7 +84,7 @@ def create_join_t_test_file(create_index=False):
 
     yield
 
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("join_t.dbf")
+    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/join_t.dbf")
 
 
 ###############################################################################
@@ -95,11 +95,11 @@ def test_ogr_index_can_join_without_index():
     expect = ["Value 5", "Value 10", "Value 9", "Value 4", "Value 3", "Value 1"]
 
     with create_index_p_test_file(), create_join_t_test_file():
-        p_ds = ogr.OpenShared("index_p.mif", update=0)
+        p_ds = ogr.OpenShared("tmp/index_p.mif", update=0)
 
         with p_ds.ExecuteSQL(
             "SELECT * FROM index_p p "
-            + 'LEFT JOIN "join_t.dbf".join_t j ON p.PKEY = j.SKEY '
+            + 'LEFT JOIN "tmp/join_t.dbf".join_t j ON p.PKEY = j.SKEY '
         ) as sql_lyr:
 
             ogrtest.check_features_against_list(sql_lyr, "VALUE", expect)
@@ -111,7 +111,7 @@ def test_ogr_index_can_join_without_index():
 
 def test_ogr_index_creating_index_causes_index_files_to_be_created():
     with create_join_t_test_file(create_index=True):
-        for filename in ["join_t.idm", "join_t.ind"]:
+        for filename in ["tmp/join_t.idm", "tmp/join_t.ind"]:
             assert os.path.exists(filename)
 
 
@@ -123,7 +123,7 @@ def test_ogr_index_indexed_single_integer_lookup_works():
     expect = ["Value 5"]
 
     with create_join_t_test_file(create_index=True):
-        s_ds = ogr.OpenShared("join_t.dbf", update=1)
+        s_ds = ogr.OpenShared("tmp/join_t.dbf", update=1)
 
         s_lyr = s_ds.GetLayerByName("join_t")
         s_lyr.SetAttributeFilter("SKEY = 5")
@@ -139,7 +139,7 @@ def test_ogr_index_indexed_single_string_works():
     expect = [5]
 
     with create_join_t_test_file(create_index=True):
-        s_ds = ogr.OpenShared("join_t.dbf", update=1)
+        s_ds = ogr.OpenShared("tmp/join_t.dbf", update=1)
         s_lyr = s_ds.GetLayerByName("join_t")
 
         s_lyr.SetAttributeFilter("VALUE='Value 5'")
@@ -155,7 +155,7 @@ def test_ogr_index_unimplemented_range_query_works():
     expect = [0, 1, 2]
 
     with create_join_t_test_file(create_index=True):
-        s_ds = ogr.OpenShared("join_t.dbf", update=1)
+        s_ds = ogr.OpenShared("tmp/join_t.dbf", update=1)
         s_lyr = s_ds.GetLayerByName("join_t")
         s_lyr.SetAttributeFilter("SKEY < 3")
 
@@ -170,10 +170,10 @@ def test_ogr_index_indexed_join_works():
     expect = ["Value 5", "Value 10", "Value 9", "Value 4", "Value 3", "Value 1"]
 
     with create_index_p_test_file(), create_join_t_test_file(create_index=True):
-        p_ds = ogr.OpenShared("index_p.mif", update=0)
+        p_ds = ogr.OpenShared("tmp/index_p.mif", update=0)
         with p_ds.ExecuteSQL(
             "SELECT * FROM index_p p "
-            + 'LEFT JOIN "join_t.dbf".join_t j ON p.PKEY = j.SKEY '
+            + 'LEFT JOIN "tmp/join_t.dbf".join_t j ON p.PKEY = j.SKEY '
         ) as sql_lyr:
 
             ogrtest.check_features_against_list(sql_lyr, "VALUE", expect)
@@ -185,13 +185,13 @@ def test_ogr_index_indexed_join_works():
 
 def test_ogr_index_drop_index_removes_files():
     with create_join_t_test_file(create_index=True):
-        with ogr.OpenShared("join_t.dbf", update=1) as s_ds:
+        with ogr.OpenShared("tmp/join_t.dbf", update=1) as s_ds:
             s_ds.ExecuteSQL("DROP INDEX ON join_t USING value")
             s_ds.ExecuteSQL("DROP INDEX ON join_t USING skey")
 
         # After dataset closing, check that the index files do not exist after
         # dropping the index
-        for filename in ["join_t.idm", "join_t.ind"]:
+        for filename in ["tmp/join_t.idm", "tmp/join_t.ind"]:
             assert not os.path.exists(filename)
 
 
@@ -203,7 +203,7 @@ def test_ogr_index_attribute_filter_works_after_drop_index():
     expect = ["Value 5"]
 
     with create_join_t_test_file(create_index=True):
-        s_ds = ogr.OpenShared("join_t.dbf", update=1)
+        s_ds = ogr.OpenShared("tmp/join_t.dbf", update=1)
         s_lyr = s_ds.GetLayerByName("join_t")
 
         s_ds.ExecuteSQL("DROP INDEX ON join_t USING value")
@@ -222,15 +222,15 @@ def test_ogr_index_attribute_filter_works_after_drop_index():
 def test_ogr_index_recreating_index_causes_index_files_to_be_created():
 
     with create_join_t_test_file(create_index=True):
-        with ogr.OpenShared("join_t.dbf", update=1) as s_ds:
+        with ogr.OpenShared("tmp/join_t.dbf", update=1) as s_ds:
             s_ds.ExecuteSQL("DROP INDEX ON join_t USING value")
             s_ds.ExecuteSQL("DROP INDEX ON join_t USING skey")
 
         # Re-create an index
-        with ogr.OpenShared("join_t.dbf", update=1) as s_ds:
+        with ogr.OpenShared("tmp/join_t.dbf", update=1) as s_ds:
             s_ds.ExecuteSQL("CREATE INDEX ON join_t USING value")
 
-        for filename in ["join_t.idm", "join_t.ind"]:
+        for filename in ["tmp/join_t.idm", "tmp/join_t.ind"]:
             try:
                 os.stat(filename)
             except (OSError, FileNotFoundError):
@@ -245,15 +245,15 @@ def test_ogr_index_recreating_index_causes_index_files_to_be_created():
 def test_ogr_index_recreating_index_causes_index_to_be_populated():
 
     with create_join_t_test_file(create_index=True):
-        with ogr.OpenShared("join_t.dbf", update=1) as s_ds:
+        with ogr.OpenShared("tmp/join_t.dbf", update=1) as s_ds:
             s_ds.ExecuteSQL("DROP INDEX ON join_t USING value")
             s_ds.ExecuteSQL("DROP INDEX ON join_t USING skey")
 
         # Re-create an index
-        with ogr.OpenShared("join_t.dbf", update=1) as s_ds:
+        with ogr.OpenShared("tmp/join_t.dbf", update=1) as s_ds:
             s_ds.ExecuteSQL("CREATE INDEX ON join_t USING value")
 
-        with open("join_t.idm", "rt") as f:
+        with open("tmp/join_t.idm", "rt") as f:
             xml = f.read()
         assert xml.find("VALUE") != -1, "VALUE column is not indexed (1)"
 
@@ -266,21 +266,21 @@ def test_ogr_index_recreating_index_causes_index_to_be_populated():
 def test_ogr_index_creating_index_in_separate_steps_works():
 
     with create_join_t_test_file(create_index=True):
-        with ogr.OpenShared("join_t.dbf", update=1) as s_ds:
+        with ogr.OpenShared("tmp/join_t.dbf", update=1) as s_ds:
             s_ds.ExecuteSQL("DROP INDEX ON join_t USING value")
             s_ds.ExecuteSQL("DROP INDEX ON join_t USING skey")
 
         # Re-create an index
-        with ogr.OpenShared("join_t.dbf", update=1) as s_ds:
+        with ogr.OpenShared("tmp/join_t.dbf", update=1) as s_ds:
             s_ds.ExecuteSQL("CREATE INDEX ON join_t USING value")
 
         # Close the dataset and re-open
-        with ogr.OpenShared("join_t.dbf", update=1) as s_ds:
+        with ogr.OpenShared("tmp/join_t.dbf", update=1) as s_ds:
             # At this point the .ind was opened in read-only. Now it
             # will be re-opened in read-write mode
             s_ds.ExecuteSQL("CREATE INDEX ON join_t USING skey")
 
-        with open("join_t.idm", "rt") as f:
+        with open("tmp/join_t.idm", "rt") as f:
             xml = f.read()
         assert xml.find("VALUE") != -1, "VALUE column is not indexed (2)"
         assert xml.find("SKEY") != -1, "SKEY column is not indexed (2)"

--- a/autotest/ogr/ogr_libkml.py
+++ b/autotest/ogr/ogr_libkml.py
@@ -439,12 +439,16 @@ def test_ogr_libkml_write_kmz_use_doc_off(tmp_vsimem):
 
 
 def test_ogr_libkml_write_kmz_simulate_cloud(tmp_vsimem):
-    with gdal.config_option("CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE", "FORCED"):
+    with gdal.config_options(
+        {"CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE": "FORCED", "CPL_TMPDIR": tmp_vsimem}
+    ):
         ogr_libkml_write(tmp_vsimem / "test_ogr_libkml_write_kmz_simulate_cloud.kmz")
 
     ogr_libkml_check_write(tmp_vsimem / "test_ogr_libkml_write_kmz_simulate_cloud.kmz")
 
-    with gdal.config_option("CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE", "FORCED"):
+    with gdal.config_options(
+        {"CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE": "FORCED", "CPL_TMPDIR": tmp_vsimem}
+    ):
         with pytest.raises(Exception):
             ogr_libkml_write("/i_do/not/exist.kmz")
 

--- a/autotest/ogr/ogr_lvbag.py
+++ b/autotest/ogr/ogr_lvbag.py
@@ -459,13 +459,15 @@ def test_ogr_lvbag_fix_identificatie():
     assert feat.GetField("identificatie") == "NL.IMBAG.Pand.0571100000003518"
 
 
-def test_ogr_lvbag_old_schema():
+def test_ogr_lvbag_old_schema(tmp_vsimem):
 
-    ds = ogr.Open("data/lvbag/lig_old.xml")
+    gdal.CopyFile("data/lvbag/lig_old.xml", tmp_vsimem / "lig_old.xml")
+
+    ds = ogr.Open(tmp_vsimem / "lig_old.xml")
     assert ds is not None, "cannot open dataset"
     assert ds.GetLayerCount() == 0, "bad layer count"
     ds = None
-    gdal.Unlink("data/lvbag/lig_old.gfs")
+    gdal.Unlink(tmp_vsimem / "lig_old.gfs")
 
 
 def test_ogr_lvbag_stringlist_feat():

--- a/autotest/ogr/ogr_mvt.py
+++ b/autotest/ogr/ogr_mvt.py
@@ -12,7 +12,6 @@
 ###############################################################################
 
 import json
-import os
 
 import gdaltest
 import ogrtest
@@ -31,10 +30,8 @@ def init():
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "ogr_mvt")
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_mvt.py
+++ b/autotest/ogr/ogr_mvt.py
@@ -12,6 +12,7 @@
 ###############################################################################
 
 import json
+import os
 
 import gdaltest
 import ogrtest
@@ -26,6 +27,13 @@ pytestmark = pytest.mark.require_driver("MVT")
 @pytest.fixture(scope="module", autouse=True)
 def init():
     with gdaltest.config_option("OGR_MVT_ENFORE_EXTERNAL_RING_IS_CLOCKWISE", "YES"):
+        yield
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
         yield
 
 

--- a/autotest/ogr/ogr_nas.py
+++ b/autotest/ogr/ogr_nas.py
@@ -163,15 +163,12 @@ def test_ogr_nas_3():
 #
 
 
-def test_ogr_nas_4():
+def test_ogr_nas_4(tmp_vsimem):
 
-    try:
-        os.remove("data/nas/delete_nas.gfs")
-    except OSError:
-        pass
+    gdal.CopyFile("data/nas/delete_nas.xml", tmp_vsimem / "delete_nas.xml")
 
     with gdal.config_option("NAS_GFS_TEMPLATE", ""):
-        ds = ogr.Open("data/nas/delete_nas.xml")
+        ds = ogr.Open(tmp_vsimem / "delete_nas.xml")
 
     assert ds.GetLayerCount() == 1, "did not get expected layer count"
 
@@ -195,10 +192,7 @@ def test_ogr_nas_4():
     del_lyr = None
     ds = None
 
-    try:
-        os.remove("data/nas/delete_nas.gfs")
-    except OSError:
-        pass
+    gdal.Unlink(tmp_vsimem / "delete_nas.gfs")
 
 
 ###############################################################################
@@ -206,15 +200,12 @@ def test_ogr_nas_4():
 #
 
 
-def test_ogr_nas_5():
+def test_ogr_nas_5(tmp_vsimem):
 
-    try:
-        os.remove("data/nas/replace_nas.gfs")
-    except OSError:
-        pass
+    gdal.CopyFile("data/nas/replace_nas.xml", tmp_vsimem / "replace_nas.xml")
 
     with gdal.config_option("NAS_GFS_TEMPLATE", ""):
-        ds = ogr.Open("data/nas/replace_nas.xml")
+        ds = ogr.Open(tmp_vsimem / "replace_nas.xml")
 
     assert ds.GetLayerCount() == 2, "did not get expected layer count"
 
@@ -262,10 +253,7 @@ def test_ogr_nas_5():
 
     ds = None
 
-    try:
-        os.remove("data/nas/replace_nas.gfs")
-    except OSError:
-        pass
+    gdal.Unlink(tmp_vsimem / "replace_nas.gfs")
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_pdf.py
+++ b/autotest/ogr/ogr_pdf.py
@@ -250,7 +250,9 @@ def test_ogr_pdf_5():
 @pytest.mark.skipif(not has_read_support(), reason="PDF driver lacks read support")
 def test_ogr_pdf_bezier_curve_and_polygon_holes():
 
-    with gdaltest.config_option("OGR_PDF_READ_NON_STRUCTURED", "YES"):
+    with gdaltest.config_options(
+        {"OGR_PDF_READ_NON_STRUCTURED": "YES", "GDAL_PAM_ENABLED": "NO"}
+    ):
         ds = ogr.Open("data/pdf/bezier_curve_and_polygon_holes.pdf")
     assert ds is not None
 

--- a/autotest/ogr/ogr_selafin.py
+++ b/autotest/ogr/ogr_selafin.py
@@ -13,11 +13,12 @@
 ###############################################################################
 
 import math
+import os
 
 import gdaltest
 import pytest
 
-from osgeo import ogr, osr
+from osgeo import gdal, ogr, osr
 
 pytestmark = pytest.mark.require_driver("Selafin")
 
@@ -26,6 +27,13 @@ pytestmark = pytest.mark.require_driver("Selafin")
 @pytest.fixture(autouse=True, scope="module")
 def module_disable_exceptions():
     with gdaltest.disable_exceptions():
+        yield
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
         yield
 
 

--- a/autotest/ogr/ogr_selafin.py
+++ b/autotest/ogr/ogr_selafin.py
@@ -13,12 +13,11 @@
 ###############################################################################
 
 import math
-import os
 
 import gdaltest
 import pytest
 
-from osgeo import gdal, ogr, osr
+from osgeo import ogr, osr
 
 pytestmark = pytest.mark.require_driver("Selafin")
 
@@ -31,10 +30,8 @@ def module_disable_exceptions():
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "ogr_selafin")
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -1458,9 +1458,11 @@ def test_ogr_shape_36():
 # Check that we can read from the root of a .tar.gz file
 
 
-def test_ogr_shape_37():
+def test_ogr_shape_37(tmp_vsimem):
 
-    ds = ogr.Open("/vsitar/data/shp/poly.tar.gz")
+    gdal.CopyFile("data/shp/poly.tar.gz", tmp_vsimem / "poly.tar.gz")
+
+    ds = ogr.Open(f"/vsitar/{tmp_vsimem}/poly.tar.gz")
     assert ds is not None
 
     lyr = ds.GetLayer(0)
@@ -1491,7 +1493,6 @@ def test_ogr_shape_37():
     )
 
     ds = None
-    gdal.Unlink("data/shp/poly.tar.gz.properties")
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_sosi.py
+++ b/autotest/ogr/ogr_sosi.py
@@ -12,8 +12,6 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
-import shutil
-
 import gdaltest
 import pytest
 
@@ -47,60 +45,57 @@ def test_ogr_sosi_1():
 # test using no appendFieldsMap
 
 
-def test_ogr_sosi_2():
+def test_ogr_sosi_2(tmp_path):
 
-    try:
-        ds = gdal.Open("data/sosi/test_duplicate_fields.sos", open_options=[])
-        lyr = ds.GetLayer(0)
-        assert lyr.GetFeatureCount() == 17
-        lyr = ds.GetLayer(1)
-        assert lyr.GetFeatureCount() == 1
-        f = lyr.GetNextFeature()
-        assert f["REINBEITEBRUKERID"] == "YD"
-        ds.Close()
-    finally:
-        shutil.rmtree("data/sosi/test_duplicate_fields")
+    gdal.CopyFile("data/sosi/test_duplicate_fields.sos", tmp_path / "test.sos")
+
+    ds = gdal.Open(tmp_path / "test.sos", open_options=[])
+    lyr = ds.GetLayer(0)
+    assert lyr.GetFeatureCount() == 17
+    lyr = ds.GetLayer(1)
+    assert lyr.GetFeatureCount() == 1
+    f = lyr.GetNextFeature()
+    assert f["REINBEITEBRUKERID"] == "YD"
+    ds.Close()
 
 
 ###############################################################################
 # test using simple open_options appendFieldsMap
 
 
-def test_ogr_sosi_3():
+def test_ogr_sosi_3(tmp_path):
 
-    try:
-        ds = gdal.Open(
-            "data/sosi/test_duplicate_fields.sos",
-            open_options=["appendFieldsMap=BEITEBRUKERID&OPPHAV"],
-        )
-        lyr = ds.GetLayer(0)
-        assert lyr.GetFeatureCount() == 17
-        lyr = ds.GetLayer(1)
-        assert lyr.GetFeatureCount() == 1
-        f = lyr.GetNextFeature()
-        assert f["REINBEITEBRUKERID"] == "YD,YG"
-        ds.Close()
-    finally:
-        shutil.rmtree("data/sosi/test_duplicate_fields")
+    gdal.CopyFile("data/sosi/test_duplicate_fields.sos", tmp_path / "test.sos")
+
+    ds = gdal.Open(
+        tmp_path / "test.sos",
+        open_options=["appendFieldsMap=BEITEBRUKERID&OPPHAV"],
+    )
+    lyr = ds.GetLayer(0)
+    assert lyr.GetFeatureCount() == 17
+    lyr = ds.GetLayer(1)
+    assert lyr.GetFeatureCount() == 1
+    f = lyr.GetNextFeature()
+    assert f["REINBEITEBRUKERID"] == "YD,YG"
+    ds.Close()
 
 
 ###############################################################################
 # test using simple open_options appendFieldsMap with semicolumns
 
 
-def test_ogr_sosi_4():
+def test_ogr_sosi_4(tmp_path):
 
-    try:
-        ds = gdal.Open(
-            "data/sosi/test_duplicate_fields.sos",
-            open_options=["appendFieldsMap=BEITEBRUKERID:;&OPPHAV:;"],
-        )
-        lyr = ds.GetLayer(0)
-        assert lyr.GetFeatureCount() == 17
-        lyr = ds.GetLayer(1)
-        assert lyr.GetFeatureCount() == 1
-        f = lyr.GetNextFeature()
-        assert f["REINBEITEBRUKERID"] == "YD;YG"
-        ds.Close()
-    finally:
-        shutil.rmtree("data/sosi/test_duplicate_fields")
+    gdal.CopyFile("data/sosi/test_duplicate_fields.sos", tmp_path / "test.sos")
+
+    ds = gdal.Open(
+        tmp_path / "test.sos",
+        open_options=["appendFieldsMap=BEITEBRUKERID:;&OPPHAV:;"],
+    )
+    lyr = ds.GetLayer(0)
+    assert lyr.GetFeatureCount() == 17
+    lyr = ds.GetLayer(1)
+    assert lyr.GetFeatureCount() == 1
+    f = lyr.GetNextFeature()
+    assert f["REINBEITEBRUKERID"] == "YD;YG"
+    ds.Close()

--- a/autotest/ogr/ogr_vdv.py
+++ b/autotest/ogr/ogr_vdv.py
@@ -72,8 +72,8 @@ def test_ogr_idf_1():
 
 
 @pytest.mark.require_driver("SQLite")
-def test_ogr_idf_1_with_temp_sqlite_db():
-    options = {"OGR_IDF_TEMP_DB_THRESHOLD": "0"}
+def test_ogr_idf_1_with_temp_sqlite_db(tmp_path):
+    options = {"OGR_IDF_TEMP_DB_THRESHOLD": "0", "CPL_TMPDIR": tmp_path}
     with gdaltest.config_options(options):
         return test_ogr_idf_1()
 

--- a/autotest/ogr/ogr_wasp.py
+++ b/autotest/ogr/ogr_wasp.py
@@ -30,9 +30,9 @@ pytestmark = pytest.mark.require_driver("WAsP")
 def test_ogr_wasp_create_ds():
 
     wasp_drv = ogr.GetDriverByName("WAsP")
-    wasp_drv.DeleteDataSource("tmp.map")
+    wasp_drv.DeleteDataSource("tmp/tmp.map")
 
-    gdaltest.wasp_ds = wasp_drv.CreateDataSource("tmp.map")
+    gdaltest.wasp_ds = wasp_drv.CreateDataSource("tmp/tmp.map")
 
     if gdaltest.wasp_ds is not None:
         return
@@ -71,7 +71,7 @@ def test_ogr_wasp_elevation_from_linestring_z():
     del gdaltest.wasp_ds
     del layer
 
-    f = open("tmp.map")
+    f = open("tmp/tmp.map")
     for i in range(4):
         f.readline()
     i = 0
@@ -133,7 +133,7 @@ def test_ogr_wasp_elevation_from_linestring_z_toler():
     del gdaltest.wasp_ds
     del layer
 
-    f = open("tmp.map")
+    f = open("tmp/tmp.map")
     for i in range(4):
         f.readline()
     i = 0
@@ -184,7 +184,7 @@ def test_ogr_wasp_elevation_from_linestring_field():
     del gdaltest.wasp_ds
     del layer
 
-    f = open("tmp.map")
+    f = open("tmp/tmp.map")
     for i in range(4):
         f.readline()
     i = 0
@@ -233,7 +233,7 @@ def test_ogr_wasp_roughness_from_linestring_fields():
     del gdaltest.wasp_ds
     del layer
 
-    f = open("tmp.map")
+    f = open("tmp/tmp.map")
     for i in range(4):
         f.readline()
     i = 0
@@ -290,7 +290,7 @@ def test_ogr_wasp_roughness_from_polygon_z():
     del gdaltest.wasp_ds
     del layer
 
-    f = open("tmp.map")
+    f = open("tmp/tmp.map")
     for i in range(4):
         f.readline()
     i = 0
@@ -356,7 +356,7 @@ def test_ogr_wasp_roughness_from_polygon_field():
     del gdaltest.wasp_ds
     del layer
 
-    f = open("tmp.map")
+    f = open("tmp/tmp.map")
     for i in range(4):
         f.readline()
     i = 0
@@ -420,7 +420,7 @@ def test_ogr_wasp_merge():
     del gdaltest.wasp_ds
     del layer
 
-    f = open("tmp.map")
+    f = open("tmp/tmp.map")
     for i in range(4):
         f.readline()
     i = 0
@@ -453,7 +453,7 @@ def test_ogr_wasp_reading():
 
     gdaltest.wasp_ds = None
 
-    ds = ogr.Open("tmp.map")
+    ds = ogr.Open("tmp/tmp.map")
 
     assert ds is not None and ds.GetLayerCount() == 1
 
@@ -475,4 +475,4 @@ def test_ogr_wasp_reading():
 def test_ogr_wasp_cleanup():
 
     wasp_drv = ogr.GetDriverByName("WAsP")
-    wasp_drv.DeleteDataSource("tmp.map")
+    wasp_drv.DeleteDataSource("tmp/tmp.map")

--- a/autotest/ogr/ogr_wfs.py
+++ b/autotest/ogr/ogr_wfs.py
@@ -799,17 +799,12 @@ def test_ogr_wfs_xmldescriptionfile_to_be_updated():
 # The following test should issue 0 WFS http request
 
 
-def test_ogr_wfs_getcapabilitiesfile():
+def test_ogr_wfs_getcapabilitiesfile(tmp_path):
 
-    ds = ogr.Open("data/wfs/getcapabilities_wfs.xml")
+    gdal.CopyFile("data/wfs/getcapabilities_wfs.xml", tmp_path / "tmp.xml")
 
-    if ds is None:
-        gdal.Unlink("data/wfs/getcapabilities_wfs.gfs")
-        pytest.fail()
-
-    ds = None
-
-    gdal.Unlink("data/wfs/getcapabilities_wfs.gfs")
+    ds = ogr.Open(tmp_path / "tmp.xml")
+    assert ds
 
 
 ###############################################################################

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -2281,3 +2281,14 @@ def algorithm_check_ogrsf(alg, tmp_path):
     assert "INFO" in ret
     assert "ERROR" not in ret
     assert "FAILURE" not in ret
+
+
+###############################################################################
+#
+def set_cpl_tmpdir(tmp_path_factory, subdir_name):
+    """Yield after having created a temporary directory subdir_name in the
+    pytest tmp_path one, and set CPL_TMPDIR to that path."""
+
+    tmpdir = tmp_path_factory.mktemp(subdir_name)
+    with gdal.config_option("CPL_TMPDIR", tmpdir):
+        yield

--- a/autotest/pyscripts/gdal2tiles/test_logger.py
+++ b/autotest/pyscripts/gdal2tiles/test_logger.py
@@ -12,6 +12,8 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import os
+
 import gdaltest
 import pytest
 
@@ -24,22 +26,29 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def test_gdal2tiles_logger():
+def test_gdal2tiles_logger(tmp_path):
 
     if gdal.GetDriverByName("PNG") is None:
         pytest.skip("PNG driver is missing")
 
-    gdal2tiles.main(
-        argv=[
-            "gdal2tiles",
-            "--verbose",
-            "--legacy",
-            "-z",
-            "13-14",
-            "../../gcore/data/byte.tif",
-            "/vsimem/gdal2tiles",
-        ]
-    )
+    gdal.CopyFile("../../gcore/data/byte.tif", tmp_path / "byte.tif")
+
+    old_pwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        gdal2tiles.main(
+            argv=[
+                "gdal2tiles",
+                "--verbose",
+                "--legacy",
+                "-z",
+                "13-14",
+                tmp_path / "byte.tif",
+                "/vsimem/gdal2tiles",
+            ]
+        )
+    finally:
+        os.chdir(old_pwd)
 
     assert set(gdal.ReadDirRecursive("/vsimem/gdal2tiles")) == set(
         [

--- a/autotest/pyscripts/test_gdal2tiles.py
+++ b/autotest/pyscripts/test_gdal2tiles.py
@@ -296,7 +296,7 @@ def test_gdal2tiles_py_invalid_srs(script_path, tmp_path):
     ret2 = test_py_scripts.run_py_script(
         script_path,
         "gdal2tiles",
-        f"-q --zoom=0-1 --s_srs EPSG:4326 {input_vrt}",
+        f"-q --zoom=0-1 --s_srs EPSG:4326 {input_vrt} {output_dir}",
     )
 
     assert "ERROR ret code" not in ret2

--- a/autotest/pyscripts/test_gdal_fillnodata.py
+++ b/autotest/pyscripts/test_gdal_fillnodata.py
@@ -69,7 +69,8 @@ def test_gdal_fillnodata_1(script_path, tmp_path):
     _, err = test_py_scripts.run_py_script(
         script_path,
         "gdal_fillnodata",
-        test_py_scripts.get_data_path("gcore") + f"byte.tif {result_tif}",
+        test_py_scripts.get_data_path("gcore")
+        + f"byte.tif {result_tif} --config CPL_TMPDIR tmp",
         return_stderr=True,
     )
     assert "UseExceptions" not in err
@@ -93,7 +94,7 @@ def test_gdal_fillnodata_2(script_path, tmp_path):
         "gdal_fillnodata",
         "-si 0 "
         + test_py_scripts.get_data_path("gcore")
-        + f"nodata_byte.tif {result_tif}",
+        + f"nodata_byte.tif {result_tif} --config CPL_TMPDIR tmp",
     )
 
     ds = gdal.Open(result_tif)
@@ -123,7 +124,7 @@ def test_gdal_fillnodata_smoothing(script_path, tmp_path):
     test_py_scripts.run_py_script(
         script_path,
         "gdal_fillnodata",
-        f"-md 1 -si 1 {input_tif} {result_tif}",
+        f"-md 1 -si 1 {input_tif} {result_tif} --config CPL_TMPDIR tmp",
     )
 
     expected_data = (20, 30, 40, 50, 30, 40, 50, 60, 40, 50, 60, 70, 50, 60, 70, 80)
@@ -153,7 +154,7 @@ def test_gdal_fillnodata_nearest(script_path, tmp_path):
     test_py_scripts.run_py_script(
         script_path,
         "gdal_fillnodata",
-        f"-interp nearest {input_tif} {result_tif}",
+        f"-interp nearest {input_tif} {result_tif} --config CPL_TMPDIR tmp",
     )
 
     expected_data = (20, 30, 40, 50, 30, 60, 70, 80, 90)

--- a/autotest/pyscripts/test_gdal_proximity.py
+++ b/autotest/pyscripts/test_gdal_proximity.py
@@ -72,7 +72,8 @@ def test_gdal_proximity_1(script_path, tmp_path):
     _, err = test_py_scripts.run_py_script(
         script_path,
         "gdal_proximity",
-        test_py_scripts.get_data_path("alg") + f"pat.tif {output_tif}",
+        test_py_scripts.get_data_path("alg")
+        + f"pat.tif {output_tif} --config CPL_TMPDIR tmp",
         return_stderr=True,
     )
     assert "UseExceptions" not in err

--- a/autotest/utilities/test_gdalalg_external.py
+++ b/autotest/utilities/test_gdalalg_external.py
@@ -11,6 +11,8 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import os
+
 import pytest
 import test_cli_utilities
 
@@ -19,6 +21,13 @@ from osgeo import gdal
 pytestmark = pytest.mark.skipif(
     test_cli_utilities.get_gdal_path() is None, reason="gdal binary not available"
 )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
+        yield
 
 
 def test_gdalalg_external_pipeline_simple_raster(tmp_vsimem, tmp_path):

--- a/autotest/utilities/test_gdalalg_external.py
+++ b/autotest/utilities/test_gdalalg_external.py
@@ -11,8 +11,7 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
-import os
-
+import gdaltest
 import pytest
 import test_cli_utilities
 
@@ -24,10 +23,8 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "test_gdalalg_external")
 
 
 def test_gdalalg_external_pipeline_simple_raster(tmp_vsimem, tmp_path):

--- a/autotest/utilities/test_gdalalg_mdim_compare.py
+++ b/autotest/utilities/test_gdalalg_mdim_compare.py
@@ -11,6 +11,8 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import shutil
+
 import pytest
 
 from osgeo import gdal
@@ -18,19 +20,21 @@ from osgeo import gdal
 pytestmark = pytest.mark.require_driver("netCDF")
 
 
-def test_gdalalg_mdim_compare_same_file():
+def test_gdalalg_mdim_compare_same_file(tmp_path):
 
+    shutil.copy("../gdrivers/data/netcdf/byte.nc", tmp_path / "byte.nc")
     with gdal.alg.mdim.compare(
-        input="../gdrivers/data/netcdf/byte.nc",
-        reference="../gdrivers/data/netcdf/byte.nc",
+        input=tmp_path / "byte.nc",
+        reference=tmp_path / "byte.nc",
     ) as alg:
         assert alg["output-string"] == ""
 
 
 def test_gdalalg_mdim_compare_diff_by_one_pixel_everywhere(tmp_path):
 
+    shutil.copy("../gdrivers/data/netcdf/byte.nc", tmp_path / "byte.nc")
     gdal.alg.raster.scale(
-        input="../gdrivers/data/netcdf/byte.nc",
+        input=tmp_path / "byte.nc",
         output=tmp_path / "out.nc",
         input_min=0,
         input_max=255,
@@ -39,7 +43,7 @@ def test_gdalalg_mdim_compare_diff_by_one_pixel_everywhere(tmp_path):
     )
 
     with gdal.alg.mdim.compare(
-        reference="../gdrivers/data/netcdf/byte.nc",
+        reference=tmp_path / "byte.nc",
         input=tmp_path / "out.nc",
         skip_binary=True,
     ) as alg:
@@ -52,8 +56,9 @@ Array /Band1: pixels differing: 399
 
 def test_gdalalg_mdim_compare_diff_by_one_pixel_everywhere_no_metric(tmp_path):
 
+    shutil.copy("../gdrivers/data/netcdf/byte.nc", tmp_path / "byte.nc")
     gdal.alg.raster.scale(
-        input="../gdrivers/data/netcdf/byte.nc",
+        input=tmp_path / "byte.nc",
         output=tmp_path / "out.nc",
         input_min=0,
         input_max=255,
@@ -62,7 +67,7 @@ def test_gdalalg_mdim_compare_diff_by_one_pixel_everywhere_no_metric(tmp_path):
     )
 
     with gdal.alg.mdim.compare(
-        reference="../gdrivers/data/netcdf/byte.nc",
+        reference=tmp_path / "byte.nc",
         input=tmp_path / "out.nc",
         skip_binary=True,
         metric="none",
@@ -72,14 +77,15 @@ def test_gdalalg_mdim_compare_diff_by_one_pixel_everywhere_no_metric(tmp_path):
 
 def test_gdalalg_mdim_compare_diff_by_one_pixel_everywhere_psnr_float(tmp_path):
 
+    shutil.copy("../gdrivers/data/netcdf/byte.nc", tmp_path / "byte.nc")
     tmp_filename = tmp_path / "out.nc"
     with gdal.alg.raster.pipeline(
-        pipeline=f"read ../gdrivers/data/netcdf/byte.nc ! set-type --output-data-type Float32 ! scale --input-min=0 --input-max=255 --output-min=1 --output-max=256 ! write {tmp_filename}"
+        pipeline=f"read {tmp_path}/byte.nc ! set-type --output-data-type Float32 ! scale --input-min=0 --input-max=255 --output-min=1 --output-max=256 ! write {tmp_filename}"
     ) as _:
         pass
 
     with gdal.alg.mdim.compare(
-        input="../gdrivers/data/netcdf/byte.nc",
+        input=tmp_path / "byte.nc",
         reference=tmp_filename,
         skip_binary=True,
         metric="PSNR",
@@ -94,8 +100,9 @@ Array /Band1: PSNR (dB): 45.1536
 
 def test_gdalalg_mdim_compare_diff_by_one_pixel_everywhere_all_metrics(tmp_path):
 
+    shutil.copy("../gdrivers/data/netcdf/byte.nc", tmp_path / "byte.nc")
     gdal.alg.raster.scale(
-        input="../gdrivers/data/netcdf/byte.nc",
+        input=tmp_path / "byte.nc",
         output=tmp_path / "out.nc",
         input_min=0,
         input_max=255,
@@ -111,7 +118,7 @@ def test_gdalalg_mdim_compare_diff_by_one_pixel_everywhere_all_metrics(tmp_path)
         return True
 
     with gdal.alg.mdim.compare(
-        input="../gdrivers/data/netcdf/byte.nc",
+        input=tmp_path / "byte.nc",
         reference=tmp_path / "out.nc",
         metric="all",
         skip_binary=True,
@@ -128,14 +135,15 @@ Array /Band1: PSNR (dB): 48.1417
     assert tab_pct[0] == 1
 
 
-def test_gdalalg_mdim_compare_errors():
+def test_gdalalg_mdim_compare_errors(tmp_path):
 
+    shutil.copy("../gdrivers/data/netcdf/byte.nc", tmp_path / "byte.nc")
     with pytest.raises(
         Exception, match="Array '/i/do/not/exist' does not exist in reference dataset"
     ):
         gdal.alg.mdim.compare(
-            input="../gdrivers/data/netcdf/byte.nc",
-            reference="../gdrivers/data/netcdf/byte.nc",
+            input=tmp_path / "byte.nc",
+            reference=tmp_path / "byte.nc",
             array="/i/do/not/exist",
             skip_binary=True,
         )
@@ -147,14 +155,14 @@ def test_gdalalg_mdim_compare_errors():
     ):
         gdal.alg.mdim.compare(
             input=src_ds,
-            reference="../gdrivers/data/netcdf/byte.nc",
+            reference=tmp_path / "byte.nc",
             array="/Band1",
             skip_binary=True,
         )
 
     with gdal.alg.mdim.compare(
         input=src_ds,
-        reference="../gdrivers/data/netcdf/byte.nc",
+        reference=tmp_path / "byte.nc",
         skip_binary=True,
     ) as alg:
         assert (
@@ -164,7 +172,7 @@ def test_gdalalg_mdim_compare_errors():
 
     with gdal.alg.mdim.compare(
         reference=src_ds,
-        input="../gdrivers/data/netcdf/byte.nc",
+        input=tmp_path / "byte.nc",
         skip_binary=True,
     ) as alg:
         assert (
@@ -175,9 +183,10 @@ def test_gdalalg_mdim_compare_errors():
 
 def test_gdalalg_mdim_compare_in_pipeline(tmp_path):
 
+    shutil.copy("../gdrivers/data/netcdf/byte.nc", tmp_path / "byte.nc")
     tmp_filename = tmp_path / "out.nc"
     gdal.alg.raster.scale(
-        input="../gdrivers/data/netcdf/byte.nc",
+        input=tmp_path / "byte.nc",
         output=tmp_filename,
         input_min=0,
         input_max=255,
@@ -186,7 +195,7 @@ def test_gdalalg_mdim_compare_in_pipeline(tmp_path):
     )
 
     with gdal.alg.mdim.pipeline(
-        pipeline=f"read {tmp_filename} ! compare ../gdrivers/data/netcdf/byte.nc --skip-binary --array Band1"
+        pipeline=f"read {tmp_filename} ! compare {tmp_path}/byte.nc --skip-binary --array Band1"
     ) as alg:
         assert (
             alg["output-string"] == """Array /Band1: maximum pixel value difference: 1

--- a/autotest/utilities/test_gdalalg_mdim_info.py
+++ b/autotest/utilities/test_gdalalg_mdim_info.py
@@ -36,9 +36,10 @@ def get_mdim_info_alg():
     return gdal.GetGlobalAlgorithmRegistry()["mdim"]["info"]
 
 
-def test_gdalalg_mdim_info():
+def test_gdalalg_mdim_info(tmp_path):
     info = get_mdim_info_alg()
-    assert info.ParseRunAndFinalize(["../gdrivers/data/netcdf/byte.nc"])
+    gdal.CopyFile("../gdrivers/data/netcdf/byte.nc", tmp_path / "byte.nc")
+    assert info.ParseRunAndFinalize([tmp_path / "byte.nc"])
     output_string = info["output-string"]
     j = json.loads(output_string)
     del j["arrays"]["Band1"]["srs"]["wkt"]
@@ -107,11 +108,12 @@ def test_gdalalg_mdim_info():
     }
 
 
-def test_gdalalg_mdim_info_all_options():
+def test_gdalalg_mdim_info_all_options(tmp_path):
     info = get_mdim_info_alg()
+    gdal.CopyFile("../gdrivers/data/netcdf/byte.nc", tmp_path / "byte.nc")
     assert info.ParseRunAndFinalize(
         [
-            "../gdrivers/data/netcdf/byte.nc",
+            tmp_path / "byte.nc",
             "--detailed",
             "--stats",
             "--limit=5",
@@ -151,10 +153,11 @@ def test_gdalalg_mdim_info_all_options():
     }
 
 
-def test_gdalalg_mdim_info_binary_json(gdal_path):
+def test_gdalalg_mdim_info_binary_json(tmp_path, gdal_path):
 
+    gdal.CopyFile("../gdrivers/data/netcdf/byte.nc", tmp_path / "byte.nc")
     out = gdaltest.runexternal(
-        f"{gdal_path} mdim info ../gdrivers/data/netcdf/byte.nc --format json"
+        f"{gdal_path} mdim info {tmp_path}/byte.nc --format json"
     )
     assert json.loads(out) == {
         "type": "group",
@@ -224,11 +227,10 @@ def test_gdalalg_mdim_info_binary_json(gdal_path):
     }
 
 
-def test_gdalalg_mdim_info_text():
+def test_gdalalg_mdim_info_text(tmp_path):
 
-    with gdal.alg.mdim.info(
-        input="../gdrivers/data/netcdf/byte.nc", format="text"
-    ) as alg:
+    gdal.CopyFile("../gdrivers/data/netcdf/byte.nc", tmp_path / "byte.nc")
+    with gdal.alg.mdim.info(input=tmp_path / "byte.nc", format="text") as alg:
         out = alg.Output()
 
     out = "\n".join([x.rstrip() for x in out.replace("\r\n", "\n").split("\n")])
@@ -310,10 +312,11 @@ Arrays:
 """, out
 
 
-def test_gdalalg_mdim_info_text_summary():
+def test_gdalalg_mdim_info_text_summary(tmp_path):
 
+    gdal.CopyFile("../gdrivers/data/netcdf/byte.nc", tmp_path / "byte.nc")
     with gdal.alg.mdim.info(
-        input="../gdrivers/data/netcdf/byte.nc", summary=True, format="text"
+        input=tmp_path / "byte.nc", summary=True, format="text"
     ) as alg:
         out = alg.Output()
 
@@ -344,10 +347,11 @@ Data variables:
 """, out
 
 
-def test_gdalalg_mdim_info_text_array_detailed_stats():
+def test_gdalalg_mdim_info_text_array_detailed_stats(tmp_path):
 
+    gdal.CopyFile("../gdrivers/data/netcdf/byte.nc", tmp_path / "byte.nc")
     with gdal.alg.mdim.info(
-        input="../gdrivers/data/netcdf/byte.nc",
+        input=tmp_path / "byte.nc",
         detailed=True,
         stats=True,
         array="/Band1",
@@ -503,9 +507,10 @@ Arrays:
 """
 
 
-def test_gdalalg_mdim_info_binary_text(gdal_path):
+def test_gdalalg_mdim_info_binary_text(tmp_path, gdal_path):
 
-    out = gdaltest.runexternal(f"{gdal_path} mdim info ../gdrivers/data/netcdf/byte.nc")
+    gdal.CopyFile("../gdrivers/data/netcdf/byte.nc", tmp_path / "byte.nc")
+    out = gdaltest.runexternal(f"{gdal_path} mdim info {tmp_path}/byte.nc")
     out = "\n".join([x.rstrip() for x in out.replace("\r\n", "\n").split("\n")])
     assert out == """Driver: netCDF
 
@@ -585,10 +590,11 @@ Arrays:
 """, out
 
 
-def test_gdalalg_mdim_info_binary_text_array_and_detailed(gdal_path):
+def test_gdalalg_mdim_info_binary_text_array_and_detailed(tmp_path, gdal_path):
 
+    gdal.CopyFile("../gdrivers/data/netcdf/byte.nc", tmp_path / "byte.nc")
     out = gdaltest.runexternal(
-        f"{gdal_path} mdim info --array Band1 --detailed ../gdrivers/data/netcdf/byte.nc"
+        f"{gdal_path} mdim info --array Band1 --detailed {tmp_path}/byte.nc"
     )
     assert (
         "\n".join([x.rstrip() for x in out.replace("\r\n", "\n").split("\n")])
@@ -671,8 +677,10 @@ def test_gdalalg_mdim_info_completion_array_option(gdal_path):
     assert "USE_DEFAULT_FILL_AS_NODATA=" in out
 
 
-def test_gdalalg_mdim_info_summary():
-    info = gdal.alg.mdim.info(input="../gdrivers/data/netcdf/byte.nc", summary=True)
+def test_gdalalg_mdim_info_summary(tmp_path):
+
+    gdal.CopyFile("../gdrivers/data/netcdf/byte.nc", tmp_path / "byte.nc")
+    info = gdal.alg.mdim.info(input=tmp_path / "byte.nc", summary=True)
     output_string = info["output-string"]
     j = json.loads(output_string)
     assert j == {

--- a/autotest/utilities/test_gdalalg_pipeline.py
+++ b/autotest/utilities/test_gdalalg_pipeline.py
@@ -23,10 +23,8 @@ from osgeo import gdal, ogr
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "test_gdalalg_pipeline")
 
 
 def get_pipeline_alg():

--- a/autotest/utilities/test_gdalalg_pipeline.py
+++ b/autotest/utilities/test_gdalalg_pipeline.py
@@ -22,6 +22,13 @@ import test_cli_utilities
 from osgeo import gdal, ogr
 
 
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
+        yield
+
+
 def get_pipeline_alg():
     return gdal.GetGlobalAlgorithmRegistry()["pipeline"]
 

--- a/autotest/utilities/test_gdalalg_raster_clean_collar.py
+++ b/autotest/utilities/test_gdalalg_raster_clean_collar.py
@@ -11,6 +11,8 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import os
+
 import pytest
 
 from osgeo import gdal
@@ -18,6 +20,13 @@ from osgeo import gdal
 
 def get_alg():
     return gdal.GetGlobalAlgorithmRegistry()["raster"]["clean-collar"]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
+        yield
 
 
 def test_gdalalg_raster_clean_collar():

--- a/autotest/utilities/test_gdalalg_raster_clean_collar.py
+++ b/autotest/utilities/test_gdalalg_raster_clean_collar.py
@@ -11,8 +11,7 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
-import os
-
+import gdaltest
 import pytest
 
 from osgeo import gdal
@@ -23,10 +22,8 @@ def get_alg():
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "test_gdalalg_raster_clean_collar")
 
 
 def test_gdalalg_raster_clean_collar():

--- a/autotest/utilities/test_gdalalg_raster_contour.py
+++ b/autotest/utilities/test_gdalalg_raster_contour.py
@@ -11,10 +11,19 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import os
+
 import gdaltest
 import pytest
 
 from osgeo import gdal, ogr
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
+        yield
 
 
 def get_contour_alg():

--- a/autotest/utilities/test_gdalalg_raster_contour.py
+++ b/autotest/utilities/test_gdalalg_raster_contour.py
@@ -11,8 +11,6 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
-import os
-
 import gdaltest
 import pytest
 
@@ -20,10 +18,8 @@ from osgeo import gdal, ogr
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "test_gdalalg_raster_contour")
 
 
 def get_contour_alg():

--- a/autotest/utilities/test_gdalalg_raster_fill_nodata.py
+++ b/autotest/utilities/test_gdalalg_raster_fill_nodata.py
@@ -11,6 +11,8 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import os
+
 import gdaltest
 import pytest
 
@@ -22,6 +24,13 @@ gdaltest.importorskip_gdal_array()
 
 def get_alg():
     return gdal.GetGlobalAlgorithmRegistry()["raster"]["fill-nodata"]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
+        yield
 
 
 def test_gdalalg_raster_fill_nodata_cannot_open_file():

--- a/autotest/utilities/test_gdalalg_raster_fill_nodata.py
+++ b/autotest/utilities/test_gdalalg_raster_fill_nodata.py
@@ -11,8 +11,6 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
-import os
-
 import gdaltest
 import pytest
 
@@ -27,10 +25,8 @@ def get_alg():
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "test_gdalalg_raster_fill_nodata")
 
 
 def test_gdalalg_raster_fill_nodata_cannot_open_file():

--- a/autotest/utilities/test_gdalalg_raster_pipeline.py
+++ b/autotest/utilities/test_gdalalg_raster_pipeline.py
@@ -24,6 +24,13 @@ def get_pipeline_alg():
     return gdal.GetGlobalAlgorithmRegistry()["raster"]["pipeline"]
 
 
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
+        yield
+
+
 def test_gdalalg_raster_pipeline_read_and_write(tmp_vsimem):
 
     out_filename = str(tmp_vsimem / "out.tif")

--- a/autotest/utilities/test_gdalalg_raster_pipeline.py
+++ b/autotest/utilities/test_gdalalg_raster_pipeline.py
@@ -25,10 +25,8 @@ def get_pipeline_alg():
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "test_gdalalg_raster_pipeline")
 
 
 def test_gdalalg_raster_pipeline_read_and_write(tmp_vsimem):

--- a/autotest/utilities/test_gdalalg_raster_polygonize.py
+++ b/autotest/utilities/test_gdalalg_raster_polygonize.py
@@ -11,8 +11,7 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
-import os
-
+import gdaltest
 import pytest
 
 from osgeo import gdal, ogr
@@ -23,10 +22,8 @@ def get_alg():
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "test_gdalalg_raster_polygonize")
 
 
 def test_gdalalg_raster_polygonize():

--- a/autotest/utilities/test_gdalalg_raster_polygonize.py
+++ b/autotest/utilities/test_gdalalg_raster_polygonize.py
@@ -11,6 +11,8 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import os
+
 import pytest
 
 from osgeo import gdal, ogr
@@ -18,6 +20,13 @@ from osgeo import gdal, ogr
 
 def get_alg():
     return gdal.GetGlobalAlgorithmRegistry()["raster"]["polygonize"]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
+        yield
 
 
 def test_gdalalg_raster_polygonize():

--- a/autotest/utilities/test_gdalalg_raster_proximity.py
+++ b/autotest/utilities/test_gdalalg_raster_proximity.py
@@ -11,8 +11,6 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
-import os
-
 import gdaltest
 import pytest
 
@@ -27,10 +25,8 @@ def get_alg():
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "test_gdalalg_raster_proximity")
 
 
 # Helper function to create a GTiff raster from a numpy array

--- a/autotest/utilities/test_gdalalg_raster_proximity.py
+++ b/autotest/utilities/test_gdalalg_raster_proximity.py
@@ -11,6 +11,8 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import os
+
 import gdaltest
 import pytest
 
@@ -22,6 +24,13 @@ np = pytest.importorskip("numpy")
 
 def get_alg():
     return gdal.GetGlobalAlgorithmRegistry()["raster"]["proximity"]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
+        yield
 
 
 # Helper function to create a GTiff raster from a numpy array

--- a/autotest/utilities/test_gdalalg_raster_tile.py
+++ b/autotest/utilities/test_gdalalg_raster_tile.py
@@ -2326,9 +2326,10 @@ def test_gdalalg_raster_tile_pipeline_materialize_explicit_filename_cog(tmp_vsim
 
 def test_gdalalg_raster_tile_pipeline_materialize_no_explicit_filename(tmp_vsimem):
 
-    gdal.alg.pipeline(
-        pipeline=f"read ../gdrivers/data/small_world.tif ! materialize ! tile {tmp_vsimem}"
-    )
+    with gdal.config_option("CPL_TMPDIR", tmp_vsimem):
+        gdal.alg.pipeline(
+            pipeline=f"read ../gdrivers/data/small_world.tif ! materialize ! tile {tmp_vsimem}"
+        )
 
     ds = gdal.Open(tmp_vsimem / "0/0/0.png")
     assert ds.GetRasterBand(1).ComputeRasterMinMax() == (0, 255)

--- a/autotest/utilities/test_gdalalg_raster_viewshed.py
+++ b/autotest/utilities/test_gdalalg_raster_viewshed.py
@@ -11,6 +11,8 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import os
+
 import gdaltest
 import pytest
 
@@ -19,6 +21,13 @@ from osgeo import gdal
 
 def get_alg():
     return gdal.GetGlobalAlgorithmRegistry()["raster"]["viewshed"]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
+        yield
 
 
 @pytest.fixture()

--- a/autotest/utilities/test_gdalalg_raster_viewshed.py
+++ b/autotest/utilities/test_gdalalg_raster_viewshed.py
@@ -11,8 +11,6 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
-import os
-
 import gdaltest
 import pytest
 
@@ -24,10 +22,8 @@ def get_alg():
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "test_gdalalg_raster_viewshed")
 
 
 @pytest.fixture()

--- a/autotest/utilities/test_gdalalg_vector_layer_algebra.py
+++ b/autotest/utilities/test_gdalalg_vector_layer_algebra.py
@@ -804,22 +804,23 @@ def test_gdal_vector_layer_algebra_pipeline(tmp_vsimem):
         assert f["method_b"] == "bar2"
         assert f.GetGeometryRef().ExportToWkt() == "POINT (-3 4)"
 
-    with gdal.alg.pipeline(
-        pipeline=f"read {tmp_vsimem}/input.gpkg ! layer-algebra --operation intersection --method {tmp_vsimem}/method.gpkg"
-    ) as alg:
-        out_ds = alg.Output()
-        check_out_ds(out_ds)
+    with gdal.config_option("CPL_TMPDIR", tmp_vsimem):
+        with gdal.alg.pipeline(
+            pipeline=f"read {tmp_vsimem}/input.gpkg ! layer-algebra --operation intersection --method {tmp_vsimem}/method.gpkg"
+        ) as alg:
+            out_ds = alg.Output()
+            check_out_ds(out_ds)
 
-    # No next usable step
-    with gdal.alg.pipeline(
-        pipeline=f"read {tmp_vsimem}/input.gpkg ! layer-algebra --operation intersection --method {tmp_vsimem}/method.gpkg ! edit"
-    ) as alg:
-        out_ds = alg.Output()
-        check_out_ds(out_ds)
+        # No next usable step
+        with gdal.alg.pipeline(
+            pipeline=f"read {tmp_vsimem}/input.gpkg ! layer-algebra --operation intersection --method {tmp_vsimem}/method.gpkg ! edit"
+        ) as alg:
+            out_ds = alg.Output()
+            check_out_ds(out_ds)
 
-    gdal.alg.pipeline(
-        pipeline=f"read {tmp_vsimem}/input.gpkg ! layer-algebra --operation intersection --method {tmp_vsimem}/method.gpkg ! write {tmp_vsimem}/out.gpkg"
-    )
+        gdal.alg.pipeline(
+            pipeline=f"read {tmp_vsimem}/input.gpkg ! layer-algebra --operation intersection --method {tmp_vsimem}/method.gpkg ! write {tmp_vsimem}/out.gpkg"
+        )
     with ogr.Open(tmp_vsimem / "out.gpkg") as out_ds:
         check_out_ds(out_ds)
 

--- a/autotest/utilities/test_gdalalg_vector_materialize.py
+++ b/autotest/utilities/test_gdalalg_vector_materialize.py
@@ -238,16 +238,18 @@ def test_gdalalg_vector_materialize_temp_output_parquet(tmp_path):
 
 @pytest.mark.require_driver("GDALG")
 @pytest.mark.require_driver("GPKG")
-def test_gdalalg_vector_materialize_read_from_gdalg():
-    with ogr.Open(
-        json.dumps(
-            {
-                "type": "gdal_streamed_alg",
-                "command_line": "gdal pipeline read ../ogr/data/poly.shp ! materialize",
-            }
-        )
-    ) as ds:
-        assert ds.GetLayer(0).GetFeatureCount() == 10
+def test_gdalalg_vector_materialize_read_from_gdalg(tmp_vsimem):
+
+    with gdal.config_option("CPL_TMPDIR", tmp_vsimem):
+        with ogr.Open(
+            json.dumps(
+                {
+                    "type": "gdal_streamed_alg",
+                    "command_line": "gdal pipeline read ../ogr/data/poly.shp ! materialize",
+                }
+            )
+        ) as ds:
+            assert ds.GetLayer(0).GetFeatureCount() == 10
 
 
 @pytest.mark.require_driver("GDALG")

--- a/autotest/utilities/test_gdalalg_vector_sort.py
+++ b/autotest/utilities/test_gdalalg_vector_sort.py
@@ -11,7 +11,6 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
-import os
 import random
 
 import gdaltest
@@ -27,10 +26,8 @@ def alg():
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "test_gdalalg_vector_sort")
 
 
 @pytest.fixture(params=("hilbert", "strtree"))

--- a/autotest/utilities/test_gdalalg_vector_sort.py
+++ b/autotest/utilities/test_gdalalg_vector_sort.py
@@ -11,6 +11,7 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import os
 import random
 
 import gdaltest
@@ -23,6 +24,13 @@ from osgeo import gdal, ogr
 @pytest.fixture()
 def alg():
     return gdal.GetGlobalAlgorithmRegistry()["vector"]["sort"]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
+        yield
 
 
 @pytest.fixture(params=("hilbert", "strtree"))

--- a/autotest/utilities/test_gdalenhance.py
+++ b/autotest/utilities/test_gdalenhance.py
@@ -38,7 +38,9 @@ def test_gdalenhance_output_histogram(gdalenhance_path, histogram_dest, tmp_path
 
     lut_fname = tmp_path / "lut.txt"
 
-    cmd = f"{gdalenhance_path} -quiet -equalize ../gcore/data/rgbsmall.tif"
+    gdal.CopyFile("../gcore/data/rgbsmall.tif", tmp_path / "rgbsmall.tif")
+
+    cmd = f"{gdalenhance_path} -quiet -equalize {tmp_path}/rgbsmall.tif"
 
     if histogram_dest == "file":
         cmd += f" -config {lut_fname}"
@@ -108,7 +110,8 @@ def test_gdalenhance_output_image(gdalenhance_path, tmp_path):
 
 def test_gdalenhance_invalid_usage(gdalenhance_path, tmp_path):
 
-    infile = "../gcore/data/rgbsmall.tif"
+    infile = tmp_path / "in.tif"
+    gdal.Translate(infile, "../gcore/data/rgbsmall.tif")
     outfile = tmp_path / "out.tif"
 
     out, err = gdaltest.runexternal_out_and_err(
@@ -125,7 +128,8 @@ def test_gdalenhance_invalid_usage(gdalenhance_path, tmp_path):
 
 def test_gdalenhance_malformed_lut(gdalenhance_path, tmp_path):
 
-    infile = "../gcore/data/rgbsmall.tif"
+    infile = tmp_path / "in.tif"
+    gdal.Translate(infile, "../gcore/data/rgbsmall.tif")
     outfile = tmp_path / "out.tif"
     lut_file = tmp_path / "lut.txt"
 
@@ -181,7 +185,8 @@ def test_gdalenhance_malformed_lut(gdalenhance_path, tmp_path):
 
 def test_gdalenhance_invalid_output_type(gdalenhance_path, tmp_path):
 
-    infile = "../gcore/data/rgbsmall.tif"
+    infile = tmp_path / "in.tif"
+    gdal.Translate(infile, "../gcore/data/rgbsmall.tif")
     outfile = tmp_path / "out.tif"
 
     out, err = gdaltest.runexternal_out_and_err(

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -16,6 +16,7 @@
 import array
 import collections
 import json
+import os
 import shutil
 import struct
 
@@ -24,6 +25,14 @@ import ogrtest
 import pytest
 
 from osgeo import gdal, ogr, osr
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_cpl_tmpdir():
+
+    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
+        yield
+
 
 ###############################################################################
 # Simple test

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -16,7 +16,6 @@
 import array
 import collections
 import json
-import os
 import shutil
 import struct
 
@@ -28,10 +27,8 @@ from osgeo import gdal, ogr, osr
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _set_cpl_tmpdir():
-
-    with gdal.config_option("CPL_TMPDIR", os.path.join(os.getcwd(), "tmp")):
-        yield
+def set_cpl_tmpdir(tmp_path_factory):
+    yield gdaltest.set_cpl_tmpdir(tmp_path_factory, "test_gdalwarp_lib")
 
 
 ###############################################################################

--- a/frmts/pds/pds4dataset.cpp
+++ b/frmts/pds/pds4dataset.cpp
@@ -1545,7 +1545,7 @@ const OGRLayer *PDS4Dataset::GetLayer(int nIndex) const
 {
     if (nIndex < 0 || nIndex >= GetLayerCount())
         return nullptr;
-    return m_apoLayers[nIndex].get();
+    return dynamic_cast<const OGRLayer *>(m_apoLayers[nIndex].get());
 }
 
 /************************************************************************/
@@ -1604,13 +1604,21 @@ bool PDS4Dataset::OpenTableCharacter(const char *pszFilename,
     const std::string osFullFilename = FixupTableFilename(CPLFormFilenameSafe(
         CPLGetPathSafe(m_osXMLFilename.c_str()).c_str(), pszFilename, nullptr));
     auto poLayer = std::make_unique<PDS4TableCharacter>(
-        this, osLayerName.c_str(), osFullFilename.c_str());
+        this, osLayerName.c_str(), osFullFilename.c_str(),
+        eAccess == GA_Update);
     if (!poLayer->ReadTableDef(psTable))
     {
         return false;
     }
-    m_apoLayers.push_back(
-        std::make_unique<PDS4EditableLayer>(std::move(poLayer)));
+    if (eAccess == GA_Update)
+    {
+        m_apoLayers.push_back(
+            std::make_unique<PDS4EditableLayer>(std::move(poLayer)));
+    }
+    else
+    {
+        m_apoLayers.push_back(std::move(poLayer));
+    }
     return true;
 }
 
@@ -1637,13 +1645,21 @@ bool PDS4Dataset::OpenTableBinary(const char *pszFilename,
     const std::string osFullFilename = FixupTableFilename(CPLFormFilenameSafe(
         CPLGetPathSafe(m_osXMLFilename.c_str()).c_str(), pszFilename, nullptr));
     auto poLayer = std::make_unique<PDS4TableBinary>(this, osLayerName.c_str(),
-                                                     osFullFilename.c_str());
+                                                     osFullFilename.c_str(),
+                                                     eAccess == GA_Update);
     if (!poLayer->ReadTableDef(psTable))
     {
         return false;
     }
-    m_apoLayers.push_back(
-        std::make_unique<PDS4EditableLayer>(std::move(poLayer)));
+    if (eAccess == GA_Update)
+    {
+        m_apoLayers.push_back(
+            std::make_unique<PDS4EditableLayer>(std::move(poLayer)));
+    }
+    else
+    {
+        m_apoLayers.push_back(std::move(poLayer));
+    }
     return true;
 }
 
@@ -1671,13 +1687,21 @@ bool PDS4Dataset::OpenTableDelimited(const char *pszFilename,
     const std::string osFullFilename = FixupTableFilename(CPLFormFilenameSafe(
         CPLGetPathSafe(m_osXMLFilename.c_str()).c_str(), pszFilename, nullptr));
     auto poLayer = std::make_unique<PDS4DelimitedTable>(
-        this, osLayerName.c_str(), osFullFilename.c_str());
+        this, osLayerName.c_str(), osFullFilename.c_str(),
+        eAccess == GA_Update);
     if (!poLayer->ReadTableDef(psTable))
     {
         return false;
     }
-    m_apoLayers.push_back(
-        std::make_unique<PDS4EditableLayer>(std::move(poLayer)));
+    if (eAccess == GA_Update)
+    {
+        m_apoLayers.push_back(
+            std::make_unique<PDS4EditableLayer>(std::move(poLayer)));
+    }
+    else
+    {
+        m_apoLayers.push_back(std::move(poLayer));
+    }
     return true;
 }
 
@@ -4796,8 +4820,8 @@ OGRLayer *PDS4Dataset::ICreateLayer(const char *pszName,
 
     if (EQUAL(pszTableType, "DELIMITED"))
     {
-        auto poLayer =
-            std::make_unique<PDS4DelimitedTable>(this, pszName, osFullFilename);
+        auto poLayer = std::make_unique<PDS4DelimitedTable>(
+            this, pszName, osFullFilename, true);
         if (!poLayer->InitializeNewLayer(poSpatialRef, false, eGType,
                                          papszOptions))
         {
@@ -4810,11 +4834,11 @@ OGRLayer *PDS4Dataset::ICreateLayer(const char *pszName,
     {
         std::unique_ptr<PDS4FixedWidthTable> poLayer;
         if (EQUAL(pszTableType, "CHARACTER"))
-            poLayer = std::make_unique<PDS4TableCharacter>(this, pszName,
-                                                           osFullFilename);
+            poLayer = std::make_unique<PDS4TableCharacter>(
+                this, pszName, osFullFilename, true);
         else
             poLayer = std::make_unique<PDS4TableBinary>(this, pszName,
-                                                        osFullFilename);
+                                                        osFullFilename, true);
         if (!poLayer->InitializeNewLayer(poSpatialRef, false, eGType,
                                          papszOptions))
         {
@@ -4823,7 +4847,7 @@ OGRLayer *PDS4Dataset::ICreateLayer(const char *pszName,
         m_apoLayers.push_back(
             std::make_unique<PDS4EditableLayer>(std::move(poLayer)));
     }
-    return m_apoLayers.back().get();
+    return dynamic_cast<OGRLayer *>(m_apoLayers.back().get());
 }
 
 /************************************************************************/

--- a/frmts/pds/pds4dataset.h
+++ b/frmts/pds/pds4dataset.h
@@ -24,15 +24,41 @@
 
 class PDS4Dataset;
 
+class PDS4TableLayerInterface CPL_NON_FINAL
+{
+  public:
+    virtual ~PDS4TableLayerInterface();
+
+    virtual const char *GetFileName() const = 0;
+
+    virtual bool IsDirtyHeader() const = 0;
+
+    virtual int GetRawFieldCount() const = 0;
+
+    virtual char **GetFileList() const = 0;
+
+    virtual void RefreshFileAreaObservational(CPLXMLNode *psFAO) = 0;
+
+    virtual GIntBig GetFeatureCount(int bForce) = 0;
+
+    virtual void SetSpatialRef(OGRSpatialReference *poSRS) = 0;
+
+    virtual const char *GetName() const = 0;
+
+    virtual OGRwkbGeometryType GetGeomType() const = 0;
+};
+
 /************************************************************************/
 /* ==================================================================== */
 /*                        PDS4TableBaseLayer                            */
 /* ==================================================================== */
 /************************************************************************/
 
-class PDS4TableBaseLayer CPL_NON_FINAL : public OGRLayer
+class PDS4TableBaseLayer CPL_NON_FINAL : public OGRLayer,
+                                         public PDS4TableLayerInterface
 {
   protected:
+    bool m_bUpdate = false;
     PDS4Dataset *m_poDS = nullptr;
     OGRFeatureDefn *m_poRawFeatureDefn = nullptr;
     OGRFeatureDefn *m_poFeatureDefn = nullptr;
@@ -63,10 +89,15 @@ class PDS4TableBaseLayer CPL_NON_FINAL : public OGRLayer
 
   public:
     PDS4TableBaseLayer(PDS4Dataset *poDS, const char *pszName,
-                       const char *pszFilename);
+                       const char *pszFilename, bool bUpdate);
     ~PDS4TableBaseLayer() override;
 
     using OGRLayer::GetLayerDefn;
+
+    const char *GetName() const override
+    {
+        return GetDescription();
+    }
 
     const OGRFeatureDefn *GetLayerDefn() const override
     {
@@ -75,25 +106,30 @@ class PDS4TableBaseLayer CPL_NON_FINAL : public OGRLayer
 
     GIntBig GetFeatureCount(int bForce) override;
 
-    const char *GetFileName() const
+    const char *GetFileName() const override
     {
         return m_osFilename.c_str();
     }
 
-    bool IsDirtyHeader() const
+    bool IsDirtyHeader() const override
     {
         return m_bDirtyHeader;
     }
 
-    int GetRawFieldCount() const
+    int GetRawFieldCount() const override
     {
         return m_poRawFeatureDefn->GetFieldCount();
     }
 
-    bool RenameFileTo(const char *pszNewName);
-    virtual char **GetFileList() const;
+    OGRwkbGeometryType GetGeomType() const override
+    {
+        return OGRLayer::GetGeomType();
+    }
 
-    virtual void RefreshFileAreaObservational(CPLXMLNode *psFAO) = 0;
+    void SetSpatialRef(OGRSpatialReference *poSRS) override;
+
+    bool RenameFileTo(const char *pszNewName);
+    char **GetFileList() const override;
 
     GDALDataset *GetDataset() override;
 };
@@ -137,7 +173,7 @@ class PDS4FixedWidthTable CPL_NON_FINAL : public PDS4TableBaseLayer
 
   public:
     PDS4FixedWidthTable(PDS4Dataset *poDS, const char *pszName,
-                        const char *pszFilename);
+                        const char *pszFilename, bool bUpdate);
 
     void ResetReading() override;
     OGRFeature *GetFeature(GIntBig nFID) override;
@@ -178,12 +214,12 @@ class PDS4TableCharacter final : public PDS4FixedWidthTable
 
   public:
     PDS4TableCharacter(PDS4Dataset *poDS, const char *pszName,
-                       const char *pszFilename);
+                       const char *pszFilename, bool bUpdate);
 
     PDS4FixedWidthTable *NewLayer(PDS4Dataset *poDS, const char *pszName,
                                   const char *pszFilename) override
     {
-        return new PDS4TableCharacter(poDS, pszName, pszFilename);
+        return new PDS4TableCharacter(poDS, pszName, pszFilename, true);
     }
 };
 
@@ -205,12 +241,12 @@ class PDS4TableBinary final : public PDS4FixedWidthTable
 
   public:
     PDS4TableBinary(PDS4Dataset *poDS, const char *pszName,
-                    const char *pszFilename);
+                    const char *pszFilename, bool bUpdate);
 
     PDS4FixedWidthTable *NewLayer(PDS4Dataset *poDS, const char *pszName,
                                   const char *pszFilename) override
     {
-        return new PDS4TableBinary(poDS, pszName, pszFilename);
+        return new PDS4TableBinary(poDS, pszName, pszFilename, true);
     }
 };
 
@@ -249,7 +285,7 @@ class PDS4DelimitedTable CPL_NON_FINAL : public PDS4TableBaseLayer
 
   public:
     PDS4DelimitedTable(PDS4Dataset *poDS, const char *pszName,
-                       const char *pszFilename);
+                       const char *pszFilename, bool bUpdate);
     ~PDS4DelimitedTable() override;
 
     void ResetReading() override;
@@ -270,7 +306,7 @@ class PDS4DelimitedTable CPL_NON_FINAL : public PDS4TableBaseLayer
     PDS4DelimitedTable *NewLayer(PDS4Dataset *poDS, const char *pszName,
                                  const char *pszFilename)
     {
-        return new PDS4DelimitedTable(poDS, pszName, pszFilename);
+        return new PDS4DelimitedTable(poDS, pszName, pszFilename, true);
     }
 };
 
@@ -280,7 +316,8 @@ class PDS4DelimitedTable CPL_NON_FINAL : public PDS4TableBaseLayer
 /* ==================================================================== */
 /************************************************************************/
 
-class PDS4EditableLayer final : public OGREditableLayer
+class PDS4EditableLayer final : public OGREditableLayer,
+                                public PDS4TableLayerInterface
 {
     PDS4TableBaseLayer *GetBaseLayer() const;
 
@@ -290,31 +327,46 @@ class PDS4EditableLayer final : public OGREditableLayer
     explicit PDS4EditableLayer(std::unique_ptr<PDS4DelimitedTable> poBaseLayer);
     ~PDS4EditableLayer() override;
 
-    void RefreshFileAreaObservational(CPLXMLNode *psFAO)
+    void RefreshFileAreaObservational(CPLXMLNode *psFAO) override
     {
         GetBaseLayer()->RefreshFileAreaObservational(psFAO);
     }
 
-    const char *GetFileName() const
+    const char *GetFileName() const override
     {
         return GetBaseLayer()->GetFileName();
     }
 
-    bool IsDirtyHeader() const
+    bool IsDirtyHeader() const override
     {
         return GetBaseLayer()->IsDirtyHeader();
     }
 
-    int GetRawFieldCount() const
+    int GetRawFieldCount() const override
     {
         return GetBaseLayer()->GetRawFieldCount();
     }
 
-    void SetSpatialRef(OGRSpatialReference *poSRS);
+    void SetSpatialRef(OGRSpatialReference *poSRS) override;
 
-    char **GetFileList() const
+    char **GetFileList() const override
     {
         return GetBaseLayer()->GetFileList();
+    }
+
+    GIntBig GetFeatureCount(int bForce) override
+    {
+        return OGREditableLayer::GetFeatureCount(bForce);
+    }
+
+    const char *GetName() const override
+    {
+        return GetBaseLayer()->GetName();
+    }
+
+    OGRwkbGeometryType GetGeomType() const override
+    {
+        return GetBaseLayer()->GetGeomType();
     }
 };
 
@@ -338,7 +390,7 @@ class PDS4Dataset final : public RawDataset
     CPLString m_osUnits{};
     bool m_bCreatedFromExistingBinaryFile = false;
 
-    std::vector<std::unique_ptr<PDS4EditableLayer>> m_apoLayers{};
+    std::vector<std::unique_ptr<PDS4TableLayerInterface>> m_apoLayers{};
 
     // Write dedicated parameters
     bool m_bMustInitImageFile = false;

--- a/frmts/pds/pds4vector.cpp
+++ b/frmts/pds/pds4vector.cpp
@@ -18,6 +18,8 @@
 #include <algorithm>
 #include <cassert>
 
+PDS4TableLayerInterface::~PDS4TableLayerInterface() = default;
+
 /************************************************************************/
 /* ==================================================================== */
 /*                        PDS4TableBaseLayer                            */
@@ -25,8 +27,9 @@
 /************************************************************************/
 
 PDS4TableBaseLayer::PDS4TableBaseLayer(PDS4Dataset *poDS, const char *pszName,
-                                       const char *pszFilename)
-    : m_poDS(poDS), m_poRawFeatureDefn(new OGRFeatureDefn(pszName)),
+                                       const char *pszFilename, bool bUpdate)
+    : m_bUpdate(bUpdate), m_poDS(poDS),
+      m_poRawFeatureDefn(new OGRFeatureDefn(pszName)),
       m_poFeatureDefn(new OGRFeatureDefn(pszName)), m_osFilename(pszFilename)
 {
     m_poRawFeatureDefn->SetGeomType(wkbNone);
@@ -37,6 +40,18 @@ PDS4TableBaseLayer::PDS4TableBaseLayer(PDS4Dataset *poDS, const char *pszName,
 
     m_bKeepGeomColmuns =
         CPLFetchBool(m_poDS->GetOpenOptions(), "KEEP_GEOM_COLUMNS", false);
+}
+
+/************************************************************************/
+/*                           SetSpatialRef()                            */
+/************************************************************************/
+
+void PDS4TableBaseLayer::SetSpatialRef(OGRSpatialReference *poSRS)
+{
+    if (GetGeomType() != wkbNone)
+    {
+        GetLayerDefn()->GetGeomFieldDefn(0)->SetSpatialRef(poSRS);
+    }
 }
 
 /************************************************************************/
@@ -476,8 +491,8 @@ GDALDataset *PDS4TableBaseLayer::GetDataset()
 /************************************************************************/
 
 PDS4FixedWidthTable::PDS4FixedWidthTable(PDS4Dataset *poDS, const char *pszName,
-                                         const char *pszFilename)
-    : PDS4TableBaseLayer(poDS, pszName, pszFilename)
+                                         const char *pszFilename, bool bUpdate)
+    : PDS4TableBaseLayer(poDS, pszName, pszFilename, bUpdate)
 {
 }
 
@@ -798,6 +813,13 @@ OGRErr PDS4FixedWidthTable::ISetFeature(OGRFeature *poFeature)
 
 OGRErr PDS4FixedWidthTable::ICreateFeature(OGRFeature *poFeature)
 {
+    if (!m_bUpdate)
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Operation not supported on read-only layer");
+        return OGRERR_FAILURE;
+    }
+
     m_nFeatureCount++;
     poFeature->SetFID(m_nFeatureCount);
     OGRErr eErr = ISetFeature(poFeature);
@@ -1596,8 +1618,8 @@ bool PDS4FixedWidthTable::InitializeNewLayer(const OGRSpatialReference *poSRS,
 /************************************************************************/
 
 PDS4TableCharacter::PDS4TableCharacter(PDS4Dataset *poDS, const char *pszName,
-                                       const char *pszFilename)
-    : PDS4FixedWidthTable(poDS, pszName, pszFilename)
+                                       const char *pszFilename, bool bUpdate)
+    : PDS4FixedWidthTable(poDS, pszName, pszFilename, bUpdate)
 {
 }
 
@@ -1690,8 +1712,8 @@ bool PDS4TableCharacter::CreateFieldInternal(OGRFieldType eType,
 /************************************************************************/
 
 PDS4TableBinary::PDS4TableBinary(PDS4Dataset *poDS, const char *pszName,
-                                 const char *pszFilename)
-    : PDS4FixedWidthTable(poDS, pszName, pszFilename)
+                                 const char *pszFilename, bool bUpdate)
+    : PDS4FixedWidthTable(poDS, pszName, pszFilename, bUpdate)
 {
 }
 
@@ -1767,8 +1789,8 @@ bool PDS4TableBinary::CreateFieldInternal(OGRFieldType eType,
 /************************************************************************/
 
 PDS4DelimitedTable::PDS4DelimitedTable(PDS4Dataset *poDS, const char *pszName,
-                                       const char *pszFilename)
-    : PDS4TableBaseLayer(poDS, pszName, pszFilename)
+                                       const char *pszFilename, bool bUpdate)
+    : PDS4TableBaseLayer(poDS, pszName, pszFilename, bUpdate)
 {
 }
 
@@ -2037,6 +2059,13 @@ CPLString PDS4DelimitedTable::QuoteIfNeeded(const char *pszVal)
 
 OGRErr PDS4DelimitedTable::ICreateFeature(OGRFeature *poFeature)
 {
+    if (!m_bUpdate)
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Operation not supported on read-only layer");
+        return OGRERR_FAILURE;
+    }
+
     if (m_bAddWKTColumnPending)
     {
         OGRFieldDefn oFieldDefn(

--- a/ogr/ogrsf_frmts/vdv/ogrvdvdatasource.cpp
+++ b/ogr/ogrsf_frmts/vdv/ogrvdvdatasource.cpp
@@ -180,7 +180,9 @@ std::pair<GDALDataset *, bool> OGRIDFDataSource::Parse() const
         if (poGPKGDriver)
         {
             CPLString osTmpFilename(m_osFilename + "_tmp.gpkg");
-            VSILFILE *fp = VSIFOpenL(osTmpFilename, "wb");
+            VSILFILE *fp = CPLGetConfigOption("CPL_TMPDIR", nullptr)
+                               ? nullptr
+                               : VSIFOpenL(osTmpFilename, "wb");
             if (fp)
             {
                 VSIFCloseL(fp);

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -127,7 +127,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "CPL_SOZIP_ENABLED", // from cpl_minizip_zip.cpp
    "CPL_SOZIP_MIN_FILE_SIZE", // from cpl_minizip_zip.cpp
    "CPL_TIMESTAMP", // from cpl_error.cpp
-   "CPL_TMPDIR", // from cogdriver.cpp, cpl_path.cpp, gdal_misc.cpp, gdalwmscache.cpp, wcsutils.cpp
+   "CPL_TMPDIR", // from cogdriver.cpp, cpl_path.cpp, gdal_misc.cpp, gdalwmscache.cpp, ogrvdvdatasource.cpp, wcsutils.cpp
    "CPL_VSI_MEM_MTIME", // from cpl_vsi_mem.cpp
    "CPL_VSIAZ_UNLINK_BATCH_SIZE", // from cpl_vsil_az.cpp
    "CPL_VSIGS_UNLINK_BATCH_SIZE", // from cpl_vsil_gs.cpp


### PR DESCRIPTION
and 2 related fixes in drivers:
- IDF: honour CPL_TMPDIR
- PDS4 vector: honor read-only mode for operations on vector layers
