### PR TITLE
[Backport release/3.13] VRT pixel functions: fix mean aborting when the band has no source

### DIFF
--- a/autotest/gdrivers/vrtderived.py
+++ b/autotest/gdrivers/vrtderived.py
@@ -2289,6 +2289,24 @@ def test_vrt_pixelfn_mean_float64_image():
     assert result == src_array
 
 
+@pytest.mark.parametrize(
+    "dt", ["Byte", "UInt16", "Int16", "Int32", "Float32", "Float64"]
+)
+def test_vrt_pixelfn_mean_no_source(dt):
+
+    xml = f"""
+    <VRTDataset rasterXSize="32" rasterYSize="1">
+      <VRTRasterBand dataType="{dt}" band="1" subclass="VRTDerivedRasterBand">
+        <PixelFunctionType>mean</PixelFunctionType>
+        <SourceTransferType>{dt}</SourceTransferType>
+      </VRTRasterBand>
+    </VRTDataset>"""
+
+    with gdal.Open(xml) as ds:
+        nbytes = 32 * gdal.GetDataTypeSize(gdal.GetDataTypeByName(dt)) // 8
+        assert ds.ReadRaster() == b"\x00" * nbytes
+
+
 @pytest.mark.parametrize("dt", ["Byte", "UInt16", "Int16", "Float32", "Float64"])
 @pytest.mark.parametrize("function", ["min", "max"])
 def test_vrt_pixelfn_min_max_image(dt, function):

--- a/frmts/vrt/pixelfunctions.cpp
+++ b/frmts/vrt/pixelfunctions.cpp
@@ -3969,7 +3969,7 @@ static CPLErr BasicPixelFunc(void **papoSources, int nSources, void *pData,
     if constexpr (std::is_same_v<Kernel, MeanKernel>)
     {
         if (!bHasNoData && eSrcType == GDT_UInt8 && eBufType == GDT_UInt8 &&
-            nPixelSpace == 1 &&
+            nPixelSpace == 1 && nSources > 0 &&
             // We use signed int16 to accumulate
             nSources <= std::numeric_limits<int16_t>::max() /
                             std::numeric_limits<uint8_t>::max())
@@ -4069,7 +4069,7 @@ static CPLErr BasicPixelFunc(void **papoSources, int nSources, void *pData,
         }
 
         if (!bHasNoData && eSrcType == GDT_UInt8 && eBufType == GDT_UInt8 &&
-            nPixelSpace == 1 &&
+            nPixelSpace == 1 && nSources > 0 &&
             // We use signed int32 to accumulate
             nSources <= std::numeric_limits<int32_t>::max() /
                             std::numeric_limits<uint8_t>::max())
@@ -4138,7 +4138,7 @@ static CPLErr BasicPixelFunc(void **papoSources, int nSources, void *pData,
         }
 
         if (!bHasNoData && eSrcType == GDT_UInt16 && eBufType == GDT_UInt16 &&
-            nPixelSpace == 2 &&
+            nPixelSpace == 2 && nSources > 0 &&
             nSources <= std::numeric_limits<int32_t>::max() /
                             std::numeric_limits<uint16_t>::max())
         {
@@ -4192,7 +4192,7 @@ static CPLErr BasicPixelFunc(void **papoSources, int nSources, void *pData,
         }
 
         if (!bHasNoData && eSrcType == GDT_Int16 && eBufType == GDT_Int16 &&
-            nPixelSpace == 2 &&
+            nPixelSpace == 2 && nSources > 0 &&
             nSources <= std::numeric_limits<int32_t>::max() /
                             std::numeric_limits<uint16_t>::max())
         {


### PR DESCRIPTION
Backport #15215
 **Authored by:** @alonfaraj