### PR TITLE
Doc: Add sphinx-copybutton

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,6 +4,7 @@ breathe
 fsspec
 numpy
 sphinx
+sphinx-copybutton
 sphinx-tabs
 # Required minimum version for allowing manpage builds
 # Cf https://github.com/sphinx-toolbox/sphinx-toolbox/pull/205

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -91,6 +91,7 @@ extensions = [
     "sphinxcontrib_programoutput_gdal",
     "sphinxcontrib.spelling",
     "myst_nb",
+    "sphinx_copybutton",
     "sphinx_tabs.tabs",
     "sphinx_toolbox.collapse",
 ]
@@ -1647,6 +1648,11 @@ spelling_word_list_filename = ["spelling_wordlist.txt"]
 nb_mime_priority_overrides = [
     ("spelling", "text/plain", 0),
 ]
+
+# -- copybutton -----------------------------------------------
+
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
 
 # -- copy data files -----------------------------------------------------
 


### PR DESCRIPTION
As suggested in https://github.com/rouault/gdal_cli_workshop/pull/6 by @ecomodeller this PR adds a copy button to any of the code snippets in the docs, allowing easy copy/paste without any prompts (e.g. `$` or `>>>` are automatically removed). 

This came up in the workshop where text for the tutorials had to be manually selected to copy and paste, but I think it is a useful addition for all GDAL doc examples

The prompt regex is taken from the plugins docs at https://sphinx-copybutton.readthedocs.io/en/latest/use.html#using-regexp-prompt-identifiers. 

In the example below, clikcing the new button in the top-right of the example, copies:

 ```
gdal.alg.raster.info(input='SENTINEL2_L2A:S2B_MSIL2A_20260423T094029_N0512_R036_T34TDR_20260423T115714.SAFE/MTD_MSIL2A.xml:10m:EPSG_32634')```
```

`>>>` is removed. 

<img width="1372" height="198" alt="image" src="https://github.com/user-attachments/assets/ef10fc95-1090-4ecc-a192-977f98a6408f" />
