### PR TITLE
style: fix "a unknown" grammatical errors to "an unknown" and one "amd" -> "and" typo

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8710,7 +8710,7 @@ Enhancements:
  * gdal_viewshed: use -cc 1.0 as default for non-Earth CRS (#6278)
  * nearblack: skip erosion when pixel at edge is valid
  * gdal_grid: produce north-up images
- * gdal_grid: add validation of algorithm parameters and warn when a unknown parameter is specified
+ * gdal_grid: add validation of algorithm parameters and warn when an unknown parameter is specified
  * gdal_grid: add a nSizeOfStructure leading structure member in GDALGridXXXXOptions structure, as a way to detect ABI issues when adding new parameters
 
 Bugfixes:

--- a/apps/commonutils.cpp
+++ b/apps/commonutils.cpp
@@ -62,7 +62,7 @@ void EarlySetConfigOptions(int argc, char **argv)
     // registered for the --format or --formats options.
 
     // Start with --debug, so that "my_command --config UNKNOWN_CONFIG_OPTION --debug on"
-    // detects and warns about a unknown config option.
+    // detects and warns about an unknown config option.
     for (int i = 1; i < argc; i++)
     {
         if (EQUAL(argv[i], "--config") && i + 1 < argc)

--- a/apps/gdalalg_abstract_pipeline.cpp
+++ b/apps/gdalalg_abstract_pipeline.cpp
@@ -745,7 +745,7 @@ bool GDALAbstractPipelineAlgorithm::ParseCommandLineArguments(
                 if (!subAlg)
                 {
                     ReportError(CE_Failure, CPLE_AppDefined,
-                                "'%s' is a unknown sub-algorithm of '%s'",
+                                "'%s' is an unknown sub-algorithm of '%s'",
                                 arg.c_str(), curStep.alg->GetName().c_str());
                     return false;
                 }

--- a/apps/gdalalg_raster_calc.cpp
+++ b/apps/gdalalg_raster_calc.cpp
@@ -1028,7 +1028,7 @@ bool GDALRasterCalcAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
             if (!pair)
             {
                 ReportError(CE_Failure, CPLE_NotSupported,
-                            "'%s' is a unknown builtin function", pszFunction);
+                            "'%s' is an unknown builtin function", pszFunction);
                 return false;
             }
             if (aosTokens.size() == 2)

--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -4690,7 +4690,7 @@ def test_tiff_read_unhandled_codec_known_name():
 
 
 ###############################################################################
-# Test reading a file with a unhandled codec of a unknown name
+# Test reading a file with a unhandled codec of an unknown name
 
 
 def test_tiff_read_unhandled_codec_unknown_name():

--- a/autotest/gcore/tiff_srs.py
+++ b/autotest/gcore/tiff_srs.py
@@ -293,7 +293,7 @@ def test_tiff_srs_angular_units():
 
 
 ###############################################################################
-# Test writing and reading a unknown datum but with a known ellipsoid
+# Test writing and reading an unknown datum but with a known ellipsoid
 
 
 def test_tiff_custom_datum_known_ellipsoid():

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -9329,7 +9329,7 @@ def test_tiff_write_compression_create_and_createcopy():
         )
 
     # FIXME: this test randomly fails, especially on Windows, but also on Linux,
-    # for a unknown reason. Nothing suspicious with Valgrind however
+    # for an unknown reason. Nothing suspicious with Valgrind however
     # if 'LERC_DEFLATE' in md['DMD_CREATIONOPTIONLIST']:
     #   tests.append((['COMPRESS=LERC_DEFLATE', 'ZLEVEL=1'],['COMPRESS=LERC_DEFLATE', 'ZLEVEL=9']))
 

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -912,7 +912,7 @@ def test_gdal_translate_lib_colorinterp():
     assert ds.GetRasterBand(2).GetColorInterpretation() == gdal.GCI_GrayIndex
     assert ds.GetRasterBand(3).GetColorInterpretation() == gdal.GCI_BlueBand
 
-    # More bands specified than available and a unknown color interpretation
+    # More bands specified than available and an unknown color interpretation
     with gdal.quiet_errors():
         ds = gdal.Translate(
             "",

--- a/autotest/utilities/test_gdalalg_pipeline.py
+++ b/autotest/utilities/test_gdalalg_pipeline.py
@@ -936,7 +936,7 @@ def test_gdalalg_pipeline_nested_errors():
         )
 
     with pytest.raises(
-        Exception, match="'not_existing' is a unknown sub-algorithm of 'overview'"
+        Exception, match="'not_existing' is an unknown sub-algorithm of 'overview'"
     ):
         gdal.Run(
             "pipeline",

--- a/doc/source/development/rfc/rfc99_geometry_coordinate_precision.rst
+++ b/doc/source/development/rfc/rfc99_geometry_coordinate_precision.rst
@@ -171,7 +171,7 @@ Corresponding additions at the C API level:
 
 .. code-block:: c
 
-    /** Value for a unknown coordinate precision. */
+    /** Value for an unknown coordinate precision. */
     #define OGR_GEOM_COORD_PRECISION_UNKNOWN 0
 
     /** Opaque type for OGRGeomCoordinatePrecision */

--- a/frmts/fits/fitsdataset.cpp
+++ b/frmts/fits/fitsdataset.cpp
@@ -1906,7 +1906,7 @@ FITSDataset::~FITSDataset()
                         // types, the GDAL Metadata mechanism works only with
                         // string values. Prior to about 2003-05-02, this driver
                         // would attempt to guess the value type from the
-                        // metadata value string amd then would use the
+                        // metadata value string and then would use the
                         // appropriate type-specific FITS keyword update
                         // routine. This was found to be troublesome (e.g. a
                         // numeric version string with leading zeros would be

--- a/frmts/nitf/rpftocwriter.cpp
+++ b/frmts/nitf/rpftocwriter.cpp
@@ -653,10 +653,11 @@ static bool RPFTOCCollectFrames(
         const std::string osDataSeriesCode(osFilenamePart.substr(9, 2));
         if (!RPFCADRGIsKnownDataSeriesCode(osDataSeriesCode.c_str()))
         {
-            CPLError(CE_Warning, CPLE_AppDefined,
-                     "Data series code '%s' in %s extension is a unknown CADRG "
-                     "series code",
-                     osDataSeriesCode.c_str(), osFullFilename.c_str());
+            CPLError(
+                CE_Warning, CPLE_AppDefined,
+                "Data series code '%s' in %s extension is an unknown CADRG "
+                "series code",
+                osDataSeriesCode.c_str(), osFullFilename.c_str());
         }
 
         int nThisScale = nReciprocalScale;

--- a/frmts/zarr/zarr_array.cpp
+++ b/frmts/zarr/zarr_array.cpp
@@ -3046,14 +3046,14 @@ static void ParseSpatialConventions(
     if (iDimNameX == 0)
     {
         CPLError(CE_Warning, CPLE_AppDefined,
-                 "spatial:dimensions[%d] = %s is a unknown "
+                 "spatial:dimensions[%d] = %s is an unknown "
                  "Zarr dimension",
                  static_cast<int>(aosSpatialDimensions.size() - 1), pszNameX);
     }
     if (iDimNameY == 0)
     {
         CPLError(CE_Warning, CPLE_AppDefined,
-                 "spatial_dimensions[%d] = %s is a unknown "
+                 "spatial_dimensions[%d] = %s is an unknown "
                  "Zarr dimension",
                  static_cast<int>(aosSpatialDimensions.size() - 2), pszNameY);
     }

--- a/frmts/zarr/zarr_v3_array.cpp
+++ b/frmts/zarr/zarr_v3_array.cpp
@@ -2092,7 +2092,7 @@ ZarrV3Group::LoadArray(const std::string &osArrayName,
             osName != "storage_transformers" && osName != "attributes")
         {
             CPLError(CE_Warning, CPLE_AppDefined,
-                     "%s array definition contains a unknown member (%s). "
+                     "%s array definition contains an unknown member (%s). "
                      "Interpretation of the array might be wrong.",
                      osZarrayFilename.c_str(), osName.c_str());
         }

--- a/gcore/gdal_misc.cpp
+++ b/gcore/gdal_misc.cpp
@@ -3830,7 +3830,7 @@ int CPL_STDCALL GDALGeneralCmdLineProcessor(int nArgc, char ***ppapszArgv,
     /* ==================================================================== */
 
     // Start with --debug, so that "my_command --config UNKNOWN_CONFIG_OPTION --debug on"
-    // detects and warns about a unknown config option.
+    // detects and warns about an unknown config option.
     for (iArg = 1; iArg < nArgc; iArg++)
     {
         if (EQUAL(papszArgv[iArg], "--config") && iArg + 2 < nArgc &&

--- a/ogr/ogr_api.h
+++ b/ogr/ogr_api.h
@@ -44,7 +44,7 @@ struct _CPLXMLNode;
 
 /* OGRGeomCoordinatePrecisionH */
 
-/** Value for a unknown coordinate precision. */
+/** Value for an unknown coordinate precision. */
 #define OGR_GEOM_COORD_PRECISION_UNKNOWN 0
 
 OGRGeomCoordinatePrecisionH CPL_DLL OGRGeomCoordinatePrecisionCreate(void);

--- a/ogr/ogr_geomcoordinateprecision.h
+++ b/ogr/ogr_geomcoordinateprecision.h
@@ -38,7 +38,7 @@ class OGRSpatialReference;
  */
 struct CPL_DLL OGRGeomCoordinatePrecision
 {
-    /** Constant for a UNKNOWN resolution. */
+    /** Constant for an UNKNOWN resolution. */
     static constexpr double UNKNOWN = 0;
 
     /** Resolution for the coordinate precision of the X and Y coordinates.

--- a/ogr/ogrct.cpp
+++ b/ogr/ogrct.cpp
@@ -528,7 +528,7 @@ int OCTCoordinateTransformationOptionsSetOperation(
  *
  * An accuracy of 0 is valid and means a coordinate operation made only of one
  * or several conversions (map projections, unit conversion, etc.) Operations
- * involving ballpark transformations have a unknown accuracy, and will be
+ * involving ballpark transformations have an unknown accuracy, and will be
  * filtered out by any dfAccuracy >= 0 value.
  *
  * If this option is specified with PROJ < 8, the OGR_CT_OP_SELECTION

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -531,7 +531,7 @@ int GDALGeoPackageDataset::GetSrsId(const OGRSpatialReference *poSRSIn)
         if (err == OGRERR_NONE)
             return nSRSId;
 
-        // The below WKT definitions are somehow questionable (using a unknown
+        // The below WKT definitions are somehow questionable (using an unknown
         // unit). For GDAL >= 3.9, they won't be used. They will only be used
         // for earlier versions.
         const char *pszSQL;

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer_write.cpp
@@ -2318,7 +2318,8 @@ bool OGROpenFileGDBLayer::PrepareFileGDBFeature(OGRFeature *poFeature,
                         m_bWarnedDateNotConvertibleUTC = true;
                         CPLError(
                             CE_Warning, CPLE_AppDefined,
-                            "Attempt at writing a datetime with a unknown time "
+                            "Attempt at writing a datetime with an unknown "
+                            "time "
                             "zone "
                             "or local time in a layer that expects dates "
                             "to be convertible to UTC. It will be written as "

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer_write.cpp
@@ -2319,8 +2319,7 @@ bool OGROpenFileGDBLayer::PrepareFileGDBFeature(OGRFeature *poFeature,
                         CPLError(
                             CE_Warning, CPLE_AppDefined,
                             "Attempt at writing a datetime with an unknown "
-                            "time "
-                            "zone "
+                            "time zone "
                             "or local time in a layer that expects dates "
                             "to be convertible to UTC. It will be written as "
                             "if it was expressed in UTC.");

--- a/ogr/ogrsf_frmts/wfs/ogrwfsdatasource.cpp
+++ b/ogr/ogrsf_frmts/wfs/ogrwfsdatasource.cpp
@@ -1385,7 +1385,7 @@ int OGRWFSDataSource::Open(const char *pszFilename, int bUpdateIn,
 
                 const auto IsValidCRSName = [](const char *pszStr)
                 {
-                    // EPSG:404000 is a GeoServer joke to indicate a unknown SRS
+                    // EPSG:404000 is a GeoServer joke to indicate an unknown SRS
                     // https://osgeo-org.atlassian.net/browse/GEOS-8993
                     return !EQUAL(pszStr, "EPSG:404000") &&
                            !EQUAL(pszStr, "urn:ogc:def:crs:EPSG::404000");

--- a/ogr/ogrspatialreference.cpp
+++ b/ogr/ogrspatialreference.cpp
@@ -4224,7 +4224,7 @@ OGRErr OGRSpatialReference::SetFromUserInput(const char *pszDefinition,
         if (strstr(pszDefinition, "datum_ensemble") != nullptr)
         {
             // PROJ < 9.0.1 doesn't like a datum_ensemble whose member have
-            // a unknown id.
+            // an unknown id.
             CPLJSONDocument oCRSDoc;
             if (!oCRSDoc.LoadMemory(pszDefinition))
                 return OGRERR_CORRUPT_DATA;

--- a/port/cpl_vsi_virtual.h
+++ b/port/cpl_vsi_virtual.h
@@ -156,7 +156,7 @@ struct CPL_DLL VSIVirtualHandle
      * Callers might use that threshold to optimize the efficiency of
      * AdviseRead().
      *
-     * A returned value of 0 indicates a unknown limit.
+     * A returned value of 0 indicates an unknown limit.
      * @since GDAL 3.9
      */
     virtual size_t GetAdviseReadTotalBytesLimit() const


### PR DESCRIPTION
Found one each with an LLM scan and hand fixed them. Skipped issues in cmake, libtiff, and libpng as those are just copied from their upstream locations.

```
find . -type f | egrep -v 'cmake|libtiff|libpng|comand_lines|pycache|doc/images|venv|git|build|_static' | xargs grep -i 'a unknown'
```