### PR TITLE
MEM: fix raster band mask flags when cloning

### DIFF
--- a/frmts/mem/memdataset.cpp
+++ b/frmts/mem/memdataset.cpp
@@ -1217,7 +1217,7 @@ std::unique_ptr<GDALDataset> MEMDataset::Clone(int nScopeFlags,
                             nRasterYSize, /* bOwnData = */ false));
                     poMaskBand->m_bIsMask = true;
                     poNewBand->poMask.reset(std::move(poMaskBand));
-                    poNewBand->nMaskFlags = poSrcMaskBand->nMaskFlags;
+                    poNewBand->nMaskFlags = poSrcMEMBand->nMaskFlags;
                 }
             }
 


### PR DESCRIPTION
MEMDataset::Clone() copies mask flags from the source mask band instead of the source raster band.

wrapping a MEM raster with GDALGetThreadSafeDataset() flags the bands GMF_ALL_VALID despite its explicit validity mask. I think this is a bug.
