### PR TITLE
gdal raster compare: fix binary comparison of datasets that are directories (like Zarr)

### DIFF
--- a/apps/gdalalg_compare_common.cpp
+++ b/apps/gdalalg_compare_common.cpp
@@ -17,11 +17,184 @@
 
 #include "cpl_vsi_virtual.h"
 
+#include <set>
+
 //! @cond Doxygen_Suppress
 
 GDALCompareCommon::GDALCompareCommon() = default;
 
 GDALCompareCommon::~GDALCompareCommon() = default;
+
+/************************************************************************/
+/*                            CompareFile()                             */
+/************************************************************************/
+
+static bool CompareFile(std::vector<std::string> &aosReport,
+                        const char *pszRefFilename,
+                        const char *pszInputFilename)
+{
+    VSIStatBufL sStatRef;
+    if (VSIStatL(pszRefFilename, &sStatRef) != 0)
+    {
+        aosReport.push_back(std::string("Reference file ")
+                                .append(pszRefFilename)
+                                .append(" does not exist"));
+        return false;
+    }
+
+    VSIStatBufL sStatInput;
+    if (VSIStatL(pszInputFilename, &sStatInput) != 0)
+    {
+        aosReport.push_back(std::string("Input file ")
+                                .append(pszInputFilename)
+                                .append(" does not exist"));
+        return false;
+    }
+
+    if (VSI_ISDIR(sStatRef.st_mode) && !VSI_ISDIR(sStatInput.st_mode))
+    {
+        aosReport.push_back(std::string("Reference file ")
+                                .append(pszRefFilename)
+                                .append(" is a directory, but input file ")
+                                .append(pszInputFilename)
+                                .append(" is not"));
+        return false;
+    }
+    else if (!VSI_ISDIR(sStatRef.st_mode) && VSI_ISDIR(sStatInput.st_mode))
+    {
+        aosReport.push_back(std::string("Reference file ")
+                                .append(pszRefFilename)
+                                .append(" is not a directory, but input file ")
+                                .append(pszInputFilename)
+                                .append(" is"));
+        return false;
+    }
+
+    if (VSI_ISDIR(sStatRef.st_mode))
+    {
+        std::unique_ptr<VSIDIR, decltype(&VSICloseDir)> psDirRef(
+            VSIOpenDir(pszRefFilename, -1, nullptr), VSICloseDir);
+        if (!psDirRef)
+        {
+            aosReport.push_back(std::string("Reference directory ")
+                                    .append(pszRefFilename)
+                                    .append(" cannot be opened"));
+            return false;
+        }
+
+        std::unique_ptr<VSIDIR, decltype(&VSICloseDir)> psDirInput(
+            VSIOpenDir(pszInputFilename, -1, nullptr), VSICloseDir);
+        if (!psDirInput)
+        {
+            aosReport.push_back(std::string("Input directory ")
+                                    .append(pszInputFilename)
+                                    .append(" cannot be opened"));
+            return false;
+        }
+
+        std::set<std::string> oSetRefFilenames;
+        while (auto psEntryRef = psDirRef->NextDirEntry())
+        {
+            oSetRefFilenames.insert(psEntryRef->pszName);
+            if (!CompareFile(aosReport,
+                             std::string(pszRefFilename)
+                                 .append("/")
+                                 .append(psEntryRef->pszName)
+                                 .c_str(),
+                             std::string(pszInputFilename)
+                                 .append("/")
+                                 .append(psEntryRef->pszName)
+                                 .c_str()))
+            {
+                return false;
+            }
+        }
+        while (auto psEntryInput = psDirInput->NextDirEntry())
+        {
+            if (!cpl::contains(oSetRefFilenames, psEntryInput->pszName))
+            {
+                aosReport.push_back(
+                    std::string("Input file ")
+                        .append(psEntryInput->pszName)
+                        .append(" does not exist in reference directory"));
+                return false;
+            }
+        }
+    }
+    else
+    {
+        VSIVirtualHandleUniquePtr fpRef(VSIFOpenL(pszRefFilename, "rb"));
+        VSIVirtualHandleUniquePtr fpInput(VSIFOpenL(pszInputFilename, "rb"));
+        if (!fpRef)
+        {
+            aosReport.push_back(std::string("Reference file '")
+                                    .append(pszRefFilename)
+                                    .append("' cannot be opened."));
+            return false;
+        }
+
+        if (!fpInput)
+        {
+            aosReport.push_back(std::string("Input file '")
+                                    .append(pszRefFilename)
+                                    .append("' cannot be opened."));
+            return false;
+        }
+
+        fpRef->Seek(0, SEEK_END);
+        fpInput->Seek(0, SEEK_END);
+        const auto nRefSize = fpRef->Tell();
+        const auto nInputSize = fpInput->Tell();
+        if (nRefSize != nInputSize)
+        {
+            aosReport.push_back(
+                std::string("Reference file '")
+                    .append(pszRefFilename)
+                    .append("' has size ")
+                    .append(std::to_string(nRefSize))
+                    .append(" bytes, whereas input file has size ")
+                    .append(std::to_string(nInputSize))
+                    .append(" bytes."));
+
+            return false;
+        }
+
+        constexpr size_t BUF_SIZE = 1024 * 1024;
+        std::vector<GByte> abyRef(BUF_SIZE);
+        std::vector<GByte> abyInput(BUF_SIZE);
+
+        fpRef->Seek(0, SEEK_SET);
+        fpInput->Seek(0, SEEK_SET);
+
+        do
+        {
+            const size_t nRefRead = fpRef->Read(abyRef.data(), 1, BUF_SIZE);
+            const size_t nInputRead =
+                fpInput->Read(abyInput.data(), 1, BUF_SIZE);
+
+            if (nRefRead != BUF_SIZE && fpRef->Tell() != nRefSize)
+            {
+                aosReport.push_back("Failed to fully read reference file");
+                return false;
+            }
+
+            if (nInputRead != BUF_SIZE && fpInput->Tell() != nRefSize)
+            {
+                aosReport.push_back("Failed to fully read input file");
+                return false;
+            }
+
+            if (abyRef != abyInput)
+            {
+                aosReport.push_back("Reference file and input file differ at "
+                                    "the binary level.");
+                return false;
+            }
+        } while (fpRef->Tell() < nRefSize);
+    }
+
+    return true;
+}
 
 /************************************************************************/
 /*            GDALRasterCompareAlgorithm::BinaryComparison()            */
@@ -69,10 +242,8 @@ bool GDALCompareCommon::BinaryComparison(GDALAlgorithm *alg,
         return false;
     }
 
-    VSIVirtualHandleUniquePtr fpRef(VSIFOpenL(poRefDS->GetDescription(), "rb"));
-    VSIVirtualHandleUniquePtr fpInput(
-        VSIFOpenL(poInputDS->GetDescription(), "rb"));
-    if (!fpRef)
+    VSIStatBufL sStat;
+    if (VSIStatL(poRefDS->GetDescription(), &sStat) != 0)
     {
         alg->ReportError(
             CE_Warning, CPLE_AppDefined,
@@ -82,7 +253,7 @@ bool GDALCompareCommon::BinaryComparison(GDALAlgorithm *alg,
         return false;
     }
 
-    if (!fpInput)
+    if (VSIStatL(poInputDS->GetDescription(), &sStat) != 0)
     {
         alg->ReportError(
             CE_Warning, CPLE_AppDefined,
@@ -91,53 +262,8 @@ bool GDALCompareCommon::BinaryComparison(GDALAlgorithm *alg,
         return false;
     }
 
-    fpRef->Seek(0, SEEK_END);
-    fpInput->Seek(0, SEEK_END);
-    const auto nRefSize = fpRef->Tell();
-    const auto nInputSize = fpInput->Tell();
-    if (nRefSize != nInputSize)
-    {
-        aosReport.push_back("Reference file has size " +
-                            std::to_string(nRefSize) +
-                            " bytes, whereas input file has size " +
-                            std::to_string(nInputSize) + " bytes.");
-
-        return false;
-    }
-
-    constexpr size_t BUF_SIZE = 1024 * 1024;
-    std::vector<GByte> abyRef(BUF_SIZE);
-    std::vector<GByte> abyInput(BUF_SIZE);
-
-    fpRef->Seek(0, SEEK_SET);
-    fpInput->Seek(0, SEEK_SET);
-
-    do
-    {
-        const size_t nRefRead = fpRef->Read(abyRef.data(), 1, BUF_SIZE);
-        const size_t nInputRead = fpInput->Read(abyInput.data(), 1, BUF_SIZE);
-
-        if (nRefRead != BUF_SIZE && fpRef->Tell() != nRefSize)
-        {
-            aosReport.push_back("Failed to fully read reference file");
-            return false;
-        }
-
-        if (nInputRead != BUF_SIZE && fpInput->Tell() != nRefSize)
-        {
-            aosReport.push_back("Failed to fully read input file");
-            return false;
-        }
-
-        if (abyRef != abyInput)
-        {
-            aosReport.push_back(
-                "Reference file and input file differ at the binary level.");
-            return false;
-        }
-    } while (fpRef->Tell() < nRefSize);
-
-    return true;
+    return CompareFile(aosReport, poRefDS->GetDescription(),
+                       poInputDS->GetDescription());
 }
 
 //! @endcond

--- a/autotest/utilities/test_gdalalg_raster_compare.py
+++ b/autotest/utilities/test_gdalalg_raster_compare.py
@@ -114,7 +114,7 @@ def test_gdalalg_raster_compare_same_content_but_not_same_binary(tmp_vsimem):
         ret = alg["output-string"].split("\n")[:-1]
         assert len(ret) == 1
         assert ret[0].startswith(
-            "Reference file has size 736 bytes, whereas input file has size"
+            "Reference file '../gcore/data/byte.tif' has size 736 bytes, whereas input file has size"
         )
 
     with gdal.Run(
@@ -123,7 +123,7 @@ def test_gdalalg_raster_compare_same_content_but_not_same_binary(tmp_vsimem):
         pipeline=f"read {tmp_vsimem}/tmp.tif ! compare --reference=../gcore/data/byte.tif",
     ) as alg:
         assert alg["output-string"].startswith(
-            "Reference file has size 736 bytes, whereas input file has size"
+            "Reference file '../gcore/data/byte.tif' has size 736 bytes, whereas input file has size"
         )
 
     with gdal.Run(
@@ -1538,3 +1538,80 @@ Band 1: PSNR (dB): 3.0103
 """
 
     assert tab_pct[0] == 1.0
+
+
+@pytest.mark.require_driver("Zarr")
+def test_gdalalg_raster_compare_zarr(tmp_vsimem):
+
+    gdal.GetDriverByName("Zarr").CreateCopy(
+        tmp_vsimem / "test.zarr",
+        gdal.Open("../gcore/data/byte.tif"),
+        options={"ARRAY_NAME": "test"},
+    )
+    gdal.GetDriverByName("Zarr").CreateCopy(
+        tmp_vsimem / "test2.zarr",
+        gdal.Open("../gcore/data/byte.tif"),
+        options={"ARRAY_NAME": "test"},
+    )
+
+    with gdal.quiet_errors(), gdal.alg.raster.compare(
+        input=tmp_vsimem / "test.zarr", reference=tmp_vsimem / "test2.zarr"
+    ) as alg:
+        assert alg["output-string"] == ""
+
+    with gdaltest.tempfile(
+        tmp_vsimem / "test.zarr" / "foo", ""
+    ), gdal.quiet_errors(), gdal.alg.raster.compare(
+        input=tmp_vsimem / "test.zarr", reference=tmp_vsimem / "test2.zarr"
+    ) as alg:
+        assert (
+            alg["output-string"]
+            == "Input file foo does not exist in reference directory\n"
+        )
+
+    with gdaltest.tempfile(
+        tmp_vsimem / "test2.zarr" / "bar", ""
+    ), gdal.quiet_errors(), gdal.alg.raster.compare(
+        input=tmp_vsimem / "test.zarr", reference=tmp_vsimem / "test2.zarr"
+    ) as alg:
+        assert (
+            alg["output-string"]
+            == f"Input file {tmp_vsimem}/test.zarr/bar does not exist\n"
+        )
+
+    with gdal.VSIFile(tmp_vsimem / "test.zarr" / "zarr.json", "rb") as f:
+        data = f.read()
+    with gdal.VSIFile(tmp_vsimem / "test.zarr" / "zarr.json", "wb") as f:
+        f.write(data + b" ")
+
+    with gdal.quiet_errors(), gdal.alg.raster.compare(
+        input=tmp_vsimem / "test.zarr", reference=tmp_vsimem / "test2.zarr"
+    ) as alg:
+        len_data = len(data)
+        len_data_p1 = len(data) + 1
+        assert (
+            alg["output-string"]
+            == f"Reference file '{tmp_vsimem}/test2.zarr/zarr.json' has size {len_data} bytes, whereas input file has size {len_data_p1} bytes.\n"
+        )
+
+    gdal.GetDriverByName("Zarr").CreateCopy(
+        tmp_vsimem / "test.zarr",
+        gdal.Open("../gcore/data/byte.tif"),
+        options={"ARRAY_NAME": "test"},
+    )
+    gdal.RmdirRecursive(tmp_vsimem / "test.zarr" / "test" / "c")
+    gdal.FileFromMemBuffer(tmp_vsimem / "test.zarr" / "test" / "c", "")
+    gdal.RmdirRecursive(tmp_vsimem / "test2.zarr" / "test" / "c")
+    gdal.Mkdir(tmp_vsimem / "test2.zarr" / "test" / "c", 0o755)
+    with gdal.quiet_errors(), gdal.alg.raster.compare(
+        input=tmp_vsimem / "test.zarr", reference=tmp_vsimem / "test2.zarr"
+    ) as alg:
+        assert alg["output-string"].startswith(
+            f"Reference file {tmp_vsimem}/test2.zarr/test/c is a directory, but input file {tmp_vsimem}/test.zarr/test/c is not\n"
+        )
+    with gdal.quiet_errors(), gdal.alg.raster.compare(
+        input=tmp_vsimem / "test2.zarr", reference=tmp_vsimem / "test.zarr"
+    ) as alg:
+        assert alg["output-string"].startswith(
+            f"Reference file {tmp_vsimem}/test.zarr/test/c is not a directory, but input file {tmp_vsimem}/test2.zarr/test/c is\n"
+        )


### PR DESCRIPTION
Fixes #15125