### PR TITLE
JP2Grok: bump grok library version to 20.4.7

### DIFF
--- a/.github/workflows/ubuntu_26.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_26.04/Dockerfile.ci
@@ -235,7 +235,7 @@ RUN curl -LO -fsS https://github.com/apache/arrow/archive/refs/heads/main.zip \
     && rm -rf arrow-main
 
 # Build Grok JPEG 2000 library
-ARG GROK_VERSION=v20.3.9
+ARG GROK_VERSION=v20.4.7
 
 RUN git clone --recursive --depth 1 --branch ${GROK_VERSION} \
     https://github.com/GrokImageCompression/grok.git grok-git && \

--- a/autotest/gdrivers/jp2grok.py
+++ b/autotest/gdrivers/jp2grok.py
@@ -592,7 +592,7 @@ def test_jp2grok_22():
     assert fourth_band.GetMetadataItem("NBITS", "IMAGE_STRUCTURE") == "1"
     ds = None
     ds = gdal.Open("/vsimem/jp2grok_22.jp2")
-    assert ds.GetRasterBand(4).Checksum() in (26477, 30223)
+    assert ds.GetRasterBand(4).Checksum() in (22499, 26477, 30223)
     ds = None
     gdal.Unlink("/vsimem/jp2grok_22.jp2")
 
@@ -721,7 +721,7 @@ def test_jp2grok_24():
     ds = None
     ds = gdal.Open("/vsimem/jp2grok_24.jp2")
     assert ds.GetRasterBand(2).GetMetadataItem("NBITS", "IMAGE_STRUCTURE") is None
-    assert ds.GetRasterBand(2).Checksum() in (27389, 30223)
+    assert ds.GetRasterBand(2).Checksum() in (22499, 27389, 30223)
     ds = None
     gdal.Unlink("/vsimem/jp2grok_24.jp2")
 


### PR DESCRIPTION
## What does this PR do?

This PR bumps grok library version to 20.4.7. Two checksums were adjusted for the new version

## Tasklist

 - [X] All CI builds and checks have passed
