### PR TITLE
VRTProcessedDataset: reject an empty LUT

### DIFF
--- a/autotest/gdrivers/vrtprocesseddataset.py
+++ b/autotest/gdrivers/vrtprocesseddataset.py
@@ -527,6 +527,22 @@ def test_vrtprocesseddataset_lut_errors(tmp_vsimem):
         </VRTDataset>
             """)
 
+    for lut in ["", ","]:
+        with pytest.raises(Exception, match="must have at least one entry"):
+            gdal.Open(f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        <ProcessingSteps>
+            <Step>
+                <Algorithm>LUT</Algorithm>
+                <Argument name="lut_1">{lut}</Argument>
+                <Argument name="lut_2">1.5:10,2.5:20</Argument>
+            </Step>
+        </ProcessingSteps>
+        </VRTDataset>
+            """)
+
     with pytest.raises(Exception, match="Invalid band in argument 'lut_3'"):
         gdal.Open(f"""<VRTDataset subclass='VRTProcessedDataset'>
         <Input>

--- a/frmts/vrt/vrtprocesseddatasetfunctions.cpp
+++ b/frmts/vrt/vrtprocesseddatasetfunctions.cpp
@@ -521,6 +521,12 @@ static CPLErr LUTInit(const char * /*pszFuncName*/, void * /*pUserData*/,
                 adfInputValues.push_back(CPLAtof(aosTokens2[0]));
                 adfOutputValues.push_back(CPLAtof(aosTokens2[1]));
             }
+            if (adfInputValues.empty())
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Argument '%s' must have at least one entry", pszKey);
+                return CE_Failure;
+            }
             oMap[nBand - 1] = std::pair(std::move(adfInputValues),
                                         std::move(adfOutputValues));
         }


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
An empty `lut_N` argument left the band's lookup table empty, and the per-pixel lookup read past the end of it. Reject it when the step is set up, so the file fails to open instead of crashing on the first read.

### Test
- `lut_errors` gains the three empty spellings (`""`, whitespace, `","`), which all open fine before the fix
- `lut_nominal` gains a single-entry LUT

## What are related issues/pull requests?
Fixes #15218

## AI tool usage

 - [ ] AI (Y-a-t-il-un-Copilot-dans-l'avion, Chat-j'ai-pété, Jean-Claude Dusse or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 26.04
* Compiler: gcc (Ubuntu 15.2.0-16ubuntu1) 15.2.0
