### PR TITLE
gml: Explicitly initialize memory for szStartTag

### DIFF
--- a/ogr/ogrsf_frmts/gml/ogrgmldatasource.cpp
+++ b/ogr/ogrsf_frmts/gml/ogrgmldatasource.cpp
@@ -3338,7 +3338,7 @@ void OGRGMLDataSource::FindAndParseTopElements(VSILFILE *fp)
     // Build a shortened XML file that contain only the global
     // boundedBy element, so as to be able to parse it easily.
 
-    char szStartTag[128];
+    char szStartTag[128] =  {};
     char *pszXML = static_cast<char *>(CPLMalloc(8192 + 128 + 3 + 1));
     VSIFSeekL(fp, 0, SEEK_SET);
     int nRead = static_cast<int>(VSIFReadL(pszXML, 1, 8192, fp));

--- a/ogr/ogrsf_frmts/gml/ogrgmldatasource.cpp
+++ b/ogr/ogrsf_frmts/gml/ogrgmldatasource.cpp
@@ -3338,7 +3338,7 @@ void OGRGMLDataSource::FindAndParseTopElements(VSILFILE *fp)
     // Build a shortened XML file that contain only the global
     // boundedBy element, so as to be able to parse it easily.
 
-    char szStartTag[128] =  {};
+    char szStartTag[128] = {};
     char *pszXML = static_cast<char *>(CPLMalloc(8192 + 128 + 3 + 1));
     VSIFSeekL(fp, 0, SEEK_SET);
     int nRead = static_cast<int>(VSIFReadL(pszXML, 1, 8192, fp));


### PR DESCRIPTION
## What does this PR do?

Similar to szSRSName above this, we should explicitly initialize szStartTag. This is done for szSRSName for some time, but omitted here.

## What are related issues/pull requests?

n/a

## AI tool usage

No AI was used to make this change, but traditional static analysis tools did flag it.

## Tasklist

 - [X ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [. ] Add test case(s)
 - [ .] Add documentation
 - [. ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS: Linux
* Compiler: gcc 15.2
