### PR TITLE
[Backport release/3.13] VRT pixel functions: fix SSE2 min/max ignoring NaN

### DIFF
--- a/autotest/gdrivers/vrtderived.py
+++ b/autotest/gdrivers/vrtderived.py
@@ -14,6 +14,7 @@
 
 import math
 import os
+import struct
 import sys
 import threading
 
@@ -2314,6 +2315,35 @@ def test_vrt_pixelfn_min_max_image(dt, function):
     src_array = src_ds.GetRasterBand(1).ReadRaster(buf_type=gdal.GetDataTypeByName(dt))
     result = gdal.Open(xml).ReadRaster()
     assert result == src_array
+
+
+@pytest.mark.parametrize("dt", ["Float32", "Float64"])
+@pytest.mark.parametrize(
+    "function,values", [("min", [5, math.nan, 7]), ("max", [5, math.nan, 3])]
+)
+def test_vrt_pixelfn_min_max_nan_source(tmp_vsimem, dt, function, values):
+
+    # No NoDataValue on the derived band: NaN source values must still be
+    # ignored. Width 16 so that the SSE2 code path is exercised.
+    src = tmp_vsimem / "src.tif"
+    with gdal.GetDriverByName("GTiff").Create(
+        src, 16, 1, len(values), gdal.GetDataTypeByName(dt)
+    ) as src_ds:
+        for i, v in enumerate(values):
+            src_ds.GetRasterBand(i + 1).Fill(v)
+
+    xml = f"""
+    <VRTDataset rasterXSize="16" rasterYSize="1">
+      <VRTRasterBand dataType="{dt}" band="1" subclass="VRTDerivedRasterBand">
+        <PixelFunctionType>{function}</PixelFunctionType>
+        <SourceTransferType>{dt}</SourceTransferType>
+        {"".join(f'<SimpleSource><SourceFilename>{src}</SourceFilename><SourceBand>{i + 1}</SourceBand></SimpleSource>' for i in range(len(values)))}
+      </VRTRasterBand>
+    </VRTDataset>"""
+
+    with gdal.Open(xml) as ds:
+        fmt = "f" if dt == "Float32" else "d"
+        assert struct.unpack(fmt * 16, ds.ReadRaster()) == (5,) * 16
 
 
 @pytest.mark.parametrize(

--- a/frmts/vrt/pixelfunctions.cpp
+++ b/frmts/vrt/pixelfunctions.cpp
@@ -2633,6 +2633,39 @@ static void OptimizedMinOrMaxSSE2(const void *const *papoSources, int nSources,
     }
 }
 
+/************************************************************************/
+/*                        NaNAwareMinOrMax()                            */
+/************************************************************************/
+
+static inline __m128 NaNAwareMinOrMax(__m128 x, __m128 y, bool bMin)
+{
+    const __m128 xIsNaN = _mm_cmpunord_ps(x, x);
+    const __m128 yIsNaN = _mm_cmpunord_ps(y, y);
+    const __m128 xx = _mm_or_ps(_mm_andnot_ps(xIsNaN, x), _mm_and_ps(xIsNaN, y));
+    const __m128 yy = _mm_or_ps(_mm_andnot_ps(yIsNaN, y), _mm_and_ps(yIsNaN, x));
+    return bMin ? _mm_min_ps(xx, yy) : _mm_max_ps(xx, yy);
+}
+
+static inline __m128d NaNAwareMinOrMax(__m128d x, __m128d y, bool bMin)
+{
+    const __m128d xIsNaN = _mm_cmpunord_pd(x, x);
+    const __m128d yIsNaN = _mm_cmpunord_pd(y, y);
+    const __m128d xx =
+        _mm_or_pd(_mm_andnot_pd(xIsNaN, x), _mm_and_pd(xIsNaN, y));
+    const __m128d yy =
+        _mm_or_pd(_mm_andnot_pd(yIsNaN, y), _mm_and_pd(yIsNaN, x));
+    return bMin ? _mm_min_pd(xx, yy) : _mm_max_pd(xx, yy);
+}
+
+template <class T> static inline T NaNAwareMinOrMax(T x, T y, bool bMin)
+{
+    if (std::isnan(x))
+        return y;
+    if (std::isnan(y))
+        return x;
+    return bMin ? std::min(x, y) : std::max(x, y);
+}
+
 // clang-format off
 namespace
 {
@@ -2727,8 +2760,8 @@ struct SSEWrapperMinFloat
 
     static inline Vec LoadU(const T *x) { return _mm_loadu_ps(x); }
     static inline void StoreU(T *x, Vec y) { _mm_storeu_ps(x, y); }
-    static inline Vec MinOrMax(Vec x, Vec y) { return _mm_min_ps(x, y); }
-    static inline T MinOrMax(T x, T y) { return std::min(x, y); }
+    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMax(x, y, true); }
+    static inline T MinOrMax(T x, T y) { return NaNAwareMinOrMax(x, y, true); }
 };
 
 struct SSEWrapperMaxFloat
@@ -2738,8 +2771,8 @@ struct SSEWrapperMaxFloat
 
     static inline Vec LoadU(const T *x) { return _mm_loadu_ps(x); }
     static inline void StoreU(T *x, Vec y) { _mm_storeu_ps(x, y); }
-    static inline Vec MinOrMax(Vec x, Vec y) { return _mm_max_ps(x, y); }
-    static inline T MinOrMax(T x, T y) { return std::max(x, y); }
+    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMax(x, y, false); }
+    static inline T MinOrMax(T x, T y) { return NaNAwareMinOrMax(x, y, false); }
 };
 
 struct SSEWrapperMinDouble
@@ -2749,8 +2782,8 @@ struct SSEWrapperMinDouble
 
     static inline Vec LoadU(const T *x) { return _mm_loadu_pd(x); }
     static inline void StoreU(T *x, Vec y) { _mm_storeu_pd(x, y); }
-    static inline Vec MinOrMax(Vec x, Vec y) { return _mm_min_pd(x, y); }
-    static inline T MinOrMax(T x, T y) { return std::min(x, y); }
+    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMax(x, y, true); }
+    static inline T MinOrMax(T x, T y) { return NaNAwareMinOrMax(x, y, true); }
 };
 
 struct SSEWrapperMaxDouble
@@ -2760,8 +2793,8 @@ struct SSEWrapperMaxDouble
 
     static inline Vec LoadU(const T *x) { return _mm_loadu_pd(x); }
     static inline void StoreU(T *x, Vec y) { _mm_storeu_pd(x, y); }
-    static inline Vec MinOrMax(Vec x, Vec y) { return _mm_max_pd(x, y); }
-    static inline T MinOrMax(T x, T y) { return std::max(x, y); }
+    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMax(x, y, false); }
+    static inline T MinOrMax(T x, T y) { return NaNAwareMinOrMax(x, y, false); }
 };
 
 }  // namespace

--- a/frmts/vrt/pixelfunctions.cpp
+++ b/frmts/vrt/pixelfunctions.cpp
@@ -2634,19 +2634,21 @@ static void OptimizedMinOrMaxSSE2(const void *const *papoSources, int nSources,
 }
 
 /************************************************************************/
-/*                        NaNAwareMinOrMax()                            */
+/*                    NaNAwareMinOrMaxFloat/Double()                    */
 /************************************************************************/
 
-static inline __m128 NaNAwareMinOrMax(__m128 x, __m128 y, bool bMin)
+static inline __m128 NaNAwareMinOrMaxFloat(__m128 x, __m128 y, bool bMin)
 {
     const __m128 xIsNaN = _mm_cmpunord_ps(x, x);
     const __m128 yIsNaN = _mm_cmpunord_ps(y, y);
-    const __m128 xx = _mm_or_ps(_mm_andnot_ps(xIsNaN, x), _mm_and_ps(xIsNaN, y));
-    const __m128 yy = _mm_or_ps(_mm_andnot_ps(yIsNaN, y), _mm_and_ps(yIsNaN, x));
+    const __m128 xx =
+        _mm_or_ps(_mm_andnot_ps(xIsNaN, x), _mm_and_ps(xIsNaN, y));
+    const __m128 yy =
+        _mm_or_ps(_mm_andnot_ps(yIsNaN, y), _mm_and_ps(yIsNaN, x));
     return bMin ? _mm_min_ps(xx, yy) : _mm_max_ps(xx, yy);
 }
 
-static inline __m128d NaNAwareMinOrMax(__m128d x, __m128d y, bool bMin)
+static inline __m128d NaNAwareMinOrMaxDouble(__m128d x, __m128d y, bool bMin)
 {
     const __m128d xIsNaN = _mm_cmpunord_pd(x, x);
     const __m128d yIsNaN = _mm_cmpunord_pd(y, y);
@@ -2760,7 +2762,7 @@ struct SSEWrapperMinFloat
 
     static inline Vec LoadU(const T *x) { return _mm_loadu_ps(x); }
     static inline void StoreU(T *x, Vec y) { _mm_storeu_ps(x, y); }
-    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMax(x, y, true); }
+    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMaxFloat(x, y, true); }
     static inline T MinOrMax(T x, T y) { return NaNAwareMinOrMax(x, y, true); }
 };
 
@@ -2771,7 +2773,7 @@ struct SSEWrapperMaxFloat
 
     static inline Vec LoadU(const T *x) { return _mm_loadu_ps(x); }
     static inline void StoreU(T *x, Vec y) { _mm_storeu_ps(x, y); }
-    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMax(x, y, false); }
+    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMaxFloat(x, y, false); }
     static inline T MinOrMax(T x, T y) { return NaNAwareMinOrMax(x, y, false); }
 };
 
@@ -2782,7 +2784,7 @@ struct SSEWrapperMinDouble
 
     static inline Vec LoadU(const T *x) { return _mm_loadu_pd(x); }
     static inline void StoreU(T *x, Vec y) { _mm_storeu_pd(x, y); }
-    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMax(x, y, true); }
+    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMaxDouble(x, y, true); }
     static inline T MinOrMax(T x, T y) { return NaNAwareMinOrMax(x, y, true); }
 };
 
@@ -2793,7 +2795,7 @@ struct SSEWrapperMaxDouble
 
     static inline Vec LoadU(const T *x) { return _mm_loadu_pd(x); }
     static inline void StoreU(T *x, Vec y) { _mm_storeu_pd(x, y); }
-    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMax(x, y, false); }
+    static inline Vec MinOrMax(Vec x, Vec y) { return NaNAwareMinOrMaxDouble(x, y, false); }
     static inline T MinOrMax(T x, T y) { return NaNAwareMinOrMax(x, y, false); }
 };
 


### PR DESCRIPTION
Backport #15205
 **Authored by:** @alonfaraj