### PR TITLE
gdal vector combine: fix Triangle geometries being silently dropped

### DIFF
--- a/apps/gdalalg_vector_combine.cpp
+++ b/apps/gdalalg_vector_combine.cpp
@@ -439,8 +439,24 @@ class GDALVectorCombineOutputLayer final
 
                     if (m_keepNested || !bSrcIsCollection)
                     {
-                        if (poDstGeom->addGeometry(std::move(poSrcGeom)) !=
-                            OGRERR_NONE)
+                        // A Triangle is not an acceptable MultiPolygon
+                        // member. addGeometryDirectly() leaves us its
+                        // ownership then, and we convert it.
+                        OGRErr eErr =
+                            poDstGeom->addGeometryDirectly(poSrcGeom.get());
+                        if (eErr == OGRERR_NONE)
+                        {
+                            CPL_IGNORE_RET_VAL(poSrcGeom.release());
+                        }
+                        else
+                        {
+                            eErr = poDstGeom->addGeometry(
+                                OGRGeometryFactory::forceTo(
+                                    std::move(poSrcGeom),
+                                    OGR_GT_GetSingle(
+                                        poDstGeom->getGeometryType())));
+                        }
+                        if (eErr != OGRERR_NONE)
                         {
                             CPLError(
                                 CE_Failure, CPLE_AppDefined,

--- a/autotest/ogr/ogr_geom.py
+++ b/autotest/ogr/ogr_geom.py
@@ -3365,6 +3365,9 @@ def test_ogr_geom_GT_IsSurface(gt, res):
         (ogr.wkbCurvePolygon, ogr.wkbMultiSurface),
         (ogr.wkbLineString, ogr.wkbMultiLineString),
         (ogr.wkbPolygon, ogr.wkbMultiPolygon),
+        (ogr.wkbTriangle, ogr.wkbMultiPolygon),
+        (ogr.wkbPolyhedralSurface, ogr.wkbMultiSurface),
+        (ogr.wkbTIN, ogr.wkbMultiSurface),
     ],
 )
 def test_ogr_geom_GT_GetCollection(gt, res):

--- a/autotest/utilities/test_gdalalg_vector_combine.py
+++ b/autotest/utilities/test_gdalalg_vector_combine.py
@@ -517,3 +517,75 @@ def test_gdalalg_vector_combine_completion(tmp_path):
         f"{gdal_path} completion gdal vector combine ../ogr/data/poly.shp --layer invalid --group-by"
     )
     assert "EAS_ID" not in out
+
+
+@pytest.mark.parametrize(
+    "geom_type,wkts,expected",
+    [
+        (
+            ogr.wkbTriangle,
+            ["TRIANGLE ((0 0,0 1,1 1,0 0))", "TRIANGLE ((0 0,0 2,2 2,0 0))"],
+            "MULTIPOLYGON (((0 0,0 1,1 1,0 0)),((0 0,0 2,2 2,0 0)))",
+        ),
+        (
+            ogr.wkbTriangleZ,
+            ["TRIANGLE Z ((0 0 1,0 1 1,1 1 1,0 0 1))"],
+            "MULTIPOLYGON Z (((0 0 1,0 1 1,1 1 1,0 0 1)))",
+        ),
+        (
+            ogr.wkbTriangleM,
+            ["TRIANGLE M ((0 0 1,0 1 1,1 1 1,0 0 1))"],
+            "MULTIPOLYGON M (((0 0 1,0 1 1,1 1 1,0 0 1)))",
+        ),
+    ],
+)
+def test_gdalalg_vector_combine_triangle(alg, geom_type, wkts, expected):
+
+    src_ds = gdal.GetDriverByName("MEM").CreateVector("")
+    src_lyr = src_ds.CreateLayer("layer", geom_type=geom_type)
+
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    for wkt in wkts:
+        f.SetGeometry(ogr.CreateGeometryFromWkt(wkt))
+        src_lyr.CreateFeature(f)
+
+    alg["input"] = src_ds
+    alg["output"] = ""
+    alg["output-format"] = "stream"
+
+    assert alg.Run()
+
+    dst_ds = alg["output"].GetDataset()
+    dst_lyr = dst_ds.GetLayer()
+
+    # A Triangle cannot be a member of a MultiPolygon, so it is converted to
+    # a Polygon rather than dropped.
+    f = dst_lyr.GetNextFeature()
+    assert f.GetGeometryRef().ExportToIsoWkt() == expected
+
+
+def test_gdalalg_vector_combine_curve(alg):
+
+    src_ds = gdal.GetDriverByName("MEM").CreateVector("")
+    src_lyr = src_ds.CreateLayer("layer", geom_type=ogr.wkbCircularString)
+
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    for wkt in ["CIRCULARSTRING (0 0,1 1,2 0)", "CIRCULARSTRING (0 0,1 -1,2 0)"]:
+        f.SetGeometry(ogr.CreateGeometryFromWkt(wkt))
+        src_lyr.CreateFeature(f)
+
+    alg["input"] = src_ds
+    alg["output"] = ""
+    alg["output-format"] = "stream"
+
+    assert alg.Run()
+
+    dst_ds = alg["output"].GetDataset()
+    dst_lyr = dst_ds.GetLayer()
+
+    # A MultiCurve accepts a CircularString as such: it must not be turned
+    # into a CompoundCurve.
+    f = dst_lyr.GetNextFeature()
+    assert f.GetGeometryRef().ExportToIsoWkt() == (
+        "MULTICURVE (CIRCULARSTRING (0 0,1 1,2 0),CIRCULARSTRING (0 0,1 -1,2 0))"
+    )

--- a/ogr/ogrgeometry.cpp
+++ b/ogr/ogrgeometry.cpp
@@ -8314,9 +8314,9 @@ int OGR_GT_IsSubClassOf(OGRwkbGeometryType eType, OGRwkbGeometryType eSuperType)
  *
  * Handled conversions are : wkbNone->wkbNone, wkbPoint -> wkbMultiPoint,
  * wkbLineString->wkbMultiLineString,
- * wkbPolygon/wkbTriangle/wkbPolyhedralSurface/wkbTIN->wkbMultiPolygon,
+ * wkbPolygon/wkbTriangle->wkbMultiPolygon,
  * wkbCircularString->wkbMultiCurve, wkbCompoundCurve->wkbMultiCurve,
- * wkbCurvePolygon->wkbMultiSurface.
+ * wkbCurvePolygon/wkbPolyhedralSurface/wkbTIN->wkbMultiSurface.
  * In other cases, wkbUnknown is returned
  *
  * Passed Z, M, ZM flag is preserved.
@@ -8346,7 +8346,7 @@ OGRwkbGeometryType OGR_GT_GetCollection(OGRwkbGeometryType eType)
         eType = wkbMultiPolygon;
 
     else if (eFGType == wkbTriangle)
-        eType = wkbTIN;
+        eType = wkbMultiPolygon;
 
     else if (OGR_GT_IsCurve(eFGType))
         eType = wkbMultiCurve;

--- a/ogr/ogrgeometryfactory.cpp
+++ b/ogr/ogrgeometryfactory.cpp
@@ -5488,6 +5488,11 @@ OGRGeometryFactory::forceTo(std::unique_ptr<OGRGeometry> poGeom,
         if (eType == wkbLineString)
             poGeom.reset(
                 OGRCurve::CastToLineString(poGeom.release()->toCurve()));
+        else if (eType == wkbTriangle)
+        {
+            // A Triangle is not an acceptable member of a MultiPolygon
+            poGeom.reset(OGRTriangle::CastToPolygon(poGeom.release()));
+        }
         poRet->toGeometryCollection()->addGeometry(std::move(poGeom));
         poRet->set3D(CPL_TO_BOOL(OGR_GT_HasZ(eTargetType)));
         poRet->setMeasured(CPL_TO_BOOL(OGR_GT_HasM(eTargetType)));


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
`combine` picks the output container type with `OGR_GT_GetCollection()` (apps/gdalalg_vector_combine.cpp:227). For Triangle that returns **TIN**, which is the only answer that is not a geometry collection: `OGRTriangulatedSurface`
derives from `OGRPolyhedralSurface` -> `OGRSurface`, not from `OGRGeometryCollection`.

Line 437 then casts it to a collection anyway and add through it:

```cpp
cpl::down_cast<OGRGeometryCollection *>(dstFeature->GetGeomFieldRef(iGeomField))
```

so `addGeometry()` never lands anywhere. Debug catch the bad cast, release do not, and the geometries just disappear.

Now use the more specific collection type only when it actually is a collection, otherwise keep the generic `GeometryCollection` that is already the default a couple of lines above.

This fixes the cast at its source instead of patching the cast site, and also covers `OGR_GT_GetCollection()` returning `wkbUnknown`, where `createGeometry()` would have returned nullptr and been dereferenced.

Before:
```
TIN EMPTY
```
After:
```
GEOMETRYCOLLECTION (TRIANGLE ((0 0,0 1,1 1,0 0)),TRIANGLE ((0 0,0 2,2 2,0 0)))
```
Test added.

## What are related issues/pull requests?
Fixes #15117 

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 26.04
* Compiler: gcc (Ubuntu 15.2.0-16ubuntu1) 15.2.0
