### PR TITLE
VRT pixel functions: fix SSE2 min/max ignoring NaN

### DIFF
--- a/autotest/gdrivers/vrtderived.py
+++ b/autotest/gdrivers/vrtderived.py
@@ -14,6 +14,7 @@
 
 import math
 import os
+import struct
 import sys
 import threading
 
@@ -2287,6 +2288,35 @@ def test_vrt_pixelfn_min_max_image(dt, function):
     src_array = src_ds.GetRasterBand(1).ReadRaster(buf_type=gdal.GetDataTypeByName(dt))
     result = gdal.Open(xml).ReadRaster()
     assert result == src_array
+
+
+@pytest.mark.parametrize("dt", ["Float32", "Float64"])
+@pytest.mark.parametrize(
+    "function,values", [("min", [5, math.nan, 7]), ("max", [5, math.nan, 3])]
+)
+def test_vrt_pixelfn_min_max_nan_source(tmp_vsimem, dt, function, values):
+
+    # No NoDataValue on the derived band: NaN source values must still be
+    # ignored. Width 16 so that the SSE2 code path is exercised.
+    src = tmp_vsimem / "src.tif"
+    with gdal.GetDriverByName("GTiff").Create(
+        src, 16, 1, len(values), gdal.GetDataTypeByName(dt)
+    ) as src_ds:
+        for i, v in enumerate(values):
+            src_ds.GetRasterBand(i + 1).Fill(v)
+
+    xml = f"""
+    <VRTDataset rasterXSize="16" rasterYSize="1">
+      <VRTRasterBand dataType="{dt}" band="1" subclass="VRTDerivedRasterBand">
+        <PixelFunctionType>{function}</PixelFunctionType>
+        <SourceTransferType>{dt}</SourceTransferType>
+        {"".join(f'<SimpleSource><SourceFilename>{src}</SourceFilename><SourceBand>{i + 1}</SourceBand></SimpleSource>' for i in range(len(values)))}
+      </VRTRasterBand>
+    </VRTDataset>"""
+
+    with gdal.Open(xml) as ds:
+        fmt = "f" if dt == "Float32" else "d"
+        assert struct.unpack(fmt * 16, ds.ReadRaster()) == (5,) * 16
 
 
 @pytest.mark.parametrize(

--- a/frmts/vrt/pixelfunctions.cpp
+++ b/frmts/vrt/pixelfunctions.cpp
@@ -2647,6 +2647,39 @@ static void OptimizedMinOrMaxSSE2(const void *const *papoSources, int nSources,
     }
 }
 
+/************************************************************************/
+/*                        NaNAwareMinOrMax()                            */
+/************************************************************************/
+
+static inline __m128 NaNAwareMinOrMax(__m128 x, __m128 y, bool bMin)
+{
+    const __m128 xIsNaN = _mm_cmpunord_ps(x, x);
+    const __m128 yIsNaN = _mm_cmpunord_ps(y, y);
+    const __m128 xx = _mm_or_ps(_mm_andnot_ps(xIsNaN, x), _mm_and_ps(xIsNaN, y));
+    const __m128 yy = _mm_or_ps(_mm_andnot_ps(yIsNaN, y), _mm_and_ps(yIsNaN, x));
+    return bMin ? _mm_min_ps(xx, yy) : _mm_max_ps(xx, yy);
+}
+
+static inline __m128d NaNAwareMinOrMax(__m128d x, __m128d y, bool bMin)
+{
+    const __m128d xIsNaN = _mm_cmpunord_pd(x, x);
+    const __m128d yIsNaN = _mm_cmpunord_pd(y, y);
+    const __m128d xx =
+        _mm_or_pd(_mm_andnot_pd(xIsNaN, x), _mm_and_pd(xIsNaN, y));
+    const __m128d yy =
+        _mm_or_pd(_mm_andnot_pd(yIsNaN, y), _mm_and_pd(yIsNaN, x));
+    return bMin ? _mm_min_pd(xx, yy) : _mm_max_pd(xx, yy);
+}
+
+template <class T> static inline T NaNAwareMinOrMax(T x, T y, bool bMin)
+{
+    if (std::isnan(x))
+        return y;
+    if (std::isnan(y))
+        return x;
+    return bMin ? std::min(x, y) : std::max(x, y);
+}
+
 // clang-format off
 namespace
 {
@@ -2741,8 +2774,8 @@ struct SSEWrapperMinFloat
 
     static inline Vec LoadU(const T *x) { return _mm_loadu_ps(x); }
     static inline void StoreU(T *x, Vec y) { _mm_storeu_ps(x, y); }
-    static inline Vec MinOrMax(Vec x, Vec y) { return _mm_min_ps(x, y); }
-    static inline T MinOrMax(T x, T y) { return std::min(x, y); }
+    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMax(x, y, true); }
+    static inline T MinOrMax(T x, T y) { return NaNAwareMinOrMax(x, y, true); }
 };
 
 struct SSEWrapperMaxFloat
@@ -2752,8 +2785,8 @@ struct SSEWrapperMaxFloat
 
     static inline Vec LoadU(const T *x) { return _mm_loadu_ps(x); }
     static inline void StoreU(T *x, Vec y) { _mm_storeu_ps(x, y); }
-    static inline Vec MinOrMax(Vec x, Vec y) { return _mm_max_ps(x, y); }
-    static inline T MinOrMax(T x, T y) { return std::max(x, y); }
+    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMax(x, y, false); }
+    static inline T MinOrMax(T x, T y) { return NaNAwareMinOrMax(x, y, false); }
 };
 
 struct SSEWrapperMinDouble
@@ -2763,8 +2796,8 @@ struct SSEWrapperMinDouble
 
     static inline Vec LoadU(const T *x) { return _mm_loadu_pd(x); }
     static inline void StoreU(T *x, Vec y) { _mm_storeu_pd(x, y); }
-    static inline Vec MinOrMax(Vec x, Vec y) { return _mm_min_pd(x, y); }
-    static inline T MinOrMax(T x, T y) { return std::min(x, y); }
+    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMax(x, y, true); }
+    static inline T MinOrMax(T x, T y) { return NaNAwareMinOrMax(x, y, true); }
 };
 
 struct SSEWrapperMaxDouble
@@ -2774,8 +2807,8 @@ struct SSEWrapperMaxDouble
 
     static inline Vec LoadU(const T *x) { return _mm_loadu_pd(x); }
     static inline void StoreU(T *x, Vec y) { _mm_storeu_pd(x, y); }
-    static inline Vec MinOrMax(Vec x, Vec y) { return _mm_max_pd(x, y); }
-    static inline T MinOrMax(T x, T y) { return std::max(x, y); }
+    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMax(x, y, false); }
+    static inline T MinOrMax(T x, T y) { return NaNAwareMinOrMax(x, y, false); }
 };
 
 }  // namespace

--- a/frmts/vrt/pixelfunctions.cpp
+++ b/frmts/vrt/pixelfunctions.cpp
@@ -2648,19 +2648,21 @@ static void OptimizedMinOrMaxSSE2(const void *const *papoSources, int nSources,
 }
 
 /************************************************************************/
-/*                        NaNAwareMinOrMax()                            */
+/*                    NaNAwareMinOrMaxFloat/Double()                    */
 /************************************************************************/
 
-static inline __m128 NaNAwareMinOrMax(__m128 x, __m128 y, bool bMin)
+static inline __m128 NaNAwareMinOrMaxFloat(__m128 x, __m128 y, bool bMin)
 {
     const __m128 xIsNaN = _mm_cmpunord_ps(x, x);
     const __m128 yIsNaN = _mm_cmpunord_ps(y, y);
-    const __m128 xx = _mm_or_ps(_mm_andnot_ps(xIsNaN, x), _mm_and_ps(xIsNaN, y));
-    const __m128 yy = _mm_or_ps(_mm_andnot_ps(yIsNaN, y), _mm_and_ps(yIsNaN, x));
+    const __m128 xx =
+        _mm_or_ps(_mm_andnot_ps(xIsNaN, x), _mm_and_ps(xIsNaN, y));
+    const __m128 yy =
+        _mm_or_ps(_mm_andnot_ps(yIsNaN, y), _mm_and_ps(yIsNaN, x));
     return bMin ? _mm_min_ps(xx, yy) : _mm_max_ps(xx, yy);
 }
 
-static inline __m128d NaNAwareMinOrMax(__m128d x, __m128d y, bool bMin)
+static inline __m128d NaNAwareMinOrMaxDouble(__m128d x, __m128d y, bool bMin)
 {
     const __m128d xIsNaN = _mm_cmpunord_pd(x, x);
     const __m128d yIsNaN = _mm_cmpunord_pd(y, y);
@@ -2774,7 +2776,7 @@ struct SSEWrapperMinFloat
 
     static inline Vec LoadU(const T *x) { return _mm_loadu_ps(x); }
     static inline void StoreU(T *x, Vec y) { _mm_storeu_ps(x, y); }
-    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMax(x, y, true); }
+    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMaxFloat(x, y, true); }
     static inline T MinOrMax(T x, T y) { return NaNAwareMinOrMax(x, y, true); }
 };
 
@@ -2785,7 +2787,7 @@ struct SSEWrapperMaxFloat
 
     static inline Vec LoadU(const T *x) { return _mm_loadu_ps(x); }
     static inline void StoreU(T *x, Vec y) { _mm_storeu_ps(x, y); }
-    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMax(x, y, false); }
+    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMaxFloat(x, y, false); }
     static inline T MinOrMax(T x, T y) { return NaNAwareMinOrMax(x, y, false); }
 };
 
@@ -2796,7 +2798,7 @@ struct SSEWrapperMinDouble
 
     static inline Vec LoadU(const T *x) { return _mm_loadu_pd(x); }
     static inline void StoreU(T *x, Vec y) { _mm_storeu_pd(x, y); }
-    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMax(x, y, true); }
+    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMaxDouble(x, y, true); }
     static inline T MinOrMax(T x, T y) { return NaNAwareMinOrMax(x, y, true); }
 };
 
@@ -2807,7 +2809,7 @@ struct SSEWrapperMaxDouble
 
     static inline Vec LoadU(const T *x) { return _mm_loadu_pd(x); }
     static inline void StoreU(T *x, Vec y) { _mm_storeu_pd(x, y); }
-    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMax(x, y, false); }
+    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMaxDouble(x, y, false); }
     static inline T MinOrMax(T x, T y) { return NaNAwareMinOrMax(x, y, false); }
 };
 


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
Make SSE2 take into account the NaN cases for min/max pixel functions.

### Test
- `test_vrt_pixelfn_nodata` is the only one with NaN values, but it sets `<NoDataValue>7</NoDataValue>`, which make it work.
- `test_vrt_pixelfn_min_max_image` use `rgbsmall.tif` but it doesn't have NaN values.
- New test `test_vrt_pixelfn_min_max_nan_source`: no `<NoDataValue>`, 3 sources with NaN in the middle, 16 columns wide,  over min/max Float32/Float64. Total 4 cases which fail before the fix.
- the `max` case uses `[5, NaN, 3]` and not `[5, NaN, 7]` - with `7` last you get a right answer by accident even when it's broken.
- 
## What are related issues/pull requests?
Fixes #15204 

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 26.04
* Compiler: gcc (Ubuntu 15.2.0-16ubuntu1) 15.2.0
