### PR TITLE
gdal raster zonal-stats: add median calculation for whole-pixel methods

### DIFF
--- a/alg/raster_stats.h
+++ b/alg/raster_stats.h
@@ -28,6 +28,7 @@ struct RasterStatsOptions
         std::numeric_limits<float>::min();  // ~1e-38
 
     float min_coverage_fraction = min_coverage_fraction_default;
+    bool calc_median = false;
     bool calc_variance = false;
     bool store_histogram = false;
     bool store_values = false;
@@ -40,6 +41,7 @@ struct RasterStatsOptions
     bool operator==(const RasterStatsOptions &other) const
     {
         return min_coverage_fraction == other.min_coverage_fraction &&
+               calc_median == other.calc_median &&
                calc_variance == other.calc_variance &&
                store_histogram == other.store_histogram &&
                store_values == other.store_values &&
@@ -258,7 +260,7 @@ template <typename ValueType> class RasterStats
             entry.m_sum_ciwi += ciwi;
         }
 
-        if (m_options.store_values)
+        if (m_options.store_values || m_options.calc_median)
         {
             m_cell_values.push_back(val);
         }
@@ -283,6 +285,53 @@ template <typename ValueType> class RasterStats
         {
             return std::numeric_limits<double>::quiet_NaN();
         }
+    }
+
+    /** The median value of cells touched by this polygon. The cell
+     *  coverage fraction is not taken into account. */
+    double median() const
+    {
+        auto n = m_cell_values.size();
+        if (n == 0)
+        {
+            return std::numeric_limits<double>::quiet_NaN();
+        }
+        if (n == 1)
+        {
+            return static_cast<double>(m_cell_values[0]);
+        }
+        if (n == 2)
+        {
+            return 0.5 * (static_cast<double>(m_cell_values[0]) +
+                          static_cast<double>(m_cell_values[1]));
+        }
+
+        std::vector<ValueType> *values = nullptr;
+        std::unique_ptr<std::vector<ValueType>> values_copy;
+
+        if (m_options.store_values)
+        {
+            values_copy =
+                std::make_unique<std::vector<ValueType>>(m_cell_values);
+            values = values_copy.get();
+        }
+        else
+        {
+            values = const_cast<std::vector<ValueType> *>(&m_cell_values);
+        }
+
+        auto mid = std::next(values->begin(), n / 2);
+        std::nth_element(values->begin(), mid, values->end());
+
+        if (n % 2 != 0)
+        {
+            return static_cast<double>(*mid);
+        }
+
+        auto lhs_max = std::max_element(values->begin(), mid);
+
+        return 0.5 *
+               (static_cast<double>(*lhs_max) + static_cast<double>(*mid));
     }
 
     /**

--- a/alg/zonal.cpp
+++ b/alg/zonal.cpp
@@ -285,6 +285,7 @@ class GDALZonalStatsImpl
         MAX_CENTER_X,
         MAX_CENTER_Y,
         MEAN,
+        MEDIAN,
         MIN,
         MIN_CENTER_X,
         MIN_CENTER_Y,
@@ -426,6 +427,17 @@ class GDALZonalStatsImpl
                              stat.c_str());
                     return false;
                 }
+
+                case MEDIAN:
+                    if (m_options.pixels == GDALZonalStatsOptions::FRACTIONAL)
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Median cannot be calculated with fractional "
+                                 "pixel coverage.");
+                        return false;
+                    }
+                    m_stats_options.calc_median = true;
+                    break;
 
                 case COVERAGE:
                     m_stats_options.store_coverage_fraction = true;
@@ -671,6 +683,8 @@ class GDALZonalStatsImpl
                 return "max_center_y";
             case MEAN:
                 return "mean";
+            case MEDIAN:
+                return "median";
             case MIN:
                 return "min";
             case MIN_CENTER_X:
@@ -740,6 +754,7 @@ class GDALZonalStatsImpl
             case MAX_CENTER_X:
             case MAX_CENTER_Y:
             case MEAN:
+            case MEDIAN:
             case MIN:
             case MIN_CENTER_X:
             case MIN_CENTER_Y:
@@ -838,6 +853,10 @@ class GDALZonalStatsImpl
         if (auto iField = GetFieldIndex(iBand, MEAN); iField != -1)
         {
             feature.SetField(iField, stats.mean());
+        }
+        if (auto iField = GetFieldIndex(iBand, MEDIAN); iField != -1)
+        {
+            feature.SetField(iField, stats.median());
         }
         if (auto iField = GetFieldIndex(iBand, MIN); iField != -1)
         {

--- a/apps/gdalalg_raster_zonal_stats.cpp
+++ b/apps/gdalalg_raster_zonal_stats.cpp
@@ -65,11 +65,11 @@ GDALRasterZonalStatsAlgorithm::GDALRasterZonalStatsAlgorithm(bool bStandalone)
         .SetRequired()
         .SetMinValueIncluded(1)
         .SetChoices("center_x", "center_y", "count", "coverage", "frac", "max",
-                    "max_center_x", "max_center_y", "mean", "min", "minority",
-                    "min_center_x", "min_center_y", "mode", "stdev", "sum",
-                    "unique", "values", "variance", "variety", "weighted_mean",
-                    "weighted_stdev", "weighted_sum", "weighted_variance",
-                    "weights");
+                    "max_center_x", "max_center_y", "mean", "median", "min",
+                    "minority", "min_center_x", "min_center_y", "mode", "stdev",
+                    "sum", "unique", "values", "variance", "variety",
+                    "weighted_mean", "weighted_stdev", "weighted_sum",
+                    "weighted_variance", "weights");
     AddArg("include-field", 0,
            _("Fields from polygon zones to include in output"),
            &m_includeFields);

--- a/autotest/utilities/test_gdalalg_raster_zonal_stats.py
+++ b/autotest/utilities/test_gdalalg_raster_zonal_stats.py
@@ -1364,3 +1364,76 @@ def test_gdalalg_raster_zonal_stats_zones_nodata(zonal):
     f = lyr.GetNextFeature()
     assert f["value"] == 0
     assert f["count"] == 398
+
+
+@pytest.mark.parametrize("include_values", (True, False))
+def test_gdalalg_raster_zonal_stats_median(zonal, pixels, include_values):
+
+    src_ds = gdal.Open("../gcore/data/byte.tif")
+
+    zones_ds = gdal.GetDriverByName("MEM").Create(
+        "", src_ds.RasterXSize, src_ds.RasterYSize, 1, gdal.GDT_Byte
+    )
+    zones_ds.SetGeoTransform(src_ds.GetGeoTransform())
+    zones_ds.SetSpatialRef(src_ds.GetSpatialRef())
+
+    # zone 1 : 3 pixels
+    zones_ds.WriteRaster(1, 1, 3, 1, struct.pack("BBB", 1, 1, 1))
+
+    # zone 2: 4 pixels
+    zones_ds.WriteRaster(1, 15, 4, 1, struct.pack("BBBB", 2, 2, 2, 2))
+
+    # zone 3: 1 pixel
+    zones_ds.WriteRaster(0, 0, 1, 1, struct.pack("B", 3))
+
+    # zone 4: 2 pixels
+    zones_ds.WriteRaster(1, 2, 2, 1, struct.pack("BB", 4, 4))
+
+    zonal["input"] = src_ds
+    zonal["zones"] = zones_ds
+    zonal["stat"] = ["median"] + (["values"] if include_values else [])
+    zonal["pixels"] = pixels
+    zonal["output-format"] = "MEM"
+    zonal["output-layer"] = "myresult"
+
+    if pixels == "fractional":
+        with pytest.raises(Exception, match="Median cannot be calculated"):
+            zonal.Run()
+        return
+
+    assert zonal.Run()
+
+    out_ds = zonal.Output()
+    lyr = out_ds.GetLayer(0)
+    assert lyr.GetFeatureCount() == 5
+
+    f = lyr.GetNextFeature()
+    assert f["value"] == 0
+
+    # odd number of values
+    f = lyr.GetNextFeature()
+    assert f["value"] == 1
+    if include_values:
+        assert f["values"] == [132, 107, 123]
+    assert f["median"] == 123
+
+    # even number of values
+    f = lyr.GetNextFeature()
+    assert f["value"] == 2
+    if include_values:
+        assert f["values"] == [148, 156, 123, 107]
+    assert f["median"] == 0.5 * (123 + 148)
+
+    # single value
+    f = lyr.GetNextFeature()
+    assert f["value"] == 3
+    if include_values:
+        assert f["values"] == [107]
+    assert f["median"] == 107
+
+    # two values
+    f = lyr.GetNextFeature()
+    assert f["value"] == 4
+    if include_values:
+        assert f["values"] == [132, 140]
+    assert f["median"] == 0.5 * (132 + 140)

--- a/doc/source/programs/gdal_raster_zonal_stats.rst
+++ b/doc/source/programs/gdal_raster_zonal_stats.rst
@@ -72,6 +72,8 @@ Supported stats
       - Cell center y-coordinate for the cell containing the maximum value intersected by the polygon. The center of this cell may or may not be inside the polygon.
     * - mean
       - Mean value of cells that intersect the polygon, weighted by the percent of each cell that is covered.
+    * - median
+      - Median value of cells that intersect the polygon. Does not take into account the percent of each cell that is covered; cannot be used with :option:`--pixels=fractional`.
     * - min
       - Minimum value of cells that intersect the polygon, not taking coverage fractions or weighting raster values into account.
     * - min_center_x


### PR DESCRIPTION
Resolves #15138 