### PR TITLE
[Backport release/3.13] gdal vector partition: fix out-of-bounds read in first pass

### DIFF
--- a/apps/gdalalg_vector_partition.cpp
+++ b/apps/gdalalg_vector_partition.cpp
@@ -1194,7 +1194,7 @@ bool GDALVectorPartitionAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
                 asSingleField[0].nIdx = 0;
                 for (auto &poFeature : *poSQLLayer)
                 {
-                    const auto sPair = BuildKey(asFields, poFeature.get());
+                    const auto sPair = BuildKey(asSingleField, poFeature.get());
                     const std::string &osKey = sPair.first;
                     oSetKeys.insert(osKey);
 #ifdef DEBUG_VERBOSE

--- a/autotest/utilities/test_gdalalg_vector_partition.py
+++ b/autotest/utilities/test_gdalalg_vector_partition.py
@@ -61,6 +61,25 @@ def src_ds(unique_constraint=False):
     return ds
 
 
+@pytest.mark.require_driver("GML")
+def test_gdalalg_vector_partition_non_append_format(tmp_vsimem):
+
+    gdal.Run(
+        "vector",
+        "partition",
+        input=src_ds(),
+        output=tmp_vsimem / "out",
+        format="GML",
+        field=["int_field"],
+        scheme="hive",
+    )
+
+    assert sorted(gdal.ReadDir(tmp_vsimem / "out" / "test")) == [
+        "int_field=1",
+        "int_field=2",
+    ]
+
+
 @pytest.mark.require_driver("GPKG")
 @pytest.mark.parametrize("max_cache_size", [100, 1])
 def test_gdalalg_vector_partition_str_field(tmp_vsimem, max_cache_size):


### PR DESCRIPTION
Backport #15176
 **Authored by:** @alonfaraj