### PR TITLE
VRT pixel functions: fix mean aborting when the band has no source

### DIFF
--- a/autotest/gdrivers/vrtderived.py
+++ b/autotest/gdrivers/vrtderived.py
@@ -2262,6 +2262,24 @@ def test_vrt_pixelfn_mean_float64_image():
     assert result == src_array
 
 
+@pytest.mark.parametrize(
+    "dt", ["Byte", "UInt16", "Int16", "Int32", "Float32", "Float64"]
+)
+def test_vrt_pixelfn_mean_no_source(dt):
+
+    xml = f"""
+    <VRTDataset rasterXSize="32" rasterYSize="1">
+      <VRTRasterBand dataType="{dt}" band="1" subclass="VRTDerivedRasterBand">
+        <PixelFunctionType>mean</PixelFunctionType>
+        <SourceTransferType>{dt}</SourceTransferType>
+      </VRTRasterBand>
+    </VRTDataset>"""
+
+    with gdal.Open(xml) as ds:
+        nbytes = 32 * gdal.GetDataTypeSize(gdal.GetDataTypeByName(dt)) // 8
+        assert ds.ReadRaster() == b"\x00" * nbytes
+
+
 @pytest.mark.parametrize("dt", ["Byte", "UInt16", "Int16", "Float32", "Float64"])
 @pytest.mark.parametrize("function", ["min", "max"])
 def test_vrt_pixelfn_min_max_image(dt, function):

--- a/frmts/vrt/pixelfunctions.cpp
+++ b/frmts/vrt/pixelfunctions.cpp
@@ -3983,7 +3983,7 @@ static CPLErr BasicPixelFunc(void **papoSources, int nSources, void *pData,
     if constexpr (std::is_same_v<Kernel, MeanKernel>)
     {
         if (!bHasNoData && eSrcType == GDT_UInt8 && eBufType == GDT_UInt8 &&
-            nPixelSpace == 1 &&
+            nPixelSpace == 1 && nSources > 0 &&
             // We use signed int16 to accumulate
             nSources <= std::numeric_limits<int16_t>::max() /
                             std::numeric_limits<uint8_t>::max())
@@ -4083,7 +4083,7 @@ static CPLErr BasicPixelFunc(void **papoSources, int nSources, void *pData,
         }
 
         if (!bHasNoData && eSrcType == GDT_UInt8 && eBufType == GDT_UInt8 &&
-            nPixelSpace == 1 &&
+            nPixelSpace == 1 && nSources > 0 &&
             // We use signed int32 to accumulate
             nSources <= std::numeric_limits<int32_t>::max() /
                             std::numeric_limits<uint8_t>::max())
@@ -4152,7 +4152,7 @@ static CPLErr BasicPixelFunc(void **papoSources, int nSources, void *pData,
         }
 
         if (!bHasNoData && eSrcType == GDT_UInt16 && eBufType == GDT_UInt16 &&
-            nPixelSpace == 2 &&
+            nPixelSpace == 2 && nSources > 0 &&
             nSources <= std::numeric_limits<int32_t>::max() /
                             std::numeric_limits<uint16_t>::max())
         {
@@ -4206,7 +4206,7 @@ static CPLErr BasicPixelFunc(void **papoSources, int nSources, void *pData,
         }
 
         if (!bHasNoData && eSrcType == GDT_Int16 && eBufType == GDT_Int16 &&
-            nPixelSpace == 2 &&
+            nPixelSpace == 2 && nSources > 0 &&
             nSources <= std::numeric_limits<int32_t>::max() /
                             std::numeric_limits<uint16_t>::max())
         {


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
With no source the SSE2 integer fast paths in `BasicPixelFunc<MeanKernel>` were entered with `nSources == 0` and built a libdivide divider from it, which `abort()` on a zero divisor. Float32/Float64 fast paths already check `nSources > 0`.
This adds the same condition to the 4 integer ones.

Added `test_vrt_pixelfn_mean_no_source` which covers six data types, 32 pixels wide so the vectorized loop would be used.

## What are related issues/pull requests?
Fixes #15214

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 26.04
* Compiler: gcc (Ubuntu 15.2.0-16ubuntu1) 15.2.0

