### PR TITLE
gdal raster proximity: update output NoData default

### DIFF
--- a/alg/gdalproximity.cpp
+++ b/alg/gdalproximity.cpp
@@ -180,7 +180,7 @@ CPLErr CPL_STDCALL GDALComputeProximity(GDALRasterBandH hSrcBand,
     pszOpt = CSLFetchNameValue(papszOptions, "NODATA");
     if (pszOpt != nullptr)
     {
-        fNoDataValue = static_cast<float>(CPLAtof(pszOpt));
+        fNoDataValue = static_cast<float>(CPLStrtod(pszOpt, nullptr));
     }
     else
     {

--- a/apps/gdalalg_raster_proximity.cpp
+++ b/apps/gdalalg_raster_proximity.cpp
@@ -108,11 +108,44 @@ bool GDALRasterProximityAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
             CPLSPrintf("FIXED_BUF_VAL=%.17g", m_fixedBufferValue));
     }
 
-    if (GetArg("output-nodata")->IsExplicitlySet())
+    if (!GetArg("output-nodata")->IsExplicitlySet())
     {
-        proximityOptions.AddString(CPLSPrintf("NODATA=%.17g", m_noDataValue));
-        dstBand->SetNoDataValue(m_noDataValue);
+        switch (outputType)
+        {
+            case GDT_Int8:
+                m_noDataValue = std::numeric_limits<std::int8_t>::max();
+                break;
+            case GDT_UInt8:
+                m_noDataValue = std::numeric_limits<std::uint8_t>::max();
+                break;
+            case GDT_Int16:
+                m_noDataValue = std::numeric_limits<std::int16_t>::max();
+                break;
+            case GDT_UInt16:
+                m_noDataValue = std::numeric_limits<std::uint16_t>::max();
+                break;
+            case GDT_Int32:
+                m_noDataValue = std::numeric_limits<std::int32_t>::max();
+                break;
+            case GDT_UInt32:
+                m_noDataValue = std::numeric_limits<std::uint32_t>::max();
+                break;
+            case GDT_Float32:
+            case GDT_Float64:
+                m_noDataValue = 65535;
+                break;
+            default:
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "No default NoData value available for data type %s",
+                         GDALGetDataTypeName(outputType));
+                break;
+        }
     }
+
+    CPLDebug("GDAL", "Using NoData value %g", m_noDataValue);
+
+    proximityOptions.AddString(CPLSPrintf("NODATA=%.17g", m_noDataValue));
+    dstBand->SetNoDataValue(m_noDataValue);
 
     // Always set this to YES. Note that this was NOT the
     // default behavior in the python implementation of the utility.

--- a/apps/gdalalg_raster_proximity.cpp
+++ b/apps/gdalalg_raster_proximity.cpp
@@ -12,6 +12,8 @@
 
 #include "gdalalg_raster_proximity.h"
 
+#include <cmath>
+
 #include "cpl_conv.h"
 
 #include "gdal_alg.h"
@@ -76,6 +78,13 @@ bool GDALRasterProximityAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
         outputType = GDALGetDataTypeByName(m_outputDataType.c_str());
     }
 
+    if (GDALDataTypeIsComplex(outputType))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Complex output types not supported");
+        return false;
+    }
+
     auto poTmpDS = CreateTemporaryDataset(
         poSrcDS->GetRasterXSize(), poSrcDS->GetRasterYSize(), 1, outputType,
         /* bTiledIfPossible = */ true, poSrcDS, /* bCopyMetadata = */ false);
@@ -108,44 +117,53 @@ bool GDALRasterProximityAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
             CPLSPrintf("FIXED_BUF_VAL=%.17g", m_fixedBufferValue));
     }
 
-    if (!GetArg("output-nodata")->IsExplicitlySet())
+    if (GetArg("output-nodata")->IsExplicitlySet())
     {
-        switch (outputType)
+        // Because GDALComputeProximity does all of its work with 32-bit floats,
+        // we need to check that a manually-specified NoData value can be represented
+        // as a 32-bit float. The default NoData value for some integer types
+        // also cannot be represented as 32-bit floats, but they still round-trip OK,
+        // so we only perform the runtime check for manually-specified values.
+        if (!std::isnan(m_noDataValue))
         {
-            case GDT_Int8:
-                m_noDataValue = std::numeric_limits<std::int8_t>::max();
-                break;
-            case GDT_UInt8:
-                m_noDataValue = std::numeric_limits<std::uint8_t>::max();
-                break;
-            case GDT_Int16:
-                m_noDataValue = std::numeric_limits<std::int16_t>::max();
-                break;
-            case GDT_UInt16:
-                m_noDataValue = std::numeric_limits<std::uint16_t>::max();
-                break;
-            case GDT_Int32:
-                m_noDataValue = std::numeric_limits<std::int32_t>::max();
-                break;
-            case GDT_UInt32:
-                m_noDataValue = std::numeric_limits<std::uint32_t>::max();
-                break;
-            case GDT_Float32:
-            case GDT_Float64:
-                m_noDataValue = std::numeric_limits<double>::quiet_NaN();
-                break;
-            default:
+            const float fNoData = static_cast<float>(m_noDataValue);
+            if (static_cast<double>(fNoData) != m_noDataValue)
+            {
                 CPLError(CE_Failure, CPLE_AppDefined,
-                         "No default NoData value available for data type %s",
-                         GDALGetDataTypeName(outputType));
-                break;
+                         "gdal raster proximity requires the output NoData "
+                         "value to be representable as a 32-bit floating point "
+                         "number, but the specified value of %g cannot.",
+                         m_noDataValue);
+                return false;
+            }
+        }
+        dstBand->SetNoDataValue(m_noDataValue);
+    }
+    else if (outputType == GDT_Float16 || outputType == GDT_Float32 ||
+             outputType == GDT_Float64)
+    {
+        dstBand->SetNoDataValue(std::numeric_limits<double>::quiet_NaN());
+    }
+    else if (outputType == GDT_Int64)
+    {
+        constexpr auto nMax = std::numeric_limits<int64_t>::max();
+        dstBand->SetNoDataValueAsInt64(nMax);
+    }
+    else
+    {
+        double dfNoData;
+        if (GDALGetDataTypeMinMaxAsDouble(outputType, nullptr, &dfNoData))
+        {
+            dstBand->SetNoDataValue(dfNoData);
+        }
+        else
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "No default NoData value for output data type %s",
+                     GDALGetDataTypeName(outputType));
+            return false;
         }
     }
-
-    CPLDebug("GDAL", "Using NoData value %g", m_noDataValue);
-
-    proximityOptions.AddString(CPLSPrintf("NODATA=%.17g", m_noDataValue));
-    dstBand->SetNoDataValue(m_noDataValue);
 
     // Always set this to YES. Note that this was NOT the
     // default behavior in the python implementation of the utility.

--- a/apps/gdalalg_raster_proximity.cpp
+++ b/apps/gdalalg_raster_proximity.cpp
@@ -13,6 +13,7 @@
 #include "gdalalg_raster_proximity.h"
 
 #include <cmath>
+#include <limits>
 
 #include "cpl_conv.h"
 

--- a/apps/gdalalg_raster_proximity.cpp
+++ b/apps/gdalalg_raster_proximity.cpp
@@ -132,7 +132,7 @@ bool GDALRasterProximityAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
                 break;
             case GDT_Float32:
             case GDT_Float64:
-                m_noDataValue = 65535;
+                m_noDataValue = std::numeric_limits<double>::quiet_NaN();
                 break;
             default:
                 CPLError(CE_Failure, CPLE_AppDefined,

--- a/autotest/cpp/test_gdal.cpp
+++ b/autotest/cpp/test_gdal.cpp
@@ -1047,6 +1047,57 @@ TEST_F(test_gdal, GDALIsValueExactAs_C_func)
 #pragma warning(pop)
 #endif
 
+// Test GDALGetDAtaTypeMinMaxAsDouble()
+TEST_F(test_gdal, GDALGetDataTypeMinMaxAsDouble)
+{
+    double dfMin, dfMax;
+
+    EXPECT_TRUE(GDALGetDataTypeMinMaxAsDouble(GDT_UInt8, &dfMin, &dfMax));
+    EXPECT_EQ(dfMin, 0.0);
+    EXPECT_EQ(dfMax, 255.0);
+    EXPECT_TRUE(GDALGetDataTypeMinMaxAsDouble(GDT_Int8, &dfMin, &dfMax));
+    EXPECT_EQ(dfMin, -128.0);
+    EXPECT_EQ(dfMax, 127.0);
+
+    EXPECT_TRUE(GDALGetDataTypeMinMaxAsDouble(GDT_UInt16, &dfMin, &dfMax));
+    EXPECT_EQ(dfMin, 0.0);
+    EXPECT_EQ(dfMax, 65535.0);
+    EXPECT_TRUE(GDALGetDataTypeMinMaxAsDouble(GDT_Int16, &dfMin, &dfMax));
+    EXPECT_EQ(dfMin, -32768.0);
+    EXPECT_EQ(dfMax, 32767.0);
+
+    EXPECT_TRUE(GDALGetDataTypeMinMaxAsDouble(GDT_UInt32, &dfMin, &dfMax));
+    EXPECT_EQ(dfMin, 0.0);
+    EXPECT_EQ(dfMax, 4294967295.0);
+    EXPECT_TRUE(GDALGetDataTypeMinMaxAsDouble(GDT_Int32, &dfMin, &dfMax));
+    EXPECT_EQ(dfMin, -2147483648.0);
+    EXPECT_EQ(dfMax, 2147483647.0);
+
+    EXPECT_TRUE(GDALGetDataTypeMinMaxAsDouble(GDT_Float16, &dfMin, &dfMax));
+    EXPECT_EQ(dfMin, cpl::NumericLimits<cpl::Float16>::lowest());
+    EXPECT_EQ(dfMax, cpl::NumericLimits<cpl::Float16>::max());
+
+    EXPECT_TRUE(GDALGetDataTypeMinMaxAsDouble(GDT_Float32, &dfMin, &dfMax));
+    EXPECT_EQ(dfMin, std::numeric_limits<float>::lowest());
+    EXPECT_EQ(dfMax, std::numeric_limits<float>::max());
+
+    EXPECT_TRUE(GDALGetDataTypeMinMaxAsDouble(GDT_Float64, &dfMin, &dfMax));
+    EXPECT_EQ(dfMin, std::numeric_limits<double>::lowest());
+    EXPECT_EQ(dfMax, std::numeric_limits<double>::max());
+
+    EXPECT_FALSE(GDALGetDataTypeMinMaxAsDouble(GDT_Int64, &dfMin, &dfMax));
+    EXPECT_FALSE(GDALGetDataTypeMinMaxAsDouble(GDT_UInt64, &dfMin, &dfMax));
+    EXPECT_FALSE(GDALGetDataTypeMinMaxAsDouble(GDT_CInt16, &dfMin, &dfMax));
+    EXPECT_FALSE(GDALGetDataTypeMinMaxAsDouble(GDT_CInt32, &dfMin, &dfMax));
+    EXPECT_FALSE(GDALGetDataTypeMinMaxAsDouble(GDT_CFloat16, &dfMin, &dfMax));
+    EXPECT_FALSE(GDALGetDataTypeMinMaxAsDouble(GDT_CFloat32, &dfMin, &dfMax));
+    EXPECT_FALSE(GDALGetDataTypeMinMaxAsDouble(GDT_CFloat64, &dfMin, &dfMax));
+    EXPECT_FALSE(GDALGetDataTypeMinMaxAsDouble(GDT_Unknown, &dfMin, &dfMax));
+    EXPECT_FALSE(GDALGetDataTypeMinMaxAsDouble(GDT_TypeCount, &dfMin, &dfMax));
+    EXPECT_FALSE(GDALGetDataTypeMinMaxAsDouble(static_cast<GDALDataType>(150),
+                                               &dfMin, &dfMax));
+}
+
 // Test GDALDataTypeIsInteger()
 TEST_F(test_gdal, GDALDataTypeIsInteger)
 {

--- a/autotest/cpp/test_gdal.cpp
+++ b/autotest/cpp/test_gdal.cpp
@@ -1074,8 +1074,8 @@ TEST_F(test_gdal, GDALGetDataTypeMinMaxAsDouble)
     EXPECT_EQ(dfMax, 2147483647.0);
 
     EXPECT_TRUE(GDALGetDataTypeMinMaxAsDouble(GDT_Float16, &dfMin, &dfMax));
-    EXPECT_EQ(dfMin, cpl::NumericLimits<cpl::Float16>::lowest());
-    EXPECT_EQ(dfMax, cpl::NumericLimits<cpl::Float16>::max());
+    EXPECT_EQ(dfMin, cpl::NumericLimits<GFloat16>::lowest());
+    EXPECT_EQ(dfMax, cpl::NumericLimits<GFloat16>::max());
 
     EXPECT_TRUE(GDALGetDataTypeMinMaxAsDouble(GDT_Float32, &dfMin, &dfMax));
     EXPECT_EQ(dfMin, std::numeric_limits<float>::lowest());

--- a/autotest/utilities/test_gdalalg_raster_proximity.py
+++ b/autotest/utilities/test_gdalalg_raster_proximity.py
@@ -315,6 +315,94 @@ def test_gdalalg_raster_proximity_overwrite(tmp_vsimem):
     assert alg3.Finalize()
 
 
+@pytest.mark.parametrize(
+    "dt",
+    (
+        gdal.GDT_Int8,
+        gdal.GDT_UInt8,
+        gdal.GDT_Int16,
+        gdal.GDT_UInt16,
+        gdal.GDT_Int32,
+        gdal.GDT_UInt32,
+        gdal.GDT_Int64,
+        gdal.GDT_Float16,
+        gdal.GDT_Float32,
+        gdal.GDT_Float64,
+    ),
+    ids=gdal.GetDataTypeName,
+)
+def test_gdalalg_raster_proximity_default_nodata(dt):
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 3, 3)
+    src_ds.WriteArray(np.array([[1, 0, 0], [0, 0, 0], [0, 0, 0]]))
+
+    alg = get_alg()
+    alg["input"] = src_ds
+    alg["output-format"] = "MEM"
+    alg["output-data-type"] = gdal.GetDataTypeName(dt)
+    alg["max-distance"] = 1
+
+    assert alg.Run()
+
+    dst_ds = alg.Output()
+
+    nodata_px = dst_ds.ReadAsArray()[-1, -1]
+
+    expected_nodata = {
+        gdal.GDT_Int8: 127,
+        gdal.GDT_UInt8: 255,
+        gdal.GDT_Int16: 2**15 - 1,
+        gdal.GDT_UInt16: 2**16 - 1,
+        gdal.GDT_Int32: 2**31 - 1,
+        gdal.GDT_UInt32: 2**32 - 1,
+        gdal.GDT_Int64: 2**63 - 1,
+        gdal.GDT_UInt64: 2**64 - 1,
+        gdal.GDT_Float16: float("nan"),
+        gdal.GDT_Float32: float("nan"),
+        gdal.GDT_Float64: float("nan"),
+    }
+
+    if math.isnan(expected_nodata[dt]):
+        assert math.isnan(nodata_px)
+        assert math.isnan(dst_ds.GetRasterBand(1).GetNoDataValue())
+    else:
+        assert nodata_px == expected_nodata[dt]
+        assert dst_ds.GetRasterBand(1).GetNoDataValue() == expected_nodata[dt]
+
+
+@pytest.mark.parametrize(
+    "dt,nodata", ((gdal.GDT_Float64, 1e39), (gdal.GDT_Int32, 2**31 - 2))
+)
+def test_gdalalg_raster_proximity_nodata_not_representable_as_float32(dt, nodata):
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 3, 3)
+    src_ds.WriteArray(np.array([[1, 0, 0], [0, 0, 0], [0, 0, 0]]))
+
+    alg = get_alg()
+    alg["input"] = src_ds
+    alg["output-format"] = "MEM"
+    alg["output-nodata"] = nodata
+    alg["output-data-type"] = gdal.GetDataTypeName(dt)
+    alg["max-distance"] = 1
+
+    with pytest.raises(Exception, match="representable as a 32-bit float"):
+        assert alg.Run()
+
+
+@pytest.mark.parametrize(
+    "dt", (gdal.GDT_CFloat32, gdal.GDT_CFloat64), ids=gdal.GetDataTypeName
+)
+def test_gdalalg_raster_proximity_invalid_output_type(dt):
+
+    alg = get_alg()
+    alg["input"] = "../gcore/data/byte.tif"
+    alg["output-format"] = "MEM"
+    alg["output-data-type"] = gdal.GetDataTypeName(dt)
+
+    with pytest.raises(Exception, match="Complex output types not supported"):
+        assert alg.Run()
+
+
 @pytest.mark.require_driver("GTiff")
 def test_gdalalg_raster_proximity_respect_input_nodata(tmp_vsimem):
     """Test the nodata value in the input dataset are not included in the proximity."""

--- a/autotest/utilities/test_gdalalg_raster_proximity.py
+++ b/autotest/utilities/test_gdalalg_raster_proximity.py
@@ -11,6 +11,8 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import math
+
 import gdaltest
 import pytest
 
@@ -220,6 +222,8 @@ def test_gdalalg_raster_proximity_options(tmp_vsimem, options, expected_output_d
     for k, v in options.items():
         alg[k] = v
 
+    set_nodata = alg["nodata"] if alg.GetArg("nodata").IsExplicitlySet() else None
+
     assert alg.Run()
     assert alg.Finalize()
 
@@ -231,6 +235,26 @@ def test_gdalalg_raster_proximity_options(tmp_vsimem, options, expected_output_d
     out_ds = gdal.Open(str(dst_filename_file))
     band_out = out_ds.GetRasterBand(1)
     assert band_out.DataType == data_type
+
+    if set_nodata is not None:
+        assert band_out.GetNoDataValue() == set_nodata
+    elif band_out.DataType == gdal.GDT_UInt8:
+        assert band_out.GetNoDataValue() == 255
+    elif band_out.DataType == gdal.GDT_Int8:
+        assert band_out.GetNoDataValue() == 127
+    elif band_out.DataType == gdal.GDT_Int16:
+        assert band_out.GetNoDataValue() == 2**15 - 1
+    elif band_out.DataType == gdal.GDT_UInt16:
+        assert band_out.GetNoDataValue() == 2**16 - 1
+    elif band_out.DataType == gdal.GDT_Int32:
+        assert band_out.GetNoDataValue() == 2**31 - 1
+    elif band_out.DataType == gdal.GDT_UInt32:
+        assert band_out.GetNoDataValue() == 2**32 - 1
+    elif band_out.DataType in (gdal.GDT_Float32, gdal.GDT_Float64):
+        assert band_out.GetNoDataValue() == 65535
+    else:
+        pytest.fail("Unhandled default NoData value")
+
     assert out_ds is not None
     output_data_file = out_ds.GetRasterBand(1).ReadAsArray()
     assert np.allclose(output_data_file, expected_output_data, atol=1e-6)

--- a/autotest/utilities/test_gdalalg_raster_proximity.py
+++ b/autotest/utilities/test_gdalalg_raster_proximity.py
@@ -173,7 +173,11 @@ def create_gtiff_from_array(
                 "fixed-value": 128,
             },
             np.array(
-                [[65535, 65535, 128], [65535, 128, 128], [128, 128, 0]],
+                [
+                    [float("nan"), float("nan"), 128],
+                    [float("nan"), 128, 128],
+                    [128, 128, 0],
+                ],
                 dtype=np.float32,
             ),
         ),
@@ -251,13 +255,15 @@ def test_gdalalg_raster_proximity_options(tmp_vsimem, options, expected_output_d
     elif band_out.DataType == gdal.GDT_UInt32:
         assert band_out.GetNoDataValue() == 2**32 - 1
     elif band_out.DataType in (gdal.GDT_Float32, gdal.GDT_Float64):
-        assert band_out.GetNoDataValue() == 65535
+        assert math.isnan(band_out.GetNoDataValue())
     else:
         pytest.fail("Unhandled default NoData value")
 
     assert out_ds is not None
     output_data_file = out_ds.GetRasterBand(1).ReadAsArray()
-    assert np.allclose(output_data_file, expected_output_data, atol=1e-6)
+    assert np.allclose(
+        output_data_file, expected_output_data, atol=1e-6, equal_nan=True
+    )
     assert out_ds.GetGeoTransform() == src_ds_opened.GetGeoTransform()
     assert out_ds.GetProjection() == src_ds_opened.GetProjection()
     if (

--- a/doc/source/programs/gdal_raster_proximity.rst
+++ b/doc/source/programs/gdal_raster_proximity.rst
@@ -98,15 +98,13 @@ Examples
 --------
 
 .. example::
-
    :title: Proximity map of a raster with max distance of 3 pixels
 
     .. code-block:: bash
 
-        $ gdal raster proximity --max-distance 3  input.tif output.tif
+        gdal raster proximity --max-distance 3 input.tif output.tif
 
 .. example::
-
    :title: Proximity map of a two bands raster with different target values for each band using a pipeline stack
 
     .. code-block:: bash

--- a/doc/source/programs/gdal_raster_proximity.rst
+++ b/doc/source/programs/gdal_raster_proximity.rst
@@ -61,10 +61,11 @@ Program-Specific Options
 
 .. option:: --output-nodata <NODATA>
 
-    Nodata value for the output raster. If not specified, the NoData value of the input band will be used.
-    If the output band does not have a NoData value, then the value 65535 will be used for floating point
-    output types and the maximum value that can be stored will be used for the integer output types.
+    NoData value for the output raster. If not specified, the value NaN will be used for floating point
+    output types and the maximum value that can be stored will be used for integer output types.
 
+    Due to an implementation detail of the proximity algorithm, the NoData value must be 
+    representable as a 32-bit floating point number.
 
 .. option:: --target-values <TARGET-VALUES>
 

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -95,6 +95,8 @@ double CPL_DLL GDALAdjustValueToDataType(GDALDataType eDT, double dfValue,
                                          int *pbClamped, int *pbRounded);
 bool CPL_DLL GDALIsValueExactAs(double dfValue, GDALDataType eDT);
 bool CPL_DLL GDALIsValueInRangeOf(double dfValue, GDALDataType eDT);
+bool CPL_DLL GDALGetDataTypeMinMaxAsDouble(GDALDataType eType, double *pdfMin,
+                                           double *pdfMax);
 GDALDataType CPL_DLL CPL_STDCALL GDALGetNonComplexDataType(GDALDataType);
 int CPL_DLL CPL_STDCALL GDALDataTypeIsConversionLossy(GDALDataType eTypeFrom,
                                                       GDALDataType eTypeTo);

--- a/gcore/gdal_misc.cpp
+++ b/gcore/gdal_misc.cpp
@@ -1065,7 +1065,7 @@ bool GDALIsValueInRangeOf(double dfValue, GDALDataType eDT)
 }
 
 /************************************************************************/
-/*                       GDALGetDataTypeLimits()                        */
+/*                   GDALGetDataTypeMinMaxAsDouble()                    */
 /************************************************************************/
 
 /**
@@ -1083,6 +1083,11 @@ bool GDALIsValueInRangeOf(double dfValue, GDALDataType eDT)
 bool GDALGetDataTypeMinMaxAsDouble(GDALDataType eType, double *pdfMin,
                                    double *pdfMax)
 {
+    if (static_cast<int>(eType) >= static_cast<int>(GDT_TypeCount))
+    {
+        return false;
+    }
+
     double dfMin, dfMax;
 
     switch (eType)
@@ -1136,26 +1141,32 @@ bool GDALGetDataTypeMinMaxAsDouble(GDALDataType eType, double *pdfMin,
                     gdal::GDALDataTypeTraits<GDT_UInt32>::type>::max());
             break;
         case GDT_Float16:
-            dfMin =
-                static_cast<double>(cpl::NumericLimits<cpl::Float16>::min());
-            dfMax =
-                static_cast<double>(cpl::NumericLimits<cpl::Float16>::max());
+            dfMin = static_cast<double>(cpl::NumericLimits<GFloat16>::lowest());
+            dfMax = static_cast<double>(cpl::NumericLimits<GFloat16>::max());
             break;
         case GDT_Float32:
             dfMin = static_cast<double>(
                 cpl::NumericLimits<
-                    gdal::GDALDataTypeTraits<GDT_Float32>::type>::min());
+                    gdal::GDALDataTypeTraits<GDT_Float32>::type>::lowest());
             dfMax = static_cast<double>(
                 cpl::NumericLimits<
                     gdal::GDALDataTypeTraits<GDT_Float32>::type>::max());
             break;
         case GDT_Float64:
             dfMin = cpl::NumericLimits<
-                gdal::GDALDataTypeTraits<GDT_Float64>::type>::min();
+                gdal::GDALDataTypeTraits<GDT_Float64>::type>::lowest();
             dfMax = cpl::NumericLimits<
                 gdal::GDALDataTypeTraits<GDT_Float64>::type>::max();
             break;
-        default:
+        case GDT_CInt16:
+        case GDT_CInt32:
+        case GDT_CFloat16:
+        case GDT_CFloat32:
+        case GDT_CFloat64:
+        case GDT_Int64:
+        case GDT_UInt64:
+        case GDT_Unknown:
+        case GDT_TypeCount:
             return false;
     }
 

--- a/gcore/gdal_misc.cpp
+++ b/gcore/gdal_misc.cpp
@@ -44,6 +44,7 @@
 #include "gdal_mdreader.h"
 #include "gdal_priv.h"
 #include "gdal_priv_templates.hpp"
+#include "gdal_typetraits.h"
 #include "ogr_core.h"
 #include "ogr_spatialref.h"
 #include "ogr_geos.h"
@@ -1060,6 +1061,108 @@ bool GDALIsValueInRangeOf(double dfValue, GDALDataType eDT)
         case GDT_TypeCount:
             break;
     }
+    return true;
+}
+
+/************************************************************************/
+/*                       GDALGetDataTypeLimits()                        */
+/************************************************************************/
+
+/**
+ * \brief Get the minimum and maximum values that can be stored in the
+ * specified data type, if those values can also be exactly stored in a double.
+ *
+ * @param eType type to check.
+ * @param pdfMin optional pointer to double where the minimum value will be stored
+ * @param pdfMax optional pointer to double where the maximum value will be stored
+ *
+ * @return true if the min/max values for the specified data type can be stored
+ * exactly in a double, false otherwise.
+ * @since GDAL 3.14
+ */
+bool GDALGetDataTypeMinMaxAsDouble(GDALDataType eType, double *pdfMin,
+                                   double *pdfMax)
+{
+    double dfMin, dfMax;
+
+    switch (eType)
+    {
+        case GDT_Int8:
+            dfMin = static_cast<double>(
+                cpl::NumericLimits<
+                    gdal::GDALDataTypeTraits<GDT_Int8>::type>::min());
+            dfMax = static_cast<double>(
+                cpl::NumericLimits<
+                    gdal::GDALDataTypeTraits<GDT_Int8>::type>::max());
+            break;
+        case GDT_UInt8:
+            dfMin = static_cast<double>(
+                cpl::NumericLimits<
+                    gdal::GDALDataTypeTraits<GDT_UInt8>::type>::min());
+            dfMax = static_cast<double>(
+                cpl::NumericLimits<
+                    gdal::GDALDataTypeTraits<GDT_UInt8>::type>::max());
+            break;
+        case GDT_Int16:
+            dfMin = static_cast<double>(
+                cpl::NumericLimits<
+                    gdal::GDALDataTypeTraits<GDT_Int16>::type>::min());
+            dfMax = static_cast<double>(
+                cpl::NumericLimits<
+                    gdal::GDALDataTypeTraits<GDT_Int16>::type>::max());
+            break;
+        case GDT_UInt16:
+            dfMin = static_cast<double>(
+                cpl::NumericLimits<
+                    gdal::GDALDataTypeTraits<GDT_UInt16>::type>::min());
+            dfMax = static_cast<double>(
+                cpl::NumericLimits<
+                    gdal::GDALDataTypeTraits<GDT_UInt16>::type>::max());
+            break;
+        case GDT_Int32:
+            dfMin = static_cast<double>(
+                cpl::NumericLimits<
+                    gdal::GDALDataTypeTraits<GDT_Int32>::type>::min());
+            dfMax = static_cast<double>(
+                cpl::NumericLimits<
+                    gdal::GDALDataTypeTraits<GDT_Int32>::type>::max());
+            break;
+        case GDT_UInt32:
+            dfMin = static_cast<double>(
+                cpl::NumericLimits<
+                    gdal::GDALDataTypeTraits<GDT_UInt32>::type>::min());
+            dfMax = static_cast<double>(
+                cpl::NumericLimits<
+                    gdal::GDALDataTypeTraits<GDT_UInt32>::type>::max());
+            break;
+        case GDT_Float16:
+            dfMin =
+                static_cast<double>(cpl::NumericLimits<cpl::Float16>::min());
+            dfMax =
+                static_cast<double>(cpl::NumericLimits<cpl::Float16>::max());
+            break;
+        case GDT_Float32:
+            dfMin = static_cast<double>(
+                cpl::NumericLimits<
+                    gdal::GDALDataTypeTraits<GDT_Float32>::type>::min());
+            dfMax = static_cast<double>(
+                cpl::NumericLimits<
+                    gdal::GDALDataTypeTraits<GDT_Float32>::type>::max());
+            break;
+        case GDT_Float64:
+            dfMin = cpl::NumericLimits<
+                gdal::GDALDataTypeTraits<GDT_Float64>::type>::min();
+            dfMax = cpl::NumericLimits<
+                gdal::GDALDataTypeTraits<GDT_Float64>::type>::max();
+            break;
+        default:
+            return false;
+    }
+
+    if (pdfMin)
+        *pdfMin = dfMin;
+    if (pdfMax)
+        *pdfMax = dfMax;
     return true;
 }
 


### PR DESCRIPTION
First commit makes `gdal raster proximity` match the documented behavior, using a default NoData value equal to the maximum value for integer data types, or 65535 for floating point types. It also modifies `gdal raster proximity` to set the NoData value on the output band in the case where a default is used.

Second commit switches the default for floating point types from 65535.0 to NaN.