### PR TITLE
fix(apps): fix error code retrieval order in GDALVSIMoveAlgorithm

### DIFF
--- a/apps/gdalalg_vsi_copy.cpp
+++ b/apps/gdalalg_vsi_copy.cpp
@@ -102,8 +102,9 @@ bool GDALVSICopyAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
 
         if (!cpl::ends_with(m_source, "/*") && !cpl::ends_with(m_source, "\\*"))
         {
-            VSIErrorReset();
             const auto nOldErrorNum = VSIGetLastErrorNo();
+            VSIErrorReset();
+
             VSIStatBufL statBufSrc;
             bool srcExists = VSIStatL(m_source.c_str(), &statBufSrc) == 0;
             if (!srcExists)
@@ -136,9 +137,10 @@ bool GDALVSICopyAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
         }
         else
         {
-            m_source.resize(m_source.size() - 2);
-            VSIErrorReset();
             const auto nOldErrorNum = VSIGetLastErrorNo();
+            VSIErrorReset();
+
+            m_source.resize(m_source.size() - 2);
             VSIStatBufL statBufSrc;
             bool srcExists = VSIStatL(m_source.c_str(), &statBufSrc) == 0;
             if (!srcExists)
@@ -155,9 +157,10 @@ bool GDALVSICopyAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
     }
     else
     {
-        VSIStatBufL statBufSrc;
-        VSIErrorReset();
         const auto nOldErrorNum = VSIGetLastErrorNo();
+        VSIErrorReset();
+
+        VSIStatBufL statBufSrc;
         bool srcExists = VSIStatL(m_source.c_str(), &statBufSrc) == 0;
         if (!srcExists)
         {

--- a/apps/gdalalg_vsi_delete.cpp
+++ b/apps/gdalalg_vsi_delete.cpp
@@ -53,10 +53,11 @@ GDALVSIDeleteAlgorithm::GDALVSIDeleteAlgorithm()
 
 bool GDALVSIDeleteAlgorithm::RunImpl(GDALProgressFunc, void *)
 {
+    const auto nOldErrorNum = VSIGetLastErrorNo();
+    VSIErrorReset();
+
     bool ret = false;
     VSIStatBufL sStat;
-    VSIErrorReset();
-    const auto nOldErrorNum = VSIGetLastErrorNo();
     if (VSIStatL(m_filename.c_str(), &sStat) != 0)
     {
         if (nOldErrorNum != VSIGetLastErrorNo())

--- a/apps/gdalalg_vsi_list.cpp
+++ b/apps/gdalalg_vsi_list.cpp
@@ -250,9 +250,10 @@ bool GDALVSIListAlgorithm::RunImpl(GDALProgressFunc, void *)
     if (m_format.empty())
         m_format = IsCalledFromCommandLine() ? "text" : "json";
 
-    VSIStatBufL sStat;
-    VSIErrorReset();
     const auto nOldErrorNum = VSIGetLastErrorNo();
+    VSIErrorReset();
+
+    VSIStatBufL sStat;
     if (VSIStatL(m_filename.c_str(), &sStat) != 0)
     {
         if (nOldErrorNum != VSIGetLastErrorNo())

--- a/apps/gdalalg_vsi_move.cpp
+++ b/apps/gdalalg_vsi_move.cpp
@@ -58,9 +58,10 @@ bool GDALVSIMoveAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
     if (VSIMove(m_source.c_str(), m_destination.c_str(), nullptr, pfnProgress,
                 pProgressData) != 0)
     {
-        VSIStatBufL statBufSrc;
-        VSIErrorReset();
         const auto nOldErrorNum = VSIGetLastErrorNo();
+        VSIErrorReset();
+
+        VSIStatBufL statBufSrc;
         const bool srcExists = VSIStatL(m_source.c_str(), &statBufSrc) == 0;
         if (!srcExists)
         {

--- a/apps/gdalalg_vsi_sync.cpp
+++ b/apps/gdalalg_vsi_sync.cpp
@@ -72,9 +72,10 @@ bool GDALVSISyncAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
     if (!VSISync(m_source.c_str(), m_destination.c_str(), aosOptions.List(),
                  pfnProgress, pProgressData, nullptr))
     {
-        VSIStatBufL sStat;
-        VSIErrorReset();
         const auto nOldErrorNum = VSIGetLastErrorNo();
+        VSIErrorReset();
+
+        VSIStatBufL sStat;
         if (VSIStatL(m_source.c_str(), &sStat) != 0)
         {
             if (nOldErrorNum != VSIGetLastErrorNo())

--- a/autotest/utilities/test_gdalalg_vsi_copy.py
+++ b/autotest/utilities/test_gdalalg_vsi_copy.py
@@ -77,24 +77,28 @@ def test_gdalalg_vsi_copy_single_source_does_not_exist_vsi():
 @pytest.mark.require_curl()
 def test_gdalalg_vsi_copy_recursive_source_does_not_exist_vsi():
 
+    gdal.ErrorReset()
+
     with gdal.config_option("OSS_SECRET_ACCESS_KEY", ""):
         alg = get_alg()
         alg["source"] = "/vsioss/i_do_not/exist.bin"
         alg["destination"] = "/vsimem/"
         alg["recursive"] = True
-        with pytest.raises(Exception, match="InvalidCredentials"):
+        with pytest.raises(Exception, match="cannot be accessed"):
             alg.Run()
 
 
 @pytest.mark.require_curl()
 def test_gdalalg_vsi_copy_recursive_slash_star_source_does_not_exist_vsi():
 
+    gdal.ErrorReset()
+
     with gdal.config_option("OSS_SECRET_ACCESS_KEY", ""):
         alg = get_alg()
         alg["source"] = "/vsioss/i_do_not/exist.bin/*"
         alg["destination"] = "/vsimem/"
         alg["recursive"] = True
-        with pytest.raises(Exception, match="InvalidCredentials"):
+        with pytest.raises(Exception, match="cannot be accessed"):
             alg.Run()
 
 

--- a/autotest/utilities/test_gdalalg_vsi_move.py
+++ b/autotest/utilities/test_gdalalg_vsi_move.py
@@ -34,10 +34,12 @@ def test_gdalalg_vsi_move_nominal(tmp_vsimem, tmp_path):
 
 def test_gdalalg_vsi_move_source_does_not_exist(tmp_vsimem):
 
+    gdal.ErrorReset()
+
     alg = get_alg()
     alg["source"] = tmp_vsimem / "i_do_not_exist.bin"
     alg["destination"] = tmp_vsimem / "dest.bin"
-    with pytest.raises(Exception, match="does not exist"):
+    with pytest.raises(Exception, match="cannot be accessed"):
         alg.Run()
 
 
@@ -56,9 +58,11 @@ def test_gdalalg_vsi_move_error(tmp_vsimem, tmp_path):
 @pytest.mark.require_curl()
 def test_gdalalg_vsi_move_source_does_not_exist_vsi():
 
+    gdal.ErrorReset()
+
     with gdal.config_option("OSS_SECRET_ACCESS_KEY", ""):
         alg = get_alg()
         alg["source"] = "/vsioss/i_do_not/exist.bin"
         alg["destination"] = "/vsimem/"
-        with pytest.raises(Exception, match="InvalidCredentials"):
+        with pytest.raises(Exception, match="does not exist or cannot be accessed"):
             alg.Run()

--- a/autotest/utilities/test_gdalalg_vsi_sync.py
+++ b/autotest/utilities/test_gdalalg_vsi_sync.py
@@ -54,9 +54,11 @@ def test_gdalalg_vsi_sync_error(tmp_vsimem, tmp_path):
 @pytest.mark.require_curl()
 def test_gdalalg_vsi_sync_source_does_not_exist_vsi():
 
+    gdal.ErrorReset()
+
     with gdal.config_option("OSS_SECRET_ACCESS_KEY", ""):
         alg = get_alg()
         alg["source"] = "/vsioss/i_do_not/exist.bin"
         alg["destination"] = "/vsimem/"
-        with pytest.raises(Exception, match="InvalidCredentials"):
+        with pytest.raises(Exception, match="does not exist or cannot be accessed"):
             alg.Run()


### PR DESCRIPTION

This is by inspection and no specific testing was done.

## What does this PR do?

Fix RunImpl so that VSIGetLastErrorNo is called before VSIErrorReset to get the actual prior error message.

Moved the statBufSrc declaration so that it is right next to where it is used.

## What are related issues/pull requests?

None

## AI tool usage

 - [X] I am experimenting with AI automated issue scanning with Gemini. There are endless amounts of slop, but I as the human bumped into this one that looks real. I hand edited the source as I think a slightly different change is more readable.

> In `GDALVSIMoveAlgorithm::RunImpl`, `VSIErrorReset()` is called on line 62 *before* capturing the previous error number into `nOldErrorNum`.
> 
> Because `VSIErrorReset()` clears the error state, `nOldErrorNum` will always be `0` (`CPLE_None`). Consequently, the conditional check `if (nOldErrorNum != VSI GetLastErrorNo())` compares against 0 instead of the actual error state prior to calling `VSIStatL`.

## Tasklist

 - [X] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s) - Skipped as I haven't observed a failure before.
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

