### PR TITLE
fix(port): correct typos in comments, error messages, and config option names

### DIFF
--- a/autotest/gcore/vsicurl_streaming.py
+++ b/autotest/gcore/vsicurl_streaming.py
@@ -214,7 +214,7 @@ def test_vsicurl_streaming_retry_at_beginning(webserver_port):
         {
             "GDAL_HTTP_MAX_RETRY": "2",
             "GDAL_HTTP_RETRY_DELAY": "0.01",
-            "CPL_VSIL_CURL_STREMAING_SIMULATED_CURL_ERROR": "Send failure: Connection was reset",
+            "CPL_VSIL_CURL_STREAMING_SIMULATED_CURL_ERROR": "Send failure: Connection was reset",
         },
         thread_local=False,
     ):
@@ -250,7 +250,7 @@ def test_vsicurl_streaming_retry_in_middle(webserver_port):
         {
             "GDAL_HTTP_MAX_RETRY": "2",
             "GDAL_HTTP_RETRY_DELAY": "0.01",
-            "CPL_VSIL_CURL_STREMAING_SIMULATED_CURL_ERROR": "Send failure: Connection was reset",
+            "CPL_VSIL_CURL_STREAMING_SIMULATED_CURL_ERROR": "Send failure: Connection was reset",
         },
         thread_local=False,
     ):
@@ -318,7 +318,7 @@ def test_vsicurl_streaming_retry_in_middle_failed(webserver_port):
         {
             "GDAL_HTTP_MAX_RETRY": "2",
             "GDAL_HTTP_RETRY_DELAY": "0.01",
-            "CPL_VSIL_CURL_STREMAING_SIMULATED_CURL_ERROR": "Send failure: Connection was reset",
+            "CPL_VSIL_CURL_STREAMING_SIMULATED_CURL_ERROR": "Send failure: Connection was reset",
         },
         thread_local=False,
     ):

--- a/port/cpl_error.cpp
+++ b/port/cpl_error.cpp
@@ -630,8 +630,8 @@ static void CPLvDebug(const char *pszCategory,
         return;
 
     /* -------------------------------------------------------------------- */
-    /*      Dal -- always log a timestamp as the first part of the line     */
-    /*      to ensure one is looking at what one should be looking at!      */
+    /*      Always log a timestamp as the first part of the line            */
+    /*      to ensure one is looking at what one should be looking at.      */
     /* -------------------------------------------------------------------- */
 
     pszMessage[0] = '\0';
@@ -1233,7 +1233,7 @@ void CPLTurnFailureIntoWarning(int bOn)
  **********************************************************************/
 
 /**
- * Install custom error handle with user's data. This method is
+ * Install custom error handler with user's data. This method is
  * essentially CPLSetErrorHandler with an added pointer to pUserData.
  * The pUserData is not returned in the CPLErrorHandler, however, and
  * must be fetched via CPLGetErrorHandlerUserData.

--- a/port/cpl_getexecpath.cpp
+++ b/port/cpl_getexecpath.cpp
@@ -38,7 +38,7 @@
  *
  * The path to the executable currently running is returned.  This path
  * includes the name of the executable. Currently this only works on
- * Windows, Linux, MacOS, FreeBSD and netBSD platforms.  The returned path is UTF-8
+ * Windows, Linux, MacOS, FreeBSD and NetBSD platforms.  The returned path is UTF-8
  * encoded, and will be nul-terminated if success is reported.
  *
  * @param pszPathBuf the buffer into which the path is placed.

--- a/port/cpl_http.cpp
+++ b/port/cpl_http.cpp
@@ -846,7 +846,7 @@ class CPLHTTPPostFields
 
                 if (nullptr == pszKey)
                 {
-                    osErrMsg = CPLSPrintf("Key #%d is not exists. Maybe wrong "
+                    osErrMsg = CPLSPrintf("Key #%d does not exist. Maybe wrong "
                                           "count of form items",
                                           i);
                     return CE_Failure;
@@ -854,7 +854,7 @@ class CPLHTTPPostFields
 
                 if (nullptr == pszValue)
                 {
-                    osErrMsg = CPLSPrintf("Value #%d is not exists. Maybe "
+                    osErrMsg = CPLSPrintf("Value #%d does not exist. Maybe "
                                           "wrong count of form items",
                                           i);
                     return CE_Failure;

--- a/port/cpl_json.cpp
+++ b/port/cpl_json.cpp
@@ -373,7 +373,7 @@ static size_t CPLJSONWriteFunction(void *pBuffer, size_t nSize, size_t nMemb,
     if (ctx->pObject != nullptr)
     {
         CPLError(CE_Failure, CPLE_AppDefined,
-                 "A complete JSon object had already been parsed before new "
+                 "A complete JSON object had already been parsed before new "
                  "content is appended to it");
         return 0;
     }

--- a/port/cpl_json_streaming_parser.cpp
+++ b/port/cpl_json_streaming_parser.cpp
@@ -562,7 +562,7 @@ bool CPLJSonStreamingParser::Parse(std::string_view sStr, bool bFinished)
                 {
                     if (nPos > m_nMaxStringSize)
                     {
-                        return EmitException("Too many characters in number");
+                        return EmitException("Too many characters in string");
                     }
                     if (!m_aeObjectState.empty() &&
                         m_aeObjectState.back() == IN_KEY)
@@ -587,7 +587,7 @@ bool CPLJSonStreamingParser::Parse(std::string_view sStr, bool bFinished)
             {
                 if (m_osToken.size() == m_nMaxStringSize)
                 {
-                    return EmitException("Too many characters in number");
+                    return EmitException("Too many characters in string");
                 }
 
                 char ch = *pStr;

--- a/port/cpl_json_streaming_parser.h
+++ b/port/cpl_json_streaming_parser.h
@@ -10,8 +10,8 @@
  * SPDX-License-Identifier: MIT
  ****************************************************************************/
 
-#ifndef CPL_JSON_STREAMIN_PARSER_H
-#define CPL_JSON_STREAMIN_PARSER_H
+#ifndef CPL_JSON_STREAMING_PARSER_H
+#define CPL_JSON_STREAMING_PARSER_H
 
 /*! @cond Doxygen_Suppress */
 
@@ -153,4 +153,4 @@ class CPL_DLL CPLJSonStreamingParser /* non final */
 
 /*! @endcond */
 
-#endif  // CPL_JSON_STREAMIN_PARSER_H
+#endif  // CPL_JSON_STREAMING_PARSER_H

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -147,7 +147,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "CPL_VSIL_CURL_MAX_RANGES", // from cpl_vsil_curl.cpp
    "CPL_VSIL_CURL_NON_CACHED", // from cpl_vsil_curl.cpp
    "CPL_VSIL_CURL_SLOW_GET_SIZE", // from cpl_vsil_curl.cpp, cpl_vsil_curl_streaming.cpp
-   "CPL_VSIL_CURL_STREMAING_SIMULATED_CURL_ERROR", // from cpl_vsil_curl_streaming.cpp
+   "CPL_VSIL_CURL_STREAMING_SIMULATED_CURL_ERROR", // from cpl_vsil_curl_streaming.cpp
    "CPL_VSIL_CURL_USE_HEAD", // from cpl_vsil_curl.cpp
    "CPL_VSIL_CURL_USE_S3_REDIRECT", // from cpl_vsil_curl.cpp
    "CPL_VSIL_DEFLATE_CHUNK_SIZE", // from cpl_minizip_zip.cpp, cpl_vsil_gzip.cpp

--- a/port/cpl_list.h
+++ b/port/cpl_list.h
@@ -20,7 +20,7 @@
  * \file cpl_list.h
  *
  * Simplest list implementation.  List contains only pointers to stored
- * objects, not objects itself. All operations regarding allocation and
+ * objects, not objects themselves. All operations regarding allocation and
  * freeing memory for objects should be performed by the caller.
  *
  */
@@ -35,7 +35,7 @@ struct _CPLList
 {
     /*! Pointer to the data object. Should be allocated and freed by the
      * caller.
-     * */
+     */
     void *pData;
     /*! Pointer to the next element in list. NULL, if current element is the
      * last one.

--- a/port/cpl_mask.h
+++ b/port/cpl_mask.h
@@ -116,4 +116,4 @@ inline void CPLMaskMerge(GUInt32 *mask1, GUInt32 *mask2, std::size_t n)
 
 #endif  // __cplusplus
 
-#endif  // CPL_MASK_H
+#endif  // CPL_MASK_H_INCLUDED

--- a/port/cpl_md5.h
+++ b/port/cpl_md5.h
@@ -1,4 +1,4 @@
-/* See md5.cpp for explanation and copyright information.  */
+/* See cpl_md5.cpp for explanation and copyright information.  */
 
 #ifndef CPL_MD5_H
 #define CPL_MD5_H

--- a/port/cpl_vsil_curl_streaming.cpp
+++ b/port/cpl_vsil_curl_streaming.cpp
@@ -1061,7 +1061,7 @@ void VSICurlStreamingHandle::DownloadInThread()
     {
         // For autotest purposes only !
         const char *pszSimulatedCurlError = CPLGetConfigOption(
-            "CPL_VSIL_CURL_STREMAING_SIMULATED_CURL_ERROR", nullptr);
+            "CPL_VSIL_CURL_STREAMING_SIMULATED_CURL_ERROR", nullptr);
         if (pszSimulatedCurlError)
             snprintf(m_szCurlErrBuf, sizeof(m_szCurlErrBuf), "%s",
                      pszSimulatedCurlError);


### PR DESCRIPTION
- autotest/vsicurl_streaming.py: Fix CPL_VSIL_CURL_STREMAING_SIMULATED_CURL_ERROR to CPL_VSIL_CURL_STREAMING_SIMULATED_CURL_ERROR across retry tests.
- cpl_error.cpp:
  - Clean up timestamp comment in cpl_error.cpp:630-635.
  - Fix typo in cpl_error.cpp:1233-1238 docstring ("error handle" -> "error handler").
- cpl_getexecpath.cpp: Capitalize "NetBSD" in docstring platform list.
- cpl_http.cpp: Fix grammar in missing key/value error messages ("is not exists" -> "does not exist").
- cpl_json.cpp: Standardize casing from "JSon" to "JSON" in error message.
- cpl_json_streaming_parser.cpp: Fix string length limit error messages ("Too many characters in number" -> "Too many characters in string").
- cpl_json_streaming_parser.h: Fix typo in header include guard (CPL_JSON_STREAMIN_PARSER_H -> CPL_JSON_STREAMING_PARSER_H).
- cpl_known_config_options.h: Fix typo in known config option name (CPL_VSIL_CURL_STREMAING_SIMULATED_CURL_ERROR ->
      CPL_VSIL_CURL_STREAMING_SIMULATED_CURL_ERROR).
- cpl_list.h: Fix grammar ("not objects itself" -> "not objects themselves") and formatted comment block.
- cpl_mask.h: Fix include guard end comment to match definition (#endif // CPL_MASK_H_INCLUDED).
- cpl_md5.h: Fix comment reference from md5.cpp to cpl_md5.cpp.
- cpl_vsil_curl_streaming.cpp: Fix typo in config option lookup for simulated error (CPL_VSIL_CURL_STREMAING_SIMULATED_CURL_ERROR -> CPL_VSIL_CURL_STREAMING_SIMULATED_CURL_ERROR).

## What does this PR do?

Fix typos

## What are related issues/pull requests?

* https://github.com/OSGeo/gdal/pull/15188 - "amd" -> "and" and "a unknown" -> "an unknown"
* https://github.com/OSGeo/gdal/pull/15203 - - docs(port): fix some typos. `CPL_AUTO_CLOSE_WARP` -> `CPL_AUTO_CLOSE_WRAP`
* https://github.com/OSGeo/gdal/issues/15213 - Probable typo: GO2A_AUD -> GOA2_AUD

## AI tool usage

 - [x] AI supported my development of this PR.  Gemini found almost all of these issues

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
