### PR TITLE
Parquet / Arrow: fix FID desync and post-filtering across skipped row groups (fixes #15119)

### DIFF
--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -5087,38 +5087,63 @@ def test_ogr_parquet_read_gh_15119(tmp_vsimem):
             geom_type=ogr.wkbPoint,
             options=["ROW_GROUP_SIZE=5"],
         )
+        lyr.CreateField(ogr.FieldDefn("MY_ID", ogr.OFTInteger))
         f = ogr.Feature(lyr.GetLayerDefn())
+
+        my_id = 0
 
         # Row group 0: x in [0, 4] -> FIDs 0..4
         for i in range(5):
             f.SetGeometry(ogr.CreateGeometryFromWkt(f"POINT ({i} 0)"))
+            f.SetField("MY_ID", my_id)
+            my_id += 1
             lyr.CreateFeature(f)
 
         # Row group 1: x in [100, 104] -> FIDs 5..9
         for i in range(5):
             f.SetGeometry(ogr.CreateGeometryFromWkt(f"POINT ({100 + i} 0)"))
+            f.SetField("MY_ID", my_id)
+            my_id += 1
             lyr.CreateFeature(f)
 
         # Row group 2: x in [0, 4] -> FIDs 10..14
         for i in range(5):
             f.SetGeometry(ogr.CreateGeometryFromWkt(f"POINT ({i} 0)"))
+            f.SetField("MY_ID", my_id)
+            my_id += 1
             lyr.CreateFeature(f)
 
     with ogr.Open(filename) as ds:
         lyr = ds.GetLayer(0)
-        # Filter that selects row groups 0 and 2, but skips row group 1
+        # Spatial filter selects row groups 0 and 2 (x in [0, 4]), and skips
+        # row group 1 (x in [100, 104]). The attribute filter only rejects
+        # part of row group 2 (FIDs 13, 14), so it cannot be resolved purely
+        # from row-group statistics and requires row-level post-filtering,
+        # which is what exercises the fixed FID computation.
         lyr.SetSpatialFilterRect(-1, -1, 5, 1)
-        lyr.SetAttributeFilter("FID >= 10")
+        lyr.SetAttributeFilter("FID <= 12")
 
-        # GetNextFeature() returns 5 features with FIDs 10..14
-        features = [f.GetFID() for f in lyr]
-        assert features == [10, 11, 12, 13, 14]
+        # GetNextFeature() returns features with FIDs 0..4 and 10..12
+        features = [(f.GetFID(), f["MY_ID"]) for f in lyr]
+        assert features == [
+            (0, 0),
+            (1, 1),
+            (2, 2),
+            (3, 3),
+            (4, 4),
+            (10, 10),
+            (11, 11),
+            (12, 12),
+        ]
 
-        # GetArrowStream() with post-filtering must also return the matching features with correct FIDs
+        # GetArrowStream() with post-filtering across the skipped row group
+        # must return the same set of features. Without the fix, the FID
+        # used to evaluate the attribute filter is desynchronized once the
+        # remapping jump occurs within a single Arrow batch, which wrongly
+        # keeps FIDs 13 and 14.
         lyr.ResetReading()
         stream = lyr.GetArrowStreamAsNumPy()
-        fids = []
+        my_ids = []
         for batch in stream:
-            fids.extend(batch["OGC_FID"].tolist())
-        assert fids == [10, 11, 12, 13, 14]
-
+            my_ids.extend(batch["MY_ID"].tolist())
+        assert my_ids == [0, 1, 2, 3, 4, 10, 11, 12]

--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -5067,3 +5067,58 @@ def test_ogr_parquet_read_gh_14610():
     lyr = ds.GetLayer(0)
     lyr.SetIgnoredFields(["OGR_GEOMETRY"])
     assert lyr.GetNextFeature()
+
+
+###############################################################################
+# Test bugfix for https://github.com/OSGeo/gdal/issues/15119
+# Case where non-consecutive row groups are selected and Arrow stream is read
+# with post-filtering on FID
+
+
+def test_ogr_parquet_read_gh_15119(tmp_vsimem):
+
+    filename = str(tmp_vsimem / "test_ogr_parquet_read_gh_15119.parquet")
+    with ogr.GetDriverByName("Parquet").CreateDataSource(filename) as ds:
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(4326)
+        lyr = ds.CreateLayer(
+            "test",
+            srs=srs,
+            geom_type=ogr.wkbPoint,
+            options=["ROW_GROUP_SIZE=5"],
+        )
+        f = ogr.Feature(lyr.GetLayerDefn())
+
+        # Row group 0: x in [0, 4] -> FIDs 0..4
+        for i in range(5):
+            f.SetGeometry(ogr.CreateGeometryFromWkt(f"POINT ({i} 0)"))
+            lyr.CreateFeature(f)
+
+        # Row group 1: x in [100, 104] -> FIDs 5..9
+        for i in range(5):
+            f.SetGeometry(ogr.CreateGeometryFromWkt(f"POINT ({100 + i} 0)"))
+            lyr.CreateFeature(f)
+
+        # Row group 2: x in [0, 4] -> FIDs 10..14
+        for i in range(5):
+            f.SetGeometry(ogr.CreateGeometryFromWkt(f"POINT ({i} 0)"))
+            lyr.CreateFeature(f)
+
+    with ogr.Open(filename) as ds:
+        lyr = ds.GetLayer(0)
+        # Filter that selects row groups 0 and 2, but skips row group 1
+        lyr.SetSpatialFilterRect(-1, -1, 5, 1)
+        lyr.SetAttributeFilter("FID >= 10")
+
+        # GetNextFeature() returns 5 features with FIDs 10..14
+        features = [f.GetFID() for f in lyr]
+        assert features == [10, 11, 12, 13, 14]
+
+        # GetArrowStream() with post-filtering must also return the matching features with correct FIDs
+        lyr.ResetReading()
+        stream = lyr.GetArrowStreamAsNumPy()
+        fids = []
+        for batch in stream:
+            fids.extend(batch["OGC_FID"].tolist())
+        assert fids == [10, 11, 12, 13, 14]
+

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
@@ -6032,9 +6032,6 @@ inline int OGRArrowLayer::GetNextArrowArray(struct ArrowArrayStream *stream,
         OverrideArrowRelease(m_poArrowDS, out_array);
 
         const auto nFeatureIdxCur = m_nFeatureIdx;
-        // TODO: We likely have an issue regarding FIDs based on m_nFeatureIdx
-        // when m_iFIDArrowColumn < 0, only a subset of row groups is
-        // selected, and this batch goes across non consecutive row groups.
         for (int64_t i = 0; i < m_nIdxInBatch; ++i)
             IncrFeatureIdx();
 

--- a/ogr/ogrsf_frmts/parquet/ogr_parquet.h
+++ b/ogr/ogrsf_frmts/parquet/ogr_parquet.h
@@ -110,6 +110,7 @@ class OGRParquetLayer final : public OGRParquetLayerBase
         m_oFeatureIdxRemappingIter{};
     //! Feature index among the potentially restricted set of selected row groups
     int64_t m_nFeatureIdxSelected = 0;
+    std::shared_ptr<arrow::RecordBatch> m_poPendingBatch{};
     std::vector<int> m_anRequestedParquetColumns{};  // only valid when
                                                      // m_bIgnoredFields is set
     CPLStringList m_aosFeatherMetadata{};

--- a/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
@@ -1830,6 +1830,7 @@ OGRFeature *OGRParquetLayer::GetFeature(GIntBig nFID)
 
 void OGRParquetLayer::ResetReading()
 {
+    m_poPendingBatch.reset();
     OGRParquetLayerBase::ResetReading();
     m_oFeatureIdxRemappingIter = m_asFeatureIdxRemapping.begin();
     m_nFeatureIdxSelected = 0;
@@ -2423,30 +2424,52 @@ bool OGRParquetLayer::ReadNextBatch()
 
     std::shared_ptr<arrow::RecordBatch> poNextBatch;
 
-    do
+    if (m_poPendingBatch != nullptr)
     {
-        ++m_iRecordBatch;
-        poNextBatch.reset();
-        auto status = m_poRecordBatchReader->ReadNext(&poNextBatch);
-        if (!status.ok())
+        poNextBatch = std::move(m_poPendingBatch);
+        m_poPendingBatch.reset();
+    }
+    else
+    {
+        do
         {
-            CPLError(CE_Failure, CPLE_AppDefined, "ReadNext() failed: %s",
-                     status.message().c_str());
+            ++m_iRecordBatch;
             poNextBatch.reset();
-        }
-        if (poNextBatch == nullptr)
-        {
-            if (m_iRecordBatch == 1 && m_poBatch && m_poAttrQuery == nullptr &&
-                m_poFilterGeom == nullptr)
+            auto status = m_poRecordBatchReader->ReadNext(&poNextBatch);
+            if (!status.ok())
             {
-                m_iRecordBatch = 0;
-                m_bSingleBatch = true;
+                CPLError(CE_Failure, CPLE_AppDefined, "ReadNext() failed: %s",
+                         status.message().c_str());
+                poNextBatch.reset();
             }
-            else
-                m_poBatch.reset();
-            return false;
+            if (poNextBatch == nullptr)
+            {
+                if (m_iRecordBatch == 1 && m_poBatch && m_poAttrQuery == nullptr &&
+                    m_poFilterGeom == nullptr)
+                {
+                    m_iRecordBatch = 0;
+                    m_bSingleBatch = true;
+                }
+                else
+                    m_poBatch.reset();
+                return false;
+            }
+        } while (poNextBatch->num_rows() == 0);
+    }
+
+    if (m_iFIDArrowColumn < 0 && !m_asFeatureIdxRemapping.empty() &&
+        m_oFeatureIdxRemappingIter != m_asFeatureIdxRemapping.end())
+    {
+        const int64_t nNextJumpSelected = m_oFeatureIdxRemappingIter->first;
+        if (m_nFeatureIdxSelected < nNextJumpSelected &&
+            m_nFeatureIdxSelected + poNextBatch->num_rows() > nNextJumpSelected)
+        {
+            const int64_t nRowsToTake =
+                nNextJumpSelected - m_nFeatureIdxSelected;
+            m_poPendingBatch = poNextBatch->Slice(nRowsToTake);
+            poNextBatch = poNextBatch->Slice(0, nRowsToTake);
         }
-    } while (poNextBatch->num_rows() == 0);
+    }
 
     SetBatch(poNextBatch);
 
@@ -2459,6 +2482,7 @@ bool OGRParquetLayer::ReadNextBatch()
 
 void OGRParquetLayer::InvalidateCachedBatches()
 {
+    m_poPendingBatch.reset();
     m_bSingleBatch = false;
     OGRParquetLayerBase::InvalidateCachedBatches();
 }


### PR DESCRIPTION
## What does this PR do?

In `OGRParquetLayer`, when reading a dataset without an explicit FID column (`m_iFIDArrowColumn < 0`) where row groups are skipped, this PR ensures that Arrow `RecordBatch` instances are sliced at remapping jump boundaries (`m_asFeatureIdxRemapping`).

This guarantees that every emitted batch has contiguous sequential dataset row indices, ensuring `BASE_SEQUENTIAL_FID` passed to `OGRFilterArrowArray` during post-filtering remains consistent with the true dataset row FIDs across all batches.

## What are related issues/pull requests?

Fixes #15119

## Tasklist

 - [x] Make sure code is correctly formatted
 - [x] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>
