### PR TITLE
Fix CPLQuadTree degradation after feature removal

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -4157,7 +4157,7 @@ TEST_F(test_cpl, CPLQuadTreeRemoveThenReinsert)
 
     CPLQuadTree *hTree = CPLQuadTreeCreate(&globalbounds, nullptr);
 
-    constexpr int N = 32;
+    static constexpr int N = 32;
     const auto featRect = [](int i)
     {
         CPLRectObj rect;

--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -4144,6 +4144,73 @@ TEST_F(test_cpl, CPLQuadTree)
     CPLQuadTreeDestroy(hTree);
 }
 
+// Removing features must not degrade the tree structure: features inserted
+// after removals should still descend and split, not accumulate in the
+// bucket of a node whose subnodes were partially destroyed.
+TEST_F(test_cpl, CPLQuadTreeRemoveThenReinsert)
+{
+    CPLRectObj globalbounds;
+    globalbounds.minx = 0;
+    globalbounds.miny = 0;
+    globalbounds.maxx = 1;
+    globalbounds.maxy = 1;
+
+    CPLQuadTree *hTree = CPLQuadTreeCreate(&globalbounds, nullptr);
+
+    constexpr int N = 32;
+    const auto featRect = [](int i)
+    {
+        CPLRectObj rect;
+        rect.minx = (0.25 + (i % N)) / N;
+        rect.miny = (0.25 + (i / N)) / N;
+        rect.maxx = rect.minx + 0.5 / N;
+        rect.maxy = rect.miny + 0.5 / N;
+        return rect;
+    };
+    const auto feat = [](int i)
+    { return reinterpret_cast<void *>(static_cast<uintptr_t>(i)); };
+
+    for (int i = 0; i < N * N; i++)
+    {
+        CPLRectObj rect = featRect(i);
+        CPLQuadTreeInsertWithBounds(hTree, feat(i), &rect);
+    }
+
+    // Empty out the left half of the domain, then reinsert the same
+    // features.
+    for (int i = 0; i < N * N; i++)
+    {
+        if (i % N < N / 2)
+        {
+            CPLRectObj rect = featRect(i);
+            CPLQuadTreeRemove(hTree, feat(i), &rect);
+        }
+    }
+    for (int i = 0; i < N * N; i++)
+    {
+        if (i % N < N / 2)
+        {
+            CPLRectObj rect = featRect(i);
+            CPLQuadTreeInsertWithBounds(hTree, feat(i), &rect);
+        }
+    }
+
+    int nFeatureCount = 0;
+    int nNodeCount = 0;
+    int nMaxDepth = 0;
+    int nMaxBucketCapacity = 0;
+    CPLQuadTreeGetStats(hTree, &nFeatureCount, &nNodeCount, &nMaxDepth,
+                        &nMaxBucketCapacity);
+    EXPECT_EQ(nFeatureCount, N * N);
+    EXPECT_LE(nMaxBucketCapacity, 16);
+
+    int nSearchCount = 0;
+    CPLFree(CPLQuadTreeSearch(hTree, &globalbounds, &nSearchCount));
+    EXPECT_EQ(nSearchCount, N * N);
+
+    CPLQuadTreeDestroy(hTree);
+}
+
 // Test bUnlinkAndSize on VSIGetMemFileBuffer
 TEST_F(test_cpl, VSIGetMemFileBuffer_unlink_and_size)
 {

--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -4167,8 +4167,9 @@ TEST_F(test_cpl, CPLQuadTreeRemoveThenReinsert)
         rect.maxy = rect.miny + 0.5 / N;
         return rect;
     };
+    // offset by 1 so no feature handle is nullptr
     const auto feat = [](int i)
-    { return reinterpret_cast<void *>(static_cast<uintptr_t>(i)); };
+    { return reinterpret_cast<void *>(static_cast<uintptr_t>(i + 1)); };
 
     for (int i = 0; i < N * N; i++)
     {

--- a/port/cpl_quad_tree.cpp
+++ b/port/cpl_quad_tree.cpp
@@ -409,25 +409,38 @@ static bool CPLQuadTreeRemoveInternal(QuadTreeNode *psNode, void *hFeature,
         {
             bRemoved |= CPLQuadTreeRemoveInternal(psNode->apSubNode[i],
                                                   hFeature, psBounds);
+        }
+    }
 
-            if (psNode->apSubNode[i]->nFeatures == 0 &&
-                psNode->apSubNode[i]->nNumSubNodes == 0)
+    /* -------------------------------------------------------------------- */
+    /*      Only collapse the subnodes when all of them are empty leaves:   */
+    /*      the node then becomes a leaf again and may re-split on a later  */
+    /*      insertion. Destroying an individual empty subnode would leave a */
+    /*      quadrant hole: features falling in it can neither descend nor   */
+    /*      trigger a split (splitting requires a node without subnodes),   */
+    /*      so they would pile up in this node's bucket forever, degrading  */
+    /*      every search overlapping it to a linear scan.                   */
+    /* -------------------------------------------------------------------- */
+    if (psNode->nNumSubNodes != 0)
+    {
+        bool bAllSubNodesEmpty = true;
+        for (int i = 0; i < psNode->nNumSubNodes; i++)
+        {
+            if (psNode->apSubNode[i]->nFeatures != 0 ||
+                psNode->apSubNode[i]->nNumSubNodes != 0)
+            {
+                bAllSubNodesEmpty = false;
+                break;
+            }
+        }
+        if (bAllSubNodesEmpty)
+        {
+            for (int i = 0; i < psNode->nNumSubNodes; i++)
             {
                 CPLQuadTreeNodeDestroy(psNode->apSubNode[i]);
-                if (i < psNode->nNumSubNodes - 1)
-                {
-#ifdef CSA_BUILD
-                    for (int j = 0; j < psNode->nNumSubNodes - 1 - i; ++j)
-                        psNode->apSubNode[i + j] = psNode->apSubNode[i + j + 1];
-#else
-                    memmove(psNode->apSubNode + i, psNode->apSubNode + i + 1,
-                            (psNode->nNumSubNodes - 1 - i) *
-                                sizeof(QuadTreeNode *));
-#endif
-                }
-                i--;
-                psNode->nNumSubNodes--;
+                psNode->apSubNode[i] = nullptr;
             }
+            psNode->nNumSubNodes = 0;
         }
     }
 

--- a/port/cpl_quad_tree.cpp
+++ b/port/cpl_quad_tree.cpp
@@ -426,8 +426,9 @@ static bool CPLQuadTreeRemoveInternal(QuadTreeNode *psNode, void *hFeature,
         bool bAllSubNodesEmpty = true;
         for (int i = 0; i < psNode->nNumSubNodes; i++)
         {
-            if (psNode->apSubNode[i]->nFeatures != 0 ||
-                psNode->apSubNode[i]->nNumSubNodes != 0)
+            if (psNode->apSubNode[i] &&
+                (psNode->apSubNode[i]->nFeatures != 0 ||
+                 psNode->apSubNode[i]->nNumSubNodes != 0))
             {
                 bAllSubNodesEmpty = false;
                 break;
@@ -437,7 +438,8 @@ static bool CPLQuadTreeRemoveInternal(QuadTreeNode *psNode, void *hFeature,
         {
             for (int i = 0; i < psNode->nNumSubNodes; i++)
             {
-                CPLQuadTreeNodeDestroy(psNode->apSubNode[i]);
+                if (psNode->apSubNode[i])
+                    CPLQuadTreeNodeDestroy(psNode->apSubNode[i]);
                 psNode->apSubNode[i] = nullptr;
             }
             psNode->nNumSubNodes = 0;


### PR DESCRIPTION
Part three of contour polygonize performance work (#14983, #15181), this time in `CPLQuadTree` itself.

`CPLQuadTreeRemoveInternal()` destroys each subnode that becomes empty. A node that has lost some but not all of its four subnodes can never split again, because splitting requires a node with no subnodes, and features falling into a destroyed quadrant cannot descend either. They accumulate in that node's bucket forever, and every search overlapping the node scans them linearly. Any workload that mixes insertions and removals degrades this way.

The polygon contour path does exactly that mix: rings captured as interior rings are removed from the per-level quadtree while later rings keep being inserted. On a 1024x1024 raster with ~150k small rings (a marsh full of ponds), the level-0 tree ended up holding 33k of its 73k features in a single bucket, and the quadtree phases of `PolygonRingAppender` took 3.5 s of a 4.6 s run.

The fix collapses subnodes only when all four are empty leaves. The node then reverts to a leaf and may re-split on a later insertion, so removal can no longer leave quadrant holes. Partially-empty sibling groups keep their empty subnodes, which costs a few dozen bytes each until they are either refilled or their siblings also empty out.

Contour timings for the marsh-like raster (release build, Apple M-series, measured together with #15181; the max bucket in the level-0 tree goes from 33,265 to 11):

| Raster | before | after |
|---|---|---|
| 1024x1024 | 4.6 s | 0.7 s |
| 2048x2048 | 48 s | 3.5 s |
| 4096x4096 | >10 min | 16 s |

`test_cpl.CPLQuadTreeRemoveThenReinsert` covers the degradation directly: it fills a tree, removes half the features, reinserts them, and checks via `CPLQuadTreeGetStats()` that the maximum bucket size stays bounded (136 before the fix, 9 after).
