### PR TITLE
fix(port): rename GO2A_AUD configuration option to GOA2_AUD

### DIFF
--- a/autotest/gcore/vsigs.py
+++ b/autotest/gcore/vsigs.py
@@ -1022,7 +1022,7 @@ def test_vsigs_GetFileMetadatabucket_root_oauth2(
     try:
         with gdaltest.config_options(
             {
-                "GO2A_AUD": "http://localhost:%d/oauth2/v4/token" % webserver_port,
+                "GOA2_AUD": "http://localhost:%d/oauth2/v4/token" % webserver_port,
                 "GOA2_NOW": "123456",
             },
             thread_local=False,
@@ -1330,7 +1330,7 @@ gwE6fxOLyJDxuWRf
 
     with gdaltest.config_options(
         {
-            "GO2A_AUD": "http://localhost:%d/oauth2/v4/token" % webserver_port,
+            "GOA2_AUD": "http://localhost:%d/oauth2/v4/token" % webserver_port,
             "GOA2_NOW": "123456",
             "GS_OAUTH2_CLIENT_EMAIL": "CLIENT_EMAIL",
         },
@@ -1438,7 +1438,7 @@ def test_vsigs_read_credentials_oauth2_service_account_json_file(
     with gdaltest.config_options(
         {
             "GOOGLE_APPLICATION_CREDENTIALS": "/vsimem/service_account.json",
-            "GO2A_AUD": "http://localhost:%d/oauth2/v4/token" % webserver_port,
+            "GOA2_AUD": "http://localhost:%d/oauth2/v4/token" % webserver_port,
             "GOA2_NOW": "123456",
         },
         thread_local=False,

--- a/autotest/gdrivers/eedai.py
+++ b/autotest/gdrivers/eedai.py
@@ -260,7 +260,7 @@ gwE6fxOLyJDxuWRf
 """,
     )
     gdal.SetConfigOption("EEDA_CLIENT_EMAIL", "my@email.com")
-    gdal.SetConfigOption("GO2A_AUD", "/vsimem/oauth2/v4/token")
+    gdal.SetConfigOption("GOA2_AUD", "/vsimem/oauth2/v4/token")
     gdal.SetConfigOption("GOA2_NOW", "123456")
     gdal.FileFromMemBuffer(
         "/vsimem/oauth2/v4/token&POSTFIELDS=grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiAibXlAZW1haWwuY29tIiwgInNjb3BlIjogImh0dHBzOi8vd3d3Lmdvb2dsZWFwaXMuY29tL2F1dGgvZWFydGhlbmdpbmUucmVhZG9ubHkiLCAiYXVkIjogIi92c2ltZW0vb2F1dGgyL3Y0L3Rva2VuIiwgImlhdCI6IDEyMzQ1NiwgImV4cCI6IDEyNzA1Nn0%3D.1W564xcQESVsqZmBEIMzj4rr0RuGa4RiUPZp5H%2FNENN9V9oPSTdacw%2BMiu3pcFf9AJv8wj0ajUeRsgTmvSicAftER49xeCQYUrs6uV122FGVsxml26kMFacNsCgRad%2Fy7xCAhMPfRJsqxS2%2BB392ssBeEzTGCSI6W3AsJg64OfA%3D",
@@ -305,7 +305,7 @@ def test_eedai_GOOGLE_APPLICATION_CREDENTIALS(use_vsi_path):
         gdal.SetConfigOption("GOOGLE_APPLICATION_CREDENTIALS", "/vsimem/my.json")
     gdal.SetConfigOption("EEDA_PRIVATE_KEY", None)
     gdal.SetConfigOption("EEDA_CLIENT_EMAIL", None)
-    gdal.SetConfigOption("GO2A_AUD", "/vsimem/oauth2/v4/token")
+    gdal.SetConfigOption("GOA2_AUD", "/vsimem/oauth2/v4/token")
     gdal.SetConfigOption("GOA2_NOW", "123456")
     gdal.FileFromMemBuffer(
         "/vsimem/oauth2/v4/token&POSTFIELDS=grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiAibXlAZW1haWwuY29tIiwgInNjb3BlIjogImh0dHBzOi8vd3d3Lmdvb2dsZWFwaXMuY29tL2F1dGgvZWFydGhlbmdpbmUucmVhZG9ubHkiLCAiYXVkIjogIi92c2ltZW0vb2F1dGgyL3Y0L3Rva2VuIiwgImlhdCI6IDEyMzQ1NiwgImV4cCI6IDEyNzA1Nn0%3D.1W564xcQESVsqZmBEIMzj4rr0RuGa4RiUPZp5H%2FNENN9V9oPSTdacw%2BMiu3pcFf9AJv8wj0ajUeRsgTmvSicAftER49xeCQYUrs6uV122FGVsxml26kMFacNsCgRad%2Fy7xCAhMPfRJsqxS2%2BB392ssBeEzTGCSI6W3AsJg64OfA%3D",
@@ -585,7 +585,7 @@ def test_eedai_cleanup():
     gdal.SetConfigOption("EEDA_URL", gdaltest.EEDA_URL)
     gdal.SetConfigOption("EEDA_PRIVATE_KEY", gdaltest.EEDA_PRIVATE_KEY)
     gdal.SetConfigOption("EEDA_CLIENT_EMAIL", gdaltest.EEDA_CLIENT_EMAIL)
-    gdal.SetConfigOption("GO2A_AUD", None)
+    gdal.SetConfigOption("GOA2_AUD", None)
     gdal.SetConfigOption("GOA2_NOW", None)
     gdal.SetConfigOption(
         "GOOGLE_APPLICATION_CREDENTIALS", gdaltest.GOOGLE_APPLICATION_CREDENTIALS

--- a/port/cpl_google_oauth2.cpp
+++ b/port/cpl_google_oauth2.cpp
@@ -420,7 +420,7 @@ char **GOA2GetAccessTokenFromServiceAccount(const char *pszPrivateKey,
     // JWT header '{"alg":"RS256","typ":"JWT"}' encoded in Base64
     const char *pszB64JWTHeader = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9";
     const char *pszAud = CPLGetConfigOption(
-        "GO2A_AUD", "https://www.googleapis.com/oauth2/v4/token");
+        "GOA2_AUD", "https://www.googleapis.com/oauth2/v4/token");
 
     CPLString osClaim;
     osClaim = "{\"iss\": \"";

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -491,7 +491,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "GMLAS_XML_MAX_LEVEL", // from ogrgmlasreader.cpp
    "GMLJP2OVERRIDE", // from gdaljp2metadata.cpp, jp2opjlikedataset.cpp
    "GMT_USE_TAB", // from ogrgmtlayer.cpp
-   "GO2A_AUD", // from cpl_google_oauth2.cpp
+   "GOA2_AUD", // from cpl_google_oauth2.cpp
    "GOA2_AUTH_URL_TOKEN", // from cpl_google_oauth2.cpp
    "GOA2_CLIENT_ID", // from cpl_google_oauth2.cpp
    "GOA2_CLIENT_SECRET", // from cpl_google_oauth2.cpp


### PR DESCRIPTION
This now matches options such as GOA2_NOW, GOA2_CLIENT_ID, and GOA2_CLIENT_SECRET

Fixes #15213

Note that I had to skip the secrets check, but that's a known situation.

```
git commit  -a 
port/cpl_google_oauth2.cpp:193:    "ya29.AHES6ZToqkIJkat5rIqMixR1b8PlWBACNO8OYbqqV-YF1Q13E2Kzjw", "token_type"
port/cpl_google_oauth2.cpp:195:    "1/eF88pciwq9Tp_rHEhuiIv9AS44Ufe4GOymGawTVPGYo"

[ERROR] Matched one or more prohibited patterns

Possible mitigations:
- Mark false positives as allowed using: git config --add secrets.allowed ...
- Mark false positives as allowed by adding regular expressions to .gitallowed at repository's root directory
- List your configured patterns: git config --get-all secrets.patterns
- List your configured allowed patterns: git config --get-all secrets.allowed
- List your configured allowed patterns in .gitallowed at repository's root directory
- Use --no-verify if this is a one-time false positive

# So I did this:
git commit --no-verify -a
```

## What does this PR do?

This is a undocumented config option, so I'm fixing the typo.

## AI tool usage

 - [x] AI supported my development of this PR. Gemini found the issue.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

