### PR TITLE
gdal raster zonal-stats: accept zones defined by lines or points

### DIFF
--- a/alg/zonal.cpp
+++ b/alg/zonal.cpp
@@ -271,6 +271,27 @@ static void CalculateCellCenters(const GDALRasterWindow &window,
     }
 }
 
+static bool IsHomogeneous(const OGRGeometryCollection &coll)
+{
+    const auto nGeoms = coll.getNumGeometries();
+
+    if (nGeoms < 2)
+    {
+        return true;
+    }
+
+    const auto nDim = coll.getGeometryRef(0)->getDimension();
+    for (int i = 1; i < nGeoms; i++)
+    {
+        if (coll.getGeometryRef(i)->getDimension() != nDim)
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 class GDALZonalStatsImpl
 {
   public:
@@ -1393,13 +1414,6 @@ class GDALZonalStatsImpl
                     continue;
                 }
 
-                if (poGeom->getDimension() != 2)
-                {
-                    CPLError(CE_Failure, CPLE_AppDefined,
-                             "Non-polygonal geometry encountered.");
-                    return false;
-                }
-
                 poGeom->getEnvelope(&oGeomExtent);
                 GEOSGeometry *poEnv = CreateGEOSEnvelope(oGeomExtent);
                 if (poEnv == nullptr)
@@ -1697,12 +1711,6 @@ class GDALZonalStatsImpl
             {
                 // do nothing
             }
-            else if (poGeom->getDimension() != 2)
-            {
-                CPLError(CE_Failure, CPLE_AppDefined,
-                         "Non-polygonal geometry encountered.");
-                return false;
-            }
             else
             {
                 poGeom->getEnvelope(&oGeomExtent);
@@ -1921,8 +1929,22 @@ class GDALZonalStatsImpl
                            const OGREnvelope &oSnappedGeomExtent, int nXSize,
                            int nYSize, GByte *pabyCoverageBuf) const
     {
+        if (wkbFlatten(poGeom->getGeometryType()) == wkbGeometryCollection)
+        {
+            const auto *poColl =
+                cpl::down_cast<const OGRGeometryCollection *>(poGeom);
+            if (!IsHomogeneous(*poColl))
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Cannot calculate pixel coverage for mixed-dimension "
+                         "GeometryCollection.");
+                return false;
+            }
+        }
+
 #if GEOS_GRID_INTERSECTION_AVAILABLE
-        if (m_options.pixels == GDALZonalStatsOptions::FRACTIONAL)
+        if (m_options.pixels == GDALZonalStatsOptions::FRACTIONAL &&
+            poGeom->getDimension() > 0)
         {
             std::memset(pabyCoverageBuf, 0,
                         static_cast<size_t>(nXSize) * nYSize *
@@ -1968,7 +1990,9 @@ class GDALZonalStatsImpl
             std::unique_ptr<MEMDataset> poMemDS(MEMDataset::Create(
                 "", nXSize, nYSize, 0, m_coverageDataType, nullptr));
             poMemDS->SetGeoTransform(oCoverageGT);
-            constexpr double dfBurnValue = 255.0;
+            const double dfBurnValue =
+                m_options.pixels == GDALZonalStatsOptions::FRACTIONAL ? 1.0
+                                                                      : 255.0;
             constexpr int nBand = 1;
 
             MEMRasterBand *poCoverageBand =

--- a/autotest/utilities/test_gdalalg_raster_zonal_stats.py
+++ b/autotest/utilities/test_gdalalg_raster_zonal_stats.py
@@ -582,16 +582,138 @@ def test_gdalalg_raster_zonal_stats_missing_weights(zonal, polyrast, stat):
         zonal.Run()
 
 
-def test_gdalalg_raster_zonal_stats_non_polygon_geometry(zonal, strategy):
+def test_gdalalg_raster_zonal_stats_linestring_geometry(zonal, pixels, strategy):
 
     zonal["input"] = "../gcore/data/byte.tif"
-    zonal["zones"] = gdaltest.wkt_ds(["LINESTRING (3 3, 8 8)"])
+    zonal["zones"] = gdaltest.wkt_ds(["LINESTRING (441123 3751053, 441287 3750402)"])
     zonal["output"] = ""
     zonal["output-format"] = "MEM"
     zonal["strategy"] = strategy
-    zonal["stat"] = "sum"
+    zonal["pixels"] = pixels
+    zonal["stat"] = ["mean", "values", "coverage"]
 
-    with pytest.raises(Exception, match="Non-polygonal geometry"):
+    assert zonal.Run()
+
+    out_ds = zonal.Output()
+    out_lyr = out_ds.GetLayer(0)
+
+    assert out_lyr.GetFeatureCount() == 1
+
+    f = out_lyr.GetNextFeature()
+
+    intersecting_pixels = [
+        115,
+        148,
+        123,
+        132,
+        123,
+        132,
+        107,
+        132,
+        148,
+        115,
+        107,
+        99,
+        132,
+        123,
+        99,
+    ]
+
+    # check result of "values"
+    if pixels in ("all-touched", "fractional"):
+        assert sorted(f["values"]) == sorted(intersecting_pixels)
+    else:
+        assert len(f["values"]) > 0 and len(f["values"]) <= len(intersecting_pixels)
+        for v in set(f["values"]):
+            assert v in intersecting_pixels
+            assert f["values"].count(v) <= intersecting_pixels.count(v)
+
+    # check result of "coverage"
+    if pixels == "default":
+        assert len(f["coverage"]) == len(f["values"])
+        assert all(x == 1 for x in f["coverage"])
+    elif pixels == "all-touched":
+        assert len(f["coverage"]) == len(intersecting_pixels)
+        assert all(x == 1 for x in f["coverage"])
+    else:
+        assert len(f["coverage"]) == len(intersecting_pixels)
+        assert all(x > 0 and x <= 120 for x in f["coverage"])
+
+    # check result of "sum"
+    if pixels == "all-touched":
+        assert f["mean"] == sum(intersecting_pixels) / len(intersecting_pixels)
+    elif pixels == "fractional":
+        assert f["mean"] == pytest.approx(
+            sum(c * v for c, v in zip(f["values"], f["coverage"])) / sum(f["coverage"])
+        )
+
+
+def test_gdalalg_raster_zonal_stats_point_geometry(zonal, pixels, strategy):
+
+    zonal["input"] = "../gcore/data/byte.tif"
+    zonal["zones"] = gdaltest.wkt_ds(
+        [
+            "MULTIPOINT ((440810 3750926))",  # single point inside raster
+            "MULTIPOINT ((440685 3750871))",  # single point outside raster
+            "MULTIPOINT ((441831 3751225),(441962 3751226))",  # one point in, one point out
+            "MULTIPOINT ((441047 3750986),(441467 3751109),(441466 3750691))",  # three points in
+        ]
+    )
+    zonal["output"] = ""
+    zonal["output-format"] = "MEM"
+    zonal["strategy"] = strategy
+    zonal["pixels"] = pixels
+    zonal["stat"] = ["mean", "values", "coverage", "count"]
+
+    assert zonal.Run()
+
+    out_ds = zonal.Output()
+    out_lyr = out_ds.GetLayer(0)
+
+    assert out_lyr.GetFeatureCount() == 4
+
+    f = [x for x in out_lyr]
+
+    # single point inside raster
+    assert f[0]["mean"] == 173
+    assert f[0]["values"] == [173]
+    assert f[0]["coverage"] == [1]
+    assert f[0]["count"] == 1
+
+    # single point outside raster
+    assert math.isnan(f[1]["mean"])
+    assert f[1]["values"] == []
+    assert f[1]["coverage"] == []
+    assert f[1]["count"] == 0
+
+    # one point inside raster, one point outside raster
+    assert f[2]["mean"] == 99.0
+    assert f[2]["values"] == [99]
+    assert f[2]["coverage"] == [1]
+    assert f[2]["count"] == 1
+
+    # three points inside raster
+    assert f[3]["mean"] == (107 + 115 + 140) / 3.0
+    assert f[3]["values"] == [107, 115, 140]
+    assert f[3]["coverage"] == [1, 1, 1]
+    assert f[3]["count"] == 3
+
+
+def test_gdalalg_raster_zonal_stats_mixed_dimension_geometry(zonal, pixels, strategy):
+
+    zonal["input"] = "../gcore/data/byte.tif"
+    zonal["zones"] = gdaltest.wkt_ds(
+        [
+            "GEOMETRYCOLLECTION (POINT (440810 3750926), LINESTRING (441123 3751053, 441287 3750402))",
+        ]
+    )
+    zonal["output"] = ""
+    zonal["output-format"] = "MEM"
+    zonal["strategy"] = strategy
+    zonal["pixels"] = pixels
+    zonal["stat"] = ["mean", "values", "coverage", "count"]
+
+    with pytest.raises(Exception, match="Cannot calculate pixel coverage"):
         zonal.Run()
 
 


### PR DESCRIPTION
Allows `gdal raster zonal-stats` to process line and point geometries, as long as a single feature does not contain multiple geometry types. I didn't enable this in the initial implementation because of hesitation about what "coverage" means for linear features. For `--pixels=default` or `--pixels=all-touched` it is either 0 or 1, whereas for `--pixels=fractional` GEOS reports it as the _length_ of the geometry intersecting the cell. It doesn't make any difference for stats like `mean` but could be confusing for others like `sum`. I don't there's much to do about this except to document it well (not done yet)

One motivating example in https://gis.stackexchange.com/questions/167372/extracting-values-from-raster-under-line-using-gdal, there are others.