### PR TITLE
Doc: Updates to Windows build and testing docs

### DIFF
--- a/doc/source/development/dev_environment.rst
+++ b/doc/source/development/dev_environment.rst
@@ -100,9 +100,8 @@ Start a Conda-enabled PowerShell console and assuming there is a ``c:\\dev`` dir
     cd c:\dev
     conda create --yes --name gdal
     conda activate gdal
-
     conda install --yes --quiet -c conda-forge compilers cmake curl libiconv icu python swig numpy `
-        pytest pytest-env pytest-benchmark filelock zlib lxml jsonschema setuptools
+        zlib lxml setuptools
     # --only-deps only installs the dependencies of the listed packages, not the packages themselves
     conda install --yes --quiet -c gdal-master -c conda-forge --only-deps `
         libgdal libgdal-hdf4 libgdal-hdf5 libgdal-netcdf libgdal-pdf libgdal-jp2openjpeg
@@ -142,6 +141,10 @@ the commands below from a Conda-enabled PowerShell console:
 .. code-block:: ps1
 
     cd c:\dev\gdal\build
+
+    # install the Python dependencies for autotest
+    python -m pip install -r ../autotest/requirements.txt
+
     # set environment variables, see section below
     ..\scripts\setdevenv.ps1
     # check the version
@@ -188,12 +191,12 @@ To verify that environment variables have been set correctly, you can check the 
 
 .. code-block:: bash
 
-    gdalinfo --version
-    # GDAL 3.13.0dev-8c3cf3de02, released 2025/11/14
+    gdal --version
+    # GDAL 3.14.0dev-b0b8dcc320-dirty, released 2026/09/04
 
 and the Python bindings:
 
 .. code-block:: bash
 
-    python3 -c 'from osgeo import gdal; print(gdal.__version__)'
-    # 3.11.0dev-c4a2e0b926-dirty
+    python -c 'from osgeo import gdal; print(gdal.__version__)'
+    # 3.14.0dev-b0b8dcc320-dirty

--- a/doc/source/development/dev_environment.rst
+++ b/doc/source/development/dev_environment.rst
@@ -100,10 +100,11 @@ Start a Conda-enabled PowerShell console and assuming there is a ``c:\\dev`` dir
     cd c:\dev
     conda create --yes --name gdal
     conda activate gdal
+
     conda install --yes --quiet -c conda-forge compilers cmake curl libiconv icu python swig numpy `
         pytest pytest-env pytest-benchmark filelock zlib lxml jsonschema setuptools
     # --only-deps only installs the dependencies of the listed packages, not the packages themselves
-    conda install --yes --quiet -c conda-forge --only-deps `
+    conda install --yes --quiet -c gdal-master -c conda-forge --only-deps `
         libgdal libgdal-hdf4 libgdal-hdf5 libgdal-netcdf libgdal-pdf libgdal-jp2openjpeg
 
 .. note::
@@ -167,19 +168,21 @@ This can be done by sourcing the following from the build directory:
 
 (with adjustments to the above path if the build directory is not a subdirectory of the GDAL source root).
 
-For Windows, a similar ``scripts/setdevenv.bat`` script exists (it currently assumes a Release build).
+For Windows, a similar ``scripts/setdevenv.bat`` script exists.
 
 .. code-block:: console
 
     cd c:\dev\gdal\build
-    ..\scripts\setdevenv.bat
+    ..\scripts\setdevenv.bat              REM uses "Release" (default)
+    ..\scripts\setdevenv.bat Debug        REM uses "Debug"
 
 Alternatively, on Windows, you can set up a PowerShell development environment using the ``scripts/setdevenv.ps1`` script:
 
 .. code-block:: ps1
 
     cd c:\dev\gdal\build
-    ..\scripts\setdevenv.ps1
+    ..\scripts\setdevenv.ps1                    # uses "Release" (default)
+    ..\scripts\setdevenv.ps1 RelWithDebInfo     # uses "RelWithDebInfo"
 
 To verify that environment variables have been set correctly, you can check the version of a GDAL binary:
 

--- a/doc/source/development/testing.rst
+++ b/doc/source/development/testing.rst
@@ -6,13 +6,24 @@ Automated testing
 
 GDAL includes a comprehensive test suite, implemented using a combination of Python (via pytest) and C++ (via gtest).
 
-After building GDAL using CMake, the complete test suite can be run using ``ctest -v --output-on-failure``. This will automatically set environment variables so that tests are run on the
-the built version of GDAL, rather than an installed system copy.
+After building GDAL using CMake (with the option ``-DBUILD_TESTING=ON`` which is enabled by default),
+the complete test suite can be run using ``ctest -V --output-on-failure``.
+This will automatically set environment variables so that tests are run on the built version of GDAL, rather than an installed system copy.
+
+See also the autotest :source_file:`autotest/README.md`.
+
+``pytest`` and the other test dependencies listed in :source_file:`autotest/requirements.txt` need to be installed,
+if not already added to the environment.
+
+.. code-block:: bash
+
+    # from within the build directory
+    python -m pip install -r ../autotest/requirements.txt
 
 Running a subset of tests using ``ctest``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The complete set of test suites known to ``ctest`` can be viewed running ``ctest -N``.
+The complete set of test suites known to ``ctest`` can be viewed by running ``ctest -N``.
 
 A subset of tests can be run using the ``-R`` argument to ``ctest``, which selects tests using a provided regular expression.
 For example, ``ctest -R autotest`` would run the Python-based tests.
@@ -34,11 +45,13 @@ can be done by running the following from the build directory:
 
     pytest autotest/gcore/vrt_read.py
 
-On Windows, the test files remain in the source tree, but the pytest configuration file ``pytest.ini`` is only available in the build directory. To accommodate this, the above command would be modified as follows:
+On Windows, the test files remain in the source tree, but the pytest configuration file ``pytest.ini`` is only available in the ``build/autotest`` directory.
+To accommodate this, the above command would be modified as follows:
 
-.. code-block:: bash
+.. code-block:: console
 
-    pytest -c pytest.ini ../autotest/gcore/vrt_read.py
+    # from within the build directory
+    pytest -c autotest/pytest.ini ../autotest/gcore/vrt_read.py
 
 A subset of tests within an individual test file can be run by providing a regular expression to the ``-k`` argument to ``pytest``.
 
@@ -54,7 +67,7 @@ example, to list tests containing "tiff" in the name:
     pytest --collect-only autotest -k tiff
 
 
-.. warning:: Not all Python tests can be run independently; some tests depend on state set by a previous tests in the same file.
+.. warning:: Not all Python tests can be run independently; some tests depend on state set by previous tests in the same file.
 
 
 Checking for memory leaks and access errors using Valgrind
@@ -119,7 +132,7 @@ Python-based tests should be preferred when possible, as productivity is higher
 in Python and there is no associated compilation time (compilation time affects
 feedback received from continuous integration).
 
-C/C++-based test should be reserved for C++-specific aspects that cannot be tested
+C/C++-based tests should be reserved for C++-specific aspects that cannot be tested
 with the SWIG Python bindings, which use the C interface. For example testing
 of C++ operators (copy/move constructors/assignment operators, iterator interfaces,
 etc.) or C/C++ functionality not mapped to SWIG (e.g. CPL utility functions/classes)
@@ -131,9 +144,11 @@ Python tests use the `pytest <https://docs.pytest.org/en/latest/>`__
 framework since :ref:`rfc-72`.
 
 Test cases should be written in a way where they are independent from other
-ones, so they can potentially be run in a isolated way or in parallel of other
+ones, so they can potentially be run in isolation or in parallel with other
 test cases. In particular temporary files should be created with a name that
-cannot conflict with other tests: preferably use pytest's ``tmp_path`` fixture <https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html#the-tmp-path-fixture>`__.
+cannot conflict with other tests: preferably use pytest's
+`tmp_path <https://docs.pytest.org/en/latest/how-to/tmp_path.html#the-tmp-path-fixture>`__
+fixture.
 
 Use ``@pytest.mark.require_driver(driver_name)`` as an annotation for a test
 case that requires an optional driver to be present.
@@ -181,16 +196,16 @@ re-register it afterwards:
 
     @pytest.fixture(scope="module", autouse=True)
     def without_filegdb_driver():
-    # remove FileGDB driver before running tests
-    filegdb_driver = ogr.GetDriverByName("FileGDB")
-    if filegdb_driver is not None:
-        filegdb_driver.Deregister()
+        # remove FileGDB driver before running tests
+        filegdb_driver = ogr.GetDriverByName("FileGDB")
+        if filegdb_driver is not None:
+            filegdb_driver.Deregister()
 
-    yield
+        yield
 
-    if filegdb_driver is not None:
-        print("Reregistering FileGDB driver")
-        filegdb_driver.Register()
+        if filegdb_driver is not None:
+            print("Reregistering FileGDB driver")
+            filegdb_driver.Register()
 
 or a fixture that runs preliminary checks to discover if a driver has
 some optional capabilities, and skip a test case if not:
@@ -199,18 +214,18 @@ some optional capabilities, and skip a test case if not:
 
     @pytest.fixture()
     def require_auto_load_extension():
-    if ogr.GetDriverByName("SQLite") is None:
-        pytest.skip()
+        if ogr.GetDriverByName("SQLite") is None:
+            pytest.skip()
 
-    ds = ogr.Open(":memory:")
-    with gdaltest.error_handler():
-        sql_lyr = ds.ExecuteSQL("PRAGMA compile_options")
-    if sql_lyr:
-        for f in sql_lyr:
-            if f.GetField(0) == "OMIT_LOAD_EXTENSION":
-                ds.ReleaseResultSet(sql_lyr)
-                pytest.skip("SQLite3 built with OMIT_LOAD_EXTENSION")
-        ds.ReleaseResultSet(sql_lyr)
+        ds = ogr.Open(":memory:")
+        with gdaltest.error_handler():
+            sql_lyr = ds.ExecuteSQL("PRAGMA compile_options")
+        if sql_lyr:
+            for f in sql_lyr:
+                if f.GetField(0) == "OMIT_LOAD_EXTENSION":
+                    ds.ReleaseResultSet(sql_lyr)
+                    pytest.skip("SQLite3 built with OMIT_LOAD_EXTENSION")
+            ds.ReleaseResultSet(sql_lyr)
 
     def test_ogr_virtualogr_1(require_auto_load_extension):
         # Invalid syntax
@@ -231,7 +246,7 @@ NULL and dereferencing it unconditionally afterwards. The ASSERT_xxxx family
 of assertions should be used for such cases where early exit of the test case
 is desired.
 
-GoogleTest also offers capabilities for parametrized tests. For example:
+GoogleTest also offers capabilities for parameterized tests. For example:
 
 .. code-block:: c++
 
@@ -291,7 +306,7 @@ and C++ autotest tests.
 
 This is used by the `Coveralls GitHub Action <https://github.com/marketplace/actions/coveralls-github-action>`__
 to upload results to https://coveralls.io/github/OSGeo/gdal, for both push
-and pull requests events.
+and pull request events.
 
 A somewhat nicer looking output of line coverage results for the latest master
 build, generated by ``lcov``, is also available at

--- a/doc/source/substitutions.rst
+++ b/doc/source/substitutions.rst
@@ -14,7 +14,7 @@
 .. |Docker| replace:: `Docker <https://www.docker.com/>`__
 .. |gdal-dev| replace:: `gdal-dev <https://lists.osgeo.org/mailman/listinfo/gdal-dev>`__
 .. |OSGeo/gdal| replace:: `OSGeo/gdal <https://github.com/OSGeo/gdal>`__
-.. |OGC| replace:: `OGC <https://www.ogc.org//>`__
+.. |OGC| replace:: `OGC <https://www.ogc.org/>`__
 .. |Sphinx| replace:: `Sphinx <https://www.sphinx-doc.org/>`__
 .. |sphinx-autobuild| replace:: `sphinx-autobuild <https://pypi.org/project/sphinx-autobuild/>`__
 .. |about-config-options| replace:: :ref:`Configuration options <configoptions>` can be specified in command-line tools using the syntax ``--config <NAME>=<VALUE>`` or using functions such as :cpp:func:`CPLSetConfigOption` (C) or :py:func:`gdal.config_options<osgeo.gdal.config_options>` (Python).

--- a/scripts/setdevenv.bat
+++ b/scripts/setdevenv.bat
@@ -1,9 +1,11 @@
 @echo off
-
 REM This is a very primitive script which must be called from a build
-REM directory and set the environment for a Release build
+REM directory and by default sets the environment for a Release build
 
-set PATH=%CD%\swig\python\bin;%CD%\apps\Release;%CD%\Release;%PATH%
+set Configuration=%~1
+if "%Configuration%"=="" set Configuration=Release
+
+set PATH=%CD%\swig\python\bin;%CD%\apps\%Configuration%;%CD%\%Configuration%;%PATH%
 set GDAL_DATA=%CD%\data
 set PYTHONPATH=%CD%\swig\python
-set GDAL_DRIVER_PATH=%CD%\gdalplugins\Release
+set GDAL_DRIVER_PATH=%CD%\gdalplugins\%Configuration%

--- a/scripts/setdevenv.ps1
+++ b/scripts/setdevenv.ps1
@@ -1,7 +1,11 @@
 # This is a very simple script which must be called from a build
-# directory and sets the environment for a Release build
+# directory and by default sets the environment for a Release build.
 
-$env:PATH = "$PWD\swig\python\bin;$PWD\apps\Release;$PWD\Release;" + $env:PATH
+param(
+    [string]$Configuration = "Release"
+)
+
+$env:PATH = "$PWD\swig\python\bin;$PWD\apps\$Configuration;$PWD\$Configuration;$env:PATH"
 $env:GDAL_DATA = "$PWD\data"
 $env:PYTHONPATH = "$PWD\swig\python"
-$env:GDAL_DRIVER_PATH = "$PWD\gdalplugins\Release"
+$env:GDAL_DRIVER_PATH = "$PWD\gdalplugins\$Configuration"


### PR DESCRIPTION
Some minor updates to the Conda Windows builds, and running `autotest` having gone through the process a few times. 
Issues were documented in #15092, but the key issues have been addressed, so only minor changes required for the docs.

- #15103 - thanks @rouault
- #15080 - thanks @gillins

Changes in PR:

- clarifications I found useful when going through the steps
- allow a build type parameter to be used for the `setenv` scripts on Windows (e.g. `RelWithDebInfo`)
- typo and Python indentation fixes