### PR TITLE
Fix quadratic segment merging in contour generation and re-enable the sawtooth test

### DIFF
--- a/alg/marching_squares/segment_merger.h
+++ b/alg/marching_squares/segment_merger.h
@@ -42,6 +42,7 @@ template <typename LineWriter, typename LevelGenerator> struct SegmentMerger
     SegmentMerger(LineWriter &lineWriter, const LevelGenerator &levelGenerator,
                   bool polygonize_)
         : polygonize(polygonize_), lineWriter_(lineWriter), lines_(),
+          endpointIndex_(),
           levelGenerator_(levelGenerator), m_anSkipLevels()
     {
     }

--- a/alg/marching_squares/segment_merger.h
+++ b/alg/marching_squares/segment_merger.h
@@ -174,9 +174,16 @@ template <typename LineWriter, typename LevelGenerator> struct SegmentMerger
         }
     };
 
-    typedef std::map<Point, std::vector<typename Lines::iterator>,
-                     PointCompare>
-        EndpointIndex;
+    // A marching squares point has degree two, so at most two line ends can
+    // sit on it (the two ends of the same line, when it has closed): a fixed
+    // two-slot entry avoids a heap allocation per endpoint.
+    struct EndpointEntry
+    {
+        typename Lines::iterator its[2];
+        int n = 0;
+    };
+
+    typedef std::map<Point, EndpointEntry, PointCompare> EndpointIndex;
     std::map<int, EndpointIndex> endpointIndex_;
 
     const LevelGenerator &levelGenerator_;
@@ -187,7 +194,9 @@ template <typename LineWriter, typename LevelGenerator> struct SegmentMerger
     void registerEndpoint_(EndpointIndex &idx, typename Lines::iterator it,
                            const Point &p)
     {
-        idx[p].push_back(it);
+        EndpointEntry &e = idx[p];
+        assert(e.n < 2);
+        e.its[e.n++] = it;
     }
 
     void unregisterEndpoint_(EndpointIndex &idx, typename Lines::iterator it,
@@ -195,11 +204,13 @@ template <typename LineWriter, typename LevelGenerator> struct SegmentMerger
     {
         auto f = idx.find(p);
         assert(f != idx.end());
-        auto &v = f->second;
-        auto e = std::find(v.begin(), v.end(), it);
-        assert(e != v.end());
-        v.erase(e);
-        if (v.empty())
+        EndpointEntry &e = f->second;
+        if (e.its[0] == it)
+            e.its[0] = e.its[1];
+        else
+            assert(e.n == 2 && e.its[1] == it);
+        e.n--;
+        if (e.n == 0)
             idx.erase(f);
     }
 
@@ -368,7 +379,7 @@ template <typename LineWriter, typename LevelGenerator> struct SegmentMerger
         auto findLine = [&](const Point &p)
         {
             auto f = idx.find(p);
-            return f == idx.end() ? lines.end() : f->second.front();
+            return f == idx.end() ? lines.end() : f->second.its[0];
         };
 
         Point matched = end;
@@ -416,12 +427,13 @@ template <typename LineWriter, typename LevelGenerator> struct SegmentMerger
             }
             // is there another line ending at `added`?
             auto f = idx.find(added);
+            assert(f != idx.end());
             typename Lines::iterator other = lines.end();
-            for (auto cand : f->second)
+            for (int i = 0; i < f->second.n; i++)
             {
-                if (cand != it)
+                if (f->second.its[i] != it)
                 {
-                    other = cand;
+                    other = f->second.its[i];
                     break;
                 }
             }
@@ -488,6 +500,11 @@ template <typename LineWriter, typename LevelGenerator> struct SegmentMerger
         {
             unregisterEndpoint_(idxIt->second, it, it->ls.front());
             unregisterEndpoint_(idxIt->second, it, it->ls.back());
+            // An emptied index means no line is open at this level anymore:
+            // drop it so the level returns to the linear path until it grows
+            // past the threshold again.
+            if (idxIt->second.empty())
+                endpointIndex_.erase(idxIt);
         }
 
         // consume "it" and remove it from the list

--- a/alg/marching_squares/segment_merger.h
+++ b/alg/marching_squares/segment_merger.h
@@ -15,8 +15,11 @@
 #include "cpl_error.h"
 #include "point.h"
 
+#include <algorithm>
+#include <cassert>
 #include <list>
 #include <map>
+#include <vector>
 
 #include <iostream>
 
@@ -156,10 +159,49 @@ template <typename LineWriter, typename LevelGenerator> struct SegmentMerger
     LineWriter &lineWriter_;
     // lines of each level
     std::map<int, Lines> lines_;
+
+    // Index of the open lines of each level, keyed by their two endpoints.
+    // Marching squares emits segments whose endpoints have degree two, so a
+    // point can only ever be shared by two segment ends; a lookup here
+    // replaces a linear scan over all open lines, which is quadratic on
+    // rasters that keep many lines open at once (e.g. many long parallel
+    // contours crossing each scanline).
+    struct PointCompare
+    {
+        bool operator()(const Point &a, const Point &b) const
+        {
+            return a.x < b.x || (a.x == b.x && a.y < b.y);
+        }
+    };
+
+    typedef std::map<Point, std::vector<typename Lines::iterator>,
+                     PointCompare>
+        EndpointIndex;
+    std::map<int, EndpointIndex> endpointIndex_;
+
     const LevelGenerator &levelGenerator_;
 
     // Store 0-indexed levels to skip when polygonize option is set
     std::vector<int> m_anSkipLevels;
+
+    void registerEndpoint_(EndpointIndex &idx, typename Lines::iterator it,
+                           const Point &p)
+    {
+        idx[p].push_back(it);
+    }
+
+    void unregisterEndpoint_(EndpointIndex &idx, typename Lines::iterator it,
+                             const Point &p)
+    {
+        auto f = idx.find(p);
+        assert(f != idx.end());
+        auto &v = f->second;
+        auto e = std::find(v.begin(), v.end(), it);
+        assert(e != v.end());
+        v.erase(e);
+        if (v.empty())
+            idx.erase(f);
+    }
 
     void addSegment_(int levelIdx, const Point &start, const Point &end)
     {
@@ -171,6 +213,37 @@ template <typename LineWriter, typename LevelGenerator> struct SegmentMerger
             debug("degenerate segment (%f %f)", start.x, start.y);
             return;
         }
+
+        auto idxIt = endpointIndex_.find(levelIdx);
+        if (idxIt == endpointIndex_.end())
+        {
+            addSegmentLinear_(levelIdx, lines, start, end);
+            // The linear scans above are quadratic when many lines stay open
+            // at once (e.g. long parallel contours crossing each scanline):
+            // past this size, switch the level to the endpoint index. Below
+            // it, the scans are cheaper than maintaining the index.
+            constexpr std::size_t INDEX_THRESHOLD = 100;
+            if (lines.size() > INDEX_THRESHOLD)
+            {
+                EndpointIndex &idx = endpointIndex_[levelIdx];
+                for (auto it = lines.begin(); it != lines.end(); ++it)
+                {
+                    registerEndpoint_(idx, it, it->ls.front());
+                    registerEndpoint_(idx, it, it->ls.back());
+                }
+            }
+        }
+        else
+        {
+            addSegmentIndexed_(levelIdx, lines, idxIt->second, start, end);
+        }
+    }
+
+    // Merge the segment by scanning the open lines: cheap while there are
+    // few of them, quadratic when there are many.
+    void addSegmentLinear_(int levelIdx, Lines &lines, const Point &start,
+                           const Point &end)
+    {
         // attempt to merge segment with existing line
         auto it = lines.begin();
         for (; it != lines.end(); ++it)
@@ -283,6 +356,125 @@ template <typename LineWriter, typename LevelGenerator> struct SegmentMerger
         }
     }
 
+    // Merge the segment through the endpoint index. Same merging rules as
+    // the linear scan (a marching squares point has degree two, so at most
+    // one line can match each of the segment's endpoints), but O(log n)
+    // lookups instead of O(n) scans.
+    void addSegmentIndexed_(int levelIdx, Lines &lines, EndpointIndex &idx,
+                            const Point &start, const Point &end)
+    {
+        // attempt to merge the segment with an existing line whose endpoint
+        // matches one of the segment's endpoints
+        auto findLine = [&](const Point &p)
+        {
+            auto f = idx.find(p);
+            return f == idx.end() ? lines.end() : f->second.front();
+        };
+
+        Point matched = end;
+        Point added = start;
+        typename Lines::iterator it = findLine(end);
+        if (it == lines.end())
+        {
+            matched = start;
+            added = end;
+            it = findLine(start);
+        }
+
+        if (it == lines.end())
+        {
+            // new line
+            lines.push_back(LineStringEx());
+            it = std::prev(lines.end());
+            it->ls.push_back(start);
+            it->ls.push_back(end);
+            it->isMerged = true;
+            registerEndpoint_(idx, it, start);
+            registerEndpoint_(idx, it, end);
+            return;
+        }
+
+        // extend the matched line with the segment's other endpoint
+        unregisterEndpoint_(idx, it, matched);
+        if (it->ls.back() == matched)
+            it->ls.push_back(added);
+        else
+            it->ls.push_front(added);
+        it->isMerged = true;
+        registerEndpoint_(idx, it, added);
+
+        // The extension may close a ring, or bring the line's new endpoint
+        // onto another line's endpoint; merging two lines moves the free
+        // endpoint again, so iterate until neither applies.
+        for (;;)
+        {
+            if (polygonize && it->ls.front() == it->ls.back())
+            {
+                // ring closed
+                emitLine_(levelIdx, it, /* closed */ true);
+                return;
+            }
+            // is there another line ending at `added`?
+            auto f = idx.find(added);
+            typename Lines::iterator other = lines.end();
+            for (auto cand : f->second)
+            {
+                if (cand != it)
+                {
+                    other = cand;
+                    break;
+                }
+            }
+            if (other == lines.end())
+                return;
+
+            // merge `other` into `it` at the shared point `added`
+            unregisterEndpoint_(idx, it, added);
+            unregisterEndpoint_(idx, other, added);
+            const Point otherEnd =
+                other->ls.front() == added ? other->ls.back()
+                                           : other->ls.front();
+            unregisterEndpoint_(idx, other, otherEnd);
+            if (it->ls.back() == added)
+            {
+                it->ls.pop_back();
+                if (other->ls.front() == added)
+                {
+                    it->ls.splice(it->ls.end(), other->ls);
+                }
+                else
+                {
+                    // opposite direction: append reversed
+                    for (auto rit = other->ls.rbegin(); rit != other->ls.rend();
+                         ++rit)
+                    {
+                        it->ls.push_back(*rit);
+                    }
+                }
+            }
+            else
+            {
+                it->ls.pop_front();
+                if (other->ls.back() == added)
+                {
+                    it->ls.splice(it->ls.begin(), other->ls);
+                }
+                else
+                {
+                    // opposite direction: prepend reversed
+                    for (auto rit = other->ls.begin(); rit != other->ls.end();
+                         ++rit)
+                    {
+                        it->ls.push_front(*rit);
+                    }
+                }
+            }
+            lines.erase(other);
+            registerEndpoint_(idx, it, otherEnd);
+            added = otherEnd;
+        }
+    }
+
     typename Lines::iterator emitLine_(int levelIdx,
                                        typename Lines::iterator it, bool closed)
     {
@@ -290,6 +482,13 @@ template <typename LineWriter, typename LevelGenerator> struct SegmentMerger
         Lines &lines = lines_[levelIdx];
         if (lines.empty())
             lines_.erase(levelIdx);
+
+        auto idxIt = endpointIndex_.find(levelIdx);
+        if (idxIt != endpointIndex_.end())
+        {
+            unregisterEndpoint_(idxIt->second, it, it->ls.front());
+            unregisterEndpoint_(idxIt->second, it, it->ls.back());
+        }
 
         // consume "it" and remove it from the list
         // but clear the line if the level should be skipped

--- a/alg/marching_squares/segment_merger.h
+++ b/alg/marching_squares/segment_merger.h
@@ -42,8 +42,7 @@ template <typename LineWriter, typename LevelGenerator> struct SegmentMerger
     SegmentMerger(LineWriter &lineWriter, const LevelGenerator &levelGenerator,
                   bool polygonize_)
         : polygonize(polygonize_), lineWriter_(lineWriter), lines_(),
-          endpointIndex_(),
-          levelGenerator_(levelGenerator), m_anSkipLevels()
+          endpointIndex_(), levelGenerator_(levelGenerator), m_anSkipLevels()
     {
     }
 
@@ -444,9 +443,9 @@ template <typename LineWriter, typename LevelGenerator> struct SegmentMerger
             // merge `other` into `it` at the shared point `added`
             unregisterEndpoint_(idx, it, added);
             unregisterEndpoint_(idx, other, added);
-            const Point otherEnd =
-                other->ls.front() == added ? other->ls.back()
-                                           : other->ls.front();
+            const Point otherEnd = other->ls.front() == added
+                                       ? other->ls.back()
+                                       : other->ls.front();
             unregisterEndpoint_(idx, other, otherEnd);
             if (it->ls.back() == added)
             {

--- a/autotest/alg/contour.py
+++ b/autotest/alg/contour.py
@@ -672,7 +672,7 @@ def test_contour_polygonize_many_disjoint_rings():
     assert total == pytest.approx(512 * 512, rel=0.02)
 
 
-def DISABLED_BECAUSE_TOO_SLOW_test_contour_polygonize_sawtooth_ring():
+def test_contour_polygonize_sawtooth_ring():
     """A comb-shaped region whose boundary ring is almost entirely vertical
     segments, each spanning nearly the full raster height. The ponds in the
     comb's base force the capture path that builds the point-in-polygon index


### PR DESCRIPTION
Follow-up to #14983, addressing [this comment](https://github.com/OSGeo/gdal/pull/14983#issuecomment-5559976273): `test_contour_polygonize_sawtooth_ring()` was disabled in d6fd56f52d because it ran for minutes. The slowness wasn't in the test itself — it exposed a second quadratic path, in `SegmentMerger`.

`SegmentMerger::addSegment_()` scans every open line of a level to find one ending at the new segment's endpoints, then scans again for a second line to merge with. The sawtooth raster keeps ~8,000 lines open at once across ~300k segments, so those scans account for nearly all of the runtime: 6.4 s in a release build at the test's 16384x16 size, minutes in a debug build, growing with the square of the raster width.

Marching squares vertices have degree two, so at most one open line can end at any given point. That makes the scans replaceable by lookups in a map keyed by each open line's two endpoints. Maintaining the map costs more than a short scan, so this is a hybrid: a level runs the existing scan code, unchanged, until it exceeds 100 open lines, then switches to the index. Typical rasters never reach the threshold, so their output stays bit-identical and they see no per-segment allocation churn. Levels that do cross the threshold can emit rings with a different start point or winding direction than before; the geometry is identical.

Timings (release build, Apple M-series):

| Case | master | this PR |
|---|---|---|
| Sawtooth test raster, 16384x16 | 6.4 s | 0.08 s |
| 2048x2048 smooth DEM, 38 polygon bands | 0.18 s | 0.17 s |

The test is re-enabled and runs in about 0.2 s.

While profiling this I found one more pathological shape, in the ring attachment added by #14983: rasters with very many small rings (a marsh full of ponds) spend most of their time in `CPLQuadTreeCollectFeatures`/`CPLQuadTreeRemove`, because ring bounding boxes that straddle split lines accumulate at shallow nodes and every search scans them. That needs a different fix and its own PR; this one only covers the segment merger.
