### PR TITLE
Fix gdal vector explode crash on a NULL geometry

### DIFF
--- a/apps/gdalalg_vector_explode.cpp
+++ b/apps/gdalalg_vector_explode.cpp
@@ -455,11 +455,11 @@ class GDALVectorExplodeLayer final : public GDALVectorPipelineOutputLayer
                         poSrcGeom.reset(
                             poSrcFeature->StealGeometry(iGeomField));
                     }
-                    else
+                    else if (const OGRGeometry *poFirstGeom =
+                                 apoOutFeatures.front()->GetGeomFieldRef(
+                                     iGeomField))
                     {
-                        poSrcGeom.reset(apoOutFeatures.front()
-                                            ->GetGeomFieldRef(iGeomField)
-                                            ->clone());
+                        poSrcGeom.reset(poFirstGeom->clone());
                     }
 
                     poDstFeature->SetGeomField(iGeomField,

--- a/autotest/utilities/test_gdalalg_vector_explode.py
+++ b/autotest/utilities/test_gdalalg_vector_explode.py
@@ -402,7 +402,8 @@ def test_gdalalg_vector_explode_geometry_multiple_multipart_and_null(alg):
     assert features[2].GetGeomFieldRef(1) is None
 
 
-def test_gdalalg_vector_explode_geometry_null(alg):
+@pytest.mark.parametrize("explode_geometry", (True, False))
+def test_gdalalg_vector_explode_geometry_null(alg, explode_geometry):
 
     src_ds = gdal.GetDriverByName("MEM").CreateVector("")
     src_lyr = src_ds.CreateLayer(
@@ -416,7 +417,8 @@ def test_gdalalg_vector_explode_geometry_null(alg):
 
     alg["input"] = src_ds
     alg["field"] = "ALL"
-    alg["geometry-field"] = "ALL"
+    if explode_geometry:
+        alg["geometry-field"] = "ALL"
     alg["output-format"] = "MEM"
 
     assert alg.Run()


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
When exploding an array field, features 2..N reused feature 1's geometry. If the source geometry was NULL, this caused a segfault. Now the clone is guarded and the output geometry stays NULL.

### Test
`test_gdalalg_vector_explode_geometry_null` already build the right input but explode the geometry field too, so this path wasn't test. Extended it to parametrized if field is exploded or not.

## What are related issues/pull requests?
Fixes #15195

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
